### PR TITLE
feat(rootfs): integrate virtiofs volume mounts into sandbox setup

### DIFF
--- a/monocore/bin/mcrun.rs
+++ b/monocore/bin/mcrun.rs
@@ -106,7 +106,22 @@ async fn main() -> Result<()> {
         } => {
             tracing_subscriber::fmt::init();
 
-            // Check that only one of native_rootfs or overlayfs_rootfs is provided
+            tracing::debug!("log_level: {:#?}", log_level);
+            tracing::debug!("native_rootfs: {:#?}", native_rootfs);
+            tracing::debug!("overlayfs_layer: {:#?}", overlayfs_layer);
+            tracing::debug!("num_vcpus: {:#?}", num_vcpus);
+            tracing::debug!("ram_mib: {:#?}", ram_mib);
+            tracing::debug!("workdir_path: {:#?}", workdir_path);
+            tracing::debug!("exec_path: {:#?}", exec_path);
+            tracing::debug!("env: {:#?}", env);
+            tracing::debug!("mapped_dir: {:#?}", mapped_dir);
+            tracing::debug!("port_map: {:#?}", port_map);
+            tracing::debug!("scope: {:#?}", scope);
+            tracing::debug!("ip: {:#?}", ip);
+            tracing::debug!("subnet: {:#?}", subnet);
+            tracing::debug!("args: {:#?}", args);
+
+            // Check that only one of native_rootfs or overlayfs_layer is provided
             let rootfs = match (native_rootfs, overlayfs_layer.is_empty()) {
                 (Some(path), true) => Rootfs::Native(path),
                 (None, false) => Rootfs::Overlayfs(overlayfs_layer),

--- a/monocore/lib/management/rootfs.rs
+++ b/monocore/lib/management/rootfs.rs
@@ -100,7 +100,7 @@ pub async fn patch_with_sandbox_scripts(
 /// - Cannot create directories in the rootfs
 /// - Cannot read or write the fstab file
 /// - Cannot set permissions on the fstab file
-async fn _patch_with_virtiofs_mounts(
+pub async fn patch_with_virtiofs_mounts(
     root_path: &Path,
     mapped_dirs: &[PathPair],
 ) -> MonocoreResult<()> {
@@ -267,7 +267,7 @@ mod tests {
         ];
 
         // Update fstab
-        _patch_with_virtiofs_mounts(root_path, &mapped_dirs).await?;
+        patch_with_virtiofs_mounts(root_path, &mapped_dirs).await?;
 
         // Verify fstab file was created with correct content
         let fstab_path = root_path.join("etc/fstab");
@@ -304,7 +304,7 @@ mod tests {
         ];
 
         // Update fstab again
-        _patch_with_virtiofs_mounts(root_path, &new_mapped_dirs).await?;
+        patch_with_virtiofs_mounts(root_path, &new_mapped_dirs).await?;
 
         // Verify updated content
         let updated_content = fs::read_to_string(&fstab_path).await?;
@@ -349,7 +349,7 @@ mod tests {
             vec![format!("{}:/container/data", host_path.display()).parse::<PathPair>()?];
 
         // Function should detect it cannot write to /etc/fstab and return an error
-        let result = _patch_with_virtiofs_mounts(readonly_path, &mapped_dirs).await;
+        let result = patch_with_virtiofs_mounts(readonly_path, &mapped_dirs).await;
 
         // Detailed error reporting for debugging
         if result.is_ok() {

--- a/monocore/lib/management/sandbox.rs
+++ b/monocore/lib/management/sandbox.rs
@@ -113,7 +113,7 @@ pub async fn run(
         ));
     };
 
-    tracing::debug!("sandbox_config: {:?}", sandbox_config);
+    tracing::debug!("original sandbox_config: {:#?}", sandbox_config);
 
     // Sandbox database path
     let sandbox_db_path = menv_path.join(SANDBOX_DB_FILENAME);
@@ -188,16 +188,34 @@ pub async fn run(
         .arg("--exec-path")
         .arg(&exec_path);
 
+    // CPU
     if let Some(cpus) = sandbox_config.get_cpus() {
         command.arg("--num-vcpus").arg(cpus.to_string());
     }
 
+    // RAM
     if let Some(ram) = sandbox_config.get_ram() {
         command.arg("--ram-mib").arg(ram.to_string());
     }
 
+    // Workdir
     if let Some(workdir) = sandbox_config.get_workdir() {
         command.arg("--workdir-path").arg(workdir);
+    }
+
+    // Env
+    for env in sandbox_config.get_envs() {
+        command.arg("--env").arg(env.to_string());
+    }
+
+    // Ports
+    for port in sandbox_config.get_ports() {
+        command.arg("--port").arg(port.to_string());
+    }
+
+    // Volumes
+    for volume in sandbox_config.get_volumes() {
+        command.arg("--mapped-dir").arg(volume.to_string());
     }
 
     // Pass the rootfs


### PR DESCRIPTION
- Make patch_with_virtiofs_mounts public and integrate into sandbox setup flow
- Add volume mount patching for both image and native rootfs types
- Update patching logic to handle both scripts and volume mounts
- Improve logging messages to reflect combined patching operations
