### PR TITLE
feat(cli): add status command and resource monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,9 +295,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -518,6 +529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +666,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "derive_more 2.0.1",
+ "document-features",
+ "mio",
+ "parking_lot 0.12.3",
+ "rustix 1.0.5",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +741,26 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "darwin-libproc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb90051930c9a0f09e585762152048e23ac74d20c10590ef7cf01c0343c3046"
+dependencies = [
+ "darwin-libproc-sys",
+ "libc",
+ "memchr",
+]
+
+[[package]]
+name = "darwin-libproc-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -748,6 +815,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +877,15 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1120,6 +1228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1292,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1598,7 +1721,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -1627,6 +1750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1770,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1704,12 +1842,14 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
+ "atty",
  "axum",
  "bon",
  "bytes",
  "chrono",
  "console",
  "criterion",
+ "crossterm",
  "dirs",
  "dotenvy",
  "file-lock",
@@ -1722,13 +1862,14 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "microsandbox-utils",
- "nix",
+ "nix 0.29.0",
  "nondestructive",
  "oci-spec",
  "pin-project",
  "pin-project-lite",
  "pretty-error-debug",
  "procspawn",
+ "psutil",
  "rand 0.9.0",
  "regex",
  "reqwest",
@@ -1804,7 +1945,7 @@ dependencies = [
  "futures",
  "indicatif",
  "libc",
- "nix",
+ "nix 0.29.0",
  "pretty-error-debug",
  "serde_json",
  "tempfile",
@@ -1867,11 +2008,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1986,6 +2138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,7 +2159,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2044,7 +2206,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2239,6 +2401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "platforms"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2531,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "psutil"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e617cc9058daa5e1fe5a0d23ed745773a5ee354111dad1ec0235b0cc16b6730"
+dependencies = [
+ "cfg-if",
+ "darwin-libproc",
+ "derive_more 0.99.20",
+ "glob",
+ "mach2",
+ "nix 0.24.3",
+ "num_cpus",
+ "once_cell",
+ "platforms",
+ "thiserror 1.0.65",
+ "unescape",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,7 +2654,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2662,7 +2849,7 @@ version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -2675,7 +2862,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2779,7 +2966,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2951,6 +3138,17 @@ checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]
@@ -3149,7 +3347,7 @@ checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "byteorder",
  "bytes",
  "crc",
@@ -3191,7 +3389,7 @@ checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3342,7 +3540,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3640,7 +3838,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "bytes",
  "http",
  "pin-project-lite",
@@ -3784,6 +3982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +4013,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -4417,7 +4627,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -192,6 +192,16 @@ async fn main() -> MicrosandboxCliResult<()> {
         }) => {
             handlers::down_subcommand(sandbox, build, group, names, path, config).await?;
         }
+        Some(MicrosandboxSubcommand::Status {
+            sandbox,
+            build,
+            group,
+            names,
+            path,
+            config,
+        }) => {
+            handlers::status_subcommand(sandbox, build, group, names, path, config).await?;
+        }
         Some(MicrosandboxSubcommand::Log {
             sandbox,
             build,
@@ -236,9 +246,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             ServerSubcommand::Keygen {
                 expire,
                 namespace,
-                all_namespaces,
+                all,
             } => {
-                handlers::server_keygen_subcommand(expire, namespace, all_namespaces).await?;
+                handlers::server_keygen_subcommand(expire, namespace, all).await?;
             }
             ServerSubcommand::Log {
                 sandbox,
@@ -252,7 +262,24 @@ async fn main() -> MicrosandboxCliResult<()> {
             ServerSubcommand::List { namespace } => {
                 handlers::server_list_subcommand(namespace).await?;
             }
+            ServerSubcommand::Status {
+                sandbox,
+                names,
+                namespace,
+            } => {
+                handlers::server_status_subcommand(sandbox, names, namespace).await?;
+            }
         },
+        Some(MicrosandboxSubcommand::Login) => {
+            handlers::login_subcommand().await?;
+        }
+        Some(MicrosandboxSubcommand::Push {
+            image,
+            image_group,
+            name,
+        }) => {
+            handlers::push_subcommand(image, image_group, name).await?;
+        }
         Some(_) => (), // TODO: implement other subcommands
         None => {
             MicrosandboxArgs::command().print_help()?;

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -146,7 +146,7 @@ pub enum MicrosandboxSubcommand {
     },
 
     /// Remove a sandbox from the project
-    #[command(name = "remove")]
+    #[command(name = "remove", alias = "rm")]
     Remove {
         /// Whether command should apply to a sandbox
         #[arg(short, long)]
@@ -444,7 +444,7 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// Start project sandboxes
+    /// Run a project's sandboxes
     #[command(name = "up")]
     Up {
         /// Whether command should apply to a sandbox
@@ -472,7 +472,7 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// Stop project sandboxes
+    /// Stop a project's sandboxes
     #[command(name = "down")]
     Down {
         /// Whether command should apply to a sandbox
@@ -500,8 +500,8 @@ pub enum MicrosandboxSubcommand {
         config: Option<String>,
     },
 
-    /// Show running status
-    #[command(name = "status")]
+    /// Show statuses of a project's running sandboxes
+    #[command(name = "status", alias = "ps", alias = "stat")]
     Status {
         /// Whether command should apply to a sandbox
         #[arg(short, long)]
@@ -515,9 +515,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         group: bool,
 
-        /// Name of the component
-        #[arg(required = true)]
-        name: String,
+        /// Names of components to show status for
+        #[arg()]
+        names: Vec<String>,
 
         /// Project path
         #[arg(short, long)]
@@ -604,6 +604,10 @@ pub enum MicrosandboxSubcommand {
         layer_path: Option<PathBuf>,
     },
 
+    /// Login to a registry
+    #[command(name = "login")]
+    Login,
+
     /// Push an image
     #[command(name = "push")]
     Push {
@@ -683,7 +687,7 @@ pub enum ServerSubcommand {
 
         /// Allow access to all namespaces
         #[arg(short = 'a', long, conflicts_with = "namespace")]
-        all_namespaces: bool,
+        all: bool,
     },
 
     /// Show logs of a sandbox
@@ -714,6 +718,22 @@ pub enum ServerSubcommand {
     #[command(name = "list")]
     List {
         /// Namespace to list sandboxes from
+        #[arg(short, long, required = true)]
+        namespace: String,
+    },
+
+    /// Show server status
+    #[command(name = "status")]
+    Status {
+        /// Whether command should apply to a sandbox
+        #[arg(short, long)]
+        sandbox: bool,
+
+        /// Name of the component
+        #[arg()]
+        names: Vec<String>,
+
+        /// Namespace to show status for
         #[arg(short, long, required = true)]
         namespace: String,
     },

--- a/microsandbox-core/Cargo.toml
+++ b/microsandbox-core/Cargo.toml
@@ -50,6 +50,7 @@ typed-path.workspace = true
 uuid.workspace = true
 xattr.workspace = true
 sysinfo = "0.34"
+psutil = "3.2.2"
 nix = { version = "0.29", features = ["mount", "user", "fs"] }
 tar = "0.4"
 flate2 = "1.0"
@@ -76,6 +77,8 @@ rand.workspace = true
 indicatif = { workspace = true, optional = true }
 console = { workspace = true, optional = true }
 which = "7.0"
+crossterm = { version = "0.29.0", features = ["events"] }
+atty = "0.2.14"
 
 [dev-dependencies]
 test-log.workspace = true

--- a/microsandbox-core/lib/management/orchestra.rs
+++ b/microsandbox-core/lib/management/orchestra.rs
@@ -10,12 +10,13 @@
 //! - `down`: Gracefully shut down all running sandboxes
 //! - `apply`: Reconcile running sandboxes with configuration
 
+use console::style;
 use microsandbox_utils::{MICROSANDBOX_ENV_DIR, SANDBOX_DB_FILENAME};
 use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{
     config::{Microsandbox, START_SCRIPT_NAME},
@@ -306,6 +307,404 @@ pub async fn down(
     Ok(())
 }
 
+/// Information about a sandbox's resource usage
+#[derive(Debug, Clone)]
+pub struct SandboxStatus {
+    /// The name of the sandbox
+    pub name: String,
+
+    /// Whether the sandbox is running
+    pub running: bool,
+
+    /// The PID of the supervisor process
+    pub supervisor_pid: Option<u32>,
+
+    /// The PID of the microVM process
+    pub microvm_pid: Option<u32>,
+
+    /// CPU usage percentage
+    pub cpu_usage: Option<f32>,
+
+    /// Memory usage in MiB
+    pub memory_usage: Option<u64>,
+
+    /// Disk usage of the RW layer in bytes
+    pub disk_usage: Option<u64>,
+
+    /// Rootfs paths
+    pub rootfs_paths: Option<String>,
+}
+
+/// Gets status information about specified sandboxes.
+///
+/// This function retrieves the current status and resource usage of the specified sandboxes:
+/// - Only reports on sandboxes that exist in the configuration
+/// - For each sandbox, reports whether it's running and resource usage if it is
+/// - If no sandbox names are specified (empty list), returns status for all sandboxes in the configuration
+///
+/// ## Arguments
+///
+/// * `sandbox_names` - List of sandbox names to get status for. If empty, all sandboxes in config are included.
+/// * `project_dir` - Optional path to the project directory. If None, defaults to current directory
+/// * `config_file` - Optional path to the Microsandbox config file. If None, uses default filename
+///
+/// ## Returns
+///
+/// Returns `MicrosandboxResult<Vec<SandboxStatus>>` containing status information for each sandbox.
+/// Possible failures include:
+/// - Config file not found or invalid
+/// - Database errors
+///
+/// ## Example
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// use microsandbox_core::management::orchestra;
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     // Get status of specific sandboxes from the default microsandbox.yaml
+///     let statuses = orchestra::status(
+///         vec!["sandbox1".to_string(), "sandbox2".to_string()],
+///         None,
+///         None
+///     ).await?;
+///
+///     // Or get status of all sandboxes from the default microsandbox.yaml
+///     let all_statuses = orchestra::status(
+///         vec![], // empty list means get all sandboxes
+///         None,
+///         None
+///     ).await?;
+///
+///     for status in statuses {
+///         println!("Sandbox: {}, Running: {}", status.name, status.running);
+///         if status.running {
+///             println!("  CPU: {:?}%, Memory: {:?}MiB, Disk: {:?}B",
+///                 status.cpu_usage, status.memory_usage, status.disk_usage);
+///         }
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+pub async fn status(
+    sandbox_names: Vec<String>,
+    project_dir: Option<&Path>,
+    config_file: Option<&str>,
+) -> MicrosandboxResult<Vec<SandboxStatus>> {
+    // Load the configuration first to validate it exists
+    let (config, canonical_project_dir, config_file) =
+        config::load_config(project_dir, config_file).await?;
+
+    // Get all sandboxes defined in config
+    let config_sandboxes = config.get_sandboxes();
+
+    // Use all sandbox names from config if no names were specified
+    let sandbox_names_to_check = if sandbox_names.is_empty() {
+        // Use all sandbox names from config
+        config_sandboxes.keys().cloned().collect()
+    } else {
+        // Validate all sandbox names exist in config before proceeding
+        validate_sandbox_names(
+            &sandbox_names,
+            &config,
+            &canonical_project_dir,
+            &config_file,
+        )?;
+
+        sandbox_names
+    };
+
+    // Ensure menv files exist
+    let menv_path = canonical_project_dir.join(MICROSANDBOX_ENV_DIR);
+    menv::ensure_menv_files(&menv_path).await?;
+
+    // Get database connection pool
+    let db_path = menv_path.join(SANDBOX_DB_FILENAME);
+    let pool = db::get_or_create_pool(&db_path, &db::SANDBOX_DB_MIGRATOR).await?;
+
+    // Get all running sandboxes from database
+    let running_sandboxes = db::get_running_config_sandboxes(&pool, &config_file).await?;
+
+    // Create a HashMap for quick lookup of running sandboxes
+    let running_sandbox_map: std::collections::HashMap<String, crate::models::Sandbox> =
+        running_sandboxes
+            .into_iter()
+            .map(|s| (s.name.clone(), s))
+            .collect();
+
+    // Get status for each sandbox name to check
+    let mut statuses = Vec::new();
+    for sandbox_name in &sandbox_names_to_check {
+        // Only process sandboxes that exist in config
+        if config_sandboxes.contains_key(sandbox_name) {
+            // Create a basic status with name and running status
+            let mut sandbox_status = SandboxStatus {
+                name: sandbox_name.clone(),
+                running: running_sandbox_map.contains_key(sandbox_name),
+                supervisor_pid: None,
+                microvm_pid: None,
+                cpu_usage: None,
+                memory_usage: None,
+                disk_usage: None,
+                rootfs_paths: None,
+            };
+
+            // If the sandbox is running, get additional stats
+            if sandbox_status.running {
+                if let Some(sandbox) = running_sandbox_map.get(sandbox_name) {
+                    sandbox_status.supervisor_pid = Some(sandbox.supervisor_pid);
+                    sandbox_status.microvm_pid = Some(sandbox.microvm_pid);
+                    sandbox_status.rootfs_paths = Some(sandbox.rootfs_paths.clone());
+
+                    // Get CPU and memory usage for the microVM process
+                    if let Ok(mut process) = psutil::process::Process::new(sandbox.microvm_pid) {
+                        // CPU usage
+                        if let Ok(cpu_percent) = process.cpu_percent() {
+                            sandbox_status.cpu_usage = Some(cpu_percent);
+                        }
+
+                        // Memory usage
+                        if let Ok(memory_info) = process.memory_info() {
+                            // Convert bytes to MiB
+                            sandbox_status.memory_usage = Some(memory_info.rss() / (1024 * 1024));
+                        }
+                    }
+
+                    // Get disk usage of the RW layer if it's an overlayfs
+                    if sandbox.rootfs_paths.starts_with("overlayfs:") {
+                        let paths: Vec<&str> = sandbox.rootfs_paths.split(':').collect();
+                        if paths.len() > 1 {
+                            // The last path should be the RW layer
+                            let rw_path = paths.last().unwrap();
+                            if let Ok(metadata) = tokio::fs::metadata(rw_path).await {
+                                // For a directory, we need to calculate the total size
+                                if metadata.is_dir() {
+                                    if let Ok(size) = get_directory_size(rw_path).await {
+                                        sandbox_status.disk_usage = Some(size);
+                                    }
+                                } else {
+                                    sandbox_status.disk_usage = Some(metadata.len());
+                                }
+                            }
+                        }
+                    } else if sandbox.rootfs_paths.starts_with("native:") {
+                        // For native rootfs, get the size of the rootfs
+                        let path = sandbox.rootfs_paths.strip_prefix("native:").unwrap();
+                        if let Ok(metadata) = tokio::fs::metadata(path).await {
+                            if metadata.is_dir() {
+                                if let Ok(size) = get_directory_size(path).await {
+                                    sandbox_status.disk_usage = Some(size);
+                                }
+                            } else {
+                                sandbox_status.disk_usage = Some(metadata.len());
+                            }
+                        }
+                    }
+                }
+            }
+
+            statuses.push(sandbox_status);
+        }
+    }
+
+    Ok(statuses)
+}
+
+/// Show the status of the sandboxes
+///
+/// ## Arguments
+///
+/// * `names` - The names of the sandboxes to show the status of
+/// * `path` - The path to the microsandbox config file
+/// * `config` - The config file to use
+///
+/// ## Returns
+///
+/// Returns `MicrosandboxResult<()>` indicating success or failure. Possible failures include:
+/// - Config file not found or invalid
+/// - Database errors
+/// - Sandbox status retrieval failures
+///
+/// ## Example
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// use microsandbox_core::management::orchestra;
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     orchestra::show_status(
+///         &["sandbox1".to_string(), "sandbox2".to_string()],
+///         None,
+///         None
+///     ).await?;
+///     Ok(())
+/// }
+/// ```
+pub async fn show_status(
+    names: &[String],
+    path: Option<&Path>,
+    config: Option<&str>,
+) -> MicrosandboxResult<()> {
+    // Check if we're in a TTY to determine if we should do live updates
+    let is_tty = atty::is(atty::Stream::Stdout);
+    let live_view = is_tty;
+    let update_interval = std::time::Duration::from_secs(2);
+
+    if live_view {
+        println!("{}", style("Press Ctrl+C to exit live view").dim());
+        // Use a loop with tokio sleep for live updates
+        loop {
+            // Clear the screen by printing ANSI escape code
+            print!("\x1B[2J\x1B[1;1H");
+
+            display_status(&names, path.as_deref(), config.as_deref()).await?;
+
+            // Show update message
+            println!(
+                "\n{}",
+                style("Updating every 2 seconds. Press Ctrl+C to exit.").dim()
+            );
+
+            // Wait for the update interval
+            tokio::time::sleep(update_interval).await;
+        }
+    } else {
+        // Just display once for non-TTY
+        display_status(&names, path.as_deref(), config.as_deref()).await?;
+    }
+
+    Ok(())
+}
+
+// Extracted the status display logic to a separate function
+async fn display_status(
+    names: &[String],
+    path: Option<&Path>,
+    config: Option<&str>,
+) -> MicrosandboxResult<()> {
+    let mut statuses = status(names.to_vec(), path, config).await?;
+
+    // Sort the statuses in a stable order to prevent entries from moving around between updates
+    // Order by: running status (running first), CPU usage (highest first),
+    // memory usage (highest first), disk usage (highest first), and finally name (alphabetical)
+    statuses.sort_by(|a, b| {
+        // First compare by running status (running sandboxes first)
+        let running_order = b.running.cmp(&a.running);
+        if running_order != std::cmp::Ordering::Equal {
+            return running_order;
+        }
+
+        // Then compare by CPU usage (highest first)
+        let cpu_order = b
+            .cpu_usage
+            .partial_cmp(&a.cpu_usage)
+            .unwrap_or(std::cmp::Ordering::Equal);
+        if cpu_order != std::cmp::Ordering::Equal {
+            return cpu_order;
+        }
+
+        // Then compare by memory usage (highest first)
+        let memory_order = b
+            .memory_usage
+            .partial_cmp(&a.memory_usage)
+            .unwrap_or(std::cmp::Ordering::Equal);
+        if memory_order != std::cmp::Ordering::Equal {
+            return memory_order;
+        }
+
+        // Then compare by disk usage (highest first)
+        let disk_order = b
+            .disk_usage
+            .partial_cmp(&a.disk_usage)
+            .unwrap_or(std::cmp::Ordering::Equal);
+        if disk_order != std::cmp::Ordering::Equal {
+            return disk_order;
+        }
+
+        // Finally sort by name (alphabetical)
+        a.name.cmp(&b.name)
+    });
+
+    // Get current timestamp
+    let now = chrono::Local::now();
+    let timestamp = now.format("%Y-%m-%d %H:%M:%S");
+
+    // Display timestamp
+    println!("{}", style(format!("Last updated: {}", timestamp)).dim());
+
+    // Print a table-like output with status information
+    println!(
+        "\n{:<15} {:<10} {:<15} {:<12} {:<12} {:<12}",
+        style("SANDBOX").bold(),
+        style("STATUS").bold(),
+        style("PIDS").bold(),
+        style("CPU").bold(),
+        style("MEMORY").bold(),
+        style("DISK").bold()
+    );
+
+    println!("{}", style("─".repeat(80)).dim());
+
+    for status in statuses {
+        let status_text = if status.running {
+            style("RUNNING").green()
+        } else {
+            style("STOPPED").red()
+        };
+
+        let pids = if status.running {
+            format!(
+                "{}/{}",
+                status.supervisor_pid.unwrap_or(0),
+                status.microvm_pid.unwrap_or(0)
+            )
+        } else {
+            "-".to_string()
+        };
+
+        let cpu = if let Some(cpu_usage) = status.cpu_usage {
+            format!("{:.1}%", cpu_usage)
+        } else {
+            "-".to_string()
+        };
+
+        let memory = if let Some(memory_usage) = status.memory_usage {
+            format!("{} MiB", memory_usage)
+        } else {
+            "-".to_string()
+        };
+
+        let disk = if let Some(disk_usage) = status.disk_usage {
+            if disk_usage > 1024 * 1024 * 1024 {
+                format!("{:.2} GB", disk_usage as f64 / (1024.0 * 1024.0 * 1024.0))
+            } else if disk_usage > 1024 * 1024 {
+                format!("{:.2} MB", disk_usage as f64 / (1024.0 * 1024.0))
+            } else if disk_usage > 1024 {
+                format!("{:.2} KB", disk_usage as f64 / 1024.0)
+            } else {
+                format!("{} B", disk_usage)
+            }
+        } else {
+            "-".to_string()
+        };
+
+        println!(
+            "{:<15} {:<10} {:<15} {:<12} {:<12} {:<12}",
+            style(&status.name).bold(),
+            status_text,
+            pids,
+            cpu,
+            memory,
+            disk
+        );
+    }
+
+    Ok(())
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
@@ -333,6 +732,28 @@ fn validate_sandbox_names(
     }
 
     Ok(())
+}
+
+/// Recursively calculate the size of a directory
+async fn get_directory_size(path: &str) -> MicrosandboxResult<u64> {
+    let mut total_size: u64 = 0;
+    let mut stack = vec![PathBuf::from(path)];
+
+    while let Some(path) = stack.pop() {
+        let mut entries = tokio::fs::read_dir(&path).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let metadata = entry.metadata().await?;
+
+            if metadata.is_file() {
+                total_size += metadata.len();
+            } else if metadata.is_dir() {
+                stack.push(entry.path());
+            }
+        }
+    }
+
+    Ok(total_size)
 }
 
 /// Checks if specified sandboxes from the configuration are running.


### PR DESCRIPTION
Add new `status` (with aliases `ps` and `stat`) command to show resource usage statistics for running sandboxes. The command displays:

- Running status
- Supervisor and microVM PIDs
- CPU usage percentage
- Memory usage in MiB
- Disk usage of RW layers
- Live updating view in TTY environments

Also includes:
- Refactored exec path determination into separate function
- Added psutil and crossterm dependencies for monitoring
- Fixed server keygen arg name from all_namespaces to all
- Added rm alias for remove command
- Improved command descriptions
