### PR TITLE
fix: wrong policy file path in ci file for vet

### DIFF
--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: vet
         uses: safedep/vet-action@v1
         with:
-          policy: .github/vet/policy.yml
+          policy: .github/vet/policy.yaml
 
           # Allow vet commenting in PR for Summary
           # https://github.com/safedep/vet-action?tab=readme-ov-file#configuration


### PR DESCRIPTION
The policy file in `.github/vet/` is `policy.yaml`, but we reference it in ci file as `.yml` which made the CI to fail . 