### PR TITLE
docs: update README with video demo and clearer copy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ To run your ai-generated code, you could try a few things:
 
 Get started with the SDK in a few easy steps:
 
-<a href="https://asciinema.org/a/zyxUsKm2drfeiIZzyfrhroerp" target="_blank"><img src="https://github.com/user-attachments/assets/1d089394-2a02-4fd2-85f8-82f70f79dc26"  width="2000" /></a>
+<div align="center">
+  <video src="https://github.com/user-attachments/assets/15299b93-b87d-4635-986b-cbbb2c9916ac" width="800" controls></video>
+</div>
 
 <div align='center'>
   <img src="https://img.shields.io/badge/macos-working-green?style=for-the-badge" alt=macos style="margin-bottom: 5px;"/>
@@ -258,7 +260,7 @@ With microsandbox, your AI can navigate websites, extract data, fill out forms, 
 
 ### Instant App Hosting
 
-Share working apps and demos in seconds without deployment headaches. When your AI creates a useful tool, calculator, visualization, or prototype, users can immediately access it through a simple link. No waiting for server setup or DNS configuration—just instant access to the application.
+Share working apps and demos in seconds without deployment headaches. When your AI creates a useful tool, calculator, visualization, or prototype, users can immediately access it through a simple link.
 
 Zero-setup deployment means your AI-generated code can be immediately useful without complex configuration. Each app runs in its own protected space with appropriate resource limits, and everything cleans up automatically when no longer needed. Perfect for educational platforms hosting student projects, AI assistants creating live demos, and users needing immediate value.
 
@@ -272,9 +274,9 @@ Zero-setup deployment means your AI-generated code can be immediately useful wit
 
 # <sub><img height="18" src="https://octicons-col.vercel.app/device-desktop/A770EF">&nbsp;&nbsp;PROJECTS&nbsp;&nbsp;<sup><sup>B E T A</sup></sup></sub>
 
-Beyond its SDK for secure execution of untrusted code, microsandbox supports project-based development with familiar package-manager workflows.
+Beyond the SDK, microsandbox supports project-based development with familiar package-manager workflows. Think of it like npm or cargo, but for sandboxes!
 
-Think of it like npm or cargo, but for sandboxes! Create a Sandboxfile, define your environments, and manage your sandboxes with simple commands.
+Create a `Sandboxfile`, define your environments, and manage your sandboxes with simple commands.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ To run your ai-generated code, you could try a few things:
 
 # <sub><img height="18" src="https://octicons-col.vercel.app/zap/A770EF">&nbsp;&nbsp;QUICK START</sub>
 
-Get started with the SDK in a few easy steps:
+Get started with few easy steps:
 
 <div align="center">
-  <video src="https://github.com/user-attachments/assets/15299b93-b87d-4635-986b-cbbb2c9916ac" width="800" controls></video>
+  <video src="https://github.com/user-attachments/assets/15299b93-b87d-4635-986b-cbbb2c9916ac" width="800" controls>
+  </video>
+
+<sup><small><a href="https://asciinema.org/a/itQE92vIJiyq1PAPnaGURzDpv" target="_blank">[ASCIINEMA →]</a></small></sup>
+
 </div>
 
 <div align='center'>
@@ -68,11 +72,11 @@ Get started with the SDK in a few easy steps:
 
 <h3><span>1</span>&nbsp;&nbsp;<img height="13" src="https://octicons-col.vercel.app/key/A770EF">&nbsp;&nbsp;Get API Key</h3>
 
-- Get your API key by <a href="./SELF_HOSTING.md">[SELF HOSTING →]</a>
-- Set key as an environment variable. For example, you could set it in your `.env` file
+- Get your API key by <a href="./SELF_HOSTING.md">[<small>SELF HOSTING →</small>]</a>
+- Set the `MSB_API_KEY` environment variable to the key.
 
-  ```env
-  MSB_API_KEY=msb_***
+  ```sh
+  export MSB_API_KEY=msb_***
   ```
 
 ##

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -6,9 +6,11 @@ Self hosting lets you manage your own data and code making it easier to comply w
 
 Let's help you start your first self-hosted sandbox server. It's easy!
 
-> [!WARNING]
+> **Platform-specific requirements:**
 >
-> `microsandbox` is beta software and not ready for production use.
+> - <a href="https://microsandbox.dev#gh-light-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/apple" height="14"/></a><a href="https://microsandbox.dev#gh-dark-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/apple/white" height="14"/></a> **macOS** — Requires Apple Silicon (M1/M2/M3/M4)
+> - <a href="https://microsandbox.dev#gh-light-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/linux/black" height="14"/></a><a href="https://microsandbox.dev#gh-dark-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/linux/white" height="14"/></a>  **Linux** <a href="https://github.com/microsandbox/microsandbox/issues/224" target="_blank"><sup><sup>#224</sup></sup></a> — KVM virtualization must be enabled
+> - <a href="https://microsandbox.dev#gh-light-mode-only" target="_blank"><img src="https://github.com/user-attachments/assets/1677b695-e359-4b51-9931-f8f5f9488e71" height="14"/></a><a href="https://microsandbox.dev#gh-dark-mode-only" target="_blank"><img src="https://github.com/user-attachments/assets/e3e5b341-b097-45d9-bea1-eb70e0769340" height="14"/></a> **Windows** <a href="https://github.com/microsandbox/microsandbox/issues/224" target="_blank"> — [Coming soon!](https://github.com/microsandbox/microsandbox/issues/47)
 
 ##
 
@@ -19,15 +21,6 @@ curl -sSL https://get.microsandbox.dev | sh
 ```
 
 This will install the `msb` CLI tool, which helps you manage sandboxes locally.
-
-> [!IMPORTANT]
->
-> The CLI is currently only available for macOS and Linux. **[Windows support is coming soon!](https://github.com/microsandbox/microsandbox/issues/47)**
->
-> **Platform-specific requirements:**
->
-> - <a href="https://microsandbox.dev#gh-light-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/apple" height="14"/></a><a href="https://microsandbox.dev#gh-dark-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/apple/white" height="14"/></a> **macOS** — Requires Apple Silicon (M1/M2/M3/M4)
-> - <a href="https://microsandbox.dev#gh-light-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/linux/black" height="14"/></a><a href="https://microsandbox.dev#gh-dark-mode-only" target="_blank"><img src="https://cdn.simpleicons.org/linux/white" height="14"/></a> **Linux** <a href="https://github.com/microsandbox/microsandbox/issues/224" target="_blank"><sup><small>[WIP →]</small></sup></a> — KVM virtualization must be enabled
 
 ##
 
@@ -40,8 +33,6 @@ msb server start
 > [!TIP]
 >
 > Use the `--detach` flag to run the server in the background.
->
-> Run `msb server stop` to stop the server if it's running in the background.
 >
 > See `msb server --help` for more options.
 
@@ -67,12 +58,7 @@ This pulls and caches the images for the SDKs to use. It is what allows you to r
 msb server keygen --expire 3mo
 ```
 
-After starting the server and generating your key, configure the environment variables to connect your SDK to your self-hosted sandbox server automatically.
-
-There are just two environment variables to set:
-
-- `MSB_API_KEY` — The API key for your sandbox server
-- `MSB_API_URL` — The URL of your sandbox server. You don't need to set this if you are running the server locally at the default port.
+After generating your key, set the `MSB_API_KEY` environment variable to the generated key.
 
 ##
 


### PR DESCRIPTION
- Replace asciinema player with direct video element
- Streamline app hosting description
- Improve Projects section readability
- Streamline quick start section in README
- Add asciinema link for demo video
- Consolidate platform requirements into a single notice
- Simplify API key setup instructions
- Remove redundant server configuration details