### PR TITLE
Add Python SDK CI checks on self-hosted runner

### DIFF
--- a/.github/workflows/sdk-python-integration.yml
+++ b/.github/workflows/sdk-python-integration.yml
@@ -1,0 +1,46 @@
+name: Python SDK Integration Tests
+
+on:
+  pull_request:
+    paths:
+      - "sdk/python/**"
+      - ".github/workflows/sdk-python-integration.yml"
+
+jobs:
+  python-sdk:
+    name: Python SDK Smoke Tests
+    runs-on: self-hosted-Linux-x86
+
+    defaults:
+      run:
+        working-directory: sdk/python
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python SDK
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Verify SDK imports
+        run: |
+          python - <<EOF
+          import microsandbox
+          from microsandbox import PythonSandbox
+          print("Python SDK imports OK")
+          EOF
+
+      - name: Run SDK smoke examples
+        env:
+          MSB_SERVER_URL: http://127.0.0.1:5555
+        run: |
+          python examples/command.py
+          python examples/node.py
+          python examples/metrics.py

--- a/.github/workflows/sdk-python-integration.yml
+++ b/.github/workflows/sdk-python-integration.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   python-sdk:
     name: Python SDK Smoke Tests
-    runs-on: self-hosted-Linux-x86
+    runs-on: self-hosted-linux-x64
 
     defaults:
       run:


### PR DESCRIPTION
## What this PR does

Adds a GitHub Actions workflow to validate the Python SDK using a self-hosted Linux runner with KVM enabled.

The workflow:
- Installs the Python SDK from source
- Verifies imports and basic API surface
- Runs minimal integration smoke checks against a running Microsandbox server

## Why this is needed

GitHub-hosted runners do not support KVM or Apple Silicon, which prevents running the Microsandbox server in CI.
Using a self-hosted runner allows us to start the server and run real SDK integration checks.

This provides early detection of:
- Packaging or install regressions
- Import/API breakage
- Basic runtime compatibility issues

## Scope / Notes

- This PR focuses **only on the Python SDK** as an initial step
- The workflow is structured so other SDKs (Node, Go, Rust) can be added incrementally
- No changes to SDK runtime behavior

## Follow-ups

- Extend CI coverage to additional SDKs
- Add deeper integration tests as the workflows mature
