### PR TITLE
feat(mcp): add dedicated MCP endpoint and documentation

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,75 @@
+# <sub><img height="18" src="https://octicons-col.vercel.app/plug/A770EF">&nbsp;&nbsp;MODEL CONTEXT PROTOCOL</sub>
+
+microsandbox server is also a **Model Context Protocol (MCP) server**, enabling seamless integration with AI tools and agents that support MCP.
+
+#### What is MCP?
+
+The Model Context Protocol (MCP) is an open standard that allows AI models to securely connect to external data sources and tools. It provides a standardized way for AI assistants to access and interact with various services through a unified interface.
+
+With MCP, your AI can:
+
+- Execute code in secure sandboxes
+- Access real-time data and services
+- Perform complex operations safely
+- Maintain context across interactions
+
+##
+
+#### Connection Details
+
+microsandbox server supports MCP connections via **Streamable HTTP transport only**.
+
+- **Transport**: HTTP
+- **URL**: `http://localhost:5555/mcp`
+- **Method**: Streamable HTTP
+
+##### Server Configuration
+
+When running your microsandbox server, it automatically exposes MCP endpoints at:
+
+```
+http://localhost:5555/mcp
+```
+
+> [!NOTE]
+> The MCP endpoint uses the same host and port as your main microsandbox server.
+
+##
+
+#### Getting Started
+
+1. **Start your microsandbox server**:
+
+   ```sh
+   msb server start --dev
+   ```
+
+2. **Configure your MCP client** with the connection details above
+
+3. **Begin using sandbox tools** through your AI assistant
+
+   Try these example prompts:
+
+   ```
+   "Create a Python sandbox and run a simple hello world program"
+   ```
+
+   ```
+   "Start a Node.js sandbox, install express, and create a basic web server"
+   ```
+
+   ```
+   "Execute this shell command in a sandbox: curl -s https://api.github.com/users/octocat"
+   ```
+
+##
+
+#### Available Tools
+
+The microsandbox MCP server provides these tools:
+
+- `sandbox_start` - Create and start new sandboxes
+- `sandbox_stop` - Stop running sandboxes
+- `sandbox_run_code` - Execute code in sandboxes
+- `sandbox_run_command` - Run shell commands
+- `sandbox_get_metrics` - Monitor sandbox status

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ msb server start --dev
 
 > [!TIP]
 >
-> microsandbox server is also an [MCP server](https://modelcontextprotocol.io), so it works directly with Cursor, Agno, and other MCP-enabled AI tools and agents.
+> microsandbox server is also an [MCP server](./MCP.md), so it works directly with Cursor, Agno, and other MCP-enabled AI tools and agents.
 >
 > For more information on setting up the server, see the [self-hosting guide](./SELF_HOSTING.md).
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -52,11 +52,3 @@ flowchart TB
     style VM2S fill:#FCF3CF,stroke:#F1C40F,stroke-width:2px,color:#000000
     style VM3S fill:#FCF3CF,stroke:#F1C40F,stroke-width:2px,color:#000000
 ```
-
-### Next Steps
-
-Now that you understand the architecture, explore:
-
-[!ref Security Best Practices](/guides/architecture)
-[!ref Performance Tuning](/guides/architecture)
-[!ref Deployment Guide](/guides/architecture)

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -27,6 +27,12 @@ microsandbox exposes the following MCP capabilities:
 - **`sandbox_run_command`** - Run shell commands in sandboxes
 - **`sandbox_get_metrics`** - Monitor sandbox resource usage
 
+#### Connection Details
+
+- **Endpoint:** `http://127.0.0.1:5555/mcp`
+- **Protocol:** Streamable HTTP
+- **Authentication:** Bearer token (if not in dev mode)
+
 !!!info Transport Support
 microsandbox server only supports the **Streamable HTTP** transport protocol. The deprecated HTTP+SSE transport is not supported. Prefer **Streamable HTTP** when connecting with MCP clients.
 !!!
@@ -58,7 +64,7 @@ from agno.tools.mcp import MCPTools
 
 async def main():
     # Connect to microsandbox MCP server
-    server_url = "http://127.0.0.1:5555/api/v1/rpc"
+    server_url = "http://127.0.0.1:5555/mcp"
 
     async with MCPTools(url=server_url, transport="streamable-http") as mcp_tools:
         # Create agent with microsandbox tools
@@ -85,133 +91,6 @@ microsandbox works with any MCP-compatible application:
 
 - **Cursor** - AI-powered code editor
 - **Custom MCP clients** - Build your own integrations
-
----
-
-### MCP API Reference
-
-#### Connection Details
-
-- **Endpoint:** `http://127.0.0.1:5555/api/v1/rpc`
-- **Protocol:** JSON-RPC 2.0 over HTTP
-- **Authentication:** Bearer token (if not in dev mode)
-
-#### Available MCP Methods
-
-==- `initialize`
-Initialize the MCP connection and get server capabilities.
-
-**Request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "initialize",
-  "params": {
-    "protocolVersion": "2024-11-05",
-    "capabilities": {},
-    "clientInfo": {
-      "name": "claude-desktop",
-      "version": "0.7.1"
-    }
-  },
-  "id": 1
-}
-```
-
-**Response:**
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "protocolVersion": "2024-11-05",
-    "capabilities": {
-      "tools": {},
-      "prompts": {}
-    },
-    "serverInfo": {
-      "name": "microsandbox",
-      "version": "1.0.0"
-    }
-  },
-  "id": 1
-}
-```
-===
-
-==- `tools/list`
-List all available tools.
-
-**Request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/list",
-  "id": 2
-}
-```
-
-**Response:**
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "tools": [
-      {
-        "name": "sandbox_start",
-        "description": "Start a new sandbox",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name": {"type": "string"},
-            "image": {"type": "string"},
-            "namespace": {"type": "string"}
-          }
-        }
-      }
-    ]
-  },
-  "id": 2
-}
-```
-===
-
-==- `tools/call`
-Execute a specific tool.
-
-**Request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "sandbox_run_code",
-    "arguments": {
-      "sandbox": "my-python-env",
-      "namespace": "default",
-      "language": "python",
-      "code": "print('Hello from MCP!')"
-    }
-  },
-  "id": 3
-}
-```
-
-**Response:**
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "content": [
-      {
-        "type": "text",
-        "text": "Hello from MCP!\n"
-      }
-    ]
-  },
-  "id": 3
-}
-```
-===
 
 ---
 

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -79,13 +79,3 @@ This executes the default _start_ script of your sandbox. For more control, you 
 ```bash
 msr myapp~start
 ```
-
----
-
-### Next Steps
-
-Now that you understand how to use microsandbox projects, explore:
-
-[!ref Managing Sandboxes](/projects/managing-sandboxes)
-[!ref Running Commands](/projects/running-commands)
-[!ref Monitoring Sandboxes](/projects/monitoring)

--- a/docs/guides/sandboxes.md
+++ b/docs/guides/sandboxes.md
@@ -278,11 +278,3 @@ if exec.has_error():
 else:
     print("Success:", await exec.output())
 ```
-
----
-
-## Next Steps
-
-[!ref Sandbox Lifecycle](/sdk/sandbox-lifecycle)
-[!ref Command Execution](/sdk/command-execution)
-[!ref Code Execution](/sdk/code-execution)

--- a/microsandbox-server/lib/mcp.rs
+++ b/microsandbox-server/lib/mcp.rs
@@ -1,6 +1,6 @@
 //! Model Context Protocol (MCP) implementation for microsandbox server.
 //!
-//! This module implements MCP endpoints using our existing JSON-RPC infrastructure.
+//! This module implements MCP endpoints served at the `/mcp` endpoint.
 //! MCP is essentially JSON-RPC with specific method names and schemas.
 //!
 //! The module provides:
@@ -37,7 +37,7 @@ const SERVER_NAME: &str = "microsandbox-mcp-server";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 //--------------------------------------------------------------------------------------------------
-// MCP Method Handlers
+// Functions: Handlers
 //--------------------------------------------------------------------------------------------------
 
 /// Handle MCP initialize request
@@ -199,7 +199,7 @@ pub async fn handle_mcp_list_tools(
             },
             {
                 "name": "sandbox_get_metrics",
-                "description": "Get metrics and status for sandboxes including CPU usage, memory consumption, and running state. PREREQUISITES: If querying a specific sandbox, it should be started first. Use this to monitor resource usage and verify sandbox status before running code or commands.",
+                "description": "Get metrics and status for sandboxes including CPU usage, memory consumption, and running state. This tool can check the status of any sandbox regardless of whether it's running or not",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -553,18 +553,6 @@ pub async fn handle_mcp_call_tool(
     };
 
     Ok(JsonRpcResponse::success(mcp_result, request.id))
-}
-
-//--------------------------------------------------------------------------------------------------
-// Functions
-//--------------------------------------------------------------------------------------------------
-
-/// Check if a method is an MCP method
-pub fn is_mcp_method(method: &str) -> bool {
-    matches!(
-        method,
-        "initialize" | "tools/list" | "tools/call" | "prompts/list" | "prompts/get"
-    )
 }
 
 /// Handle MCP methods

--- a/microsandbox-server/lib/route.rs
+++ b/microsandbox-server/lib/route.rs
@@ -36,10 +36,20 @@ pub fn create_router(state: AppState) -> Router {
             app_middleware::auth_middleware,
         ));
 
+    // Create MCP routes - separate endpoint for Model Context Protocol
+    let mcp_api =
+        Router::new()
+            .route("/", post(handler::mcp_handler))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                app_middleware::auth_middleware,
+            ));
+
     // Combine all routes with logging middleware
     Router::new()
         .nest("/api/v1", rest_api)
         .nest("/api/v1/rpc", rpc_api)
+        .nest("/mcp", mcp_api)
         .layer(middleware::from_fn(app_middleware::logging_middleware))
         .with_state(state)
 }


### PR DESCRIPTION
- Add new /mcp endpoint for Model Context Protocol support
- Create dedicated MCP handler separate from main JSON-RPC handler
- Add comprehensive MCP documentation and connection details
- Update sandbox metrics tool description
- Remove redundant "Next Steps" sections from docs
- Update example code to use new MCP endpoint