### PR TITLE
feat(clean): enhance sandbox cleanup functionality

### DIFF
--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -177,8 +177,16 @@ async fn main() -> MicrosandboxResult<()> {
             handlers::log_subcommand(sandbox, build, group, name, path, config, follow, tail)
                 .await?;
         }
-        Some(MicrosandboxSubcommand::Clean { global, all, path }) => {
-            handlers::clean_subcommand(global, all, path).await?;
+        Some(MicrosandboxSubcommand::Clean {
+            sandbox,
+            name,
+            global,
+            all,
+            path,
+            config,
+            force,
+        }) => {
+            handlers::clean_subcommand(sandbox, name, global, all, path, config, force).await?;
         }
         Some(MicrosandboxSubcommand::Self_ { action }) => {
             handlers::self_subcommand(action).await?;

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -60,15 +60,15 @@ pub enum MicrosandboxSubcommand {
     /// Add a new sandbox to the project
     #[command(name = "add")]
     Add {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -144,15 +144,15 @@ pub enum MicrosandboxSubcommand {
     /// Remove a sandbox from the project
     #[command(name = "remove")]
     Remove {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -172,15 +172,15 @@ pub enum MicrosandboxSubcommand {
     /// List sandboxs in the project
     #[command(name = "list")]
     List {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -196,15 +196,15 @@ pub enum MicrosandboxSubcommand {
     /// Show logs of a running build, sandbox, or group
     #[command(name = "log")]
     Log {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -232,15 +232,15 @@ pub enum MicrosandboxSubcommand {
     /// Show tree of layers that make up a sandbox
     #[command(name = "tree")]
     Tree {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -256,11 +256,11 @@ pub enum MicrosandboxSubcommand {
     /// Run a sandbox script
     #[command(name = "run", alias = "r")]
     Run {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
@@ -292,11 +292,11 @@ pub enum MicrosandboxSubcommand {
     /// Open a shell in a sandbox
     #[command(name = "shell")]
     Shell {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
@@ -324,7 +324,7 @@ pub enum MicrosandboxSubcommand {
     /// Create a temporary sandbox
     #[command(name = "tmp", alias = "t")]
     Tmp {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         image: bool,
 
@@ -372,7 +372,7 @@ pub enum MicrosandboxSubcommand {
     /// Install a script from an image
     #[command(name = "install", alias = "i")]
     Install {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         image: bool,
 
@@ -443,15 +443,15 @@ pub enum MicrosandboxSubcommand {
     /// Start project sandboxes
     #[command(name = "up")]
     Up {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -471,15 +471,15 @@ pub enum MicrosandboxSubcommand {
     /// Stop project sandboxes
     #[command(name = "down")]
     Down {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -499,15 +499,15 @@ pub enum MicrosandboxSubcommand {
     /// Show running status
     #[command(name = "status")]
     Status {
-        /// Whether command should apply for a sandbox
+        /// Whether command should apply to a sandbox
         #[arg(short, long)]
         sandbox: bool,
 
-        /// Whether command should apply for a build sandbox
+        /// Whether command should apply to a build sandbox
         #[arg(short, long)]
         build: bool,
 
-        /// Whether command should apply for a group
+        /// Whether command should apply to a group
         #[arg(short, long)]
         group: bool,
 
@@ -527,6 +527,14 @@ pub enum MicrosandboxSubcommand {
     /// Clean cached sandbox layers, metadata, etc.
     #[command(name = "clean")]
     Clean {
+        /// Whether command should apply to a sandbox
+        #[arg(short, long)]
+        sandbox: bool,
+
+        /// Name of the component
+        #[arg()]
+        name: Option<String>,
+
         /// Clean globally. This cleans $MICROSANDBOX_HOME
         #[arg(long)]
         global: bool,
@@ -538,6 +546,14 @@ pub enum MicrosandboxSubcommand {
         /// Project path
         #[arg(short, long)]
         path: Option<PathBuf>,
+
+        /// Config file path
+        #[arg(short, long)]
+        config: Option<String>,
+
+        /// Force clean
+        #[arg(short, long)]
+        force: bool,
     },
 
     /// Build images
@@ -567,11 +583,11 @@ pub enum MicrosandboxSubcommand {
     /// Pull an image
     #[command(name = "pull")]
     Pull {
-        /// Whether command should apply for an image
+        /// Whether command should apply to an image
         #[arg(short, long)]
         image: bool,
 
-        /// Whether command should apply for an image group
+        /// Whether command should apply to an image group
         #[arg(short = 'G', long)]
         image_group: bool,
 
@@ -587,11 +603,11 @@ pub enum MicrosandboxSubcommand {
     /// Push an image
     #[command(name = "push")]
     Push {
-        /// Whether command should apply for an image
+        /// Whether command should apply to an image
         #[arg(short, long)]
         image: bool,
 
-        /// Whether command should apply for an image group
+        /// Whether command should apply to an image group
         #[arg(short = 'G', long)]
         image_group: bool,
 

--- a/microsandbox-core/lib/management/db.rs
+++ b/microsandbox-core/lib/management/db.rs
@@ -298,6 +298,26 @@ pub(crate) async fn get_running_config_sandboxes(
         .collect())
 }
 
+/// Deletes a sandbox from the database by name and config file.
+pub(crate) async fn delete_sandbox(
+    pool: &Pool<Sqlite>,
+    name: &str,
+    config_file: &str,
+) -> MicrosandboxResult<()> {
+    sqlx::query(
+        r#"
+        DELETE FROM sandboxes
+        WHERE name = ? AND config_file = ?
+        "#,
+    )
+    .bind(name)
+    .bind(config_file)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions: Images
 //--------------------------------------------------------------------------------------------------

--- a/microsandbox-core/lib/management/home.rs
+++ b/microsandbox-core/lib/management/home.rs
@@ -58,7 +58,7 @@ pub async fn clean() -> MicrosandboxResult<()> {
     }
 
     #[cfg(feature = "cli-viz")]
-    remove_home_dir_sp.finish_with_message(REMOVE_HOME_DIR_MSG);
+    remove_home_dir_sp.finish();
 
     Ok(())
 }

--- a/microsandbox-core/lib/management/image.rs
+++ b/microsandbox-core/lib/management/image.rs
@@ -221,7 +221,7 @@ pub async fn pull_from_docker_registry(
     }
 
     #[cfg(feature = "cli-viz")]
-    extract_layers_sp.finish_with_message(EXTRACT_LAYERS_MSG);
+    extract_layers_sp.finish();
 
     Ok(())
 }

--- a/microsandbox-core/lib/management/menv.rs
+++ b/microsandbox-core/lib/management/menv.rs
@@ -13,10 +13,12 @@ use crate::{
 
 #[cfg(feature = "cli-viz")]
 use crate::utils::viz;
+#[cfg(feature = "cli-viz")]
+use console::style;
 use std::path::{Path, PathBuf};
 use tokio::{fs, io::AsyncWriteExt};
 
-use crate::utils::path::{LOG_SUBDIR, MICROSANDBOX_ENV_DIR, SANDBOX_DB_FILENAME};
+use crate::utils::path::{LOG_SUBDIR, MICROSANDBOX_ENV_DIR, PATCH_SUBDIR, SANDBOX_DB_FILENAME};
 
 use super::db;
 
@@ -32,6 +34,8 @@ const INITIALIZE_MENV_DIR_MSG: &str = "Initialize .menv directory";
 const CREATE_DEFAULT_CONFIG_MSG: &str = "Create default config file";
 #[cfg(feature = "cli-viz")]
 const UPDATE_GITIGNORE_MSG: &str = "Update .gitignore";
+#[cfg(feature = "cli-viz")]
+const CLEAN_SANDBOX_MSG: &str = "Clean sandbox";
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -80,7 +84,7 @@ pub async fn initialize(project_dir: Option<PathBuf>) -> MicrosandboxResult<()> 
 
     #[cfg(feature = "cli-viz")]
     if let Some(sp) = initialize_menv_dir_sp {
-        sp.finish_with_message(INITIALIZE_MENV_DIR_MSG);
+        sp.finish();
     }
 
     // Create default config file if it doesn't exist
@@ -97,58 +101,171 @@ pub async fn initialize(project_dir: Option<PathBuf>) -> MicrosandboxResult<()> 
     update_gitignore(&project_dir).await?;
 
     #[cfg(feature = "cli-viz")]
-    update_gitignore_sp.finish_with_message(UPDATE_GITIGNORE_MSG);
+    update_gitignore_sp.finish();
 
     Ok(())
 }
 
-/// Clean up the microsandbox environment for a project
+/// Clean up the microsandbox environment for a project or a specific sandbox
 ///
-/// This removes the .menv directory and all its contents, effectively
-/// cleaning up all microsandbox data for the project.
+/// This function can either:
+/// 1. Remove the entire .menv directory and all its contents (when sandbox_name is None)
+/// 2. Remove just a specific sandbox's data (when sandbox_name is provided)
 ///
 /// ## Arguments
 /// * `project_dir` - Optional path where the microsandbox environment should be cleaned.
 ///                   If None, uses current directory
+/// * `config_file` - Optional path to the Microsandbox config file. If None, uses default filename
+/// * `sandbox_name` - Optional name of the sandbox to clean. If None, cleans entire project
+/// * `force` - Whether to force cleaning even if the sandbox exists in config or config file exists
 ///
 /// ## Example
 /// ```no_run
 /// use microsandbox_core::management::menv;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// // Clean in current directory
-/// menv::clean(None).await?;
+/// // Clean entire project in current directory
+/// menv::clean(None, None, None, false).await?;
 ///
-/// // Clean in specific directory
-/// menv::clean(Some("my_project".into())).await?;
+/// // Clean specific sandbox in current directory
+/// menv::clean(None, None, Some("dev"), false).await?;
+///
+/// // Clean specific sandbox with custom config file, forcing cleanup
+/// menv::clean(None, Some("custom.yaml"), Some("dev"), true).await?;
 /// # Ok(())
 /// # }
 /// ```
-pub async fn clean(project_dir: Option<PathBuf>) -> MicrosandboxResult<()> {
+pub async fn clean(
+    project_dir: Option<PathBuf>,
+    config_file: Option<&str>,
+    sandbox_name: Option<&str>,
+    force: bool,
+) -> MicrosandboxResult<()> {
     // Get the target path, defaulting to current directory if none specified
     let project_dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
     let menv_path = project_dir.join(MICROSANDBOX_ENV_DIR);
 
-    #[cfg(feature = "cli-viz")]
-    let remove_menv_dir_sp = viz::create_spinner(REMOVE_MENV_DIR_MSG.to_string(), None, None);
+    // Try to load the configuration if the file exists
+    let config_result =
+        crate::management::config::load_config(Some(&project_dir), config_file).await;
 
-    // Check if .menv directory exists
-    if menv_path.exists() {
-        // Remove the .menv directory and all its contents
-        fs::remove_dir_all(&menv_path).await?;
+    // If no sandbox name is provided, clean the entire project
+    if sandbox_name.is_none() {
+        #[cfg(feature = "cli-viz")]
+        let remove_menv_dir_sp = viz::create_spinner(REMOVE_MENV_DIR_MSG.to_string(), None, None);
+
+        // If the config file exists and force is false, don't clean
+        if config_result.is_ok() && !force {
+            #[cfg(feature = "cli-viz")]
+            viz::finish_with_error(&remove_menv_dir_sp);
+
+            #[cfg(feature = "cli-viz")]
+            println!(
+                "Configuration file exists. Use {} to clean the entire environment",
+                style("--force").yellow()
+            );
+
+            tracing::info!(
+                "Configuration file exists. Use --force to clean the entire environment"
+            );
+            return Ok(());
+        }
+
+        // Check if .menv directory exists
+        if menv_path.exists() {
+            // Remove the .menv directory and all its contents
+            fs::remove_dir_all(&menv_path).await?;
+            tracing::info!(
+                "Removed microsandbox environment at {}",
+                menv_path.display()
+            );
+        } else {
+            tracing::info!(
+                "No microsandbox environment found at {}",
+                menv_path.display()
+            );
+        }
+
+        #[cfg(feature = "cli-viz")]
+        remove_menv_dir_sp.finish();
+
+        return Ok(());
+    }
+
+    // At this point we know we're cleaning a specific sandbox
+    let sandbox_name = sandbox_name.unwrap();
+    let config_file = config_file.unwrap_or(MICROSANDBOX_CONFIG_FILENAME);
+
+    #[cfg(feature = "cli-viz")]
+    let clean_sandbox_sp = viz::create_spinner(
+        format!("{} '{}'", CLEAN_SANDBOX_MSG, sandbox_name),
+        None,
+        None,
+    );
+
+    // If the sandbox exists in the config and force is false, don't clean
+    if let Ok((config, _, _)) = config_result {
+        if config.get_sandbox(sandbox_name).is_some() && !force {
+            #[cfg(feature = "cli-viz")]
+            viz::finish_with_error(&clean_sandbox_sp);
+
+            #[cfg(feature = "cli-viz")]
+            println!(
+                "Sandbox '{}' exists in configuration. Use {} to clean it",
+                sandbox_name,
+                style("--force").yellow()
+            );
+
+            tracing::info!(
+                "Sandbox '{}' exists in configuration. Use --force to clean it",
+                sandbox_name
+            );
+            return Ok(());
+        }
+    }
+
+    // Get sandbox namespace
+    let namespaced_name = PathBuf::from(config_file).join(sandbox_name);
+
+    // Clean up sandbox-specific directories
+    let rw_path = menv_path.join(RW_SUBDIR).join(&namespaced_name);
+    let patch_path = menv_path.join(PATCH_SUBDIR).join(&namespaced_name);
+
+    // Remove sandbox directories if they exist
+    if rw_path.exists() {
+        fs::remove_dir_all(&rw_path).await?;
+        tracing::info!("Removed sandbox RW directory at {}", rw_path.display());
+    }
+
+    if patch_path.exists() {
+        fs::remove_dir_all(&patch_path).await?;
         tracing::info!(
-            "Removed microsandbox environment at {}",
-            menv_path.display()
-        );
-    } else {
-        tracing::info!(
-            "No microsandbox environment found at {}",
-            menv_path.display()
+            "Removed sandbox patch directory at {}",
+            patch_path.display()
         );
     }
 
+    // Remove log file if it exists
+    let log_file = menv_path
+        .join(LOG_SUBDIR)
+        .join(config_file)
+        .join(format!("{}.log", sandbox_name));
+
+    if log_file.exists() {
+        fs::remove_file(&log_file).await?;
+        tracing::info!("Removed sandbox log file at {}", log_file.display());
+    }
+
+    // Remove sandbox from database
+    let db_path = menv_path.join(SANDBOX_DB_FILENAME);
+    if db_path.exists() {
+        let pool = db::get_or_create_pool(&db_path, &db::SANDBOX_DB_MIGRATOR).await?;
+        db::delete_sandbox(&pool, sandbox_name, config_file).await?;
+        tracing::info!("Removed sandbox {} from database", sandbox_name);
+    }
+
     #[cfg(feature = "cli-viz")]
-    remove_menv_dir_sp.finish_with_message(REMOVE_MENV_DIR_MSG);
+    clean_sandbox_sp.finish();
 
     Ok(())
 }
@@ -189,7 +306,7 @@ pub(crate) async fn create_default_config(project_dir: &Path) -> MicrosandboxRes
         file.write_all(DEFAULT_CONFIG.as_bytes()).await?;
 
         #[cfg(feature = "cli-viz")]
-        create_default_config_sp.finish_with_message(CREATE_DEFAULT_CONFIG_MSG);
+        create_default_config_sp.finish();
     }
 
     Ok(())

--- a/microsandbox-core/lib/management/server.rs
+++ b/microsandbox-core/lib/management/server.rs
@@ -79,7 +79,7 @@ pub async fn start(
 
             if process_running {
                 #[cfg(feature = "cli-viz")]
-                viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+                viz::finish_with_error(&start_server_sp);
 
                 #[cfg(feature = "cli-viz")]
                 println!(
@@ -113,7 +113,7 @@ pub async fn start(
         microsandbox_utils::path::resolve_env_path(MSBRUN_EXE_ENV_VAR, &*DEFAULT_MSBRUN_EXE_PATH)
             .map_err(|e| {
             #[cfg(feature = "cli-viz")]
-            viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+            viz::finish_with_error(&start_server_sp);
             e
         })?;
 
@@ -153,7 +153,7 @@ pub async fn start(
         // Write the key to file
         fs::write(&key_file_path, &server_key).await.map_err(|e| {
             #[cfg(feature = "cli-viz")]
-            viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+            viz::finish_with_error(&start_server_sp);
 
             MicrosandboxError::SandboxServerError(format!(
                 "failed to write key file {}: {}",
@@ -188,7 +188,7 @@ pub async fn start(
 
     let mut child = command.spawn().map_err(|e| {
         #[cfg(feature = "cli-viz")]
-        viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+        viz::finish_with_error(&start_server_sp);
 
         MicrosandboxError::SandboxServerError(format!("failed to spawn server process: {}", e))
     })?;
@@ -207,7 +207,7 @@ pub async fn start(
         .await
         .map_err(|e| {
             #[cfg(feature = "cli-viz")]
-            viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+            viz::finish_with_error(&start_server_sp);
 
             MicrosandboxError::SandboxServerError(format!(
                 "failed to write PID file {}: {}",
@@ -217,7 +217,7 @@ pub async fn start(
         })?;
 
     #[cfg(feature = "cli-viz")]
-    start_server_sp.finish_with_message(START_SERVER_MSG);
+    start_server_sp.finish();
 
     // Show success message with server address
     #[cfg(feature = "cli-viz")]
@@ -245,7 +245,7 @@ pub async fn start(
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .map_err(|e| {
             #[cfg(feature = "cli-viz")]
-            viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+            viz::finish_with_error(&start_server_sp);
 
             MicrosandboxError::SandboxServerError(format!(
                 "failed to set up signal handlers: {}",
@@ -256,7 +256,7 @@ pub async fn start(
     let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
         .map_err(|e| {
             #[cfg(feature = "cli-viz")]
-            viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+            viz::finish_with_error(&start_server_sp);
 
             MicrosandboxError::SandboxServerError(format!(
                 "failed to set up signal handlers: {}",
@@ -277,7 +277,7 @@ pub async fn start(
                 cleanup_server_files(&pid_file_path, &key_file_path).await?;
 
                 #[cfg(feature = "cli-viz")]
-                viz::finish_with_error(&start_server_sp, START_SERVER_MSG);
+                viz::finish_with_error(&start_server_sp);
 
                 return Err(MicrosandboxError::SandboxServerError(format!(
                     "child process — sandbox server — failed with exit status: {:?}",
@@ -343,7 +343,7 @@ pub async fn stop() -> MicrosandboxResult<()> {
     // Check if PID file exists
     if !pid_file_path.exists() {
         #[cfg(feature = "cli-viz")]
-        viz::finish_with_error(&stop_server_sp, STOP_SERVER_MSG);
+        viz::finish_with_error(&stop_server_sp);
 
         return Err(MicrosandboxError::SandboxServerError(
             "server is not running (PID file not found)".to_string(),
@@ -365,7 +365,7 @@ pub async fn stop() -> MicrosandboxResult<()> {
                 cleanup_server_files(&pid_file_path, &key_file_path).await?;
 
                 #[cfg(feature = "cli-viz")]
-                viz::finish_with_error(&stop_server_sp, STOP_SERVER_MSG);
+                viz::finish_with_error(&stop_server_sp);
 
                 return Err(MicrosandboxError::SandboxServerError(
                     "server process not found (stale PID file removed)".to_string(),
@@ -373,7 +373,7 @@ pub async fn stop() -> MicrosandboxResult<()> {
             }
 
             #[cfg(feature = "cli-viz")]
-            viz::finish_with_error(&stop_server_sp, STOP_SERVER_MSG);
+            viz::finish_with_error(&stop_server_sp);
 
             return Err(MicrosandboxError::SandboxServerError(format!(
                 "failed to stop server process (PID: {})",
@@ -386,7 +386,7 @@ pub async fn stop() -> MicrosandboxResult<()> {
     cleanup_server_files(&pid_file_path, &key_file_path).await?;
 
     #[cfg(feature = "cli-viz")]
-    stop_server_sp.finish_with_message(STOP_SERVER_MSG);
+    stop_server_sp.finish();
 
     #[cfg(feature = "cli-viz")]
     println!("Stopped sandbox server (PID: {})", pid);
@@ -407,7 +407,7 @@ pub async fn keygen(expire: Option<Duration>) -> MicrosandboxResult<()> {
     // Check if server key file exists
     if !key_file_path.exists() {
         #[cfg(feature = "cli-viz")]
-        viz::finish_with_error(&keygen_sp, KEYGEN_MSG);
+        viz::finish_with_error(&keygen_sp);
 
         return Err(MicrosandboxError::SandboxServerError(
             "Server key file not found. Make sure the server is running in secure mode."
@@ -418,7 +418,7 @@ pub async fn keygen(expire: Option<Duration>) -> MicrosandboxResult<()> {
     // Read the server key
     let server_key = fs::read_to_string(&key_file_path).await.map_err(|e| {
         #[cfg(feature = "cli-viz")]
-        viz::finish_with_error(&keygen_sp, KEYGEN_MSG);
+        viz::finish_with_error(&keygen_sp);
 
         MicrosandboxError::SandboxServerError(format!(
             "Failed to read server key file {}: {}",
@@ -447,7 +447,7 @@ pub async fn keygen(expire: Option<Duration>) -> MicrosandboxResult<()> {
     )
     .map_err(|e| {
         #[cfg(feature = "cli-viz")]
-        viz::finish_with_error(&keygen_sp, KEYGEN_MSG);
+        viz::finish_with_error(&keygen_sp);
 
         MicrosandboxError::SandboxServerError(format!("Failed to generate token: {}", e))
     })?;
@@ -460,7 +460,7 @@ pub async fn keygen(expire: Option<Duration>) -> MicrosandboxResult<()> {
     let expiry_str = expiry.to_rfc3339();
 
     #[cfg(feature = "cli-viz")]
-    keygen_sp.finish_with_message(KEYGEN_MSG);
+    keygen_sp.finish();
 
     tracing::info!("Generated API token with expiry {}", expiry_str);
 

--- a/microsandbox-core/lib/oci/implementations/docker.rs
+++ b/microsandbox-core/lib/oci/implementations/docker.rs
@@ -408,7 +408,7 @@ impl OciRegistryPull for DockerRegistry {
         db::save_config(&self.oci_db, manifest_id, &config).await?;
 
         #[cfg(feature = "cli-viz")]
-        fetch_details_sp.finish_with_message(FETCH_IMAGE_DETAILS_MSG);
+        fetch_details_sp.finish();
 
         let layers = manifest.layers();
 
@@ -489,7 +489,7 @@ impl OciRegistryPull for DockerRegistry {
         }
 
         #[cfg(feature = "cli-viz")]
-        download_layers_sp.finish_with_message(DOWNLOAD_LAYER_MSG);
+        download_layers_sp.finish();
 
         Ok(())
     }

--- a/microsandbox-core/lib/utils/viz.rs
+++ b/microsandbox-core/lib/utils/viz.rs
@@ -26,21 +26,7 @@ static ERROR_MARK: LazyLock<String> = LazyLock::new(|| format!("{}", console::st
 pub(crate) static TICK_STRINGS: LazyLock<[&str; 11]> =
     LazyLock::new(|| ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", &CHECKMARK]);
 
-pub(crate) static ERROR_TICK_STRINGS: LazyLock<[&str; 11]> = LazyLock::new(|| {
-    [
-        "⠋",
-        "⠙",
-        "⠹",
-        "⠸",
-        "⠼",
-        "⠴",
-        "⠦",
-        "⠧",
-        "⠇",
-        "⠏",
-        &ERROR_MARK,
-    ]
-});
+pub(crate) static ERROR_TICK_STRINGS: LazyLock<[&str; 2]> = LazyLock::new(|| ["⠏", &ERROR_MARK]);
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -99,13 +85,12 @@ pub(crate) fn create_spinner(
 /// ## Arguments
 ///
 /// * `pb` - The progress bar to finish with an error mark
-/// * `message` - The message to display next to the error mark
 #[cfg(feature = "cli-viz")]
-pub(crate) fn finish_with_error(pb: &ProgressBar, message: &str) {
+pub(crate) fn finish_with_error(pb: &ProgressBar) {
     let style = ProgressStyle::with_template("{spinner} {msg}")
         .unwrap()
         .tick_strings(&*ERROR_TICK_STRINGS);
 
     pb.set_style(style);
-    pb.finish_with_message(message.to_string());
+    pb.finish();
 }


### PR DESCRIPTION
- Add ability to clean specific sandboxes by name
- Add force flag to override config file checks
- Add config file parameter for targeted cleanup
- Update clean subcommand handler with new parameters
- Add database function to delete specific sandboxes
- Improve spinner visualization for cleanup operations
- Fix "for" to "to" in CLI argument help messages
- Remove redundant message strings from spinner finishes
