### PR TITLE
refactor: move cloud hosting guide to dedicated file

### DIFF
--- a/CLOUD_HOSTING.md
+++ b/CLOUD_HOSTING.md
@@ -1,0 +1,29 @@
+# <sub><img height="18" src="https://octicons-col.vercel.app/cloud/A770EF">&nbsp;&nbsp;CLOUD HOSTING</sub>
+
+Because of KVM virtualization requirement, `msb` can only work with dedicated servers or cloud instances with nested virtualization enabled. Many cloud providers offer servers that support either or both. Some examples are:
+
+##
+
+#### Bare‑Metal Providers
+
+The best option for self-hosting is a dedicated server.
+
+| #   | Provider                                                                                        | Type                                                                                              | Cheapest Server | Price      | Notes                           |
+| --- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------- | ---------- | ------------------------------- |
+| 1   | **[Scaleway](https://www.scaleway.com/en/dedibox/start/)**                                      | **[Bare‑Metal](https://www.scaleway.com/en/dedibox/start/)**                                      | START-1-M-SSD   | **≈ $11**  | Unmetered traffic; Paris/Warsaw |
+| 2   | **[OVHcloud](https://eco.ovhcloud.com/en/?_gl=1*1fvpjnw*_gcl_au*MTc0MTg2MjQxMy4xNzQ1OTIxOTEx)** | **[Bare‑Metal](https://eco.ovhcloud.com/en/?_gl=1*1fvpjnw*_gcl_au*MTc0MTg2MjQxMy4xNzQ1OTIxOTEx)** | SYS‑LE-1        | **≈ $25**  | 500 Mbps; EU/CA                 |
+| 3   | **[Hetzner](https://www.hetzner.com/dedicated-rootserver)**                                     | **[Bare‑Metal](https://www.hetzner.com/dedicated-rootserver)**                                    | AX41            | **≈ $42**  | One‑time setup fee; DE & FI     |
+| 4   | **[Vultr](https://www.vultr.com/products/bare-metal/)**                                         | **[Bare‑Metal](https://www.vultr.com/products/bare-metal/)**                                      | c1.small        | **≈ $120** | Hourly billing; global regions  |
+
+##
+
+#### Cloud VPS / VM Providers (Nested Virtualization)
+
+> [!WARNING]
+> Nested virtualization (running VMs inside VMs) may have slower performance compared to bare-metal solutions. For production workloads with heavy usage, consider using bare-metal servers for optimal performance.
+
+| #   | Provider                                                                            | Type                                                                         | Cheapest Plan      | Price     | Nested Virt       | Notes                                              |
+| --- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ | --------- | ----------------- | -------------------------------------------------- |
+| 1   | **[DigitalOcean](https://www.digitalocean.com/products/droplets)**                  | **[Cloud VPS](https://www.digitalocean.com/products/droplets)**              | Basic Droplet 1 GB | **≈ $4**  | Yes (default)     | Modest perf, all regions                           |
+| 2   | **[Google Cloud](https://cloud.google.com/compute)**                                | **[Cloud VM](https://cloud.google.com/compute)**                             | n1‑standard‑1      | **≈ $34** | Yes (enable flag) | Must enable Nested Virtualization; Intel host only |
+| 3   | **[Microsoft Azure](https://azure.microsoft.com/en-us/products/virtual-machines/)** | **[Cloud VM](https://azure.microsoft.com/en-us/products/virtual-machines/)** | D2s_v3             | **≈ $70** | Yes (Dv3/Ev3)     | VT‑x exposed by default on Gen‑2 VMs               |

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Get started with the SDK in a few easy steps:
 
 <h3><span>1</span>&nbsp;&nbsp;<img height="13" src="https://octicons-col.vercel.app/key/A770EF">&nbsp;&nbsp;Get API Key</h3>
 
-- Get your API key <a href="./SELF_HOSTING.md">[→]</a>
-- Configure API key environment variable, for example by setting it in your `.env` file
+- Get your API key by <a href="./SELF_HOSTING.md">[self-hosting →]</a>
+- Set API key environment variable. For example, you could set it in your `.env` file
 
   ```env
   MSB_API_KEY=msb_***

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Get started with the SDK in a few easy steps:
 
 <h3><span>1</span>&nbsp;&nbsp;<img height="13" src="https://octicons-col.vercel.app/key/A770EF">&nbsp;&nbsp;Get API Key</h3>
 
-- Get your API key by <a href="./SELF_HOSTING.md">[self-hosting →]</a>
-- Set API key environment variable. For example, you could set it in your `.env` file
+- Get your API key by <a href="./SELF_HOSTING.md">[SELF HOSTING →]</a>
+- Set key as an environment variable. For example, you could set it in your `.env` file
 
   ```env
   MSB_API_KEY=msb_***
@@ -191,6 +191,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+##
 
 > [!NOTE]
 >

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -53,8 +53,6 @@ msb server start
 msb server keygen --expire 3mo
 ```
 
-##
-
 After starting the server and generating your key, configure the environment variables to connect your SDK to your self-hosted sandbox server automatically.
 
 There are just two environment variables to set:
@@ -62,34 +60,8 @@ There are just two environment variables to set:
 - `MSB_API_KEY` — The API key for your sandbox server
 - `MSB_API_URL` — The URL of your sandbox server. You don't need to set this if you are running the server locally at the default port.
 
-<div align='center'>• • •</div>
-
-# <sub><img height="18" src="https://octicons-col.vercel.app/cloud/A770EF">&nbsp;&nbsp;CLOUD HOSTING</sub>
-
-Because of KVM virtualization requirement, `msb` can only work with dedicated servers or cloud instances with nested virtualization enabled. Many cloud providers offer servers that support either or both. Some examples are:
-
 ##
 
-#### Bare‑Metal Providers
-
-The best option for self-hosting is a dedicated server.
-
-| #   | Provider                                                                                        | Type                                                                                              | Cheapest Server | Price      | Notes                           |
-| --- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------- | ---------- | ------------------------------- |
-| 1   | **[Scaleway](https://www.scaleway.com/en/dedibox/start/)**                                      | **[Bare‑Metal](https://www.scaleway.com/en/dedibox/start/)**                                      | START-1-M-SSD   | **≈ $11**  | Unmetered traffic; Paris/Warsaw |
-| 2   | **[OVHcloud](https://eco.ovhcloud.com/en/?_gl=1*1fvpjnw*_gcl_au*MTc0MTg2MjQxMy4xNzQ1OTIxOTEx)** | **[Bare‑Metal](https://eco.ovhcloud.com/en/?_gl=1*1fvpjnw*_gcl_au*MTc0MTg2MjQxMy4xNzQ1OTIxOTEx)** | SYS‑LE-1        | **≈ $25**  | 500 Mbps; EU/CA                 |
-| 3   | **[Hetzner](https://www.hetzner.com/dedicated-rootserver)**                                     | **[Bare‑Metal](https://www.hetzner.com/dedicated-rootserver)**                                    | AX41            | **≈ $42**  | One‑time setup fee; DE & FI     |
-| 4   | **[Vultr](https://www.vultr.com/products/bare-metal/)**                                         | **[Bare‑Metal](https://www.vultr.com/products/bare-metal/)**                                      | c1.small        | **≈ $120** | Hourly billing; global regions  |
-
-##
-
-#### Cloud VPS / VM Providers (Nested Virtualization)
-
-> [!WARNING]
-> Nested virtualization (running VMs inside VMs) may have slower performance compared to bare-metal solutions. For production workloads with heavy usage, consider using bare-metal servers for optimal performance.
-
-| #   | Provider                                                                            | Type                                                                         | Cheapest Plan      | Price     | Nested Virt       | Notes                                              |
-| --- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ | --------- | ----------------- | -------------------------------------------------- |
-| 1   | **[DigitalOcean](https://www.digitalocean.com/products/droplets)**                  | **[Cloud VPS](https://www.digitalocean.com/products/droplets)**              | Basic Droplet 1 GB | **≈ $4**  | Yes (default)     | Modest perf, all regions                           |
-| 2   | **[Google Cloud](https://cloud.google.com/compute)**                                | **[Cloud VM](https://cloud.google.com/compute)**                             | n1‑standard‑1      | **≈ $34** | Yes (enable flag) | Must enable Nested Virtualization; Intel host only |
-| 3   | **[Microsoft Azure](https://azure.microsoft.com/en-us/products/virtual-machines/)** | **[Cloud VM](https://azure.microsoft.com/en-us/products/virtual-machines/)** | D2s_v3             | **≈ $70** | Yes (Dv3/Ev3)     | VT‑x exposed by default on Gen‑2 VMs               |
+> [!TIP]
+>
+> For self-hosting on a cloud provider, refer to our [cloud hosting guide](CLOUD_HOSTING.md) for a list of cloud providers that would support running a sandbox server.


### PR DESCRIPTION
- Extract cloud hosting section from SELF_HOSTING.md into new CLOUD_HOSTING.md
- Update self-hosting guide to reference the new cloud hosting guide
- Improve wording in README.md for getting started steps
