### PR TITLE
fix: canonicalize host paths for virtiofs mounts

### DIFF
--- a/microsandbox-core/lib/management/rootfs.rs
+++ b/microsandbox-core/lib/management/rootfs.rs
@@ -5,7 +5,11 @@
 //! Container Initiative) specifications.
 
 use std::{
-    borrow::Cow, collections::HashMap, fs::Permissions, os::unix::fs::PermissionsExt, path::Path,
+    borrow::Cow,
+    collections::HashMap,
+    fs::Permissions,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
 };
 
 use async_recursion::async_recursion;
@@ -29,7 +33,7 @@ pub const WHITEOUT_PREFIX: &str = ".wh.";
 
 /// RAII guard that temporarily changes file permissions and restores them when dropped
 struct PermissionGuard {
-    path: std::path::PathBuf,
+    path: PathBuf,
     original_mode: u32,
 }
 


### PR DESCRIPTION
- Use PathBuf import directly instead of fully qualified path
- Canonicalize host paths before adding them as virtiofs mounts to ensure absolute paths and resolve any symlinks
