### PR TITLE
feat: add command aliases and rename tmp to exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ MSBRUN_RELEASE_BIN := target/release/msbrun
 EXAMPLES_DIR := target/release/examples
 BENCHES_DIR := target/release
 BUILD_DIR := build
+SCRIPT_DIR := scripts
+ALIASES_DIR := $(SCRIPT_DIR)/aliases
 
 # -----------------------------------------------------------------------------
 # Library Detection
@@ -43,7 +45,7 @@ endif
 # -----------------------------------------------------------------------------
 # Phony Targets Declaration
 # -----------------------------------------------------------------------------
-.PHONY: all build install clean build_libkrun example bench bin _run_example _run_bench _run_bin help uninstall microsandbox
+.PHONY: all build install clean build_libkrun example bench bin _run_example _run_bench _run_bin help uninstall microsandbox _build_aliases
 
 # -----------------------------------------------------------------------------
 # Main Targets
@@ -52,11 +54,19 @@ all: build
 
 build: build_libkrun
 	@$(MAKE) _build_msb
+	@$(MAKE) _build_aliases
 
 _build_msb: $(MSB_RELEASE_BIN) $(MSBRUN_RELEASE_BIN)
 	@cp $(MSB_RELEASE_BIN) $(BUILD_DIR)/
 	@cp $(MSBRUN_RELEASE_BIN) $(BUILD_DIR)/
 	@echo "Msb build artifacts copied to $(BUILD_DIR)/"
+
+_build_aliases:
+	@mkdir -p $(BUILD_DIR)
+	@cp $(ALIASES_DIR)/msr $(BUILD_DIR)/
+	@cp $(ALIASES_DIR)/msx $(BUILD_DIR)/
+	@cp $(ALIASES_DIR)/msi $(BUILD_DIR)/
+	@echo "Alias scripts copied to $(BUILD_DIR)/"
 
 # -----------------------------------------------------------------------------
 # Binary Building
@@ -87,6 +97,9 @@ install: build
 	install -d $(HOME_LIB)
 	install -m 755 $(BUILD_DIR)/msb $(HOME_BIN)/msb
 	install -m 755 $(BUILD_DIR)/msbrun $(HOME_BIN)/msbrun
+	install -m 755 $(BUILD_DIR)/msr $(HOME_BIN)/msr
+	install -m 755 $(BUILD_DIR)/msx $(HOME_BIN)/msx
+	install -m 755 $(BUILD_DIR)/msi $(HOME_BIN)/msi
 	@if [ -n "$(LIBKRUNFW_FILE)" ]; then \
 		install -m 755 $(LIBKRUNFW_FILE) $(HOME_LIB)/; \
 		cd $(HOME_LIB) && ln -sf $(notdir $(LIBKRUNFW_FILE)) libkrunfw.dylib; \
@@ -110,6 +123,9 @@ clean:
 uninstall:
 	rm -f $(HOME_BIN)/msb
 	rm -f $(HOME_BIN)/msbrun
+	rm -f $(HOME_BIN)/msr
+	rm -f $(HOME_BIN)/msx
+	rm -f $(HOME_BIN)/msi
 	rm -f $(HOME_LIB)/libkrunfw.dylib
 	rm -f $(HOME_LIB)/libkrun.dylib
 	@if [ -n "$(LIBKRUNFW_FILE)" ]; then \

--- a/microsandbox-cli/Cargo.toml
+++ b/microsandbox-cli/Cargo.toml
@@ -14,7 +14,6 @@ path = "bin/msb/main.rs"
 name = "msbrun"
 path = "bin/msbrun.rs"
 
-
 [lib]
 name = "microsandbox_cli"
 path = "lib/lib.rs"

--- a/microsandbox-cli/bin/msb/handlers.rs
+++ b/microsandbox-cli/bin/msb/handlers.rs
@@ -248,7 +248,7 @@ pub async fn script_run_subcommand(
     .await
 }
 
-pub async fn tmp_subcommand(
+pub async fn exe_subcommand(
     name: String,
     cpus: Option<u8>,
     memory: Option<u32>,

--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -129,7 +129,7 @@ async fn main() -> MicrosandboxResult<()> {
             )
             .await?;
         }
-        Some(MicrosandboxSubcommand::Tmp {
+        Some(MicrosandboxSubcommand::Exe {
             image: _image,
             name,
             cpus,
@@ -142,7 +142,7 @@ async fn main() -> MicrosandboxResult<()> {
             exec,
             args,
         }) => {
-            handlers::tmp_subcommand(
+            handlers::exe_subcommand(
                 name, cpus, memory, volumes, ports, envs, workdir, scope, exec, args,
             )
             .await?;

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -321,9 +321,9 @@ pub enum MicrosandboxSubcommand {
         args: Vec<String>,
     },
 
-    /// Create a temporary sandbox
-    #[command(name = "tmp", alias = "t")]
-    Tmp {
+    /// Run a temporary sandbox
+    #[command(name = "exe", alias = "x")]
+    Exe {
         /// Whether command should apply to a sandbox
         #[arg(short, long)]
         image: bool,

--- a/microsandbox-core/lib/management/toolchain.rs
+++ b/microsandbox-core/lib/management/toolchain.rs
@@ -20,7 +20,7 @@ use crate::{
 ///
 /// This removes all installed binaries and libraries related to Microsandbox from
 /// the user's system, including:
-/// - Binaries in ~/.local/bin (msb, msbrun)
+/// - Executables in ~/.local/bin (msb, msbrun, msr, msx, msi)
 /// - Libraries in ~/.local/lib (libkrun, libkrunfw)
 ///
 /// ## Example
@@ -33,8 +33,8 @@ use crate::{
 /// # }
 /// ```
 pub async fn uninstall() -> MicrosandboxResult<()> {
-    // Uninstall binaries
-    uninstall_binaries().await?;
+    // Uninstall executables
+    uninstall_executables().await?;
 
     // Uninstall libraries
     uninstall_libraries().await?;
@@ -49,20 +49,20 @@ pub async fn uninstall() -> MicrosandboxResult<()> {
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-/// Uninstall Microsandbox binaries from the user's system.
-async fn uninstall_binaries() -> MicrosandboxResult<()> {
+/// Uninstall Microsandbox executables from the user's system.
+async fn uninstall_executables() -> MicrosandboxResult<()> {
     let bin_dir = XDG_HOME_DIR.join(XDG_BIN_DIR);
 
-    // List of binary files to remove
-    let binaries = ["msb", "msbrun"];
+    // List of executable files to remove
+    let executables = ["msb", "msbrun", "msr", "msx", "msi"];
 
-    for binary in binaries {
-        let binary_path = bin_dir.join(binary);
-        if binary_path.exists() {
-            fs::remove_file(&binary_path).await?;
-            tracing::info!("removed binary: {}", binary_path.display());
+    for executable in executables {
+        let executable_path = bin_dir.join(executable);
+        if executable_path.exists() {
+            fs::remove_file(&executable_path).await?;
+            tracing::info!("removed executable: {}", executable_path.display());
         } else {
-            tracing::info!("binary not found: {}", binary_path.display());
+            tracing::info!("executable not found: {}", executable_path.display());
         }
     }
 

--- a/scripts/aliases/msi
+++ b/scripts/aliases/msi
@@ -1,0 +1,15 @@
+#!/bin/sh
+# MSB-ALIAS: msi
+# Alias for 'msb install'
+
+# Find the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Assuming msb is in the same directory as this script
+if [ -x "$SCRIPT_DIR/msb" ]; then
+  MSB_PATH="$SCRIPT_DIR/msb"
+else
+  # Otherwise, rely on PATH
+  MSB_PATH="msb"
+fi
+
+exec "$MSB_PATH" install "$@"

--- a/scripts/aliases/msr
+++ b/scripts/aliases/msr
@@ -1,0 +1,15 @@
+#!/bin/sh
+# MSB-ALIAS: msr
+# Alias for 'msb run'
+
+# Find the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Assuming msb is in the same directory as this script
+if [ -x "$SCRIPT_DIR/msb" ]; then
+  MSB_PATH="$SCRIPT_DIR/msb"
+else
+  # Otherwise, rely on PATH
+  MSB_PATH="msb"
+fi
+
+exec "$MSB_PATH" run "$@"

--- a/scripts/aliases/msx
+++ b/scripts/aliases/msx
@@ -1,0 +1,15 @@
+#!/bin/sh
+# MSB-ALIAS: msx
+# Alias for 'msb exe'
+
+# Find the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Assuming msb is in the same directory as this script
+if [ -x "$SCRIPT_DIR/msb" ]; then
+  MSB_PATH="$SCRIPT_DIR/msb"
+else
+  # Otherwise, rely on PATH
+  MSB_PATH="msb"
+fi
+
+exec "$MSB_PATH" exe "$@"

--- a/scripts/install_microsandbox.sh
+++ b/scripts/install_microsandbox.sh
@@ -20,7 +20,7 @@
 #   6. Creates unversioned library symlinks
 #
 # Installation Paths:
-#   Binaries: ~/.local/bin/
+#   Executables: ~/.local/bin/
 #   Libraries: ~/.local/lib/
 
 # Color variables
@@ -168,14 +168,19 @@ install_files() {
     EXTRACT_DIR="microsandbox-${VERSION}-${PLATFORM}"
     cd "$EXTRACT_DIR" || { error "Failed to enter extract directory"; exit 1; }
 
-    # Install binaries
-    info "Installing binaries..."
+    # Install main executables
+    info "Installing executables..."
     install -m 755 msb "$BIN_DIR/" || { error "Failed to install msb"; exit 1; }
     install -m 755 msbrun "$BIN_DIR/" || { error "Failed to install msbrun"; exit 1; }
 
+    # Install alias executables
+    install -m 755 msr "$BIN_DIR/" || { error "Failed to install msr"; exit 1; }
+    install -m 755 msx "$BIN_DIR/" || { error "Failed to install msx"; exit 1; }
+    install -m 755 msi "$BIN_DIR/" || { error "Failed to install msi"; exit 1; }
+
     # Self codesign on macOS
     if [ "$OS" = "darwin" ]; then
-        info "Attempting to codesign binaries on macOS..."
+        info "Attempting to codesign executables on macOS..."
         codesign --force -s - "$BIN_DIR/msb" 2>/dev/null || true
         codesign --force -s - "$BIN_DIR/msbrun" 2>/dev/null || true
         info "Codesigning done"
@@ -317,7 +322,12 @@ main() {
     fi
 
     info "Installation completed successfully!"
-    info "Binaries installed to: $BIN_DIR"
+    info "Executables installed to: $BIN_DIR"
+    info "  - msb: main microsandbox command"
+    info "  - msbrun: microsandbox runtime executable"
+    info "  - msr: alias for 'msb run'"
+    info "  - msx: alias for 'msb exe'"
+    info "  - msi: alias for 'msb install'"
     info "Libraries installed to: $LIB_DIR"
     info "Please restart your shell or source your shell's config file to use microsandbox"
 }

--- a/scripts/package_microsandbox.sh
+++ b/scripts/package_microsandbox.sh
@@ -88,12 +88,20 @@ info "Creating package directory..."
 mkdir -p "$PACKAGE_DIR"
 check_success "Failed to create package directory"
 
-info "Copying binaries..."
-# Copy microsandbox and monokrun
+info "Copying executables..."
+# Copy main executables
 cp "$BUILD_DIR/msb" "$PACKAGE_DIR/"
-check_success "Failed to copy msb binary"
+check_success "Failed to copy msb executable"
 cp "$BUILD_DIR/msbrun" "$PACKAGE_DIR/"
-check_success "Failed to copy msbrun binary"
+check_success "Failed to copy msbrun executable"
+
+# Copy alias executables
+cp "$BUILD_DIR/msr" "$PACKAGE_DIR/"
+check_success "Failed to copy msr executable"
+cp "$BUILD_DIR/msx" "$PACKAGE_DIR/"
+check_success "Failed to copy msx executable"
+cp "$BUILD_DIR/msi" "$PACKAGE_DIR/"
+check_success "Failed to copy msi executable"
 
 # Copy libraries based on OS type
 info "Copying libraries..."


### PR DESCRIPTION
- Add shell script aliases (msr, msx, msi) for common commands
- Rename 'tmp' subcommand to 'exe' for better clarity
- Update build system to handle new alias scripts
- Update installation/uninstallation to manage alias executables
- Update documentation and messages to use "executables" instead of "binaries"
