### PR TITLE
refactor(cli): implement server log subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ dependencies = [
  "typed-path",
  "uuid",
  "walkdir",
+ "which",
  "xattr",
 ]
 

--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -240,6 +240,15 @@ async fn main() -> MicrosandboxCliResult<()> {
             } => {
                 handlers::server_keygen_subcommand(expire, namespace, all_namespaces).await?;
             }
+            ServerSubcommand::Log {
+                sandbox,
+                name,
+                namespace,
+                follow,
+                tail,
+            } => {
+                handlers::server_log_subcommand(sandbox, name, namespace, follow, tail).await?;
+            }
         },
         Some(_) => (), // TODO: implement other subcommands
         None => {

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -197,7 +197,7 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// Show logs of a running build, sandbox, or group
+    /// Show logs of a build, sandbox, or group
     #[command(name = "log")]
     Log {
         /// Whether command should apply to a sandbox
@@ -229,7 +229,7 @@ pub enum MicrosandboxSubcommand {
         follow: bool,
 
         /// Number of lines to show from the end
-        #[arg(short = 'n', long)]
+        #[arg(short, long)]
         tail: Option<usize>,
     },
 
@@ -288,7 +288,7 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         exec: Option<String>,
 
-        /// Additional arguments after `--`
+        /// Additional arguments after `--`. Passed to the script or exec.
         #[arg(last = true)]
         args: Vec<String>,
     },
@@ -320,7 +320,7 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         detach: bool,
 
-        /// Additional arguments after `--`
+        /// Additional arguments after `--`. Passed to the shell.
         #[arg(last = true)]
         args: Vec<String>,
     },
@@ -368,7 +368,7 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         exec: Option<String>,
 
-        /// Additional arguments after `--`
+        /// Additional arguments after `--`. Passed to the script or exec.
         #[arg(last = true)]
         args: Vec<String>,
     },
@@ -420,7 +420,7 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         exec: Option<String>,
 
-        /// Additional arguments after `--`
+        /// Additional arguments after `--`. Passed to the script or exec.
         #[arg(last = true)]
         args: Vec<String>,
     },
@@ -684,6 +684,30 @@ pub enum ServerSubcommand {
         /// Allow access to all namespaces
         #[arg(short = 'a', long, conflicts_with = "namespace")]
         all_namespaces: bool,
+    },
+
+    /// Show logs of a sandbox
+    #[command(name = "log")]
+    Log {
+        /// Whether command should apply to a sandbox
+        #[arg(short, long)]
+        sandbox: bool,
+
+        /// Name of the component
+        #[arg(required = true)]
+        name: String,
+
+        /// Namespace for the logs
+        #[arg(short, long)]
+        namespace: String,
+
+        /// Follow the logs
+        #[arg(short, long)]
+        follow: bool,
+
+        /// Number of lines to show from the end
+        #[arg(short, long)]
+        tail: Option<usize>,
     },
 }
 

--- a/microsandbox-core/Cargo.toml
+++ b/microsandbox-core/Cargo.toml
@@ -75,6 +75,7 @@ jsonwebtoken = "9.3.1"
 rand.workspace = true
 indicatif = { workspace = true, optional = true }
 console = { workspace = true, optional = true }
+which = "7.0"
 
 [dev-dependencies]
 test-log.workspace = true

--- a/microsandbox-core/lib/error.rs
+++ b/microsandbox-core/lib/error.rs
@@ -294,8 +294,12 @@ pub enum MicrosandboxError {
     MissingStartOrExecOrShell,
 
     /// An error that occurred when trying to install a script with the same name as an existing command.
-    #[error("{0}")]
+    #[error("command already exists: {0}")]
     CommandExists(String),
+
+    /// An error that occurred when a command was not found.
+    #[error("command not found: {0}")]
+    CommandNotFound(String),
 }
 
 /// An error that occurred when an invalid MicroVm configuration was used.

--- a/microsandbox-core/lib/management/home.rs
+++ b/microsandbox-core/lib/management/home.rs
@@ -199,10 +199,7 @@ pub async fn install(
 
     // Check if a command with this name already exists in the system PATH
     if command_exists(&alias_name) {
-        return Err(MicrosandboxError::CommandExists(format!(
-            "A command with the name '{}' already exists in your PATH. Please choose a different alias name.",
-            alias_name
-        )));
+        return Err(MicrosandboxError::CommandExists(alias_name));
     }
 
     // Initialize .menv in the installs directory if it doesn't exist


### PR DESCRIPTION
- Move log viewing logic from handlers to menv module
- Add server log subcommand for viewing namespace logs
- Add command existence checks for tail utility
- Improve error messages for command not found cases
- Update CLI help text for clarity
