### PR TITLE
fix: forward_rpc_to_portal wait

### DIFF
--- a/microsandbox-server/lib/handler.rs
+++ b/microsandbox-server/lib/handler.rs
@@ -259,8 +259,10 @@ pub async fn forward_rpc_to_portal(
     let client = reqwest::Client::new();
 
     // Configure connection retry parameters
-    const MAX_RETRIES: u32 = 10_000;
+    // The portal inside the sandbox may take some time to start, so we need to retry
+    const MAX_RETRIES: u32 = 300;
     const TIMEOUT_MS: u64 = 50;
+    const RETRY_DELAY_MS: u64 = 10;
 
     // Try to establish a connection to the portal before sending the actual request
     let mut retry_count = 0;
@@ -293,6 +295,9 @@ pub async fn forward_rpc_to_portal(
 
         // Increment retry counter
         retry_count += 1;
+
+        // Wait before the next retry to give the portal time to start
+        sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
     }
 
     // If we've hit the max retries and still can't connect, report the error


### PR DESCRIPTION
Adjusts the retry logic for connecting to the portal service inside the sandbox. It adds a short delay between retries to avoid overwhelming the service.

**Retry logic improvements:**

* Reduced the `MAX_RETRIES` constant from 10,000 to 300 to prevent excessively long retry loops and improve error reporting speed.
* Introduced a `RETRY_DELAY_MS` constant and added a short 10ms delay between retries to give the portal time to start before the next attempt.


fixes https://github.com/zerocore-ai/microsandbox/issues/314