### PR TITLE
feat(rootfs): add container stat override support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.1.0"
+version = "0.1.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/microsandbox/microsandbox"
-version = "0.1.0"
+version = "0.1.0-alpha"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/microsandbox-core/lib/management/menv.rs
+++ b/microsandbox-core/lib/management/menv.rs
@@ -33,8 +33,6 @@ const INITIALIZE_MENV_DIR_MSG: &str = "Initialize .menv directory";
 #[cfg(feature = "cli-viz")]
 const CREATE_DEFAULT_CONFIG_MSG: &str = "Create default config file";
 #[cfg(feature = "cli-viz")]
-const UPDATE_GITIGNORE_MSG: &str = "Update .gitignore";
-#[cfg(feature = "cli-viz")]
 const CLEAN_SANDBOX_MSG: &str = "Clean sandbox";
 
 //--------------------------------------------------------------------------------------------------
@@ -94,14 +92,8 @@ pub async fn initialize(project_dir: Option<PathBuf>) -> MicrosandboxResult<()> 
         project_dir.join(MICROSANDBOX_CONFIG_FILENAME).display()
     );
 
-    #[cfg(feature = "cli-viz")]
-    let update_gitignore_sp = viz::create_spinner(UPDATE_GITIGNORE_MSG.to_string(), None, None);
-
     // Update .gitignore to include .menv directory
     update_gitignore(&project_dir).await?;
-
-    #[cfg(feature = "cli-viz")]
-    update_gitignore_sp.finish();
 
     Ok(())
 }

--- a/microsandbox-core/lib/management/sandbox.rs
+++ b/microsandbox-core/lib/management/sandbox.rs
@@ -578,6 +578,9 @@ async fn setup_image_rootfs(
             tracing::info!("patching with {} volume mounts", volumes.len());
             rootfs::patch_with_virtiofs_mounts(&patch_dir, volumes).await?;
         }
+
+        // Set stat override on the rootfs to ensure proper permissions inside the container
+        rootfs::patch_with_stat_override(&top_rw_path).await?;
     } else {
         tracing::info!("skipping sandbox patch - config unchanged");
     }
@@ -638,6 +641,9 @@ async fn setup_native_rootfs(
             // For native rootfs, mount points should be created under the root path
             rootfs::patch_with_virtiofs_mounts(root_path, volumes).await?;
         }
+
+        // Set stat override on the rootfs to ensure proper permissions inside the container
+        rootfs::patch_with_stat_override(root_path).await?;
     } else {
         tracing::info!("skipping sandbox patch - config unchanged");
     }


### PR DESCRIPTION
Add xattr-based stat override functionality to ensure proper rootfs permissions inside containers. This sets user.containers.override_stat to "0:0:0555" on the rootfs directory.

Additional changes:
- Remove redundant gitignore update visualization
- Update version to 0.1.0-alpha
