### PR TITLE
feat: add lto for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ version = "0.2.6"
 license = "Apache-2.0"
 edition = "2021"
 
+[profile.release]
+codegen-units = 1
+lto = true
 
 [workspace.dependencies]
 async-stream = "0.3"


### PR DESCRIPTION
Add LTO option in the root cargo.toml file for better smaller build sizes for release builds.

Previous: `msb` binary was about 15mb
After: `msb` binary was about 11mb.

addresses: #267 . pretty much a copy/paste and running. big thanks to the author