### PR TITLE
Use stable std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,17 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,15 +1057,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1597,7 +1577,6 @@ name = "microsandbox-cli"
 version = "0.2.6"
 dependencies = [
  "anyhow",
- "atty",
  "axum",
  "chrono",
  "clap",
@@ -1623,7 +1602,6 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "atty",
  "bytes",
  "chrono",
  "console",
@@ -1766,7 +1744,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -1917,7 +1895,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ uzers = "0.12"
 console = "0.15"
 indicatif = "0.17"
 jsonwebtoken = "9.3"
-atty = "0.2"
 crossterm = { version = "0.29.0", features = ["events"] }
 once_cell = "1.19"
 tar = "0.4"

--- a/deny.toml
+++ b/deny.toml
@@ -48,7 +48,6 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2021-0145", # atty on windows only
     "RUSTSEC-2023-0071", # Impacts rsa crate, which is only used in dev, see
     # https://github.com/RustCrypto/RSA/pull/394 for remediation
     "RUSTSEC-2024-0336", # Ignore a DOS issue w/ rustls-0.20.9. This will go

--- a/microsandbox-cli/Cargo.toml
+++ b/microsandbox-cli/Cargo.toml
@@ -40,7 +40,6 @@ console.workspace = true
 pretty-error-debug.workspace = true
 thiserror.workspace = true
 tower-http.workspace = true
-atty.workspace = true
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/microsandbox-core/Cargo.toml
+++ b/microsandbox-core/Cargo.toml
@@ -19,7 +19,6 @@ harness = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-atty.workspace = true
 bytes.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 dirs.workspace = true

--- a/microsandbox-core/lib/management/orchestra.rs
+++ b/microsandbox-core/lib/management/orchestra.rs
@@ -25,6 +25,8 @@ use nix::{
     unistd::Pid,
 };
 use once_cell::sync::Lazy;
+#[cfg(feature = "cli")]
+use std::io::{self, IsTerminal};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -809,7 +811,7 @@ pub async fn show_status(
     config: Option<&str>,
 ) -> MicrosandboxResult<()> {
     // Check if we're in a TTY to determine if we should do live updates
-    let is_tty = atty::is(atty::Stream::Stdout);
+    let is_tty = io::stdin().is_terminal();
     let live_view = is_tty;
     let update_interval = std::time::Duration::from_secs(2);
 
@@ -888,7 +890,7 @@ pub async fn show_status_namespaces(
     namespaces_parent_dir: &Path,
 ) -> MicrosandboxResult<()> {
     // Check if we're in a TTY to determine if we should do live updates
-    let is_tty = atty::is(atty::Stream::Stdout);
+    let is_tty = io::stdin().is_terminal();
     let live_view = is_tty;
     let update_interval = std::time::Duration::from_secs(2);
 


### PR DESCRIPTION
This PR replaces the usage of the `atty` crate with the stable [`std::io::IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) for checking terminal status as it's no longer maintained as encouraged [here](https://github.com/softprops/atty/blob/master/README.md?plain=1#L3-L7).