### PR TITLE
feat(db): add database foundation with migrations, entities, and pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Sandboxfile*
 
 # Retype
 .retype/
+.claude

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -58,16 +188,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -147,6 +372,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +419,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -164,6 +435,21 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -192,6 +478,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,10 +511,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dirs"
@@ -235,14 +659,29 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -270,6 +709,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,10 +753,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -305,6 +789,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -349,6 +839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,7 +863,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -395,6 +896,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +931,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -453,9 +970,83 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -665,6 +1256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,7 +1289,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -710,6 +1318,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -760,10 +1374,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -771,8 +1400,28 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -802,6 +1451,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,8 +1482,11 @@ dependencies = [
  "dirs",
  "futures",
  "microsandbox-filesystem",
+ "microsandbox-migration",
  "microsandbox-utils",
  "reqwest",
+ "sea-orm",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "typed-builder",
@@ -852,6 +1523,13 @@ dependencies = [
 [[package]]
 name = "microsandbox-image"
 version = "0.2.6"
+
+[[package]]
+name = "microsandbox-migration"
+version = "0.2.6"
+dependencies = [
+ "sea-orm-migration",
+]
 
 [[package]]
 name = "microsandbox-network"
@@ -917,12 +1595,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -930,6 +1661,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -942,6 +1679,45 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -961,9 +1737,18 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -971,6 +1756,15 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -985,6 +1779,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1819,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1003,12 +1836,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1041,7 +1938,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1083,13 +1980,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1099,7 +2023,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1121,6 +2054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +2071,44 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
 ]
 
 [[package]]
@@ -1189,10 +2169,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1278,6 +2345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +2375,176 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sea-orm"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive_more",
+ "futures-util",
+ "log",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-binder",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94492e2ab6c045b4cc38013809ce255d14c3d352c9f0d11e6b920e2adc948ad"
+dependencies = [
+ "chrono",
+ "clap",
+ "dotenvy",
+ "glob",
+ "regex",
+ "sea-schema",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7315c0cadb7e60fb17ee2bb282aa27d01911fc2a7e5836ec1d4ac37d19250bb4"
+dependencies = [
+ "async-trait",
+ "clap",
+ "dotenvy",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "inherent",
+ "ordered-float",
+ "rust_decimal",
+ "sea-query-derive",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "rust_decimal",
+ "sea-query",
+ "serde_json",
+ "sqlx",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+dependencies = [
+ "futures",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +2566,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1361,7 +2610,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1375,6 +2624,49 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1394,10 +2686,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1410,6 +2718,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1422,16 +2733,284 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bigdecimal",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rust_decimal",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bigdecimal",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bigdecimal",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rand 0.8.5",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1461,7 +3040,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1483,6 +3062,25 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1511,7 +3109,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1522,7 +3120,47 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1575,7 +3213,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1585,6 +3223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1599,6 +3248,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -1652,8 +3331,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1663,6 +3355,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1688,14 +3395,47 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1717,7 +3457,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1757,6 +3497,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +3558,12 @@ checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1836,7 +3611,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1893,11 +3668,30 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -1930,7 +3724,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1941,7 +3735,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1990,6 +3784,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2028,6 +3831,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2071,6 +3889,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2089,6 +3913,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2104,6 +3934,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2137,6 +3973,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2152,6 +3994,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2173,6 +4021,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2191,6 +4045,12 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2200,6 +4060,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2212,6 +4081,21 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
@@ -2232,7 +4116,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2253,7 +4137,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2273,7 +4157,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2313,7 +4197,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "microsandbox-cli",
     "microsandbox-filesystem",
     "microsandbox-image",
+    "microsandbox-migration",
     "microsandbox-network",
     "microsandbox-protocol",
     "microsandbox-runtime",
@@ -78,7 +79,6 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 serial_test = "3.2.0"
 sha2 = "0.10"
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
 structstruck = "0.5"
 tar = "0.4"
 tempfile = "3.15"
@@ -99,5 +99,7 @@ walkdir = "2.4"
 which = "8"
 xattr = "1.3"
 rstest = "0.26"
+sea-orm = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
+sea-orm-migration = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls"] }
 ureq = "3"
 

--- a/justfile
+++ b/justfile
@@ -25,7 +25,6 @@ build-agentd:
     id=$(docker create microsandbox-agentd-build /dev/null)
     trap 'docker rm "$id" >/dev/null 2>&1' EXIT
     docker cp "$id:/agentd" build/agentd
-    docker rm "$id" > /dev/null
 
 # Build libkrunfw on Linux. Requires: kernel build dependencies (gcc, make, flex, bison, etc.).
 [linux]

--- a/microsandbox-migration/Cargo.toml
+++ b/microsandbox-migration/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "microsandbox-migration"
+description = "Database migrations for the microsandbox project."
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[lib]
+name = "microsandbox_migration"
+path = "lib/lib.rs"
+
+[dependencies]
+sea-orm-migration.workspace = true

--- a/microsandbox-migration/lib/lib.rs
+++ b/microsandbox-migration/lib/lib.rs
@@ -1,0 +1,35 @@
+//! Database migrations for microsandbox.
+
+mod m20260305_000001_create_image_tables;
+mod m20260305_000002_create_sandbox_tables;
+mod m20260305_000003_create_storage_tables;
+
+use sea_orm_migration::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use sea_orm_migration::MigratorTrait;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The migrator that runs all migrations in order.
+pub struct Migrator;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![
+            Box::new(m20260305_000001_create_image_tables::Migration),
+            Box::new(m20260305_000002_create_sandbox_tables::Migration),
+            Box::new(m20260305_000003_create_storage_tables::Migration),
+        ]
+    }
+}

--- a/microsandbox-migration/lib/m20260305_000001_create_image_tables.rs
+++ b/microsandbox-migration/lib/m20260305_000001_create_image_tables.rs
@@ -1,0 +1,353 @@
+//! Migration: Create image tables (images, indexes, manifests, configs, layers, manifest_layers).
+
+use sea_orm_migration::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Types: Identifiers
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Iden)]
+enum Image {
+    Table,
+    Id,
+    Reference,
+    SizeBytes,
+    LastUsedAt,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum Index {
+    Table,
+    Id,
+    ImageId,
+    SchemaVersion,
+    MediaType,
+    PlatformOs,
+    PlatformArch,
+    PlatformVariant,
+    Annotations,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum Manifest {
+    Table,
+    Id,
+    ImageId,
+    IndexId,
+    Digest,
+    SchemaVersion,
+    MediaType,
+    Annotations,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum Config {
+    Table,
+    Id,
+    ManifestId,
+    Digest,
+    Architecture,
+    Os,
+    OsVariant,
+    Env,
+    Cmd,
+    Entrypoint,
+    WorkingDir,
+    Volumes,
+    ExposedPorts,
+    User,
+    RootfsType,
+    RootfsDiffIds,
+    History,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum Layer {
+    Table,
+    Id,
+    Digest,
+    DiffId,
+    MediaType,
+    SizeBytes,
+    CreatedAt,
+}
+
+#[derive(Iden)]
+enum ManifestLayer {
+    Table,
+    Id,
+    ManifestId,
+    LayerId,
+    Position,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260305_000001_create_image_tables"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // images
+        manager
+            .create_table(
+                Table::create()
+                    .table(Image::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Image::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Image::Reference)
+                            .text()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Image::SizeBytes).big_integer())
+                    .col(ColumnDef::new(Image::LastUsedAt).date_time())
+                    .col(ColumnDef::new(Image::CreatedAt).date_time())
+                    .to_owned(),
+            )
+            .await?;
+
+        // indexes
+        manager
+            .create_table(
+                Table::create()
+                    .table(Index::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Index::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Index::ImageId).integer().not_null())
+                    .col(ColumnDef::new(Index::SchemaVersion).integer())
+                    .col(ColumnDef::new(Index::MediaType).text())
+                    .col(ColumnDef::new(Index::PlatformOs).text())
+                    .col(ColumnDef::new(Index::PlatformArch).text())
+                    .col(ColumnDef::new(Index::PlatformVariant).text())
+                    .col(ColumnDef::new(Index::Annotations).text())
+                    .col(ColumnDef::new(Index::CreatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Index::Table, Index::ImageId)
+                            .to(Image::Table, Image::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // manifests
+        manager
+            .create_table(
+                Table::create()
+                    .table(Manifest::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Manifest::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Manifest::ImageId).integer().not_null())
+                    .col(ColumnDef::new(Manifest::IndexId).integer())
+                    .col(
+                        ColumnDef::new(Manifest::Digest)
+                            .text()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Manifest::SchemaVersion).integer())
+                    .col(ColumnDef::new(Manifest::MediaType).text())
+                    .col(ColumnDef::new(Manifest::Annotations).text())
+                    .col(ColumnDef::new(Manifest::CreatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Manifest::Table, Manifest::ImageId)
+                            .to(Image::Table, Image::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Manifest::Table, Manifest::IndexId)
+                            .to(Index::Table, Index::Id)
+                            .on_delete(ForeignKeyAction::SetNull),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // configs
+        manager
+            .create_table(
+                Table::create()
+                    .table(Config::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Config::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Config::ManifestId)
+                            .integer()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Config::Digest).text().not_null())
+                    .col(ColumnDef::new(Config::Architecture).text())
+                    .col(ColumnDef::new(Config::Os).text())
+                    .col(ColumnDef::new(Config::OsVariant).text())
+                    .col(ColumnDef::new(Config::Env).text())
+                    .col(ColumnDef::new(Config::Cmd).text())
+                    .col(ColumnDef::new(Config::Entrypoint).text())
+                    .col(ColumnDef::new(Config::WorkingDir).text())
+                    .col(ColumnDef::new(Config::Volumes).text())
+                    .col(ColumnDef::new(Config::ExposedPorts).text())
+                    .col(ColumnDef::new(Config::User).text())
+                    .col(ColumnDef::new(Config::RootfsType).text())
+                    .col(ColumnDef::new(Config::RootfsDiffIds).text())
+                    .col(ColumnDef::new(Config::History).text())
+                    .col(ColumnDef::new(Config::CreatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Config::Table, Config::ManifestId)
+                            .to(Manifest::Table, Manifest::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // layers
+        manager
+            .create_table(
+                Table::create()
+                    .table(Layer::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Layer::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Layer::Digest)
+                            .text()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Layer::DiffId).text().not_null())
+                    .col(ColumnDef::new(Layer::MediaType).text())
+                    .col(ColumnDef::new(Layer::SizeBytes).big_integer())
+                    .col(ColumnDef::new(Layer::CreatedAt).date_time())
+                    .to_owned(),
+            )
+            .await?;
+
+        // manifest_layers
+        manager
+            .create_table(
+                Table::create()
+                    .table(ManifestLayer::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ManifestLayer::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ManifestLayer::ManifestId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ManifestLayer::LayerId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(ManifestLayer::Position).integer().not_null())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(ManifestLayer::Table, ManifestLayer::ManifestId)
+                            .to(Manifest::Table, Manifest::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(ManifestLayer::Table, ManifestLayer::LayerId)
+                            .to(Layer::Table, Layer::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Unique index on manifest_layers(manifest_id, layer_id)
+        manager
+            .create_index(
+                sea_orm_migration::prelude::Index::create()
+                    .name("idx_manifest_layers_unique")
+                    .table(ManifestLayer::Table)
+                    .col(ManifestLayer::ManifestId)
+                    .col(ManifestLayer::LayerId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(ManifestLayer::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Layer::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Config::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Manifest::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Index::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Image::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}

--- a/microsandbox-migration/lib/m20260305_000002_create_sandbox_tables.rs
+++ b/microsandbox-migration/lib/m20260305_000002_create_sandbox_tables.rs
@@ -1,0 +1,297 @@
+//! Migration: Create sandbox tables (sandboxes, supervisors, microvms, msbnets, sandbox_metrics).
+
+use sea_orm_migration::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Types: Identifiers
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Iden)]
+enum Sandbox {
+    Table,
+    Id,
+    Name,
+    Config,
+    Status,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(Iden)]
+enum Supervisor {
+    Table,
+    Id,
+    SandboxId,
+    Pid,
+    Status,
+    StartedAt,
+    StoppedAt,
+}
+
+#[derive(Iden)]
+enum Microvm {
+    Table,
+    Id,
+    SandboxId,
+    SupervisorId,
+    Pid,
+    Status,
+    ExitCode,
+    ExitSignal,
+    TerminationReason,
+    TerminationDetail,
+    SignalsSent,
+    StartedAt,
+    TerminatedAt,
+}
+
+#[derive(Iden)]
+enum Msbnet {
+    Table,
+    Id,
+    SandboxId,
+    SupervisorId,
+    Pid,
+    Status,
+    StartedAt,
+    StoppedAt,
+}
+
+#[derive(Iden)]
+enum SandboxMetric {
+    Table,
+    Id,
+    SandboxId,
+    CpuPercent,
+    MemoryBytes,
+    DiskReadBytes,
+    DiskWriteBytes,
+    NetRxBytes,
+    NetTxBytes,
+    SampledAt,
+    CreatedAt,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260305_000002_create_sandbox_tables"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // sandboxes
+        manager
+            .create_table(
+                Table::create()
+                    .table(Sandbox::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Sandbox::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Sandbox::Name)
+                            .text()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Sandbox::Config).text().not_null())
+                    .col(ColumnDef::new(Sandbox::Status).text().not_null())
+                    .col(ColumnDef::new(Sandbox::CreatedAt).date_time())
+                    .col(ColumnDef::new(Sandbox::UpdatedAt).date_time())
+                    .to_owned(),
+            )
+            .await?;
+
+        // supervisors
+        manager
+            .create_table(
+                Table::create()
+                    .table(Supervisor::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Supervisor::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Supervisor::SandboxId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Supervisor::Pid).integer())
+                    .col(ColumnDef::new(Supervisor::Status).text().not_null())
+                    .col(ColumnDef::new(Supervisor::StartedAt).date_time())
+                    .col(ColumnDef::new(Supervisor::StoppedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Supervisor::Table, Supervisor::SandboxId)
+                            .to(Sandbox::Table, Sandbox::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // microvms
+        manager
+            .create_table(
+                Table::create()
+                    .table(Microvm::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Microvm::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Microvm::SandboxId).integer().not_null())
+                    .col(ColumnDef::new(Microvm::SupervisorId).integer().not_null())
+                    .col(ColumnDef::new(Microvm::Pid).integer())
+                    .col(ColumnDef::new(Microvm::Status).text().not_null())
+                    .col(ColumnDef::new(Microvm::ExitCode).integer())
+                    .col(ColumnDef::new(Microvm::ExitSignal).integer())
+                    .col(ColumnDef::new(Microvm::TerminationReason).text())
+                    .col(ColumnDef::new(Microvm::TerminationDetail).text())
+                    .col(ColumnDef::new(Microvm::SignalsSent).text())
+                    .col(ColumnDef::new(Microvm::StartedAt).date_time())
+                    .col(ColumnDef::new(Microvm::TerminatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Microvm::Table, Microvm::SandboxId)
+                            .to(Sandbox::Table, Sandbox::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Microvm::Table, Microvm::SupervisorId)
+                            .to(Supervisor::Table, Supervisor::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // msbnets
+        manager
+            .create_table(
+                Table::create()
+                    .table(Msbnet::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Msbnet::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Msbnet::SandboxId).integer().not_null())
+                    .col(ColumnDef::new(Msbnet::SupervisorId).integer().not_null())
+                    .col(ColumnDef::new(Msbnet::Pid).integer())
+                    .col(ColumnDef::new(Msbnet::Status).text().not_null())
+                    .col(ColumnDef::new(Msbnet::StartedAt).date_time())
+                    .col(ColumnDef::new(Msbnet::StoppedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Msbnet::Table, Msbnet::SandboxId)
+                            .to(Sandbox::Table, Sandbox::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Msbnet::Table, Msbnet::SupervisorId)
+                            .to(Supervisor::Table, Supervisor::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // sandbox_metrics
+        manager
+            .create_table(
+                Table::create()
+                    .table(SandboxMetric::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(SandboxMetric::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(SandboxMetric::SandboxId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SandboxMetric::CpuPercent).float())
+                    .col(ColumnDef::new(SandboxMetric::MemoryBytes).big_integer())
+                    .col(ColumnDef::new(SandboxMetric::DiskReadBytes).big_integer())
+                    .col(ColumnDef::new(SandboxMetric::DiskWriteBytes).big_integer())
+                    .col(ColumnDef::new(SandboxMetric::NetRxBytes).big_integer())
+                    .col(ColumnDef::new(SandboxMetric::NetTxBytes).big_integer())
+                    .col(ColumnDef::new(SandboxMetric::SampledAt).date_time())
+                    .col(ColumnDef::new(SandboxMetric::CreatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(SandboxMetric::Table, SandboxMetric::SandboxId)
+                            .to(Sandbox::Table, Sandbox::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Composite index for time-range queries on sandbox metrics
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_sandbox_metrics_sandbox_sampled")
+                    .table(SandboxMetric::Table)
+                    .col(SandboxMetric::SandboxId)
+                    .col(SandboxMetric::SampledAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(SandboxMetric::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Msbnet::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Microvm::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Supervisor::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Sandbox::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}

--- a/microsandbox-migration/lib/m20260305_000003_create_storage_tables.rs
+++ b/microsandbox-migration/lib/m20260305_000003_create_storage_tables.rs
@@ -1,0 +1,149 @@
+//! Migration: Create storage tables (volumes, snapshots).
+
+use sea_orm_migration::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Types: Identifiers
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Iden)]
+enum Volume {
+    Table,
+    Id,
+    Name,
+    QuotaMib,
+    SizeBytes,
+    Labels,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(Iden)]
+enum Snapshot {
+    Table,
+    Id,
+    Name,
+    SandboxId,
+    SizeBytes,
+    Description,
+    CreatedAt,
+}
+
+/// Reference to the sandbox table (defined in migration 2).
+#[derive(Iden)]
+enum Sandbox {
+    Table,
+    Id,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260305_000003_create_storage_tables"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // volumes
+        manager
+            .create_table(
+                Table::create()
+                    .table(Volume::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Volume::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Volume::Name)
+                            .text()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Volume::QuotaMib).integer())
+                    .col(ColumnDef::new(Volume::SizeBytes).big_integer())
+                    .col(ColumnDef::new(Volume::Labels).text())
+                    .col(ColumnDef::new(Volume::CreatedAt).date_time())
+                    .col(ColumnDef::new(Volume::UpdatedAt).date_time())
+                    .to_owned(),
+            )
+            .await?;
+
+        // snapshots
+        manager
+            .create_table(
+                Table::create()
+                    .table(Snapshot::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Snapshot::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Snapshot::Name).text().not_null())
+                    .col(ColumnDef::new(Snapshot::SandboxId).integer())
+                    .col(ColumnDef::new(Snapshot::SizeBytes).big_integer())
+                    .col(ColumnDef::new(Snapshot::Description).text())
+                    .col(ColumnDef::new(Snapshot::CreatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Snapshot::Table, Snapshot::SandboxId)
+                            .to(Sandbox::Table, Sandbox::Id)
+                            .on_delete(ForeignKeyAction::SetNull),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Unique index on snapshots(name, sandbox_id) for sandbox-bound snapshots
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_snapshots_name_sandbox_unique")
+                    .table(Snapshot::Table)
+                    .col(Snapshot::Name)
+                    .col(Snapshot::SandboxId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        // Partial unique index for sandbox-independent snapshots.
+        // SQLite treats NULLs as distinct in unique indexes, so the composite
+        // index above won't prevent duplicate names when sandbox_id IS NULL.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE UNIQUE INDEX idx_snapshots_name_unique_no_sandbox ON snapshot (name) WHERE sandbox_id IS NULL",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Snapshot::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Volume::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}

--- a/microsandbox/Cargo.toml
+++ b/microsandbox/Cargo.toml
@@ -20,10 +20,12 @@ prebuilt = ["microsandbox-filesystem/prebuilt", "dep:ureq"]
 
 [dependencies]
 microsandbox-filesystem = { path = "../microsandbox-filesystem" }
+microsandbox-migration = { path = "../microsandbox-migration" }
 microsandbox-utils = { path = "../microsandbox-utils" }
 dirs.workspace = true
 futures.workspace = true
 reqwest.workspace = true
+sea-orm.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 typed-builder.workspace = true
@@ -33,3 +35,4 @@ microsandbox-utils = { path = "../microsandbox-utils" }
 ureq = { workspace = true, optional = true }
 
 [dev-dependencies]
+tempfile.workspace = true

--- a/microsandbox/lib/db/entity/config.rs
+++ b/microsandbox/lib/db/entity/config.rs
@@ -1,0 +1,61 @@
+//! Entity definition for the `configs` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The OCI image config entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "config")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    #[sea_orm(unique)]
+    pub manifest_id: i32,
+    pub digest: String,
+    pub architecture: Option<String>,
+    pub os: Option<String>,
+    pub os_variant: Option<String>,
+    pub env: Option<String>,
+    pub cmd: Option<String>,
+    pub entrypoint: Option<String>,
+    pub working_dir: Option<String>,
+    pub volumes: Option<String>,
+    pub exposed_ports: Option<String>,
+    pub user: Option<String>,
+    pub rootfs_type: Option<String>,
+    pub rootfs_diff_ids: Option<String>,
+    pub history: Option<String>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the config entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A config belongs to a manifest (1:1).
+    #[sea_orm(
+        belongs_to = "super::manifest::Entity",
+        from = "Column::ManifestId",
+        to = "super::manifest::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Manifest,
+}
+
+impl Related<super::manifest::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Manifest.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/image.rs
+++ b/microsandbox/lib/db/entity/image.rs
@@ -1,0 +1,54 @@
+//! Entity definition for the `images` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The OCI image entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "image")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    #[sea_orm(unique)]
+    pub reference: String,
+    pub size_bytes: Option<i64>,
+    pub last_used_at: Option<DateTime>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the image entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// An image has many indexes.
+    #[sea_orm(has_many = "super::index::Entity")]
+    Index,
+
+    /// An image has many manifests.
+    #[sea_orm(has_many = "super::manifest::Entity")]
+    Manifest,
+}
+
+impl Related<super::index::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Index.def()
+    }
+}
+
+impl Related<super::manifest::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Manifest.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/index.rs
+++ b/microsandbox/lib/db/entity/index.rs
@@ -1,0 +1,62 @@
+//! Entity definition for the `indexes` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The OCI index entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "index")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub image_id: i32,
+    pub schema_version: Option<i32>,
+    pub media_type: Option<String>,
+    pub platform_os: Option<String>,
+    pub platform_arch: Option<String>,
+    pub platform_variant: Option<String>,
+    pub annotations: Option<String>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the index entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// An index belongs to an image.
+    #[sea_orm(
+        belongs_to = "super::image::Entity",
+        from = "Column::ImageId",
+        to = "super::image::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Image,
+
+    /// An index has many manifests.
+    #[sea_orm(has_many = "super::manifest::Entity")]
+    Manifest,
+}
+
+impl Related<super::image::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Image.def()
+    }
+}
+
+impl Related<super::manifest::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Manifest.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/layer.rs
+++ b/microsandbox/lib/db/entity/layer.rs
@@ -1,0 +1,55 @@
+//! Entity definition for the `layers` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The OCI layer entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "layer")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    #[sea_orm(unique)]
+    pub digest: String,
+    pub diff_id: String,
+    pub media_type: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the layer entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A layer has many manifest_layers.
+    #[sea_orm(has_many = "super::manifest_layer::Entity")]
+    ManifestLayer,
+}
+
+impl Related<super::manifest_layer::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::ManifestLayer.def()
+    }
+}
+
+impl Related<super::manifest::Entity> for Entity {
+    fn to() -> RelationDef {
+        super::manifest_layer::Relation::Manifest.def()
+    }
+
+    fn via() -> Option<RelationDef> {
+        Some(super::manifest_layer::Relation::Layer.def().rev())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/manifest.rs
+++ b/microsandbox/lib/db/entity/manifest.rs
@@ -1,0 +1,97 @@
+//! Entity definition for the `manifests` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The OCI manifest entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "manifest")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub image_id: i32,
+    pub index_id: Option<i32>,
+    #[sea_orm(unique)]
+    pub digest: String,
+    pub schema_version: Option<i32>,
+    pub media_type: Option<String>,
+    pub annotations: Option<String>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the manifest entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A manifest belongs to an image.
+    #[sea_orm(
+        belongs_to = "super::image::Entity",
+        from = "Column::ImageId",
+        to = "super::image::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Image,
+
+    /// A manifest optionally belongs to an index.
+    #[sea_orm(
+        belongs_to = "super::index::Entity",
+        from = "Column::IndexId",
+        to = "super::index::Column::Id",
+        on_delete = "SetNull"
+    )]
+    Index,
+
+    /// A manifest has one config.
+    #[sea_orm(has_one = "super::config::Entity")]
+    Config,
+
+    /// A manifest has many manifest_layers.
+    #[sea_orm(has_many = "super::manifest_layer::Entity")]
+    ManifestLayer,
+}
+
+impl Related<super::image::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Image.def()
+    }
+}
+
+impl Related<super::index::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Index.def()
+    }
+}
+
+impl Related<super::config::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Config.def()
+    }
+}
+
+impl Related<super::manifest_layer::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::ManifestLayer.def()
+    }
+}
+
+impl Related<super::layer::Entity> for Entity {
+    fn to() -> RelationDef {
+        super::manifest_layer::Relation::Layer.def()
+    }
+
+    fn via() -> Option<RelationDef> {
+        Some(super::manifest_layer::Relation::Manifest.def().rev())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/manifest_layer.rs
+++ b/microsandbox/lib/db/entity/manifest_layer.rs
@@ -1,0 +1,62 @@
+//! Entity definition for the `manifest_layers` junction table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The manifest-layer junction entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "manifest_layer")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub manifest_id: i32,
+    pub layer_id: i32,
+    pub position: i32,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the manifest_layer entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A manifest_layer belongs to a manifest.
+    #[sea_orm(
+        belongs_to = "super::manifest::Entity",
+        from = "Column::ManifestId",
+        to = "super::manifest::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Manifest,
+
+    /// A manifest_layer belongs to a layer.
+    #[sea_orm(
+        belongs_to = "super::layer::Entity",
+        from = "Column::LayerId",
+        to = "super::layer::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Layer,
+}
+
+impl Related<super::manifest::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Manifest.def()
+    }
+}
+
+impl Related<super::layer::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Layer.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/microvm.rs
+++ b/microsandbox/lib/db/entity/microvm.rs
@@ -1,0 +1,70 @@
+//! Entity definition for the `microvms` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The microVM process entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "microvm")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub sandbox_id: i32,
+    pub supervisor_id: i32,
+    pub pid: Option<i32>,
+    pub status: String,
+    pub exit_code: Option<i32>,
+    pub exit_signal: Option<i32>,
+    pub termination_reason: Option<String>,
+    pub termination_detail: Option<String>,
+    pub signals_sent: Option<String>,
+    pub started_at: Option<DateTime>,
+    pub terminated_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the microvm entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A microvm belongs to a sandbox.
+    #[sea_orm(
+        belongs_to = "super::sandbox::Entity",
+        from = "Column::SandboxId",
+        to = "super::sandbox::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Sandbox,
+
+    /// A microvm belongs to a supervisor.
+    #[sea_orm(
+        belongs_to = "super::supervisor::Entity",
+        from = "Column::SupervisorId",
+        to = "super::supervisor::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Supervisor,
+}
+
+impl Related<super::sandbox::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sandbox.def()
+    }
+}
+
+impl Related<super::supervisor::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Supervisor.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/mod.rs
+++ b/microsandbox/lib/db/entity/mod.rs
@@ -1,0 +1,15 @@
+//! SeaORM entity definitions for all microsandbox database tables.
+
+pub mod config;
+pub mod image;
+pub mod index;
+pub mod layer;
+pub mod manifest;
+pub mod manifest_layer;
+pub mod microvm;
+pub mod msbnet;
+pub mod sandbox;
+pub mod sandbox_metric;
+pub mod snapshot;
+pub mod supervisor;
+pub mod volume;

--- a/microsandbox/lib/db/entity/msbnet.rs
+++ b/microsandbox/lib/db/entity/msbnet.rs
@@ -1,0 +1,65 @@
+//! Entity definition for the `msbnets` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The msbnet process entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "msbnet")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub sandbox_id: i32,
+    pub supervisor_id: i32,
+    pub pid: Option<i32>,
+    pub status: String,
+    pub started_at: Option<DateTime>,
+    pub stopped_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the msbnet entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// An msbnet belongs to a sandbox.
+    #[sea_orm(
+        belongs_to = "super::sandbox::Entity",
+        from = "Column::SandboxId",
+        to = "super::sandbox::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Sandbox,
+
+    /// An msbnet belongs to a supervisor.
+    #[sea_orm(
+        belongs_to = "super::supervisor::Entity",
+        from = "Column::SupervisorId",
+        to = "super::supervisor::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Supervisor,
+}
+
+impl Related<super::sandbox::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sandbox.def()
+    }
+}
+
+impl Related<super::supervisor::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Supervisor.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/sandbox.rs
+++ b/microsandbox/lib/db/entity/sandbox.rs
@@ -1,0 +1,85 @@
+//! Entity definition for the `sandboxes` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The sandbox entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "sandbox")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    #[sea_orm(unique)]
+    pub name: String,
+    pub config: String,
+    pub status: String,
+    pub created_at: Option<DateTime>,
+    pub updated_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the sandbox entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A sandbox has many supervisors.
+    #[sea_orm(has_many = "super::supervisor::Entity")]
+    Supervisor,
+
+    /// A sandbox has many microvms.
+    #[sea_orm(has_many = "super::microvm::Entity")]
+    Microvm,
+
+    /// A sandbox has many msbnets.
+    #[sea_orm(has_many = "super::msbnet::Entity")]
+    Msbnet,
+
+    /// A sandbox has many metrics.
+    #[sea_orm(has_many = "super::sandbox_metric::Entity")]
+    SandboxMetric,
+
+    /// A sandbox has many snapshots.
+    #[sea_orm(has_many = "super::snapshot::Entity")]
+    Snapshot,
+}
+
+impl Related<super::supervisor::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Supervisor.def()
+    }
+}
+
+impl Related<super::microvm::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Microvm.def()
+    }
+}
+
+impl Related<super::msbnet::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Msbnet.def()
+    }
+}
+
+impl Related<super::sandbox_metric::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SandboxMetric.def()
+    }
+}
+
+impl Related<super::snapshot::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Snapshot.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/sandbox_metric.rs
+++ b/microsandbox/lib/db/entity/sandbox_metric.rs
@@ -1,0 +1,53 @@
+//! Entity definition for the `sandbox_metrics` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The sandbox metrics entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "sandbox_metric")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub sandbox_id: i32,
+    pub cpu_percent: Option<f32>,
+    pub memory_bytes: Option<i64>,
+    pub disk_read_bytes: Option<i64>,
+    pub disk_write_bytes: Option<i64>,
+    pub net_rx_bytes: Option<i64>,
+    pub net_tx_bytes: Option<i64>,
+    pub sampled_at: Option<DateTime>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the sandbox_metric entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A metric belongs to a sandbox.
+    #[sea_orm(
+        belongs_to = "super::sandbox::Entity",
+        from = "Column::SandboxId",
+        to = "super::sandbox::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Sandbox,
+}
+
+impl Related<super::sandbox::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sandbox.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/snapshot.rs
+++ b/microsandbox/lib/db/entity/snapshot.rs
@@ -1,0 +1,49 @@
+//! Entity definition for the `snapshots` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The snapshot entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "snapshot")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+    pub sandbox_id: Option<i32>,
+    pub size_bytes: Option<i64>,
+    pub description: Option<String>,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the snapshot entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A snapshot optionally belongs to a sandbox.
+    #[sea_orm(
+        belongs_to = "super::sandbox::Entity",
+        from = "Column::SandboxId",
+        to = "super::sandbox::Column::Id",
+        on_delete = "SetNull"
+    )]
+    Sandbox,
+}
+
+impl Related<super::sandbox::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sandbox.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/supervisor.rs
+++ b/microsandbox/lib/db/entity/supervisor.rs
@@ -1,0 +1,69 @@
+//! Entity definition for the `supervisors` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The supervisor process entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "supervisor")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub sandbox_id: i32,
+    pub pid: Option<i32>,
+    pub status: String,
+    pub started_at: Option<DateTime>,
+    pub stopped_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the supervisor entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// A supervisor belongs to a sandbox.
+    #[sea_orm(
+        belongs_to = "super::sandbox::Entity",
+        from = "Column::SandboxId",
+        to = "super::sandbox::Column::Id",
+        on_delete = "Cascade"
+    )]
+    Sandbox,
+
+    /// A supervisor has many microvms.
+    #[sea_orm(has_many = "super::microvm::Entity")]
+    Microvm,
+
+    /// A supervisor has many msbnets.
+    #[sea_orm(has_many = "super::msbnet::Entity")]
+    Msbnet,
+}
+
+impl Related<super::sandbox::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sandbox.def()
+    }
+}
+
+impl Related<super::microvm::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Microvm.def()
+    }
+}
+
+impl Related<super::msbnet::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Msbnet.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/entity/volume.rs
+++ b/microsandbox/lib/db/entity/volume.rs
@@ -1,0 +1,36 @@
+//! Entity definition for the `volumes` table.
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The volume entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "volume")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    #[sea_orm(unique)]
+    pub name: String,
+    pub quota_mib: Option<i32>,
+    pub size_bytes: Option<i64>,
+    pub labels: Option<String>,
+    pub created_at: Option<DateTime>,
+    pub updated_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the volume entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/microsandbox/lib/db/mod.rs
+++ b/microsandbox/lib/db/mod.rs
@@ -1,0 +1,194 @@
+//! Database connection pool and entity definitions.
+//!
+//! Provides dual-pool access for global (`~/.microsandbox/db/msb.db`) and
+//! project-local (`.microsandbox/db/msb.db`) databases. Migrations are
+//! automatically applied on first connection.
+
+#[allow(missing_docs)]
+pub mod entity;
+
+use std::path::{Path, PathBuf};
+
+use microsandbox_migration::{Migrator, MigratorTrait};
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use tokio::sync::OnceCell;
+
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Default maximum number of connections in the pool.
+const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+static GLOBAL_POOL: OnceCell<DatabaseConnection> = OnceCell::const_new();
+static PROJECT_POOL: OnceCell<(PathBuf, DatabaseConnection)> = OnceCell::const_new();
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Initialize the global database connection pool at `~/.microsandbox/db/msb.db`.
+///
+/// Migrations are applied automatically. This is idempotent — calling it
+/// multiple times returns the existing pool.
+pub async fn init_global(max_connections: Option<u32>) -> MicrosandboxResult<&'static DatabaseConnection> {
+    GLOBAL_POOL
+        .get_or_try_init(|| async {
+            let base = dirs::home_dir()
+                .ok_or_else(|| crate::MicrosandboxError::Custom("cannot determine home directory".into()))?;
+
+            let db_dir = base
+                .join(microsandbox_utils::BASE_DIR_NAME)
+                .join(microsandbox_utils::DB_SUBDIR);
+
+            connect_and_migrate(&db_dir, max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS)).await
+        })
+        .await
+}
+
+/// Initialize a project-local database connection pool at `<project>/.microsandbox/db/msb.db`.
+///
+/// Migrations are applied automatically. This is idempotent — calling it
+/// multiple times returns the existing pool. Returns an error if called
+/// with a different project directory than the first call.
+pub async fn init_project(
+    project_dir: impl AsRef<Path>,
+    max_connections: Option<u32>,
+) -> MicrosandboxResult<&'static DatabaseConnection> {
+    let requested = project_dir.as_ref().to_path_buf();
+
+    let pair = PROJECT_POOL
+        .get_or_try_init(|| async {
+            let db_dir = requested
+                .join(microsandbox_utils::BASE_DIR_NAME)
+                .join(microsandbox_utils::DB_SUBDIR);
+
+            let conn = connect_and_migrate(&db_dir, max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS)).await?;
+            Ok::<_, crate::MicrosandboxError>((requested.clone(), conn))
+        })
+        .await?;
+
+    // Verify the requested project matches the initialized one.
+    if pair.0 != requested {
+        return Err(crate::MicrosandboxError::Custom(format!(
+            "project pool already initialized for '{}', cannot reinitialize for '{}'",
+            pair.0.display(),
+            requested.display(),
+        )));
+    }
+
+    Ok(&pair.1)
+}
+
+/// Get the global database connection pool.
+///
+/// Returns `None` if [`init_global`] has not been called yet.
+pub fn global() -> Option<&'static DatabaseConnection> {
+    GLOBAL_POOL.get()
+}
+
+/// Get the project-local database connection pool.
+///
+/// Returns `None` if [`init_project`] has not been called yet.
+pub fn project() -> Option<&'static DatabaseConnection> {
+    PROJECT_POOL.get().map(|(_, conn)| conn)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+async fn connect_and_migrate(
+    db_dir: &Path,
+    max_connections: u32,
+) -> MicrosandboxResult<DatabaseConnection> {
+    tokio::fs::create_dir_all(db_dir).await?;
+
+    let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+    let db_path_str = db_path.to_str().ok_or_else(|| {
+        crate::MicrosandboxError::Custom(format!(
+            "database path is not valid UTF-8: {}",
+            db_path.display()
+        ))
+    })?;
+    let db_url = format!("sqlite://{db_path_str}?mode=rwc");
+
+    let mut opts = ConnectOptions::new(&db_url);
+    opts.max_connections(max_connections);
+
+    let conn = Database::connect(opts).await?;
+    Migrator::up(&conn, None).await?;
+
+    Ok(conn)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, Statement};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_connect_and_migrate_creates_db_and_tables() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+
+        let conn = connect_and_migrate(&db_dir, 1).await.unwrap();
+
+        // DB file should exist on disk.
+        assert!(db_dir.join(microsandbox_utils::DB_FILENAME).exists());
+
+        // All 13 tables should be present.
+        let rows = conn
+            .query_all(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'seaql_%' AND name != 'sqlite_sequence' ORDER BY name",
+            ))
+            .await
+            .unwrap();
+
+        let table_names: Vec<String> = rows
+            .iter()
+            .map(|r| r.try_get_by_index::<String>(0).unwrap())
+            .collect();
+
+        let expected = vec![
+            "config",
+            "image",
+            "index",
+            "layer",
+            "manifest",
+            "manifest_layer",
+            "microvm",
+            "msbnet",
+            "sandbox",
+            "sandbox_metric",
+            "snapshot",
+            "supervisor",
+            "volume",
+        ];
+
+        assert_eq!(table_names, expected);
+    }
+
+    #[tokio::test]
+    async fn test_connect_and_migrate_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+
+        let conn1 = connect_and_migrate(&db_dir, 1).await.unwrap();
+
+        // Running migrations again on the same DB should succeed.
+        Migrator::up(&conn1, None).await.unwrap();
+    }
+}

--- a/microsandbox/lib/error.rs
+++ b/microsandbox/lib/error.rs
@@ -22,6 +22,10 @@ pub enum MicrosandboxError {
     #[error("libkrunfw not found: {0}")]
     LibkrunfwNotFound(String),
 
+    /// A database error occurred.
+    #[error("database error: {0}")]
+    Database(#[from] sea_orm::DbErr),
+
     /// A custom error message.
     #[error("{0}")]
     Custom(String),

--- a/microsandbox/lib/lib.rs
+++ b/microsandbox/lib/lib.rs
@@ -9,6 +9,8 @@ mod error;
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+#[allow(dead_code)]
+pub(crate) mod db;
 pub mod setup;
 
 pub use error::*;


### PR DESCRIPTION
## Summary

- Add the complete database layer (Phase 2.5) that all subsequent phases (3-14) depend on
- Create `microsandbox-migration` crate with 3 grouped SeaORM migrations defining 13 tables across image, sandbox, and storage domains
- Implement 13 SeaORM entity definitions with full relationship graph in `microsandbox/lib/db/entity/`
- Implement dual `OnceCell` connection pool for global and project-local SQLite databases with auto-migration on first connect
- Add `sea-orm` 1.1 and `sea-orm-migration` 1.1 workspace dependencies; remove unused `sqlx` dependency

## Changes

### New crate: `microsandbox-migration/`
- `Cargo.toml` with `sea-orm-migration` dependency
- `lib/lib.rs` with `Migrator` struct implementing `MigratorTrait`, re-exporting `MigratorTrait` for consumers
- `m20260305_000001_create_image_tables.rs`: 6 tables (image, index, manifest, config, layer, manifest_layer) with FK cascades, unique constraints, and composite unique index on manifest_layers
- `m20260305_000002_create_sandbox_tables.rs`: 5 tables (sandbox, supervisor, microvm, msbnet, sandbox_metric) with FK cascades and composite index on `(sandbox_id, sampled_at)` for time-series queries
- `m20260305_000003_create_storage_tables.rs`: 2 tables (volume, snapshot) with ON DELETE SET NULL for snapshot-sandbox FK, composite unique index on `(name, sandbox_id)`, and partial unique index `WHERE sandbox_id IS NULL` to handle SQLite NULL-distinctness

### New module: `microsandbox/lib/db/`
- `entity/mod.rs` + 13 entity files: SeaORM `Model`, `Relation`, `ActiveModel` for every table with full relationship definitions (has_many, belongs_to, N:M via junction table)
- `mod.rs`: dual `OnceCell` pool (`GLOBAL_POOL`, `PROJECT_POOL`), `init_global()`, `init_project()` with path-mismatch detection, `global()`, `project()` accessors, `connect_and_migrate()` helper with UTF-8 path validation
- 2 integration tests verifying migration creates all 13 tables and is idempotent

### Modified files
- `Cargo.toml`: add `microsandbox-migration` workspace member, add `sea-orm` and `sea-orm-migration` deps, remove unused `sqlx` dep
- `microsandbox/Cargo.toml`: add `microsandbox-migration`, `sea-orm`, `tempfile` (dev) dependencies
- `microsandbox/lib/error.rs`: add `Database(#[from] sea_orm::DbErr)` variant preserving structured error chain
- `microsandbox/lib/lib.rs`: add `pub(crate) mod db` with `#[allow(dead_code)]` (foundational infrastructure, not yet consumed)
- `.gitignore`: add `.claude` directory
- `justfile`: remove trailing blank line

## Test Plan

- Run `cargo check --workspace` to verify clean compilation with zero warnings
- Run `cargo test -p microsandbox --lib db::tests` to verify both integration tests pass:
  - `test_connect_and_migrate_creates_db_and_tables`: creates temp DB, runs migrations, asserts all 13 tables exist
  - `test_connect_and_migrate_is_idempotent`: verifies re-running migrations on existing DB succeeds