### PR TITLE
feat: add progress bars for image downloads and layer extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +774,12 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1354,6 +1373,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1660,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "console",
  "criterion",
  "dirs",
  "dotenvy",
@@ -1636,6 +1669,7 @@ dependencies = [
  "futures",
  "getset",
  "hex",
+ "indicatif",
  "ipnetwork",
  "jsonwebtoken",
  "libc",
@@ -1643,6 +1677,7 @@ dependencies = [
  "nix",
  "nondestructive",
  "oci-spec",
+ "once_cell",
  "pin-project",
  "pin-project-lite",
  "pretty-error-debug",
@@ -1869,6 +1904,12 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"
@@ -2143,6 +2184,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -3656,6 +3703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,6 +3920,16 @@ name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Makefile
+++ b/Makefile
@@ -64,19 +64,19 @@ _build_msb: $(MSB_RELEASE_BIN) $(MSBRUN_RELEASE_BIN)
 $(MSB_RELEASE_BIN): build_libkrun
 	cd microsandbox-core
 ifeq ($(OS),Darwin)
-	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib,-rpath,@executable_path" cargo build --release --bin msb $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib,-rpath,@executable_path" cargo build --release --bin msb --features cli-viz $(FEATURES)
 	codesign --entitlements microsandbox.entitlements --force -s - $@
 else
-	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib,-rpath,\$$ORIGIN" cargo build --release --bin msb $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib,-rpath,\$$ORIGIN" cargo build --release --bin msb --features cli-viz $(FEATURES)
 endif
 
 $(MSBRUN_RELEASE_BIN): build_libkrun
 	cd microsandbox-core
 ifeq ($(OS),Darwin)
-	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib,-rpath,@executable_path" cargo build --release --bin msbrun $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,@executable_path/../lib,-rpath,@executable_path" cargo build --release --bin msbrun --features cli-viz $(FEATURES)
 	codesign --entitlements microsandbox.entitlements --force -s - $@
 else
-	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib,-rpath,\$$ORIGIN" cargo build --release --bin msbrun $(FEATURES)
+	RUSTFLAGS="-C link-args=-Wl,-rpath,\$$ORIGIN/../lib,-rpath,\$$ORIGIN" cargo build --release --bin msbrun --features cli-viz $(FEATURES)
 endif
 
 # -----------------------------------------------------------------------------

--- a/microsandbox-core/Cargo.toml
+++ b/microsandbox-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "microsandbox-core"
 version = "0.2.1"
-description = "`microsandbox-core` is a tool for managing lightweight virtual machines and images."
+description = "`microsandbox-core` is a tool for managing lightweight sandboxes and images."
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
@@ -14,10 +14,12 @@ path = "lib/lib.rs"
 [[bin]]
 name = "msb"
 path = "bin/msb/main.rs"
+required-features = ["cli-viz"]
 
 [[bin]]
 name = "msbrun"
 path = "bin/msbrun.rs"
+required-features = ["cli-viz"]
 
 [[test]]
 name = "integration_cli"
@@ -83,11 +85,14 @@ which = "7.0"
 nondestructive = { version = "0.0.26", features = ["serde"] }
 jsonwebtoken = "9.3.1"
 rand.workspace = true
+indicatif = { version = "0.17.0", optional = true }
+once_cell = { version = "1.18", optional = true }
+console = "0.15.11"
 
 [dev-dependencies]
 test-log.workspace = true
 criterion.workspace = true
 serial_test = "3.2.0"
-
 [features]
 default = []
+cli-viz = ["indicatif", "once_cell"]

--- a/microsandbox-core/lib/cli/args/msb.rs
+++ b/microsandbox-core/lib/cli/args/msb.rs
@@ -8,7 +8,7 @@ use typed_path::Utf8UnixPathBuf;
 // Types
 //-------------------------------------------------------------------------------------------------
 
-/// msb (microsandbox) is a tool for managing lightweight virtual machines and images
+/// msb (microsandbox) is a tool for managing lightweight sandboxes and images
 #[derive(Debug, Parser)]
 #[command(name = "msb", author, styles=styles::styles())]
 pub struct MicrosandboxArgs {

--- a/microsandbox-core/lib/utils/mod.rs
+++ b/microsandbox-core/lib/utils/mod.rs
@@ -5,6 +5,11 @@ pub mod env;
 pub mod file;
 pub mod path;
 
+// The CLI visualisation utilities (progress bars, spinners, etc.) are only
+// compiled when the `cli-viz` feature is enabled so we gate the module here.
+#[cfg(feature = "cli-viz")]
+pub mod viz;
+
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------

--- a/microsandbox-core/lib/utils/viz.rs
+++ b/microsandbox-core/lib/utils/viz.rs
@@ -1,0 +1,26 @@
+//! This module provides a global multi-progress bar for CLI visualizations.
+//! It allows for tracking multiple progress bars in a single view.
+//!
+//! The `MULTI_PROGRESS` constant is a lazy-initialized `Arc<MultiProgress>` that
+//! manages a collection of progress bars. It is used to display multiple progress
+//! indicators simultaneously, such as when downloading multiple layers or
+
+use indicatif::{MultiProgress, MultiProgressAlignment};
+use once_cell::sync::Lazy;
+use std::sync::{Arc, LazyLock};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(feature = "cli-viz")]
+pub(crate) static MULTI_PROGRESS: Lazy<Arc<MultiProgress>> = Lazy::new(|| {
+    let mp = MultiProgress::new();
+    mp.set_alignment(MultiProgressAlignment::Top);
+    Arc::new(mp)
+});
+
+static CHECKMARK: LazyLock<String> = LazyLock::new(|| format!("{}", console::style("✓").green()));
+
+pub(crate) static TICK_STRINGS: LazyLock<[&str; 11]> =
+    LazyLock::new(|| ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", &CHECKMARK]);


### PR DESCRIPTION
- Add CLI visualization feature flag and dependencies (indicatif, once_cell, console)
- Implement progress bars and spinners for layer downloads and extraction
- Replace system tar with native implementation when cli-viz enabled
- Update package description to use "sandboxes" instead of "virtual machines"
- Make cli-viz a required feature for msb and msbrun binaries

The changes improve user experience by providing visual feedback during potentially long-running operations like image downloads and layer extraction.
