### PR TITLE
refactor: rename sandbox.command.execute to sandbox.command.run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-portal"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/microsandbox/microsandbox"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 edition = "2021"
 
@@ -47,9 +47,9 @@ rand = "0.9"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 reqwest-middleware = "0.3" # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
 reqwest-retry = "0.6"      # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
-microsandbox-utils = { version = "0.2.1", path = "./microsandbox-utils" }
-microsandbox-core = { version = "0.2.1", path = "./microsandbox-core" }
-microsandbox-server = { version = "0.2.1", path = "./microsandbox-server" }
+microsandbox-utils = { version = "0.2.2", path = "./microsandbox-utils" }
+microsandbox-core = { version = "0.2.2", path = "./microsandbox-core" }
+microsandbox-server = { version = "0.2.2", path = "./microsandbox-server" }
 multihash = "0.19"
 multihash-codetable = "0.1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Get started with the SDK in a few easy steps:
 
 <div align='center'>
   <img src="https://img.shields.io/badge/macos-working-green?style=for-the-badge" alt=macos style="margin-bottom: 5px;"/>
-  <img src="https://img.shields.io/badge/linux-mostly_working-yellow?style=for-the-badge" alt=linux style="margin-bottom: 5px;"/>
-  <img src="https://img.shields.io/badge/windows-not_working-red?style=for-the-badge" alt=windows style="margin-bottom: 5px;"/>
+  <img src="https://img.shields.io/badge/linux-working-green?style=for-the-badge" alt=linux style="margin-bottom: 5px;"/>
+  <img src="https://img.shields.io/badge/windows-wip-yellow?style=for-the-badge" alt=windows style="margin-bottom: 5px;"/>
 </div>
 
 ##

--- a/microsandbox-portal/examples/repl.rs
+++ b/microsandbox-portal/examples/repl.rs
@@ -62,7 +62,7 @@ use std::error::Error;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Start the engines - this initializes all enabled engines
-    let engine_handle = start_engines().await?;
+    let _engine_handle = start_engines().await?;
     println!("✅ Engines started successfully");
 
     // Example 1: Execute Python code in REPL
@@ -89,7 +89,7 @@ for i, fruit in enumerate(fruits):
     print(f"{i+1}. {fruit}")
         "#;
 
-        let result = engine_handle
+        let result = _engine_handle
             .eval(python_code, Language::Python, "123", Some(60))
             .await?;
 
@@ -147,7 +147,7 @@ fetchData().then(result => {
 console.log("Waiting for data...");
         "#;
 
-        let result = engine_handle
+        let result = _engine_handle
             .eval(javascript_code, Language::Node, "123", Some(60))
             .await?;
 
@@ -164,7 +164,7 @@ console.log("Waiting for data...");
 
         // First execution - define a variable
         let python_step1 = "x = 10";
-        let result1 = engine_handle
+        let result1 = _engine_handle
             .eval(python_step1, Language::Python, "123", None)
             .await?;
         for line in result1 {
@@ -173,7 +173,7 @@ console.log("Waiting for data...");
 
         // Second execution - use the variable defined in the first step
         let python_step2 = "print(f'The value of x is {x}')";
-        let result2 = engine_handle
+        let result2 = _engine_handle
             .eval(python_step2, Language::Python, "123", None)
             .await?;
         for line in result2 {
@@ -188,7 +188,7 @@ console.log("Waiting for data...");
 
         // First execution - define a variable
         let nodejs_step1 = "const greeting = 'Hello from JavaScript!';";
-        let result1 = engine_handle
+        let result1 = _engine_handle
             .eval(nodejs_step1, Language::Node, "123", None)
             .await?;
         for line in result1 {
@@ -197,7 +197,7 @@ console.log("Waiting for data...");
 
         // Second execution - use the variable defined in the first step
         let nodejs_step2 = "console.log(greeting);";
-        let result2 = engine_handle
+        let result2 = _engine_handle
             .eval(nodejs_step2, Language::Node, "123", None)
             .await?;
         for line in result2 {

--- a/microsandbox-portal/examples/repl_timer.rs
+++ b/microsandbox-portal/examples/repl_timer.rs
@@ -48,13 +48,16 @@
 //! [Stderr] Execution timed out after 10 seconds
 //! ```
 
-use microsandbox_portal::portal::repl::{start_engines, Language};
+use microsandbox_portal::portal::repl::start_engines;
+#[cfg(any(feature = "python", feature = "nodejs"))]
+use microsandbox_portal::portal::repl::Language;
 use std::error::Error;
 
 /// Fixed timeout duration for all executions in this example
 const TIMEOUT_SECONDS: u64 = 10;
 
 /// Print output lines from a REPL execution with a prefix
+#[cfg(any(feature = "python", feature = "nodejs"))]
 fn print_output(prefix: &str, lines: &[microsandbox_portal::portal::repl::Line]) {
     println!("{} execution result:", prefix);
     if lines.is_empty() {
@@ -70,7 +73,7 @@ fn print_output(prefix: &str, lines: &[microsandbox_portal::portal::repl::Line])
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Start the engines - this initializes all enabled engines
-    let engine_handle = start_engines().await?;
+    let _engine_handle = start_engines().await?;
     println!("✅ Engines started successfully\n");
     println!(
         "🕒 Running examples with {}-second timeout\n",
@@ -92,7 +95,7 @@ for i in range(1, 6):
 print("Python counting complete!")
         "#;
 
-        let result = engine_handle
+        let result = _engine_handle
             .eval(
                 python_normal,
                 Language::Python,
@@ -119,7 +122,7 @@ while True:
     time.sleep(0.5)  # Sleep for half a second
         "#;
 
-        let result = engine_handle
+        let result = _engine_handle
             .eval(
                 python_infinite,
                 Language::Python,
@@ -152,7 +155,7 @@ for (let i = 1; i <= 5; i++) {
 console.log("Node.js counting complete!");
         "#;
 
-        let result = engine_handle
+        let result = _engine_handle
             .eval(
                 js_normal,
                 Language::Node,
@@ -185,7 +188,7 @@ while (true) {
 }
         "#;
 
-        let result = engine_handle
+        let result = _engine_handle
             .eval(
                 js_infinite,
                 Language::Node,

--- a/microsandbox-portal/examples/rpc_command.rs
+++ b/microsandbox-portal/examples/rpc_command.rs
@@ -10,7 +10,7 @@
 //!
 //! # API Methods Demonstrated
 //!
-//! - `sandbox.command.execute`: Execute a command in a sandboxed environment
+//! - `sandbox.command.run`: Execute a command in a sandboxed environment
 //!
 //! # Running the Example
 //!
@@ -64,7 +64,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 
 // Import the parameter types from the microsandbox-portal crate
-use microsandbox_portal::payload::{JsonRpcRequest, SandboxCommandExecuteParams, JSONRPC_VERSION};
+use microsandbox_portal::payload::{JsonRpcRequest, SandboxCommandRunParams, JSONRPC_VERSION};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -138,13 +138,13 @@ async fn main() -> Result<()> {
 
     // Execute a simple 'ls' command using the typed params
     println!("\n📁 Running 'ls' command:");
-    let ls_params = SandboxCommandExecuteParams {
+    let ls_params = SandboxCommandRunParams {
         command: "ls".to_string(),
         args: vec!["-la".to_string()],
         timeout: Some(30), // Add a 30 second timeout
     };
 
-    let result = send_rpc_request(&client, "sandbox.command.execute", ls_params).await?;
+    let result = send_rpc_request(&client, "sandbox.command.run", ls_params).await?;
 
     // Extract command execution details
     let command = result
@@ -183,13 +183,13 @@ async fn main() -> Result<()> {
 
     // Execute another command with environment variables using the typed params
     println!("\n🔄 Running 'echo' command:");
-    let echo_params = SandboxCommandExecuteParams {
+    let echo_params = SandboxCommandRunParams {
         command: "echo".to_string(),
         args: vec!["Hello from the sandbox!".to_string()],
         timeout: None, // No timeout needed for simple echo command
     };
 
-    let result = send_rpc_request(&client, "sandbox.command.execute", echo_params).await?;
+    let result = send_rpc_request(&client, "sandbox.command.run", echo_params).await?;
 
     // Extract command execution details
     let command = result
@@ -228,14 +228,14 @@ async fn main() -> Result<()> {
 
     // Execute a command that will fail to demonstrate error handling
     println!("\n❌ Running a command that will fail:");
-    let fail_params = SandboxCommandExecuteParams {
+    let fail_params = SandboxCommandRunParams {
         command: "nonexistent_command".to_string(),
         args: vec![],
         timeout: Some(5), // Short timeout
     };
 
     // This will likely fail, so handle the error case
-    match send_rpc_request(&client, "sandbox.command.execute", fail_params).await {
+    match send_rpc_request(&client, "sandbox.command.run", fail_params).await {
         Ok(result) => {
             // Still might get a result with error details
             let exit_code = result

--- a/microsandbox-portal/lib/handler.rs
+++ b/microsandbox-portal/lib/handler.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use crate::{
     error::PortalError,
     payload::{
-        JsonRpcError, JsonRpcRequest, JsonRpcResponse, SandboxCommandExecuteParams,
+        JsonRpcError, JsonRpcRequest, JsonRpcResponse, SandboxCommandRunParams,
         SandboxReplRunParams, JSONRPC_VERSION,
     },
     portal::command::create_command_executor,
@@ -59,7 +59,7 @@ pub async fn json_rpc_handler(
                 }
             }
         }
-        "sandbox.command.execute" => {
+        "sandbox.command.run" => {
             // Call the sandbox_command_run_impl function
             match sandbox_command_run_impl(state, request.params).await {
                 Ok(result) => {
@@ -186,12 +186,12 @@ async fn sandbox_run_impl(_state: SharedState, params: Value) -> Result<Value, P
     Ok(result)
 }
 
-/// Implementation for sandbox command execute method
+/// Implementation for sandbox command run method
 async fn sandbox_command_run_impl(state: SharedState, params: Value) -> Result<Value, PortalError> {
-    debug!(?params, "Sandbox command execute method called");
+    debug!(?params, "Sandbox command run method called");
 
     // Deserialize parameters using the structured type
-    let params: SandboxCommandExecuteParams = serde_json::from_value(params)
+    let params: SandboxCommandRunParams = serde_json::from_value(params)
         .map_err(|e| PortalError::JsonRpc(format!("Invalid parameters: {}", e)))?;
 
     // Get or initialize command executor handle

--- a/microsandbox-portal/lib/payload.rs
+++ b/microsandbox-portal/lib/payload.rs
@@ -82,7 +82,7 @@ pub struct SandboxReplRunParams {
 
 /// Request parameters for executing a shell command
 #[derive(Debug, Deserialize, Serialize)]
-pub struct SandboxCommandExecuteParams {
+pub struct SandboxCommandRunParams {
     /// Command to execute
     pub command: String,
 

--- a/microsandbox-server/lib/payload.rs
+++ b/microsandbox-server/lib/payload.rs
@@ -102,13 +102,13 @@ pub struct SandboxStopParams {
     pub namespace: String,
 }
 
-/// Request payload for getting sandbox status
+/// Request payload for getting sandbox metrics
 #[derive(Debug, Deserialize)]
-pub struct SandboxStatusParams {
+pub struct SandboxMetricsGetParams {
     /// Optional sandbox name - if not provided, all sandboxes in the namespace will be included
     pub sandbox: Option<String>,
 
-    /// Namespace - use "*" to get status from all namespaces
+    /// Namespace - use "*" to get metrics from all namespaces
     pub namespace: String,
 }
 
@@ -181,7 +181,7 @@ pub struct SandboxReplGetOutputParams {
 
 /// Request parameters for executing a shell command
 #[derive(Debug, Deserialize, Serialize)]
-pub struct SandboxCommandExecuteParams {
+pub struct SandboxCommandRunParams {
     /// Command to execute
     pub command: String,
 

--- a/scripts/install_microsandbox.sh
+++ b/scripts/install_microsandbox.sh
@@ -8,7 +8,7 @@
 #   ./install_microsandbox.sh [options]
 #
 # Options:
-#   --version       Specify version to install (default: 0.2.1)
+#   --version       Specify version to install (default: 0.2.2)
 #   --no-cleanup   Skip cleanup of temporary files after installation
 #
 # The script performs the following tasks:
@@ -43,7 +43,7 @@ error() {
 }
 
 # Default values
-VERSION="0.2.1"
+VERSION="0.2.2"
 NO_CLEANUP=false
 TEMP_DIR="/tmp/microsandbox-install"
 GITHUB_REPO="microsandbox/microsandbox"

--- a/sdk/python/microsandbox/command.py
+++ b/sdk/python/microsandbox/command.py
@@ -57,7 +57,7 @@ class Command:
         # Prepare the request data
         request_data = {
             "jsonrpc": "2.0",
-            "method": "sandbox.command.execute",
+            "method": "sandbox.command.run",
             "params": {
                 "sandbox": self._sandbox._name,
                 "namespace": self._sandbox._namespace,

--- a/sdk/python/microsandbox/command_execution.py
+++ b/sdk/python/microsandbox/command_execution.py
@@ -21,7 +21,7 @@ class CommandExecution:
         Initialize a command execution instance.
 
         Args:
-            output_data: Output data from the sandbox.command.execute response
+            output_data: Output data from the sandbox.command.run response
         """
         self._output_lines: List[Dict[str, str]] = []
         self._command = ""
@@ -35,7 +35,7 @@ class CommandExecution:
 
     def _process_output_data(self, output_data: Dict[str, Any]) -> None:
         """
-        Process output data from the sandbox.command.execute response.
+        Process output data from the sandbox.command.run response.
 
         Args:
             output_data: Dictionary containing the output data

--- a/sdk/rust/src/command.rs
+++ b/sdk/rust/src/command.rs
@@ -217,7 +217,7 @@ impl Command {
         // Execute command
         let base = self.sandbox.lock().await;
         let result: HashMap<String, Value> =
-            base.make_request("sandbox.command.execute", params).await?;
+            base.make_request("sandbox.command.run", params).await?;
 
         Ok(CommandExecution::new(result))
     }


### PR DESCRIPTION
Rename RPC method from sandbox.command.execute to sandbox.command.run for better
consistency with other API methods. This includes:

- Updating method name in RPC handlers
- Renaming SandboxCommandExecuteParams to SandboxCommandRunParams
- Updating documentation and examples
- Updating Python and Rust SDK implementations
