### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/microsandbox-utils/lib/runtime/supervisor.rs
+++ b/microsandbox-utils/lib/runtime/supervisor.rs
@@ -127,8 +127,7 @@ where
             // Set up child's session and controlling terminal
             unsafe {
                 command.pre_exec(|| {
-                    nix::unistd::setsid()
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    libc::setsid();
                     if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 1 as libc::c_long) < 0
                     {
                         return Err(std::io::Error::last_os_error());


### PR DESCRIPTION
`Error::new` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, which microsandbox AFAIK is. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

I've found two other places where `setsid` are invoked, and there it's called through `libc`, ignoring the resulting error (which should be impossible in a new process anyway). I adjusted the third place to use the same pattern.