### PR TITLE
feat: add self-management and improve logging

### DIFF
--- a/microsandbox-core/bin/msb/main.rs
+++ b/microsandbox-core/bin/msb/main.rs
@@ -22,10 +22,12 @@ const SHELL_SCRIPT: &str = "shell";
 
 #[tokio::main]
 async fn main() -> MicrosandboxResult<()> {
-    tracing_subscriber::fmt::init();
-
     // Parse command line arguments
     let args = MicrosandboxArgs::parse();
+
+    handlers::log_level(&args);
+    tracing_subscriber::fmt::init();
+
     match args.subcommand {
         Some(MicrosandboxSubcommand::Init {
             path,
@@ -51,13 +53,13 @@ async fn main() -> MicrosandboxResult<()> {
             scripts,
             imports,
             exports,
-            reach,
+            scope,
             path,
             config,
         }) => {
             handlers::add_subcommand(
                 sandbox, build, group, names, image, memory, cpus, volumes, ports, envs, env_file,
-                depends_on, workdir, shell, scripts, imports, exports, reach, path, config,
+                depends_on, workdir, shell, scripts, imports, exports, scope, path, config,
             )
             .await?;
         }
@@ -154,11 +156,12 @@ async fn main() -> MicrosandboxResult<()> {
             ports,
             envs,
             workdir,
+            scope,
             exec,
             args,
         }) => {
             handlers::tmp_subcommand(
-                name, cpus, memory, volumes, ports, envs, workdir, exec, args,
+                name, cpus, memory, volumes, ports, envs, workdir, scope, exec, args,
             )
             .await?;
         }
@@ -200,6 +203,9 @@ async fn main() -> MicrosandboxResult<()> {
         }
         Some(MicrosandboxSubcommand::Clean { global, all, path }) => {
             handlers::clean_subcommand(global, all, path).await?;
+        }
+        Some(MicrosandboxSubcommand::Self_ { action }) => {
+            handlers::self_subcommand(action).await?;
         }
         Some(MicrosandboxSubcommand::Server { subcommand }) => match subcommand {
             ServerSubcommand::Start {

--- a/microsandbox-core/lib/cli/args/msb.rs
+++ b/microsandbox-core/lib/cli/args/msb.rs
@@ -16,13 +16,29 @@ pub struct MicrosandboxArgs {
     #[command(subcommand)]
     pub subcommand: Option<MicrosandboxSubcommand>,
 
-    /// Enable verbose logging
-    #[arg(short = 'V', long)]
-    pub verbose: bool,
-
     /// Show version
-    #[arg(short = 'v', long)]
+    #[arg(short = 'v', long, global = true)]
     pub version: bool,
+
+    /// Show logs with error level
+    #[arg(long, global = true)]
+    pub error: bool,
+
+    /// Show logs with warn level
+    #[arg(long, global = true)]
+    pub warn: bool,
+
+    /// Show logs with info level
+    #[arg(long, global = true)]
+    pub info: bool,
+
+    /// Show logs with debug level
+    #[arg(long, global = true)]
+    pub debug: bool,
+
+    /// Show logs with trace level
+    #[arg(long, global = true)]
+    pub trace: bool,
 }
 
 /// Available subcommands for managing services
@@ -111,9 +127,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(long = "export", name = "EXPORT", value_parser = parse_key_val::<String, String>)]
         exports: Vec<(String, String)>,
 
-        /// Network reach, options: local, public, any, none
+        /// Network scope, options: local, public, any, none
         #[arg(long)]
-        reach: Option<String>,
+        scope: Option<String>,
 
         /// Project path
         #[arg(short, long)]
@@ -371,6 +387,10 @@ pub enum MicrosandboxSubcommand {
         #[arg(long)]
         workdir: Option<Utf8UnixPathBuf>,
 
+        /// Network scope, options: local, public, any, none
+        #[arg(long)]
+        scope: Option<String>,
+
         /// Execute a command within the sandbox
         #[arg(short, long)]
         exec: Option<String>,
@@ -383,23 +403,53 @@ pub enum MicrosandboxSubcommand {
     /// Install a script from an image
     #[command(name = "install")]
     Install {
-        /// Whether to install from an image
+        /// Whether to create a temporary sandbox from an image
         #[arg(short, long)]
         image: bool,
 
-        /// Whether to install from an image group
-        #[arg(short = 'G', long)]
-        image_group: bool,
-
-        /// Name of the image or image group
-        #[arg(required = true)]
+        /// Name of the image
+        #[arg(required = true, name = "NAME[~SCRIPT]")]
         name: String,
 
-        /// Script to install
-        script: Option<String>,
+        /// Alias for the script
+        #[arg()]
+        alias: Option<String>,
 
-        /// New name for the script
-        rename: Option<String>,
+        /// Number of CPUs
+        #[arg(long, alias = "cpu")]
+        cpus: Option<u8>,
+
+        /// Memory in MB
+        #[arg(long)]
+        memory: Option<u32>,
+
+        /// Volume mappings, format: <host_path>:<container_path>
+        #[arg(long = "volume", name = "VOLUME")]
+        volumes: Vec<String>,
+
+        /// Port mappings, format: <host_port>:<container_port>
+        #[arg(long = "port", name = "PORT")]
+        ports: Vec<String>,
+
+        /// Environment variables, format: <key>=<value>
+        #[arg(long = "env", name = "ENV")]
+        envs: Vec<String>,
+
+        /// Working directory
+        #[arg(long)]
+        workdir: Option<Utf8UnixPathBuf>,
+
+        /// Network scope, options: local, public, any, none
+        #[arg(long)]
+        scope: Option<String>,
+
+        /// Execute a command within the sandbox
+        #[arg(short, long)]
+        exec: Option<String>,
+
+        /// Additional arguments after `--`
+        #[arg(last = true)]
+        args: Vec<String>,
     },
 
     /// Uninstall a script
@@ -407,18 +457,6 @@ pub enum MicrosandboxSubcommand {
     Uninstall {
         /// Script to uninstall
         script: Option<String>,
-
-        /// Whether to uninstall from an image
-        #[arg(short, long)]
-        image: bool,
-
-        /// Whether to uninstall from an image group
-        #[arg(short = 'G', long)]
-        image_group: bool,
-
-        /// Name of the image or image group
-        #[arg(required = true)]
-        name: String,
     },
 
     /// Start or stop project sandboxes based on configuration

--- a/microsandbox-core/lib/config/microsandbox/builder.rs
+++ b/microsandbox-core/lib/config/microsandbox/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     MicrosandboxResult,
 };
 
-use super::{Build, Group, Meta, Microsandbox, Module, NetworkScope, Proxy, Sandbox, SandboxGroup};
+use super::{Build, Group, Meta, Microsandbox, Module, NetworkScope, Sandbox, SandboxGroup};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -73,7 +73,6 @@ pub struct SandboxBuilder<I, S> {
     imports: HashMap<String, Utf8UnixPathBuf>,
     exports: HashMap<String, Utf8UnixPathBuf>,
     scope: NetworkScope,
-    proxy: Option<Proxy>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -163,7 +162,6 @@ impl<I, S> SandboxBuilder<I, S> {
             imports: self.imports,
             exports: self.exports,
             scope: self.scope,
-            proxy: self.proxy,
         }
     }
 
@@ -247,7 +245,6 @@ impl<I, S> SandboxBuilder<I, S> {
             imports: self.imports,
             exports: self.exports,
             scope: self.scope,
-            proxy: self.proxy,
         }
     }
 
@@ -283,12 +280,6 @@ impl<I, S> SandboxBuilder<I, S> {
         self.scope = scope;
         self
     }
-
-    /// Sets the proxy for the sandbox
-    pub fn proxy(mut self, proxy: Proxy) -> SandboxBuilder<I, S> {
-        self.proxy = Some(proxy);
-        self
-    }
 }
 
 impl SandboxBuilder<ReferenceOrPath, String> {
@@ -303,7 +294,6 @@ impl SandboxBuilder<ReferenceOrPath, String> {
             volumes: self.volumes,
             ports: self.ports,
             envs: self.envs,
-            env_file: self.env_file,
             groups: self.groups,
             depends_on: self.depends_on,
             workdir: self.workdir,
@@ -312,7 +302,6 @@ impl SandboxBuilder<ReferenceOrPath, String> {
             imports: self.imports,
             exports: self.exports,
             scope: self.scope,
-            proxy: self.proxy,
         }
     }
 }
@@ -341,7 +330,6 @@ impl Default for SandboxBuilder<(), String> {
             imports: HashMap::new(),
             exports: HashMap::new(),
             scope: NetworkScope::Group,
-            proxy: None,
         }
     }
 }

--- a/microsandbox-core/lib/management/config.rs
+++ b/microsandbox-core/lib/management/config.rs
@@ -69,8 +69,8 @@ pub enum Component {
         /// The exports to use for the sandbox.
         exports: HashMap<String, Utf8UnixPathBuf>,
 
-        /// The network reach to use for the sandbox.
-        reach: Option<String>,
+        /// The network scope to use for the sandbox.
+        scope: Option<String>,
     },
     /// A build component.
     Build {},
@@ -140,7 +140,7 @@ pub async fn add(
                 scripts,
                 imports,
                 exports,
-                reach,
+                scope,
             } => {
                 let doc_mut = doc.as_mut();
                 let mut root_mapping = doc_mut.make_mapping();
@@ -274,13 +274,13 @@ pub async fn add(
                     }
                 }
 
-                // Add network reach if provided
-                if let Some(reach_value) = reach {
+                // Add network scope if provided
+                if let Some(scope_value) = scope {
                     let mut network_mapping = sandbox_mapping
                         .insert("network", yaml::Separator::Auto)
                         .make_mapping();
 
-                    network_mapping.insert_str("reach", reach_value);
+                    network_mapping.insert_str("scope", scope_value);
                 }
             }
             Component::Build {} => {}

--- a/microsandbox-core/lib/management/mod.rs
+++ b/microsandbox-core/lib/management/mod.rs
@@ -27,3 +27,4 @@ pub mod orchestra;
 pub mod rootfs;
 pub mod sandbox;
 pub mod server;
+pub mod toolchain;

--- a/microsandbox-core/lib/management/sandbox.rs
+++ b/microsandbox-core/lib/management/sandbox.rs
@@ -387,6 +387,7 @@ pub async fn run_temp(
     ports: Vec<String>,
     envs: Vec<String>,
     workdir: Option<Utf8UnixPathBuf>,
+    scope: Option<String>,
     exec: Option<&str>,
     args: Vec<String>,
     use_image_defaults: bool,
@@ -429,6 +430,10 @@ pub async fn run_temp(
 
         if !envs.is_empty() {
             b = b.envs(envs);
+        }
+
+        if let Some(scope) = scope {
+            b = b.scope(scope.parse()?);
         }
 
         b.build()

--- a/microsandbox-core/lib/management/toolchain.rs
+++ b/microsandbox-core/lib/management/toolchain.rs
@@ -1,0 +1,123 @@
+//! Toolchain management for Microsandbox.
+//!
+//! This module provides functionality for managing the Microsandbox toolchain,
+//! including installation, upgrades, and uninstallation. It handles the binaries
+//! and libraries that make up the Microsandbox runtime.
+
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+use crate::{
+    utils::path::{XDG_BIN_DIR, XDG_HOME_DIR, XDG_LIB_DIR},
+    MicrosandboxResult,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Uninstall the Microsandbox toolchain.
+///
+/// This removes all installed binaries and libraries related to Microsandbox from
+/// the user's system, including:
+/// - Binaries in ~/.local/bin (msb, msbrun)
+/// - Libraries in ~/.local/lib (libkrun, libkrunfw)
+///
+/// ## Example
+/// ```no_run
+/// use microsandbox_core::management::toolchain;
+///
+/// # async fn example() -> anyhow::Result<()> {
+/// toolchain::uninstall().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn uninstall() -> MicrosandboxResult<()> {
+    // Uninstall binaries
+    uninstall_binaries().await?;
+
+    // Uninstall libraries
+    uninstall_libraries().await?;
+
+    // Log success
+    tracing::info!("Microsandbox toolchain has been successfully uninstalled");
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Uninstall Microsandbox binaries from the user's system.
+async fn uninstall_binaries() -> MicrosandboxResult<()> {
+    let bin_dir = XDG_HOME_DIR.join(XDG_BIN_DIR);
+
+    // List of binary files to remove
+    let binaries = ["msb", "msbrun"];
+
+    for binary in binaries {
+        let binary_path = bin_dir.join(binary);
+        if binary_path.exists() {
+            fs::remove_file(&binary_path).await?;
+            tracing::info!("Removed binary: {}", binary_path.display());
+        } else {
+            tracing::info!("Binary not found: {}", binary_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+/// Uninstall Microsandbox libraries from the user's system.
+async fn uninstall_libraries() -> MicrosandboxResult<()> {
+    let lib_dir = XDG_HOME_DIR.join(XDG_LIB_DIR);
+
+    // Remove base library symlinks first
+    remove_if_exists(lib_dir.join("libkrun.dylib")).await?;
+    remove_if_exists(lib_dir.join("libkrunfw.dylib")).await?;
+    remove_if_exists(lib_dir.join("libkrun.so")).await?;
+    remove_if_exists(lib_dir.join("libkrunfw.so")).await?;
+
+    // Remove versioned libraries
+    uninstall_versioned_libraries(&lib_dir, "libkrun").await?;
+    uninstall_versioned_libraries(&lib_dir, "libkrunfw").await?;
+
+    Ok(())
+}
+
+/// Remove a file if it exists, ignoring if it doesn't exist.
+async fn remove_if_exists(path: PathBuf) -> MicrosandboxResult<()> {
+    if path.exists() {
+        fs::remove_file(&path).await?;
+        tracing::info!("Removed library: {}", path.display());
+    } else {
+        tracing::debug!("Library not found: {}", path.display());
+    }
+    Ok(())
+}
+
+/// Uninstall versioned library files matching a prefix pattern.
+async fn uninstall_versioned_libraries(lib_dir: &Path, lib_prefix: &str) -> MicrosandboxResult<()> {
+    // Get directory entries
+    let mut entries = fs::read_dir(lib_dir).await?;
+
+    // Process each entry
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+            // Check if it's one of our versioned libraries
+            let is_dylib =
+                filename.starts_with(&format!("{}.", lib_prefix)) && filename.ends_with(".dylib");
+            let is_so = filename.starts_with(&format!("{}.", lib_prefix))
+                || filename.starts_with(&format!("{}.so.", lib_prefix));
+
+            if is_dylib || is_so {
+                fs::remove_file(&path).await?;
+                tracing::info!("Removed versioned library: {}", path.display());
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/microsandbox-core/lib/utils/path.rs
+++ b/microsandbox-core/lib/utils/path.rs
@@ -1,5 +1,7 @@
 //! Utility functions for working with paths.
 
+use std::{path::PathBuf, sync::LazyLock};
+
 use microsandbox_utils::SupportedPathType;
 
 use crate::{MicrosandboxError, MicrosandboxResult};
@@ -86,6 +88,22 @@ pub const SERVER_PID_FILE: &str = "server.pid";
 ///
 /// Example: <MICROSANDBOX_HOME_DIR>/<SERVER_KEY_FILE>
 pub const SERVER_KEY_FILE: &str = "server.key";
+
+/// The XDG home directory
+///
+/// Example: <HOME>/.local
+pub static XDG_HOME_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| dirs::home_dir().unwrap().join(".local"));
+
+/// The bin subdirectory for microsandbox
+///
+/// Example: <XDG_HOME_DIR>/bin
+pub const XDG_BIN_DIR: &str = "bin";
+
+/// The lib subdirectory for microsandbox
+///
+/// Example: <XDG_HOME_DIR>/lib
+pub const XDG_LIB_DIR: &str = "lib";
 
 //--------------------------------------------------------------------------------------------------
 // Functions


### PR DESCRIPTION
- Add self subcommand for upgrade/uninstall functionality
- Replace verbose flag with granular log levels (error/warn/info/debug/trace)
- Add toolchain management module for handling installation/uninstallation
- Remove proxy configuration and env_file options
- Rename 'reach' parameter to 'scope' for network configuration
- Add scope option to temporary sandboxes
- Restructure install/uninstall commands
- Remove proxy configuration support
- Remove env_file option from sandbox config
- Rename network 'reach' to 'scope' in CLI and handlers
