### PR TITLE
feat(cli): add server list command and unified sandbox listing

### DIFF
--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -249,6 +249,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             } => {
                 handlers::server_log_subcommand(sandbox, name, namespace, follow, tail).await?;
             }
+            ServerSubcommand::List { namespace } => {
+                handlers::server_list_subcommand(namespace).await?;
+            }
         },
         Some(_) => (), // TODO: implement other subcommands
         None => {

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -709,6 +709,14 @@ pub enum ServerSubcommand {
         #[arg(short, long)]
         tail: Option<usize>,
     },
+
+    /// List sandboxes in a namespace
+    #[command(name = "list")]
+    List {
+        /// Namespace to list sandboxes from
+        #[arg(short, long, required = true)]
+        namespace: String,
+    },
 }
 
 /// Actions for the self subcommand

--- a/microsandbox-cli/lib/error.rs
+++ b/microsandbox-cli/lib/error.rs
@@ -33,4 +33,8 @@ pub enum MicrosandboxCliError {
     /// Process wait error
     #[error("process wait error: {0}")]
     ProcessWaitError(String),
+
+    /// Configuration error
+    #[error("configuration error: {0}")]
+    ConfigError(String),
 }


### PR DESCRIPTION
- Add new `server list` subcommand to display sandboxes in a namespace
- Create reusable `show_list` function in menv module for consistent sandbox display
- Update existing list subcommand to use the new show_list function
- Add ConfigError variant to MicrosandboxCliError enum
