### PR TITLE
feat: add vet ci integration for OSS security auditing 

### DIFF
--- a/.github/vet/policy.yaml
+++ b/.github/vet/policy.yaml
@@ -1,0 +1,34 @@
+name: General Purpose OSS Best Practices
+
+description: |
+  This filter suite contains rules for implementing minimum
+  security guardrails against risky OSS components.
+
+tags:
+  - general
+  - microsandbox
+
+filters:
+  - name: critical-or-high-vulns
+    check_type: CheckTypeVulnerability
+    summary: Critical or high risk vulnerabilities were found
+    value: |
+      vulns.critical.exists(p, true) || vulns.high.exists(p, true)
+
+  - name: unmaintained-packages
+    check_type: CheckTypeSecurityScorecard
+    summary: Unmaintained packages were found
+    value: |
+      scorecard.scores["Maintained"] == 0
+
+  - name: low-popularity
+    check_type: CheckTypePopularity
+    summary: Component popularity is low by Github stars count
+    value: |
+      projects.exists(p, (p.type == "GITHUB") && (p.stars < 10))
+
+  - name: osv-malware
+    check_type: CheckTypeMalware
+    summary: Malicious (malware) component detected
+    value: |
+      vulns.all.exists(v, v.id.startsWith("MAL-"))

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -14,6 +14,9 @@ permissions:
   issues: write
   pull-requests: write
 
+  # For uploading SARIF report
+  security-events: write
+
 jobs:
   # https://github.com/safedep/vet
   vet:

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -33,6 +33,10 @@ jobs:
         uses: safedep/vet-action@v1
         with:
           policy: .github/vet/policy.yml
+
+          # Allow vet commenting in PR for Summary
+          # https://github.com/safedep/vet-action?tab=readme-ov-file#configuration
+          enable-comments-proxy: true
         env:
           # Required for writing pull request comment
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -1,0 +1,43 @@
+name: vet OSS Components
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  # Required for actions/checkout@v4
+  contents: read
+
+  # Required for writing pull request comment
+  issues: write
+  pull-requests: write
+
+jobs:
+  # https://github.com/safedep/vet
+  vet:
+    name: vet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Run vet
+        id: vet
+        uses: safedep/vet-action@v1
+        with:
+          policy: .github/vet/policy.yml
+        env:
+          # Required for writing pull request comment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Upload SARIF report to GitHub for showing findings in centralized location in Security Tab
+      - name: Upload SARIF
+        if: steps.vet.outputs.report != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.vet.outputs.report }}
+          category: vet


### PR DESCRIPTION
Ref: https://github.com/microsandbox/microsandbox/issues/260

As discussed in this issue, we are introducing [vet](https://github.com/safedep/vet) in CI for continuous scanning and vetting of OSS components used in this project , introduced via PR etc. for finding any vulnerability and malware. 

I have drawn inspiration from https://github.com/CircuitVerse/CircuitVerse ([PR #5114](https://github.com/CircuitVerse/CircuitVerse/pull/5114/)) project by having same minimal `Policy for vet` for starting. We can define policy of our own security requirements.

Currently our policy is configured to:

- Find any `High` and `Critical` Vulnurability
- Find any `malicious` packages
- Find any `un-maintained` packages. 
- Find any package with `low-popularity`

REF:
vet-action repo: https://github.com/safedep/vet-action