### PR TITLE
doc-test: Fixed no_run doc code examples

### DIFF
--- a/microsandbox-core/lib/management/image.rs
+++ b/microsandbox-core/lib/management/image.rs
@@ -66,14 +66,14 @@ const EXTRACT_LAYERS_MSG: &str = "Extracting layers";
 ///     let layer_output_dir = Some(PathBuf::from("/custom/path"));
 ///
 ///     // Pull a single image from Docker registry
-///     image::pull("docker.io/library/ubuntu:latest".parse().unwrap(), layer_output_dir).await?;
+///     image::pull("docker.io/library/ubuntu:latest".parse().unwrap(), layer_output_dir.clone()).await?;
 ///
 ///     // Pull an image from the default registry (when no registry is specified in the reference)
-///     image::pull("nginx:latest".parse().unwrap(), layer_output_dir).await?;
+///     image::pull("nginx:latest".parse().unwrap(), layer_output_dir.clone()).await?;
 ///
 ///     // You can set the OCI_REGISTRY_DOMAIN environment variable to specify your default registry
-///     std::env::set_var("OCI_REGISTRY_DOMAIN", "docker.io");
-///     image::pull("alpine:latest".parse().unwrap(), layer_output_dir).await?;
+///     unsafe { std::env::set_var("OCI_REGISTRY_DOMAIN", "docker.io"); }
+///     image::pull("alpine:latest".parse().unwrap(), layer_output_dir.clone()).await?;
 ///
 ///     // Pull an image from Docker registry and store the layers in a custom directory
 ///     image::pull("docker.io/library/ubuntu:latest".parse().unwrap(), layer_output_dir).await?;

--- a/microsandbox-core/lib/management/menv.rs
+++ b/microsandbox-core/lib/management/menv.rs
@@ -272,16 +272,17 @@ pub async fn clean(
 /// ## Example
 /// ```no_run
 /// use microsandbox_core::management::menv;
+/// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// // Show all logs for a sandbox
-/// menv::show_log(None, None, "my-sandbox", false, None).await?;
+/// menv::show_log(None::<&Path>, None, "my-sandbox", false, None).await?;
 ///
 /// // Show last 100 lines of logs
-/// menv::show_log(None, None, "my-sandbox", false, Some(100)).await?;
+/// menv::show_log(None::<&Path>, None, "my-sandbox", false, Some(100)).await?;
 ///
 /// // Follow logs in real-time
-/// menv::show_log(None, None, "my-sandbox", true, None).await?;
+/// menv::show_log(None::<&Path>, None, "my-sandbox", true, None).await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -377,13 +378,15 @@ pub async fn show_log(
 /// ```no_run
 /// use microsandbox_core::management::menv;
 /// use microsandbox_core::management::config;
+/// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// // Show all sandboxes for a local project
-/// let (config, _, _) = config::load_config(None, None).await?;
+/// let (config, _, _) = config::load_config(None::<&Path>, None).await?;
 /// menv::show_list(config.get_sandboxes());
 ///
-/// // Show all sandboxes for a remote namespace
+/// // Show all sandboxes for a specific namespace directory
+/// let namespace_path = Path::new("/path/to/namespace");
 /// let (config, _, _) = config::load_config(Some(namespace_path), None).await?;
 /// menv::show_list(config.get_sandboxes());
 /// # Ok(())

--- a/microsandbox-core/lib/management/orchestra.rs
+++ b/microsandbox-core/lib/management/orchestra.rs
@@ -861,24 +861,21 @@ pub async fn show_status(
 /// ## Example
 ///
 /// ```no_run
-/// use std::path::PathBuf;
+/// use std::path::Path;
 /// use microsandbox_core::management::orchestra;
 ///
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {
-///     // Get all namespace directories
-///     let namespaces = vec![
-///         PathBuf::from("/path/to/namespaces/ns1"),
-///         PathBuf::from("/path/to/namespaces/ns2"),
-///     ];
+///     // Parent directory containing all namespace subdirectories
+///     let namespaces_parent = Path::new("/path/to/namespaces");
 ///
 ///     // Show status for all sandboxes in all namespaces
-///     orchestra::show_status_namespaces(&[], namespaces.iter().map(|p| p.as_path()).collect()).await?;
+///     orchestra::show_status_namespaces(&[], namespaces_parent).await?;
 ///
 ///     // Or show status for specific sandboxes
 ///     orchestra::show_status_namespaces(
 ///         &["sandbox1".to_string(), "sandbox2".to_string()],
-///         namespaces.iter().map(|p| p.as_path()).collect()
+///         namespaces_parent
 ///     ).await?;
 ///
 ///     Ok(())

--- a/microsandbox-core/lib/management/sandbox.rs
+++ b/microsandbox-core/lib/management/sandbox.rs
@@ -418,7 +418,7 @@ pub async fn prepare_run(
 ///     // Run a temporary Ubuntu sandbox with custom resources
 ///     sandbox::run_temp(
 ///         &image,
-///         Some("start"),
+///         Some("start"),     // Script name
 ///         Some(2),           // 2 CPUs
 ///         Some(1024),        // 1GB RAM
 ///         vec![              // Mount host's /tmp to sandbox's /data
@@ -431,6 +431,7 @@ pub async fn prepare_run(
 ///             "DEBUG=1".to_string()
 ///         ],
 ///         Some("/app".into()), // Set working directory
+///         None,              // No network scope override
 ///         None,              // No exec command
 ///         vec![],            // No additional args
 ///         true               // Use image defaults

--- a/microsandbox-core/lib/management/toolchain.rs
+++ b/microsandbox-core/lib/management/toolchain.rs
@@ -19,16 +19,13 @@ use crate::MicrosandboxResult;
 /// This removes all scripts in ~/.local/bin that contain the MSB-ALIAS marker,
 /// except for the core toolchain scripts (msi, msx, msr).
 ///
-/// ## Arguments
-/// * `force` - Whether to force cleaning even if script files exist
-///
 /// ## Example
 /// ```no_run
 /// use microsandbox_core::management::toolchain;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// // Clean all user-installed scripts
-/// toolchain::clean(true).await?;
+/// toolchain::clean().await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/microsandbox-core/lib/vm/vm.rs
+++ b/microsandbox-core/lib/vm/vm.rs
@@ -39,7 +39,7 @@ pub const VIRTIOFS_TAG_PREFIX: &str = "virtiofs";
 /// let temp_dir = TempDir::new()?;
 /// let vm = MicroVm::builder()
 ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-///     .ram_mib(1024)
+///     .memory_mib(1024)
 ///     .exec_path("/bin/echo")
 ///     .args(["Hello, World!"])
 ///     .build()?;
@@ -225,7 +225,7 @@ impl MicroVm {
     /// let temp_dir = TempDir::new()?;
     /// let vm = MicroVm::builder()
     ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-    ///     .ram_mib(1024)
+    ///     .memory_mib(1024)
     ///     .exec_path("/bin/echo")
     ///     .build()?;
     /// # Ok(())
@@ -250,7 +250,7 @@ impl MicroVm {
     /// let temp_dir = TempDir::new()?;
     /// let vm = MicroVm::builder()
     ///     .rootfs(Rootfs::Native(temp_dir.path().to_path_buf()))
-    ///     .ram_mib(1024)
+    ///     .memory_mib(1024)
     ///     .exec_path("/usr/bin/python3")
     ///     .args(["-c", "print('Hello from MicroVm!')"])
     ///     .build()?;

--- a/microsandbox-portal/lib/portal/mod.rs
+++ b/microsandbox-portal/lib/portal/mod.rs
@@ -32,15 +32,16 @@
 //! ```no_run
 //! use microsandbox_portal::repl::{start_engines, Language};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Initialize REPL engines
-//!     let engines = start_engines()?;
+//!     let engines = start_engines().await?;
 //!
 //!     // Execute Python code in REPL
 //!     #[cfg(feature = "python")]
 //!     let result = engines.eval("print('Hello from microsandbox!')", Language::Python)?;
 //!
-//!     engines.shutdown()?;
+//!     engines.shutdown().await?;
 //!     Ok(())
 //! }
 //! ```
@@ -55,8 +56,8 @@
 //!     // Create a command executor
 //!     let cmd_handle = create_command_executor();
 //!
-//!     // Execute a system command
-//!     let (exit_code, output) = cmd_handle.execute("ls", vec!["-la"]).await?;
+//!     // Execute a system command (command, args, timeout)
+//!     let (exit_code, output) = cmd_handle.execute("ls", vec!["-la".to_string()], None).await?;
 //!
 //!     // Process the output
 //!     for line in output {

--- a/microsandbox-portal/lib/portal/repl/engine.rs
+++ b/microsandbox-portal/lib/portal/repl/engine.rs
@@ -31,18 +31,19 @@
 //! # Example
 //!
 //! ```no_run
-//! use microsandbox_portal::code::{start_engines, Language};
+//! use microsandbox_portal::repl::{start_engines, Language};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Start the engines
-//!     let handle = start_engines()?;
+//!     let handle = start_engines().await?;
 //!
 //!     // Evaluate Python code
 //!     #[cfg(feature = "python")]
 //!     let result = handle.eval("print('Hello, world!')", Language::Python)?;
 //!
 //!     // Shutdown
-//!     handle.shutdown()?;
+//!     handle.shutdown().await?;
 //!     Ok(())
 //! }
 //! ```

--- a/microsandbox-portal/lib/portal/repl/mod.rs
+++ b/microsandbox-portal/lib/portal/repl/mod.rs
@@ -25,11 +25,12 @@
 //! To use the code evaluation system, start the engines and then evaluate code:
 //!
 //! ```no_run
-//! use microsandbox_portal::code::{start_engines, Language};
+//! use microsandbox_portal::repl::{start_engines, Language};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Start all enabled engines
-//!     let handle = start_engines()?;
+//!     let handle = start_engines().await?;
 //!
 //!     // Evaluate code in different languages
 //!     #[cfg(feature = "python")]
@@ -39,7 +40,7 @@
 //!     let js_result = handle.eval("console.log('Hello from JavaScript')", Language::Node)?;
 //!
 //!     // Shutdown engines when done
-//!     handle.shutdown()?;
+//!     handle.shutdown().await?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
doc-test: Fixed code in doc comments

Running `cargo test --all` failed because of code examples in docs. This made test files fail on compile, since code is marked no_run, not ignore. (I believe this is correct since it helps catch changes in the code itself)