### PR TITLE
feat: add metrics support to Python and Rust SDKs

### DIFF
--- a/sdk/python/examples/metrics.py
+++ b/sdk/python/examples/metrics.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating how to retrieve sandbox metrics.
+"""
+
+import asyncio
+import time
+
+import aiohttp
+from microsandbox import PythonSandbox
+
+
+async def basic_metrics_example():
+    """Example showing how to get individual metrics for a sandbox."""
+    print("\n=== Basic Metrics Example ===")
+
+    # Create a sandbox using a context manager
+    async with PythonSandbox.create(name="metrics-example") as sandbox:
+        # Run a command to generate some load
+        print("Running commands to generate some sandbox activity...")
+        await sandbox.command.run("ls", ["-la", "/"])
+        await sandbox.command.run(
+            "dd", ["if=/dev/zero", "of=/tmp/testfile", "bs=1M", "count=10"]
+        )
+
+        # Sleep a moment to allow metrics to update
+        time.sleep(1)
+
+        # Get individual metrics
+        print("\nGetting individual metrics for this sandbox:")
+
+        try:
+            # Get CPU usage
+            cpu = await sandbox.metrics.cpu()
+            # CPU metrics may be 0.0 when idle or None if unavailable
+            if cpu is None:
+                print("CPU Usage: Not available")
+            else:
+                print(f"CPU Usage: {cpu}%")
+
+            # Get memory usage
+            memory = await sandbox.metrics.memory()
+            print(f"Memory Usage: {memory or 'Not available'} MiB")
+
+            # Get disk usage
+            disk = await sandbox.metrics.disk()
+            print(f"Disk Usage: {disk or 'Not available'} bytes")
+
+            # Check if running
+            running = await sandbox.metrics.is_running()
+            print(f"Is Running: {running}")
+        except RuntimeError as e:
+            print(f"Error getting metrics: {e}")
+
+
+async def all_metrics_example():
+    """Example showing how to get all metrics at once."""
+    print("\n=== All Metrics Example ===")
+
+    # Create a sandbox
+    async with PythonSandbox.create(name="all-metrics-example") as sandbox:
+        try:
+            # Run some commands to generate activity
+            print("Running commands to generate some sandbox activity...")
+            await sandbox.command.run("cat", ["/etc/os-release"])
+            # Using a simpler command that won't time out or cause errors
+            await sandbox.command.run("ls", ["-la", "/usr"])
+
+            # Sleep a moment to allow metrics to update
+            time.sleep(1)
+
+            # Get all metrics at once
+            print("\nGetting all metrics as a dictionary:")
+            all_metrics = await sandbox.metrics.all()
+
+            # Print formatted metrics
+            print(
+                f"Sandbox: {all_metrics.get('name')} (namespace: {all_metrics.get('namespace')})"
+            )
+            print(f"  Running: {all_metrics.get('running')}")
+
+            # Handle CPU metrics which may be 0.0 or None
+            cpu = all_metrics.get("cpu_usage")
+            if cpu is None:
+                print("  CPU Usage: Not available")
+            else:
+                print(f"  CPU Usage: {cpu}%")
+
+            print(
+                f"  Memory Usage: {all_metrics.get('memory_usage') or 'Not available'} MiB"
+            )
+            print(
+                f"  Disk Usage: {all_metrics.get('disk_usage') or 'Not available'} bytes"
+            )
+        except Exception as e:
+            print(f"Error in all_metrics_example: {e}")
+
+
+async def continuous_monitoring_example():
+    """Example showing how to continuously monitor sandbox metrics."""
+    print("\n=== Continuous Monitoring Example ===")
+
+    # Create a sandbox
+    async with PythonSandbox.create(name="monitoring-example") as sandbox:
+        try:
+            print("Starting continuous monitoring (5 seconds)...")
+
+            # Generate load with a simple and safe command
+            _ = await sandbox.command.run(
+                "sh",
+                [
+                    "-c",
+                    "for i in $(seq 1 5); do ls -la / > /dev/null; sleep 0.2; done &",
+                ],
+            )
+
+            # Monitor for 5 seconds
+            start_time = time.time()
+            while time.time() - start_time < 5:
+                try:
+                    # Get metrics
+                    cpu = await sandbox.metrics.cpu()
+                    memory = await sandbox.metrics.memory()
+
+                    # Format CPU usage (could be 0.0 or None)
+                    cpu_str = f"{cpu}%" if cpu is not None else "Not available"
+
+                    # Print current values
+                    print(
+                        f"[{time.time() - start_time:.1f}s] CPU: {cpu_str}, Memory: {memory or 'Not available'} MiB"
+                    )
+                except Exception as e:
+                    print(f"Error getting metrics: {e}")
+
+                # Wait before next check
+                await asyncio.sleep(1)
+
+            print("Monitoring complete.")
+        except Exception as e:
+            print(f"Error in continuous_monitoring_example: {e}")
+
+
+async def cpu_load_test_example():
+    """Example generating CPU load to test CPU metrics."""
+    print("\n=== CPU Load Test Example ===")
+
+    # Create a sandbox
+    async with PythonSandbox.create(name="cpu-load-test") as sandbox:
+        try:
+            # Run a CPU-intensive Python script
+            print("Running CPU-intensive task...")
+
+            # First create a Python script that will use CPU
+            cpu_script = """
+import time
+start = time.time()
+duration = 10  # seconds
+
+# CPU-intensive calculation
+while time.time() - start < duration:
+    # Calculate prime numbers - CPU intensive
+    for i in range(1, 100000):
+        is_prime = True
+        for j in range(2, int(i ** 0.5) + 1):
+            if i % j == 0:
+                is_prime = False
+                break
+
+    # Print progress every second
+    elapsed = time.time() - start
+    if int(elapsed) == elapsed:
+        print(f"Running for {int(elapsed)} seconds...")
+
+print("CPU load test complete")
+"""
+            # Write the script to a file
+            await sandbox.command.run(
+                "bash", ["-c", f"cat > /tmp/cpu_test.py << 'EOF'\n{cpu_script}\nEOF"]
+            )
+
+            # Run the script in the background
+            print("Starting CPU test (running for 10 seconds)...")
+            await sandbox.command.run("python", ["/tmp/cpu_test.py", "&"])
+
+            # Monitor CPU usage while the script runs
+            print("\nMonitoring CPU usage...")
+            for i in range(5):
+                # Wait a moment
+                await asyncio.sleep(2)
+
+                # Get metrics
+                cpu = await sandbox.metrics.cpu()
+                memory = await sandbox.metrics.memory()
+
+                # Format CPU usage (could be 0.0 or None)
+                cpu_str = f"{cpu}%" if cpu is not None else "Not available"
+
+                # Print current values
+                print(
+                    f"[{i * 2} seconds] CPU: {cpu_str}, Memory: {memory or 'Not available'} MiB"
+                )
+
+            print("CPU load test complete.")
+        except Exception as e:
+            print(f"Error in cpu_load_test_example: {e}")
+
+
+async def error_handling_example():
+    """Example showing error handling with metrics."""
+    print("\n=== Error Handling Example ===")
+
+    # Create a sandbox without starting it immediately
+    sandbox = PythonSandbox(name="error-example")
+
+    try:
+        # Try to get metrics before starting the sandbox
+        print("Trying to get metrics before starting the sandbox...")
+        cpu = await sandbox.metrics.cpu()
+        print(f"CPU: {cpu}%")  # This shouldn't be reached
+    except RuntimeError as e:
+        print(f"Expected error: {e}")
+
+    try:
+        # Now properly start the sandbox
+        print("\nStarting the sandbox properly...")
+        sandbox._session = aiohttp.ClientSession()
+        await sandbox.start()
+
+        # Get metrics after starting
+        cpu = await sandbox.metrics.cpu()
+        # Format CPU usage (could be 0.0 or None)
+        cpu_str = f"{cpu}%" if cpu is not None else "Not available"
+        print(f"CPU usage after starting: {cpu_str}")
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        # Clean up
+        if sandbox._is_started:
+            await sandbox.stop()
+        if sandbox._session and not sandbox._session.closed:
+            await sandbox._session.close()
+
+
+async def main():
+    """Main function to run all examples."""
+    print("Sandbox Metrics Examples")
+    print("=======================")
+
+    try:
+        await basic_metrics_example()
+        await all_metrics_example()
+        await continuous_monitoring_example()
+        await cpu_load_test_example()
+        await error_handling_example()
+    except Exception as e:
+        print(f"Error in main: {e}")
+
+    print("\nAll examples completed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -1,7 +1,5 @@
 """
 Microsandbox Python SDK
-
-A minimal SDK for the Microsandbox project.
 """
 
 __version__ = "0.1.0"
@@ -10,6 +8,7 @@ from .base_sandbox import BaseSandbox
 from .command import Command
 from .command_execution import CommandExecution
 from .execution import Execution
+from .metrics import Metrics
 from .node_sandbox import NodeSandbox
 from .python_sandbox import PythonSandbox
 
@@ -21,5 +20,4 @@ __all__ = [
     "CommandExecution",
     "Command",
     "Metrics",
-    "SandboxMetrics",
 ]

--- a/sdk/python/microsandbox/metrics.py
+++ b/sdk/python/microsandbox/metrics.py
@@ -1,0 +1,153 @@
+"""
+Metrics interface for the Microsandbox Python SDK.
+"""
+
+import uuid
+from typing import Optional
+
+
+class Metrics:
+    """
+    Metrics class for retrieving resource metrics for a sandbox.
+
+    This class provides methods to access specific metrics (CPU, memory, disk)
+    for the sandbox instance it's attached to.
+    """
+
+    def __init__(self, sandbox_instance):
+        """
+        Initialize the metrics instance.
+
+        Args:
+            sandbox_instance: The sandbox instance this metrics object belongs to
+        """
+        self._sandbox = sandbox_instance
+
+    async def _get_metrics(self) -> dict:
+        """
+        Internal method to fetch current metrics from the server.
+
+        Returns:
+            A dictionary containing the metrics data for the sandbox
+
+        Raises:
+            RuntimeError: If the request to the server fails
+        """
+        if not self._sandbox._is_started:
+            raise RuntimeError("Sandbox is not started. Call start() first.")
+
+        headers = {"Content-Type": "application/json"}
+        if self._sandbox._api_key:
+            headers["Authorization"] = f"Bearer {self._sandbox._api_key}"
+
+        # Prepare the request data
+        request_data = {
+            "jsonrpc": "2.0",
+            "method": "sandbox.metrics.get",
+            "params": {
+                "namespace": self._sandbox._namespace,
+                "sandbox": self._sandbox._name,
+            },
+            "id": str(uuid.uuid4()),
+        }
+
+        try:
+            async with self._sandbox._session.post(
+                f"{self._sandbox._server_url}/api/v1/rpc",
+                json=request_data,
+                headers=headers,
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise RuntimeError(f"Failed to get sandbox metrics: {error_text}")
+
+                response_data = await response.json()
+                if "error" in response_data:
+                    raise RuntimeError(
+                        f"Failed to get sandbox metrics: {response_data['error']['message']}"
+                    )
+
+                result = response_data.get("result", {})
+                sandboxes = result.get("sandboxes", [])
+
+                # We expect exactly one sandbox in the response (our own)
+                if not sandboxes:
+                    return {}
+
+                # Return the first (and should be only) sandbox data
+                return sandboxes[0]
+        except Exception as e:
+            raise RuntimeError(f"Failed to get sandbox metrics: {e}")
+
+    async def all(self) -> dict:
+        """
+        Get all metrics for the current sandbox.
+
+        Returns:
+            A dictionary containing all metrics for the sandbox:
+            {
+                "name": str,
+                "namespace": str,
+                "running": bool,
+                "cpu_usage": Optional[float],
+                "memory_usage": Optional[int],
+                "disk_usage": Optional[int]
+            }
+
+        Raises:
+            RuntimeError: If the sandbox is not started or if the request fails
+        """
+        return await self._get_metrics()
+
+    async def cpu(self) -> Optional[float]:
+        """
+        Get CPU usage percentage for the current sandbox.
+
+        Returns:
+            CPU usage as a percentage (0-100) or None if not available.
+            May return 0.0 for idle sandboxes or when metrics are not precise.
+
+        Raises:
+            RuntimeError: If the sandbox is not started or if the request fails
+        """
+        metrics = await self._get_metrics()
+        return metrics.get("cpu_usage")
+
+    async def memory(self) -> Optional[int]:
+        """
+        Get memory usage for the current sandbox.
+
+        Returns:
+            Memory usage in MiB or None if not available
+
+        Raises:
+            RuntimeError: If the sandbox is not started or if the request fails
+        """
+        metrics = await self._get_metrics()
+        return metrics.get("memory_usage")
+
+    async def disk(self) -> Optional[int]:
+        """
+        Get disk usage for the current sandbox.
+
+        Returns:
+            Disk usage in bytes or None if not available
+
+        Raises:
+            RuntimeError: If the sandbox is not started or if the request fails
+        """
+        metrics = await self._get_metrics()
+        return metrics.get("disk_usage")
+
+    async def is_running(self) -> bool:
+        """
+        Check if the sandbox is currently running.
+
+        Returns:
+            True if the sandbox is running, False otherwise
+
+        Raises:
+            RuntimeError: If the request to the server fails
+        """
+        metrics = await self._get_metrics()
+        return metrics.get("running", False)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "microsandbox"
-version = "0.1.7"
+version = "0.1.8"
 description = "Microsandbox Python SDK"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -636,7 +636,7 @@ wheels = [
 
 [[package]]
 name = "microsandbox"
-version = "0.1.6"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsandbox"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Microsandbox Team <team@microsandbox.dev>"]
 description = "Rust SDK for microsandbox - secure self-hosted sandboxes for your AI agents"

--- a/sdk/rust/examples/metrics.rs
+++ b/sdk/rust/examples/metrics.rs
@@ -1,0 +1,391 @@
+//! Example demonstrating how to retrieve sandbox metrics.
+//!
+//! This example shows:
+//! 1. Basic metrics retrieval for individual metrics
+//! 2. Getting all metrics at once
+//! 3. Continuous monitoring of metrics
+//! 4. Generating CPU load to test metrics
+//! 5. Error handling with metrics
+//!
+//! Before running this example:
+//!     1. Install the package as a dependency
+//!     2. Start the Microsandbox server (microsandbox-server)
+//!     3. Run this script: cargo run --example metrics
+
+use microsandbox::{BaseSandbox, PythonSandbox};
+use std::{
+    error::Error,
+    time::{Duration, Instant},
+};
+use tokio::time::sleep;
+
+/// Example showing how to get individual metrics for a sandbox.
+async fn basic_metrics_example() -> Result<(), Box<dyn Error + Send + Sync>> {
+    println!("\n=== Basic Metrics Example ===");
+
+    // Create a sandbox
+    let mut sandbox = PythonSandbox::create("metrics-example").await?;
+
+    // Start the sandbox
+    sandbox.start(None).await?;
+
+    // Get the command interface
+    let cmd = sandbox.command().await?;
+
+    // Run commands to generate some load
+    println!("Running commands to generate some sandbox activity...");
+    cmd.run("ls", Some(vec!["-la", "/"]), None).await?;
+    cmd.run(
+        "dd",
+        Some(vec![
+            "if=/dev/zero",
+            "of=/tmp/testfile",
+            "bs=1M",
+            "count=10",
+        ]),
+        None,
+    )
+    .await?;
+
+    // Sleep a moment to allow metrics to update
+    sleep(Duration::from_secs(1)).await;
+
+    // Get the metrics interface
+    let metrics = sandbox.metrics().await?;
+
+    // Get individual metrics
+    println!("\nGetting individual metrics for this sandbox:");
+
+    // Get CPU usage
+    let cpu = metrics.cpu().await?;
+    // CPU metrics may be 0.0 when idle or None if unavailable
+    match cpu {
+        Some(value) => println!("CPU Usage: {}%", value),
+        None => println!("CPU Usage: Not available"),
+    }
+
+    // Get memory usage
+    let memory = metrics.memory().await?;
+    match memory {
+        Some(value) => println!("Memory Usage: {} MiB", value),
+        None => println!("Memory Usage: Not available"),
+    }
+
+    // Get disk usage
+    let disk = metrics.disk().await?;
+    match disk {
+        Some(value) => println!("Disk Usage: {} bytes", value),
+        None => println!("Disk Usage: Not available"),
+    }
+
+    // Check if running
+    let running = metrics.is_running().await?;
+    println!("Is Running: {}", running);
+
+    // Stop the sandbox
+    sandbox.stop().await?;
+
+    Ok(())
+}
+
+/// Example showing how to get all metrics at once.
+async fn all_metrics_example() -> Result<(), Box<dyn Error + Send + Sync>> {
+    println!("\n=== All Metrics Example ===");
+
+    // Create a sandbox
+    let mut sandbox = PythonSandbox::create("all-metrics-example").await?;
+
+    // Start the sandbox
+    sandbox.start(None).await?;
+
+    // Get the command interface
+    let cmd = sandbox.command().await?;
+
+    // Run some commands to generate activity
+    println!("Running commands to generate some sandbox activity...");
+    cmd.run("cat", Some(vec!["/etc/os-release"]), None).await?;
+    cmd.run("ls", Some(vec!["-la", "/usr"]), None).await?;
+
+    // Sleep a moment to allow metrics to update
+    sleep(Duration::from_secs(1)).await;
+
+    // Get the metrics interface
+    let metrics = sandbox.metrics().await?;
+
+    // Get all metrics at once
+    println!("\nGetting all metrics as a JSON object:");
+    let all_metrics = metrics.all().await?;
+
+    // Print formatted metrics
+    println!(
+        "Sandbox: {} (namespace: {})",
+        all_metrics
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown"),
+        all_metrics
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+    );
+    println!(
+        "  Running: {}",
+        all_metrics
+            .get("running")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    );
+
+    // Handle CPU metrics which may be 0.0 or None
+    match all_metrics.get("cpu_usage").and_then(|v| v.as_f64()) {
+        Some(cpu) => println!("  CPU Usage: {}%", cpu),
+        None => println!("  CPU Usage: Not available"),
+    }
+
+    match all_metrics.get("memory_usage").and_then(|v| v.as_u64()) {
+        Some(mem) => println!("  Memory Usage: {} MiB", mem),
+        None => println!("  Memory Usage: Not available"),
+    }
+
+    match all_metrics.get("disk_usage").and_then(|v| v.as_u64()) {
+        Some(disk) => println!("  Disk Usage: {} bytes", disk),
+        None => println!("  Disk Usage: Not available"),
+    }
+
+    // Stop the sandbox
+    sandbox.stop().await?;
+
+    Ok(())
+}
+
+/// Example showing how to continuously monitor sandbox metrics.
+async fn continuous_monitoring_example() -> Result<(), Box<dyn Error + Send + Sync>> {
+    println!("\n=== Continuous Monitoring Example ===");
+
+    // Create a sandbox
+    let mut sandbox = PythonSandbox::create("monitoring-example").await?;
+
+    // Start the sandbox
+    sandbox.start(None).await?;
+
+    // Get the command interface
+    let cmd = sandbox.command().await?;
+
+    println!("Starting continuous monitoring (5 seconds)...");
+
+    // Generate load with a simple and safe command
+    cmd.run(
+        "sh",
+        Some(vec![
+            "-c",
+            "for i in $(seq 1 5); do ls -la / > /dev/null; sleep 0.2; done &",
+        ]),
+        None,
+    )
+    .await?;
+
+    // Get the metrics interface
+    let metrics = sandbox.metrics().await?;
+
+    // Monitor for 5 seconds
+    let start_time = Instant::now();
+    while start_time.elapsed() < Duration::from_secs(5) {
+        // Get metrics
+        let cpu = metrics.cpu().await?;
+        let memory = metrics.memory().await?;
+
+        // Format CPU usage (could be 0.0 or None)
+        let cpu_str = match cpu {
+            Some(value) => format!("{}%", value),
+            None => "Not available".to_string(),
+        };
+
+        // Format memory usage
+        let memory_str = match memory {
+            Some(value) => format!("{} MiB", value),
+            None => "Not available".to_string(),
+        };
+
+        // Print current values
+        println!(
+            "[{:.1}s] CPU: {}, Memory: {}",
+            start_time.elapsed().as_secs_f32(),
+            cpu_str,
+            memory_str
+        );
+
+        // Wait before next check
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    println!("Monitoring complete.");
+
+    // Stop the sandbox
+    sandbox.stop().await?;
+
+    Ok(())
+}
+
+/// Example generating CPU load to test CPU metrics.
+async fn cpu_load_test_example() -> Result<(), Box<dyn Error + Send + Sync>> {
+    println!("\n=== CPU Load Test Example ===");
+
+    // Create a sandbox
+    let mut sandbox = PythonSandbox::create("cpu-load-test").await?;
+
+    // Start the sandbox
+    sandbox.start(None).await?;
+
+    // Get the command interface
+    let cmd = sandbox.command().await?;
+
+    // Run a CPU-intensive Python script
+    println!("Running CPU-intensive task...");
+
+    // First create a Python script that will use CPU
+    let cpu_script = r#"
+import time
+start = time.time()
+duration = 10  # seconds
+
+# CPU-intensive calculation
+while time.time() - start < duration:
+    # Calculate prime numbers - CPU intensive
+    for i in range(1, 100000):
+        is_prime = True
+        for j in range(2, int(i ** 0.5) + 1):
+            if i % j == 0:
+                is_prime = False
+                break
+
+    # Print progress every second
+    elapsed = time.time() - start
+    if int(elapsed) == elapsed:
+        print(f"Running for {int(elapsed)} seconds...")
+
+print("CPU load test complete")
+"#;
+
+    // Write the script to a file
+    cmd.run(
+        "bash",
+        Some(vec![
+            "-c",
+            &format!("cat > /tmp/cpu_test.py << 'EOF'\n{}\nEOF", cpu_script),
+        ]),
+        None,
+    )
+    .await?;
+
+    // Run the script in the background
+    println!("Starting CPU test (running for 10 seconds)...");
+    cmd.run("python", Some(vec!["/tmp/cpu_test.py", "&"]), None)
+        .await?;
+
+    // Get the metrics interface
+    let metrics = sandbox.metrics().await?;
+
+    // Monitor CPU usage while the script runs
+    println!("\nMonitoring CPU usage...");
+    for i in 0..5 {
+        // Wait a moment
+        sleep(Duration::from_secs(2)).await;
+
+        // Get metrics
+        let cpu = metrics.cpu().await?;
+        let memory = metrics.memory().await?;
+
+        // Format CPU usage (could be 0.0 or None)
+        let cpu_str = match cpu {
+            Some(value) => format!("{}%", value),
+            None => "Not available".to_string(),
+        };
+
+        // Format memory usage
+        let memory_str = match memory {
+            Some(value) => format!("{} MiB", value),
+            None => "Not available".to_string(),
+        };
+
+        // Print current values
+        println!(
+            "[{} seconds] CPU: {}, Memory: {}",
+            i * 2,
+            cpu_str,
+            memory_str
+        );
+    }
+
+    println!("CPU load test complete.");
+
+    // Stop the sandbox
+    sandbox.stop().await?;
+
+    Ok(())
+}
+
+/// Example showing error handling with metrics.
+async fn error_handling_example() -> Result<(), Box<dyn Error + Send + Sync>> {
+    println!("\n=== Error Handling Example ===");
+
+    // Create a sandbox without starting it
+    let sandbox = PythonSandbox::create("error-example").await?;
+
+    // Try to get metrics before starting the sandbox
+    println!("Trying to get metrics before starting the sandbox...");
+    match sandbox.metrics().await {
+        Ok(metrics) => match metrics.cpu().await {
+            Ok(cpu) => match cpu {
+                Some(value) => println!("CPU: {}%", value),
+                None => println!("CPU: Not available"),
+            },
+            Err(e) => println!("Expected error: {}", e),
+        },
+        Err(e) => println!("Expected error when getting metrics: {}", e),
+    }
+
+    // Now properly start the sandbox
+    println!("\nStarting the sandbox properly...");
+    let mut sandbox = PythonSandbox::create("error-example").await?;
+    sandbox.start(None).await?;
+
+    // Get metrics after starting
+    match sandbox.metrics().await {
+        Ok(metrics) => {
+            match metrics.cpu().await {
+                Ok(cpu) => {
+                    // Format CPU usage (could be 0.0 or None)
+                    let cpu_str = match cpu {
+                        Some(value) => format!("{}%", value),
+                        None => "Not available".to_string(),
+                    };
+                    println!("CPU usage after starting: {}", cpu_str);
+                }
+                Err(e) => println!("Error: {}", e),
+            }
+        }
+        Err(e) => println!("Error: {}", e),
+    }
+
+    // Stop the sandbox
+    sandbox.stop().await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    println!("Sandbox Metrics Examples");
+    println!("=======================");
+
+    // Run all examples
+    basic_metrics_example().await?;
+    all_metrics_example().await?;
+    continuous_monitoring_example().await?;
+    cpu_load_test_example().await?;
+    error_handling_example().await?;
+
+    println!("\nAll examples completed!");
+
+    Ok(())
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -12,6 +12,7 @@ pub use builder::SandboxOptions;
 pub use command::Command;
 pub use error::SandboxError;
 pub use execution::Execution;
+pub use metrics::Metrics;
 pub use node::NodeSandbox;
 pub use python::PythonSandbox;
 pub use start_options::StartOptions;
@@ -21,6 +22,7 @@ mod builder;
 mod command;
 mod error;
 mod execution;
+mod metrics;
 mod node;
 mod python;
 mod start_options;
@@ -64,4 +66,7 @@ pub trait BaseSandbox: Send + Sync {
 
     /// Stop the sandbox container
     async fn stop(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+    /// Get the metrics interface for the sandbox
+    async fn metrics(&self) -> Result<Metrics, Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/sdk/rust/src/metrics.rs
+++ b/sdk/rust/src/metrics.rs
@@ -1,0 +1,182 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use serde_json::json;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::base::SandboxBase;
+
+/// Metrics interface for the Microsandbox Rust SDK.
+pub struct Metrics {
+    /// Base sandbox implementation
+    base: Arc<Mutex<SandboxBase>>,
+}
+
+impl Metrics {
+    /// Create a new Metrics instance
+    pub fn new(base: Arc<Mutex<SandboxBase>>) -> Self {
+        Self { base }
+    }
+
+    /// Internal method to fetch current metrics from the server
+    async fn get_metrics(&self) -> Result<serde_json::Value, Box<dyn Error + Send + Sync>> {
+        // Check if sandbox is started
+        let is_started = {
+            let base = self.base.lock().await;
+            base.is_started
+        };
+
+        if !is_started {
+            return Err(Box::new(crate::SandboxError::NotStarted));
+        }
+
+        // Extract sandbox details
+        let (server_url, namespace, sandbox_name, api_key) = {
+            let base = self.base.lock().await;
+            (
+                base.server_url.clone(),
+                base.namespace.clone(),
+                base.name.clone(),
+                base.api_key.clone(),
+            )
+        };
+
+        // Build request payload
+        let request_id = Uuid::new_v4().to_string();
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "method": "sandbox.metrics.get",
+            "params": {
+                "namespace": namespace,
+                "sandbox": sandbox_name,
+            },
+            "id": request_id,
+        });
+
+        // Create HTTP client
+        let client = reqwest::Client::new();
+        let mut req_builder = client
+            .post(&format!("{}/api/v1/rpc", server_url))
+            .json(&payload)
+            .header("Content-Type", "application/json");
+
+        // Add API key if present
+        if let Some(key) = api_key {
+            req_builder = req_builder.header("Authorization", format!("Bearer {}", key));
+        }
+
+        // Send request
+        let response = req_builder
+            .send()
+            .await
+            .map_err(|e| Box::new(crate::SandboxError::RequestFailed(e.to_string())))?;
+
+        // Check status
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(Box::new(crate::SandboxError::RequestFailed(format!(
+                "Failed to get sandbox metrics: {} - {}",
+                status, error_text
+            ))));
+        }
+
+        // Parse response
+        let response_data: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| Box::new(crate::SandboxError::InvalidResponse(e.to_string())))?;
+
+        // Check for errors in response
+        if let Some(error) = response_data.get("error") {
+            let message = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Box::new(crate::SandboxError::RequestFailed(format!(
+                "Failed to get sandbox metrics: {}",
+                message
+            ))));
+        }
+
+        // Extract result and sandboxes array
+        let result = response_data.get("result").ok_or_else(|| {
+            crate::SandboxError::InvalidResponse("Missing 'result' field".to_string())
+        })?;
+
+        let sandboxes = result
+            .get("sandboxes")
+            .and_then(|s| s.as_array())
+            .ok_or_else(|| {
+                crate::SandboxError::InvalidResponse("Missing 'sandboxes' array".to_string())
+            })?;
+
+        // We expect exactly one sandbox in the response (our own)
+        if sandboxes.is_empty() {
+            return Ok(json!({}));
+        }
+
+        // Return the first (and should be only) sandbox data
+        Ok(sandboxes[0].clone())
+    }
+
+    /// Get all metrics for the current sandbox
+    ///
+    /// Returns a JSON object containing all metrics for the sandbox:
+    /// ```json
+    /// {
+    ///   "name": "sandbox-name",
+    ///   "namespace": "namespace",
+    ///   "running": true,
+    ///   "cpu_usage": 0.5,
+    ///   "memory_usage": 128,
+    ///   "disk_usage": 1024
+    /// }
+    /// ```
+    pub async fn all(&self) -> Result<serde_json::Value, Box<dyn Error + Send + Sync>> {
+        self.get_metrics().await
+    }
+
+    /// Get CPU usage percentage for the current sandbox
+    ///
+    /// Returns CPU usage as a percentage (0-100) or None if not available.
+    /// May return 0.0 for idle sandboxes or when metrics are not precise.
+    pub async fn cpu(&self) -> Result<Option<f32>, Box<dyn Error + Send + Sync>> {
+        let metrics = self.get_metrics().await?;
+        Ok(metrics
+            .get("cpu_usage")
+            .and_then(|v| v.as_f64())
+            .map(|v| v as f32))
+    }
+
+    /// Get memory usage for the current sandbox
+    ///
+    /// Returns memory usage in MiB or None if not available
+    pub async fn memory(&self) -> Result<Option<u64>, Box<dyn Error + Send + Sync>> {
+        let metrics = self.get_metrics().await?;
+        Ok(metrics.get("memory_usage").and_then(|v| v.as_u64()))
+    }
+
+    /// Get disk usage for the current sandbox
+    ///
+    /// Returns disk usage in bytes or None if not available
+    pub async fn disk(&self) -> Result<Option<u64>, Box<dyn Error + Send + Sync>> {
+        let metrics = self.get_metrics().await?;
+        Ok(metrics.get("disk_usage").and_then(|v| v.as_u64()))
+    }
+
+    /// Check if the sandbox is currently running
+    ///
+    /// Returns true if the sandbox is running, false otherwise
+    pub async fn is_running(&self) -> Result<bool, Box<dyn Error + Send + Sync>> {
+        let metrics = self.get_metrics().await?;
+        Ok(metrics
+            .get("running")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false))
+    }
+}

--- a/sdk/rust/src/node.rs
+++ b/sdk/rust/src/node.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::command::Command;
-use crate::{BaseSandbox, Execution, SandboxBase, SandboxOptions, StartOptions};
+use crate::{BaseSandbox, Execution, Metrics, SandboxBase, SandboxOptions, StartOptions};
 
 /// Node.js-specific sandbox for executing JavaScript code
 pub struct NodeSandbox {
@@ -40,6 +40,11 @@ impl NodeSandbox {
     pub async fn command(&self) -> Result<Command, Box<dyn Error + Send + Sync>> {
         Ok(Command::new(self.base.clone()))
     }
+
+    /// Get the metrics interface for retrieving sandbox metrics
+    pub async fn metrics(&self) -> Result<Metrics, Box<dyn Error + Send + Sync>> {
+        Ok(Metrics::new(self.base.clone()))
+    }
 }
 
 #[async_trait]
@@ -66,7 +71,7 @@ impl BaseSandbox for NodeSandbox {
 
         // Execute code
         let base = self.base.lock().await;
-        base.run_code("node", code).await
+        base.run_code("javascript", code).await
     }
 
     async fn start(
@@ -98,5 +103,9 @@ impl BaseSandbox for NodeSandbox {
         // Stop sandbox
         let mut base = self.base.lock().await;
         base.stop_sandbox().await
+    }
+
+    async fn metrics(&self) -> Result<Metrics, Box<dyn Error + Send + Sync>> {
+        Ok(Metrics::new(self.base.clone()))
     }
 }

--- a/sdk/rust/src/python.rs
+++ b/sdk/rust/src/python.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::command::Command;
-use crate::{BaseSandbox, Execution, SandboxBase, SandboxOptions, StartOptions};
+use crate::{BaseSandbox, Execution, Metrics, SandboxBase, SandboxOptions, StartOptions};
 
 /// Python-specific sandbox for executing Python code
 pub struct PythonSandbox {
@@ -39,6 +39,11 @@ impl PythonSandbox {
     /// Get the command interface for executing shell commands
     pub async fn command(&self) -> Result<Command, Box<dyn Error + Send + Sync>> {
         Ok(Command::new(self.base.clone()))
+    }
+
+    /// Get the metrics interface for retrieving sandbox metrics
+    pub async fn metrics(&self) -> Result<Metrics, Box<dyn Error + Send + Sync>> {
+        Ok(Metrics::new(self.base.clone()))
     }
 }
 
@@ -98,5 +103,9 @@ impl BaseSandbox for PythonSandbox {
         // Stop sandbox
         let mut base = self.base.lock().await;
         base.stop_sandbox().await
+    }
+
+    async fn metrics(&self) -> Result<Metrics, Box<dyn Error + Send + Sync>> {
+        Ok(Metrics::new(self.base.clone()))
     }
 }


### PR DESCRIPTION
- Add Metrics class to Python SDK for retrieving sandbox resource metrics
- Add Metrics struct to Rust SDK with equivalent functionality
- Add metrics examples for both Python and Rust SDKs
- Update BaseSandbox trait to include metrics() method
- Add metrics support to NodeSandbox and PythonSandbox implementations
- Bump SDK versions (Python 0.1.8, Rust 0.1.2)

The metrics interface provides methods to:
- Get CPU usage percentage
- Get memory usage in MiB
- Get disk usage in bytes
- Check if sandbox is running
- Get all metrics at once as a dictionary/JSON object