### PR TITLE
feat(cli): visualization for server mgmt

### DIFF
--- a/microsandbox-core/Cargo.toml
+++ b/microsandbox-core/Cargo.toml
@@ -75,7 +75,7 @@ jsonwebtoken = "9.3.1"
 rand.workspace = true
 indicatif = { version = "0.17.0", optional = true }
 once_cell = { version = "1.18", optional = true }
-console = "0.15.11"
+console = { version = "0.15.11", optional = true }
 
 [dev-dependencies]
 test-log.workspace = true
@@ -84,4 +84,4 @@ serial_test = "3.2.0"
 
 [features]
 default = []
-cli-viz = ["indicatif", "once_cell"]
+cli-viz = ["indicatif", "once_cell", "console"]

--- a/microsandbox-core/lib/utils/viz.rs
+++ b/microsandbox-core/lib/utils/viz.rs
@@ -21,9 +21,26 @@ pub(crate) static MULTI_PROGRESS: Lazy<Arc<MultiProgress>> = Lazy::new(|| {
 });
 
 static CHECKMARK: LazyLock<String> = LazyLock::new(|| format!("{}", console::style("✓").green()));
+static ERROR_MARK: LazyLock<String> = LazyLock::new(|| format!("{}", console::style("✗").red()));
 
 pub(crate) static TICK_STRINGS: LazyLock<[&str; 11]> =
     LazyLock::new(|| ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", &CHECKMARK]);
+
+pub(crate) static ERROR_TICK_STRINGS: LazyLock<[&str; 11]> = LazyLock::new(|| {
+    [
+        "⠋",
+        "⠙",
+        "⠹",
+        "⠸",
+        "⠼",
+        "⠴",
+        "⠦",
+        "⠧",
+        "⠇",
+        "⠏",
+        &ERROR_MARK,
+    ]
+});
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -74,4 +91,21 @@ pub(crate) fn create_spinner(
     pb.set_message(message);
     pb.enable_steady_tick(std::time::Duration::from_millis(80));
     pb
+}
+
+/// Finishes a spinner with an error mark (✗) instead of a checkmark.
+/// Used for error paths to visually indicate failure.
+///
+/// ## Arguments
+///
+/// * `pb` - The progress bar to finish with an error mark
+/// * `message` - The message to display next to the error mark
+#[cfg(feature = "cli-viz")]
+pub(crate) fn finish_with_error(pb: &ProgressBar, message: &str) {
+    let style = ProgressStyle::with_template("{spinner} {msg}")
+        .unwrap()
+        .tick_strings(&*ERROR_TICK_STRINGS);
+
+    pb.set_style(style);
+    pb.finish_with_message(message.to_string());
 }


### PR DESCRIPTION
- Add error state visualization for server operations with red "✗" mark
- Display server URL and PID after successful start
- Make console dependency optional and tie it to cli-viz feature
- Add visual feedback for server start, stop, and keygen operations
- Improve error handling with visual feedback
- Show token expiry information in keygen output
