### PR TITLE
refactor(cli): reorganize CLI arguments and improve registry handling

### DIFF
--- a/microsandbox-core/bin/msb/handlers.rs
+++ b/microsandbox-core/bin/msb/handlers.rs
@@ -1,12 +1,9 @@
 use clap::{error::ErrorKind, CommandFactory};
 use microsandbox_core::{
-    cli::{AnsiStyles, MicrosandboxArgs, SelfAction},
-    management::{
+    cli::{AnsiStyles, MicrosandboxArgs, SelfAction}, config::DEFAULT_SHELL, management::{
         config::{self, Component, ComponentType},
         home, menv, orchestra, sandbox, server, toolchain,
-    },
-    oci::Reference,
-    MicrosandboxError, MicrosandboxResult,
+    }, oci::Reference, MicrosandboxError, MicrosandboxResult
 };
 use std::path::PathBuf;
 use typed_path::Utf8UnixPathBuf;
@@ -79,7 +76,7 @@ pub async fn add_subcommand(
         env_file,
         depends_on,
         workdir,
-        shell,
+        shell: Some(shell.unwrap_or(DEFAULT_SHELL.to_string())),
         scripts: scripts.into_iter().map(|(k, v)| (k, v.into())).collect(),
         imports: imports.into_iter().map(|(k, v)| (k, v.into())).collect(),
         exports: exports.into_iter().map(|(k, v)| (k, v.into())).collect(),
@@ -157,11 +154,11 @@ pub async fn run_subcommand(
     sandbox: bool,
     build: bool,
     name: String,
-    args: Vec<String>,
     path: Option<PathBuf>,
     config: Option<String>,
     detach: bool,
     exec: Option<String>,
+    args: Vec<String>,
 ) -> MicrosandboxResult<()> {
     if build && sandbox {
         MicrosandboxArgs::command()
@@ -213,11 +210,10 @@ pub async fn script_run_subcommand(
     build: bool,
     name: String,
     script: String,
-    args: Vec<String>,
     path: Option<PathBuf>,
     config: Option<String>,
     detach: bool,
-    exec: Option<String>,
+    args: Vec<String>,
 ) -> MicrosandboxResult<()> {
     if build && sandbox {
         MicrosandboxArgs::command()
@@ -242,7 +238,7 @@ pub async fn script_run_subcommand(
         config.as_deref(),
         args,
         detach,
-        exec.as_deref(),
+        None,
         true,
     )
     .await

--- a/microsandbox-core/bin/msb/main.rs
+++ b/microsandbox-core/bin/msb/main.rs
@@ -13,7 +13,6 @@ use msb::handlers;
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-const START_SCRIPT: &str = "start";
 const SHELL_SCRIPT: &str = "shell";
 
 //--------------------------------------------------------------------------------------------------
@@ -94,56 +93,33 @@ async fn main() -> MicrosandboxResult<()> {
             sandbox,
             build,
             name,
-            args,
             path,
             config,
             detach,
             exec,
-        }) => {
-            handlers::run_subcommand(sandbox, build, name, args, path, config, detach, exec)
-                .await?;
-        }
-        Some(MicrosandboxSubcommand::Start {
-            sandbox,
-            build,
-            name,
             args,
-            path,
-            config,
-            detach,
         }) => {
-            handlers::script_run_subcommand(
-                sandbox,
-                build,
-                name,
-                START_SCRIPT.to_string(),
-                args,
-                path,
-                config,
-                detach,
-                None,
-            )
-            .await?;
+            handlers::run_subcommand(sandbox, build, name, path, config, detach, exec, args)
+                .await?;
         }
         Some(MicrosandboxSubcommand::Shell {
             sandbox,
             build,
             name,
-            args,
             path,
             config,
             detach,
+            args,
         }) => {
             handlers::script_run_subcommand(
                 sandbox,
                 build,
                 name,
                 SHELL_SCRIPT.to_string(),
-                args,
                 path,
                 config,
                 detach,
-                None,
+                args,
             )
             .await?;
         }

--- a/microsandbox-core/lib/cli/args/msb.rs
+++ b/microsandbox-core/lib/cli/args/msb.rs
@@ -56,18 +56,18 @@ pub enum MicrosandboxSubcommand {
         path_with_flag: Option<PathBuf>,
     },
 
-    /// Add a new build, sandbox, or group component to the project
+    /// Add a new sandbox to the project
     #[command(name = "add")]
     Add {
-        /// Whether to add a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to add a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to add a group
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -140,18 +140,18 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// Remove a build, sandbox, or group component from the project
+    /// Remove a sandbox from the project
     #[command(name = "remove")]
     Remove {
-        /// Whether to remove a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to remove a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to remove a group
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -168,18 +168,18 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// List build, sandbox, or group components in the project
+    /// List sandboxs in the project
     #[command(name = "list")]
     List {
-        /// Whether to list sandboxes
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to list build sandboxes
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to list groups
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -195,15 +195,15 @@ pub enum MicrosandboxSubcommand {
     /// Show logs of a running build, sandbox, or group
     #[command(name = "log")]
     Log {
-        /// Whether to show logs of a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to show logs of a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to show logs of a group
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -228,18 +228,18 @@ pub enum MicrosandboxSubcommand {
         tail: Option<usize>,
     },
 
-    /// Show tree of layers that make up a build, sandbox, or group component
+    /// Show tree of layers that make up a sandbox
     #[command(name = "tree")]
     Tree {
-        /// Whether to show a sandbox tree
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to show a build sandbox tree
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to show a group tree
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -253,13 +253,13 @@ pub enum MicrosandboxSubcommand {
     },
 
     /// Run a sandbox script
-    #[command(name = "run")]
+    #[command(name = "run", alias = "r")]
     Run {
-        /// Whether to run start or specific script for a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to run start or specific script for a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
@@ -288,46 +288,14 @@ pub enum MicrosandboxSubcommand {
         args: Vec<String>,
     },
 
-    /// Start a sandbox
-    #[command(name = "start")]
-    Start {
-        /// Whether to run start script for a sandbox
-        #[arg(short, long)]
-        sandbox: bool,
-
-        /// Whether to run start script for a build sandbox
-        #[arg(short, long)]
-        build: bool,
-
-        /// Name of the component
-        #[arg(required = true)]
-        name: String,
-
-        /// Project path
-        #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
-
-        /// Additional arguments
-        #[arg(last = true)]
-        args: Vec<String>,
-
-        /// Run sandbox in the background
-        #[arg(short, long)]
-        detach: bool,
-    },
-
     /// Open a shell in a sandbox
     #[command(name = "shell")]
     Shell {
-        /// Whether to open a shell in a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to open a shell in a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
@@ -343,19 +311,19 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         config: Option<String>,
 
-        /// Additional arguments
-        #[arg(last = true)]
-        args: Vec<String>,
-
         /// Run sandbox in the background
         #[arg(short, long)]
         detach: bool,
+
+        /// Additional arguments after `--`
+        #[arg(last = true)]
+        args: Vec<String>,
     },
 
     /// Create a temporary sandbox
-    #[command(name = "tmp")]
+    #[command(name = "tmp", alias = "t")]
     Tmp {
-        /// Whether to create a temporary sandbox from an image
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         image: bool,
 
@@ -401,9 +369,9 @@ pub enum MicrosandboxSubcommand {
     },
 
     /// Install a script from an image
-    #[command(name = "install")]
+    #[command(name = "install", alias = "i")]
     Install {
-        /// Whether to create a temporary sandbox from an image
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         image: bool,
 
@@ -474,15 +442,15 @@ pub enum MicrosandboxSubcommand {
     /// Start project sandboxes
     #[command(name = "up")]
     Up {
-        /// Whether to start a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to start a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to start a group
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -502,15 +470,15 @@ pub enum MicrosandboxSubcommand {
     /// Stop project sandboxes
     #[command(name = "down")]
     Down {
-        /// Whether to stop a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to stop a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to stop a group
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -530,15 +498,15 @@ pub enum MicrosandboxSubcommand {
     /// Show running status
     #[command(name = "status")]
     Status {
-        /// Whether to show a sandbox
+        /// Whether command should apply for a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether to show a build sandbox
+        /// Whether command should apply for a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether to show a group
+        /// Whether command should apply for a group
         #[arg(short, long)]
         group: bool,
 
@@ -598,11 +566,11 @@ pub enum MicrosandboxSubcommand {
     /// Pull an image
     #[command(name = "pull")]
     Pull {
-        /// Whether to pull an image
+        /// Whether command should apply for an image
         #[arg(short, long)]
         image: bool,
 
-        /// Whether to pull an image group
+        /// Whether command should apply for an image group
         #[arg(short = 'G', long)]
         image_group: bool,
 
@@ -618,11 +586,11 @@ pub enum MicrosandboxSubcommand {
     /// Push an image
     #[command(name = "push")]
     Push {
-        /// Whether to push an image
+        /// Whether command should apply for an image
         #[arg(short, long)]
         image: bool,
 
-        /// Whether to push an image group
+        /// Whether command should apply for an image group
         #[arg(short = 'G', long)]
         image_group: bool,
 

--- a/microsandbox-core/lib/management/toolchain.rs
+++ b/microsandbox-core/lib/management/toolchain.rs
@@ -1,8 +1,8 @@
 //! Toolchain management for Microsandbox.
 //!
 //! This module provides functionality for managing the Microsandbox toolchain,
-//! including installation, upgrades, and uninstallation. It handles the binaries
-//! and libraries that make up the Microsandbox runtime.
+//! including upgrades, and uninstallation. It handles the binaries and libraries
+//! that make up the Microsandbox runtime.
 
 use std::path::{Path, PathBuf};
 use tokio::fs;


### PR DESCRIPTION
- Remove `start` subcommand in favor of using `run` with default script
- Reorder arguments in `run` and `script_run` handlers
- Update help text for CLI flags to be more consistent
- Change registry handling behavior for sandboxes.io
- Add aliases for common commands (r=run, t=tmp, i=install)
- Add SANDBOXES_REGISTRY constant and implement pull functionality
- Make shell argument required with default value
- Improve documentation for registry handling
- Standardize CLI flag descriptions
- Clean up imports and formatting
