### PR TITLE
refactor(scope): change default network scope to public

### DIFF
--- a/microsandbox-core/lib/config/defaults.rs
+++ b/microsandbox-core/lib/config/defaults.rs
@@ -2,6 +2,8 @@ use std::{fs, path::PathBuf, sync::LazyLock};
 
 use crate::utils::MICROSANDBOX_HOME_DIR;
 
+use super::NetworkScope;
+
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -48,3 +50,6 @@ pub const DEFAULT_SERVER_NAMESPACE: &str = "default";
 
 /// The default port for the sandbox server.
 pub const DEFAULT_SERVER_PORT: u16 = 5050;
+
+/// The default network scope for a sandbox.
+pub const DEFAULT_NETWORK_SCOPE: NetworkScope = NetworkScope::Public;

--- a/microsandbox-core/lib/config/microsandbox/builder.rs
+++ b/microsandbox-core/lib/config/microsandbox/builder.rs
@@ -329,7 +329,7 @@ impl Default for SandboxBuilder<(), String> {
             scripts: HashMap::new(),
             imports: HashMap::new(),
             exports: HashMap::new(),
-            scope: NetworkScope::Group,
+            scope: NetworkScope::default(),
         }
     }
 }

--- a/microsandbox-core/lib/config/microsandbox/config.rs
+++ b/microsandbox-core/lib/config/microsandbox/config.rs
@@ -210,11 +210,11 @@ pub enum NetworkScope {
 
     /// Sandboxes can only communicate within their subnet
     #[serde(rename = "group")]
-    #[default]
     Group = 1,
 
     /// Sandboxes can communicate with any other non-private address
     #[serde(rename = "public")]
+    #[default]
     Public = 2,
 
     /// Sandboxes can communicate with any address

--- a/microsandbox-core/lib/management/rootfs.rs
+++ b/microsandbox-core/lib/management/rootfs.rs
@@ -5,11 +5,7 @@
 //! Container Initiative) specifications.
 
 use std::{
-    borrow::Cow,
-    collections::HashMap,
-    fs::Permissions,
-    os::unix::fs::PermissionsExt,
-    path::{Path, PathBuf},
+    borrow::Cow, collections::HashMap, fs::Permissions, os::unix::fs::PermissionsExt, path::Path,
 };
 
 use async_recursion::async_recursion;
@@ -387,6 +383,8 @@ async fn copy_file_with_permissions(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use tempfile::TempDir;
 
     use crate::MicrosandboxError;

--- a/microsandbox-core/lib/management/sandbox.rs
+++ b/microsandbox-core/lib/management/sandbox.rs
@@ -444,6 +444,7 @@ pub async fn run_temp(
         .sandboxes([(TEMPORARY_SANDBOX_NAME.to_string(), sandbox)])
         .build_unchecked();
 
+
     // Write the config to the temporary directory
     let config_path = temp_dir_path.join(MICROSANDBOX_CONFIG_FILENAME);
     tokio::fs::write(&config_path, serde_yaml::to_string(&config)?).await?;

--- a/microsandbox-core/lib/vm/builder.rs
+++ b/microsandbox-core/lib/vm/builder.rs
@@ -1090,7 +1090,7 @@ impl Default for MicroVmConfigBuilder<(), ()> {
             memory_mib: DEFAULT_MEMORY_MIB,
             mapped_dirs: vec![],
             port_map: vec![],
-            scope: NetworkScope::Group,
+            scope: NetworkScope::default(),
             ip: None,
             subnet: None,
             rlimits: vec![],


### PR DESCRIPTION
- Move #[default] attribute from NetworkScope::Group to NetworkScope::Public
- Update SandboxBuilder and MicroVmConfigBuilder to use NetworkScope::default()
- Add DEFAULT_NETWORK_SCOPE constant
- Clean up imports in rootfs.rs
