### PR TITLE
chore(config): deserialise null fields to default

### DIFF
--- a/sdk/go/cmd/command-example/main.go
+++ b/sdk/go/cmd/command-example/main.go
@@ -17,7 +17,7 @@ func basicExample() {
 	)
 
 	// Start the sandbox
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -76,7 +76,7 @@ func errorHandlingExample() {
 		msb.WithName("error-example"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -117,7 +117,7 @@ func advancedExample() {
 		msb.WithName("advanced-example"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -203,7 +203,7 @@ func explicitLifecycleExample() {
 
 	// Manually start the sandbox
 	fmt.Println("Starting sandbox...")
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 

--- a/sdk/go/cmd/concurrent-example/main.go
+++ b/sdk/go/cmd/concurrent-example/main.go
@@ -19,7 +19,7 @@ func sequentialExample() {
 		msb.WithName("sequential-example"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -57,7 +57,7 @@ func goroutineConcurrentExample() {
 		msb.WithName("concurrent-example"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -117,7 +117,7 @@ func workerPoolExample() {
 		msb.WithName("worker-pool-example"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -200,7 +200,7 @@ func contextCancellationExample() {
 		msb.WithHTTPClient(client),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -252,7 +252,7 @@ func channelCoordinationExample() {
 		msb.WithName("channel-coordination"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -343,7 +343,7 @@ func metricsMonitoringExample() {
 		msb.WithName("metrics-monitoring"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {

--- a/sdk/go/cmd/metrics-example/main.go
+++ b/sdk/go/cmd/metrics-example/main.go
@@ -16,7 +16,7 @@ func basicMetricsExample() {
 		msb.WithName("metrics-example"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -78,7 +78,7 @@ func allMetricsExample() {
 		msb.WithName("all-metrics-example"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -123,7 +123,7 @@ func continuousMonitoringExample() {
 		msb.WithName("monitoring-example"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -178,7 +178,7 @@ func cpuLoadTestExample() {
 		msb.WithName("cpu-load-test"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -268,7 +268,7 @@ func errorHandlingExample() {
 
 	// Now properly start the sandbox
 	fmt.Println("\nStarting the sandbox properly...")
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {

--- a/sdk/go/cmd/node-example/main.go
+++ b/sdk/go/cmd/node-example/main.go
@@ -16,7 +16,7 @@ func basicExample() {
 		msb.WithName("node-basic"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -62,7 +62,7 @@ func errorHandlingExample() {
 		msb.WithName("node-error"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -108,7 +108,7 @@ func moduleExample() {
 		msb.WithName("node-module"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -155,7 +155,7 @@ func executionChainingExample() {
 		msb.WithName("node-chain"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -202,7 +202,7 @@ func jsonAndDataExample() {
 		msb.WithName("node-json"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {

--- a/sdk/go/cmd/repl-example/main.go
+++ b/sdk/go/cmd/repl-example/main.go
@@ -17,7 +17,7 @@ func contextManagerEquivalentExample() {
 	)
 
 	// Start the sandbox
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	// Use defer for automatic cleanup (Go's equivalent of context manager)
@@ -52,7 +52,7 @@ func explicitLifecycleExample() {
 	)
 
 	// Start with resource constraints
-	if err := sandbox.Start("", 1024, 2); err != nil { // 1GB RAM, 2 CPU cores
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil { // 1GB RAM, 2 CPU cores
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func executionChainingExample() {
 		msb.WithName("sandbox-chain"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -149,7 +149,7 @@ func dataProcessingExample() {
 		msb.WithName("sandbox-data"),
 	)
 
-	if err := sandbox.Start("", 1024, 2); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 1024, CPUs: 2}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {
@@ -227,7 +227,7 @@ func errorRecoveryExample() {
 		msb.WithName("sandbox-error-recovery"),
 	)
 
-	if err := sandbox.Start("", 512, 1); err != nil {
+	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 		log.Fatalf("Failed to start sandbox: %v", err)
 	}
 	defer func() {

--- a/sdk/go/lang.go
+++ b/sdk/go/lang.go
@@ -9,7 +9,7 @@ import "errors"
 // Example usage:
 //
 //	sandbox := msb.NewPythonSandbox(msb.WithName("my-sandbox"))
-//	if err := sandbox.Start("", 512, 1); err != nil {
+//	if err := sandbox.Start(msb.StartConfig{Memory: 512, CPUs: 1}); err != nil {
 //		log.Fatal(err)
 //	}
 //	defer sandbox.Stop()
@@ -68,11 +68,11 @@ func newLangSandbox(lang progLang, options ...Option) *langSandbox {
 	return n
 }
 
-func (ls *langSandbox) Start(image string, memoryMB int, cpus int) error {
-	if image == "" {
-		image = ls.l.DefaultImage()
+func (ls *langSandbox) Start(cfg StartConfig) error {
+	if cfg.Image == "" {
+		cfg.Image = ls.l.DefaultImage()
 	}
-	return starter{ls.b}.Start(image, memoryMB, cpus)
+	return starter{ls.b}.Start(cfg)
 }
 
 func (ls *langSandbox) Stop() error {

--- a/sdk/javascript/src/types.ts
+++ b/sdk/javascript/src/types.ts
@@ -42,6 +42,46 @@ export interface SandboxOptions {
   cpus?: number;
 
   /**
+   * Volumes to mount
+   */
+  volumes?: string[];
+
+  /**
+   * Ports to expose
+   */
+  ports?: string[];
+
+  /**
+   * Environment variables to use
+   */
+  envs?: string[];
+
+  /**
+   * Sandboxes to depend on
+   */
+  dependsOn?: string[];
+
+  /**
+   * Working directory to use
+   */
+  workdir?: string;
+
+  /**
+   * Shell to use
+   */
+  shell?: string;
+
+  /**
+   * Scripts that can be run
+   */
+  scripts?: Record<string, string>;
+
+  /**
+   * Exec command to run
+   */
+  exec?: string;
+
+  /**
    * Maximum time in seconds to wait for the sandbox to start
    */
   timeout?: number;
@@ -106,6 +146,70 @@ export class SandboxOptionsBuilder {
    */
   cpus(cpus: number): SandboxOptionsBuilder {
     this.options.cpus = cpus;
+    return this;
+  }
+
+  /**
+   * Set volumes
+   */
+  volumes(volumes: string[]): SandboxOptionsBuilder {
+    this.options.volumes = volumes;
+    return this;
+  }
+
+  /**
+   * Set ports
+   */
+  ports(ports: string[]): SandboxOptionsBuilder {
+    this.options.ports = ports;
+    return this;
+  }
+
+  /**
+   * Set environment variables
+   */
+  envs(envs: string[]): SandboxOptionsBuilder {
+    this.options.envs = envs;
+    return this;
+  }
+
+  /**
+   * Set sandbox dependencies
+   */
+  dependsOn(dependsOn: string[]): SandboxOptionsBuilder {
+    this.options.dependsOn = dependsOn;
+    return this;
+  }
+
+  /**
+   * Set working directory
+   */
+  workdir(workdir: string): SandboxOptionsBuilder {
+    this.options.workdir = workdir;
+    return this;
+  }
+
+  /**
+   * Set shell
+   */
+  shell(shell: string): SandboxOptionsBuilder {
+    this.options.shell = shell;
+    return this;
+  }
+
+  /**
+   * Set scripts
+   */
+  scripts(scripts: Record<string, string>): SandboxOptionsBuilder {
+    this.options.scripts = scripts;
+    return this;
+  }
+
+  /**
+   * Set exec command
+   */
+  exec(exec: string): SandboxOptionsBuilder {
+    this.options.exec = exec;
     return this;
   }
 

--- a/sdk/rust/examples/repl.rs
+++ b/sdk/rust/examples/repl.rs
@@ -59,7 +59,7 @@ async fn example_explicit_lifecycle() -> Result<(), Box<dyn Error + Send + Sync>
         image: None,
         memory: 1024, // 1GB RAM
         cpus: 2.0,    // 2 CPU cores
-        timeout: 180.0,
+        ..Default::default()
     };
 
     // Start the sandbox

--- a/sdk/rust/src/base.rs
+++ b/sdk/rust/src/base.rs
@@ -1,12 +1,9 @@
-use std::collections::HashMap;
-use std::env;
-use std::error::Error;
-use std::time::Duration;
+use std::{collections::HashMap, env, error::Error, time::Duration};
 
 use dotenv::dotenv;
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::{Execution, SandboxError, SandboxOptions};
@@ -137,26 +134,53 @@ impl SandboxBase {
     pub async fn start_sandbox(
         &mut self,
         image: Option<String>,
-        memory: u32,
-        cpus: f32,
-        timeout: f32,
+        opts: &crate::StartOptions,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         if self.is_started {
             return Ok(());
         }
 
+        let mut config = json!({
+            "image": image,
+            "memory": opts.memory,
+            "cpus": opts.cpus.round() as i32,
+        });
+
+        if let Some(obj) = config.as_object_mut() {
+            if !opts.volumes.is_empty() {
+                obj.insert("volumes".to_string(), json!(opts.volumes));
+            }
+            if !opts.ports.is_empty() {
+                obj.insert("ports".to_string(), json!(opts.ports));
+            }
+            if !opts.envs.is_empty() {
+                obj.insert("envs".to_string(), json!(opts.envs));
+            }
+            if !opts.depends_on.is_empty() {
+                obj.insert("depends_on".to_string(), json!(opts.depends_on));
+            }
+            if let Some(ref workdir) = opts.workdir {
+                obj.insert("workdir".to_string(), json!(workdir));
+            }
+            if let Some(ref shell) = opts.shell {
+                obj.insert("shell".to_string(), json!(shell));
+            }
+            if !opts.scripts.is_empty() {
+                obj.insert("scripts".to_string(), json!(opts.scripts));
+            }
+            if let Some(ref exec) = opts.exec {
+                obj.insert("exec".to_string(), json!(exec));
+            }
+        }
+
         let params = json!({
             "namespace": self.namespace,
             "sandbox": self.name,
-            "config": {
-                "image": image,
-                "memory": memory,
-                "cpus": cpus.round() as i32,
-            }
+            "config": config,
         });
 
         // Set client timeout to be slightly longer than the server timeout
-        let client_timeout = Duration::from_secs_f32(timeout + 30.0);
+        let client_timeout = Duration::from_secs_f32(opts.timeout + 30.0);
         let client = reqwest::Client::builder().timeout(client_timeout).build()?;
 
         let request_data = json!({
@@ -190,7 +214,7 @@ impl SandboxBase {
                 if e.is_timeout() {
                     return Err(Box::new(SandboxError::Timeout(format!(
                         "Timed out waiting for sandbox to start after {} seconds",
-                        timeout
+                        opts.timeout
                     ))));
                 }
                 return Err(Box::new(SandboxError::HttpError(e.to_string())));

--- a/sdk/rust/src/node.rs
+++ b/sdk/rust/src/node.rs
@@ -1,13 +1,13 @@
 //! Node.js-specific sandbox implementation
 
-use std::error::Error;
-use std::sync::Arc;
+use std::{error::Error, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
-use crate::command::Command;
-use crate::{BaseSandbox, Execution, Metrics, SandboxBase, SandboxOptions, StartOptions};
+use crate::{
+    BaseSandbox, Execution, Metrics, SandboxBase, SandboxOptions, StartOptions, command::Command,
+};
 
 /// Node.js-specific sandbox for executing JavaScript code
 pub struct NodeSandbox {
@@ -82,11 +82,10 @@ impl BaseSandbox for NodeSandbox {
 
         // Get default image
         let default_image = self.get_default_image().await;
-        let image = opts.image.or_else(|| Some(default_image));
+        let image = opts.image.clone().or_else(|| Some(default_image));
 
         let mut base = self.base.lock().await;
-        base.start_sandbox(image, opts.memory, opts.cpus, opts.timeout)
-            .await
+        base.start_sandbox(image, &opts).await
     }
 
     async fn stop(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/sdk/rust/src/python.rs
+++ b/sdk/rust/src/python.rs
@@ -1,13 +1,13 @@
 //! Python-specific sandbox implementation
 
-use std::error::Error;
-use std::sync::Arc;
+use std::{error::Error, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
-use crate::command::Command;
-use crate::{BaseSandbox, Execution, Metrics, SandboxBase, SandboxOptions, StartOptions};
+use crate::{
+    BaseSandbox, Execution, Metrics, SandboxBase, SandboxOptions, StartOptions, command::Command,
+};
 
 /// Python-specific sandbox for executing Python code
 pub struct PythonSandbox {
@@ -82,11 +82,10 @@ impl BaseSandbox for PythonSandbox {
 
         // Get default image
         let default_image = self.get_default_image().await;
-        let image = opts.image.or_else(|| Some(default_image));
+        let image = opts.image.clone().or_else(|| Some(default_image));
 
         let mut base = self.base.lock().await;
-        base.start_sandbox(image, opts.memory, opts.cpus, opts.timeout)
-            .await
+        base.start_sandbox(image, &opts).await
     }
 
     async fn stop(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/sdk/rust/src/start_options.rs
+++ b/sdk/rust/src/start_options.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 /// Options for starting a sandbox
 #[derive(Debug, Clone)]
 pub struct StartOptions {
@@ -10,6 +12,30 @@ pub struct StartOptions {
     /// CPU limit
     pub cpus: f32,
 
+    /// Volumes to mount
+    pub volumes: Vec<String>,
+
+    /// Ports to expose
+    pub ports: Vec<String>,
+
+    /// Environment variables to use
+    pub envs: Vec<String>,
+
+    /// Sandboxes to depend on
+    pub depends_on: Vec<String>,
+
+    /// Working directory to use
+    pub workdir: Option<String>,
+
+    /// Shell to use
+    pub shell: Option<String>,
+
+    /// Scripts that can be run
+    pub scripts: HashMap<String, String>,
+
+    /// Exec command to run
+    pub exec: Option<String>,
+
     /// Maximum time in seconds to wait for the sandbox to start
     pub timeout: f32,
 }
@@ -20,6 +46,14 @@ impl Default for StartOptions {
             image: None,
             memory: 512,
             cpus: 1.0,
+            volumes: Vec::new(),
+            ports: Vec::new(),
+            envs: Vec::new(),
+            depends_on: Vec::new(),
+            workdir: None,
+            shell: None,
+            scripts: HashMap::new(),
+            exec: None,
             timeout: 180.0,
         }
     }


### PR DESCRIPTION
this MR does the following:
- makes the relevant  `volumes`, `ports`, `envs`, `depends_on` and `scripts` all optional
- updates all the SDKs to reflect this new changes (and if a corresponding field didn't exist, i added it).

fixes #367 