### PR TITLE
fix: downgrade nix to 0.29 and fix PTY handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "microsandbox-utils",
- "nix 0.30.0",
+ "nix 0.29.0",
  "nondestructive",
  "oci-spec",
  "once_cell",
@@ -1948,7 +1948,7 @@ dependencies = [
  "futures",
  "indicatif",
  "libc",
- "nix 0.30.0",
+ "nix 0.29.0",
  "pretty-error-debug",
  "serde_json",
  "tempfile",
@@ -2022,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537bc3c4a347b87fd52ac6c03a02ab1302962cfd93373c5d7a112cdc337854cc"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.22"
 dirs = "6.0"
 hex = "0.4"
 libc = "0.2"
-nix = "0.30"
+nix = "0.29" # Cannot upgrade to 0.30 because pty no longer works correctly. Yet to investigate properly.
 axum = "0.8"
 bytes = "1.9"
 serde = { version = "1.0", features = ["derive"] }
@@ -42,8 +42,8 @@ getset = "0.1"
 procspawn = "1.0"
 rand = "0.9"
 reqwest = { version = "0.12", features = ["stream", "json"] }
-reqwest-middleware = "0.3"                                        # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
-reqwest-retry = "0.6"                                             # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
+reqwest-middleware = "0.3" # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
+reqwest-retry = "0.6"      # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
 microsandbox-utils = { version = "0.1.0", path = "./microsandbox-utils" }
 microsandbox-core = { version = "0.1.0", path = "./microsandbox-core" }
 microsandbox-server = { version = "0.1.0", path = "./microsandbox-server" }


### PR DESCRIPTION
* Downgrade nix crate from 0.30 to 0.29 due to PTY functionality issues
* Remove unused AsFd import and update PTY code to use as_raw_fd()
* Clean up comment formatting in Cargo.toml
