### PR TITLE
fix(script): downgrade microsandbox version to 0.1.0 in script

### DIFF
--- a/scripts/install_microsandbox.sh
+++ b/scripts/install_microsandbox.sh
@@ -43,7 +43,7 @@ error() {
 }
 
 # Default values
-VERSION="0.2.1"
+VERSION="0.1.0"
 NO_CLEANUP=false
 TEMP_DIR="/tmp/microsandbox-install"
 GITHUB_REPO="microsandbox/microsandbox"


### PR DESCRIPTION
The installation script has been updated to use microsandbox version 0.1.0 instead of 0.2.1.
