### PR TITLE
refactor(cli): consolidate path and config flags into single --file flag

### DIFF
--- a/microsandbox-cli/bin/msb/main.rs
+++ b/microsandbox-cli/bin/msb/main.rs
@@ -33,11 +33,9 @@ async fn main() -> MicrosandboxCliResult<()> {
     }
 
     match args.subcommand {
-        Some(MicrosandboxSubcommand::Init {
-            path,
-            path_with_flag,
-        }) => {
-            handlers::init_subcommand(path, path_with_flag).await?;
+        Some(MicrosandboxSubcommand::Init { file }) => {
+            let (path, _) = handlers::parse_file_path(file);
+            handlers::init_subcommand(path).await?;
         }
         Some(MicrosandboxSubcommand::Add {
             sandbox,
@@ -59,9 +57,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             imports,
             exports,
             scope,
-            path,
-            config,
+            file,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::add_subcommand(
                 sandbox, build, group, names, image, memory, cpus, volumes, ports, envs, env_file,
                 depends_on, workdir, shell, scripts, start, imports, exports, scope, path, config,
@@ -73,18 +71,18 @@ async fn main() -> MicrosandboxCliResult<()> {
             build,
             group,
             names,
-            path,
-            config,
+            file,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::remove_subcommand(sandbox, build, group, names, path, config).await?;
         }
         Some(MicrosandboxSubcommand::List {
             sandbox,
             build,
             group,
-            path,
-            config,
+            file,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::list_subcommand(sandbox, build, group, path, config).await?;
         }
         Some(MicrosandboxSubcommand::Pull {
@@ -99,12 +97,12 @@ async fn main() -> MicrosandboxCliResult<()> {
             sandbox,
             build,
             name,
-            path,
-            config,
+            file,
             detach,
             exec,
             args,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::run_subcommand(sandbox, build, name, path, config, detach, exec, args)
                 .await?;
         }
@@ -112,11 +110,11 @@ async fn main() -> MicrosandboxCliResult<()> {
             sandbox,
             build,
             name,
-            path,
-            config,
+            file,
             detach,
             args,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::script_run_subcommand(
                 sandbox,
                 build,
@@ -169,7 +167,8 @@ async fn main() -> MicrosandboxCliResult<()> {
         Some(MicrosandboxSubcommand::Uninstall { script }) => {
             handlers::uninstall_subcommand(script).await?;
         }
-        Some(MicrosandboxSubcommand::Apply { path, config }) => {
+        Some(MicrosandboxSubcommand::Apply { file }) => {
+            let (path, config) = handlers::parse_file_path(file);
             orchestra::apply(path.as_deref(), config.as_deref()).await?;
         }
         Some(MicrosandboxSubcommand::Up {
@@ -177,9 +176,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             build,
             group,
             names,
-            path,
-            config,
+            file,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::up_subcommand(sandbox, build, group, names, path, config).await?;
         }
         Some(MicrosandboxSubcommand::Down {
@@ -187,9 +186,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             build,
             group,
             names,
-            path,
-            config,
+            file,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::down_subcommand(sandbox, build, group, names, path, config).await?;
         }
         Some(MicrosandboxSubcommand::Status {
@@ -197,9 +196,9 @@ async fn main() -> MicrosandboxCliResult<()> {
             build,
             group,
             names,
-            path,
-            config,
+            file,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::status_subcommand(sandbox, build, group, names, path, config).await?;
         }
         Some(MicrosandboxSubcommand::Log {
@@ -207,11 +206,11 @@ async fn main() -> MicrosandboxCliResult<()> {
             build,
             group,
             name,
-            path,
-            config,
+            file,
             follow,
             tail,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::log_subcommand(sandbox, build, group, name, path, config, follow, tail)
                 .await?;
         }
@@ -220,10 +219,10 @@ async fn main() -> MicrosandboxCliResult<()> {
             name,
             user,
             all,
-            path,
-            config,
+            file,
             force,
         }) => {
+            let (path, config) = handlers::parse_file_path(file);
             handlers::clean_subcommand(sandbox, name, user, all, path, config, force).await?;
         }
         Some(MicrosandboxSubcommand::Self_ { action }) => {

--- a/microsandbox-cli/lib/args/msb.rs
+++ b/microsandbox-cli/lib/args/msb.rs
@@ -48,13 +48,9 @@ pub enum MicrosandboxSubcommand {
     /// Initialize a new microsandbox project
     #[command(name = "init")]
     Init {
-        /// Specifies the directory to initialize the project in
-        #[arg(required = false, name = "PATH")]
-        path: Option<PathBuf>,
-
-        /// Specifies the directory to initialize the project in
-        #[arg(short, long = "path", name = "PATH\0")]
-        path_with_flag: Option<PathBuf>,
+        /// Path to the sandbox file or the project directory
+        #[arg(short, long)]
+        file: Option<PathBuf>,
     },
 
     /// Add a new sandbox to the project
@@ -93,7 +89,7 @@ pub enum MicrosandboxSubcommand {
         volumes: Vec<String>,
 
         /// Port mappings, format: <host_port>:<container_port>
-        #[arg(long = "port", name = "PORT")]
+        #[arg(short, long = "port", name = "PORT")]
         ports: Vec<String>,
 
         /// Environment variables, format: <key>=<value>
@@ -136,13 +132,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(long)]
         scope: Option<String>,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// Remove a sandbox from the project
@@ -164,13 +156,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(required = true)]
         names: Vec<String>,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// List sandboxs in the project
@@ -188,13 +176,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         group: bool,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// Show logs of a build, sandbox, or group
@@ -216,13 +200,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(required = true)]
         name: String,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
 
         /// Follow the logs
         #[arg(short, long)]
@@ -272,20 +252,16 @@ pub enum MicrosandboxSubcommand {
         #[arg(required = true, name = "NAME[~SCRIPT]")]
         name: String,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
 
         /// Run sandbox in the background
         #[arg(short, long)]
         detach: bool,
 
         /// Execute a command within the sandbox
-        #[arg(short, long)]
+        #[arg(short, long, short_alias = 'x')]
         exec: Option<String>,
 
         /// Additional arguments after `--`. Passed to the script or exec.
@@ -308,13 +284,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(required = true)]
         name: String,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
 
         /// Run sandbox in the background
         #[arg(short, long)]
@@ -349,7 +321,7 @@ pub enum MicrosandboxSubcommand {
         volumes: Vec<String>,
 
         /// Port mappings, format: <host_port>:<container_port>
-        #[arg(long = "port", name = "PORT")]
+        #[arg(short, long = "port", name = "PORT")]
         ports: Vec<String>,
 
         /// Environment variables, format: <key>=<value>
@@ -365,7 +337,7 @@ pub enum MicrosandboxSubcommand {
         scope: Option<String>,
 
         /// Execute a command within the sandbox
-        #[arg(short, long)]
+        #[arg(short, long, short_alias = 'x')]
         exec: Option<String>,
 
         /// Additional arguments after `--`. Passed to the script or exec.
@@ -401,7 +373,7 @@ pub enum MicrosandboxSubcommand {
         volumes: Vec<String>,
 
         /// Port mappings, format: <host_port>:<container_port>
-        #[arg(long = "port", name = "PORT")]
+        #[arg(short, long = "port", name = "PORT")]
         ports: Vec<String>,
 
         /// Environment variables, format: <key>=<value>
@@ -417,7 +389,7 @@ pub enum MicrosandboxSubcommand {
         scope: Option<String>,
 
         /// Execute a command within the sandbox
-        #[arg(short, long)]
+        #[arg(short, long, short_alias = 'x')]
         exec: Option<String>,
 
         /// Additional arguments after `--`. Passed to the script or exec.
@@ -435,13 +407,9 @@ pub enum MicrosandboxSubcommand {
     /// Start or stop project sandboxes based on configuration
     #[command(name = "apply")]
     Apply {
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// Run a project's sandboxes
@@ -463,13 +431,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(required = true)]
         names: Vec<String>,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// Stop a project's sandboxes
@@ -491,13 +455,9 @@ pub enum MicrosandboxSubcommand {
         #[arg(required = true)]
         names: Vec<String>,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// Show statuses of a project's running sandboxes
@@ -519,13 +479,9 @@ pub enum MicrosandboxSubcommand {
         #[arg()]
         names: Vec<String>,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
     },
 
     /// Clean cached sandbox layers, metadata, etc.
@@ -547,16 +503,12 @@ pub enum MicrosandboxSubcommand {
         #[arg(short, long)]
         all: bool,
 
-        /// Project path
+        /// Path to the sandbox file or the project directory
         #[arg(short, long)]
-        path: Option<PathBuf>,
-
-        /// Config file path
-        #[arg(short, long)]
-        config: Option<String>,
+        file: Option<PathBuf>,
 
         /// Force clean
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 

--- a/microsandbox-cli/lib/args/msbrun.rs
+++ b/microsandbox-cli/lib/args/msbrun.rs
@@ -79,6 +79,7 @@ pub enum McrunSubcommand {
         #[arg(last = true)]
         args: Vec<String>,
     },
+
     /// Run as supervisor
     Supervisor {
         /// Directory for log files

--- a/microsandbox-core/lib/config/path_pair.rs
+++ b/microsandbox-core/lib/config/path_pair.rs
@@ -46,6 +46,7 @@ pub enum PathPair {
         /// The guest path.
         guest: Utf8UnixPathBuf,
     },
+
     /// The guest path and host path are the same.
     Same(Utf8UnixPathBuf),
 }


### PR DESCRIPTION
- Removed separate -p/--path and -c/--config flags from all commands
- Added new -f/--file flag that handles both project and config paths
- Added parse_file_path helper to determine if input is directory or file
- Simplified init_subcommand to take single path parameter
- Added -x as short alias for --exec flag
- Changed -p to be short form of --port instead of --path
