### PR TITLE
refactor: change build steps from HashMap to Vec and fix registry URL

### DIFF
--- a/microsandbox-core/lib/config/reference_path.rs
+++ b/microsandbox-core/lib/config/reference_path.rs
@@ -242,7 +242,7 @@ mod tests {
         let test_cases = vec![
             ("./local/path", "./local/path"),
             ("/absolute/path", "/absolute/path"),
-            ("alpine:latest", "sandboxes.io/library/alpine:latest"),
+            ("alpine:latest", "docker.io/library/alpine:latest"),
             (
                 "registry.example.com/app:v1.0",
                 "registry.example.com/library/app:v1.0",


### PR DESCRIPTION
## Summary
- Changed build steps configuration from `HashMap<String, String>` to `Vec<String>` to ensure ordered execution
- Updated default Docker registry from `sandboxes.io` to `docker.io` in reference path tests
- Updated all related test cases to use the new Vec format

## Changes
- Modified `Build` struct in `config.rs` to use `Vec<String>` for steps instead of `HashMap<String, String>`
- Updated YAML parsing tests to use array syntax for steps (e.g., `steps: ["command"]` instead of `steps: {name: "command"}`)
- Fixed registry URL in `reference_path.rs` tests from `sandboxes.io` to `docker.io`