### PR TITLE
feat(runtime): wire agent_fd through virtio-console multi-port (#383)

### DIFF
--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -129,9 +129,11 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
         builder = builder.kernel(|k| k.cmdline(&format!("init={}", init_path.display())));
     }
 
-    // TODO: Wire agent_fd through ConsoleBuilder.port() for virtio-console multi-port (hvc1).
-    // Blocked on msb_krun: the Rust `ConsoleBuilder::port(name, input_fd, output_fd)` wrapper
-    // has not been added yet. The underlying C API (krun_add_console_port_inout) exists in libkrun.
+    // Agent — wire agent_fd through virtio-console multi-port.
+    // Guest discovers port by name via /sys/class/virtio-ports/agent.
+    if let Some(agent_fd) = config.agent_fd {
+        builder = builder.console(|c| c.port("agent", agent_fd, agent_fd));
+    }
 
     // Network — use msb_krun's built-in Unixgram backend to relay frames to msbnet.
     if let Some(raw_fd) = config.net_fd {


### PR DESCRIPTION
## Summary

- Wire agent_fd through msb_krun's ConsoleBuilder::port() for host-guest communication
- Replace the Phase 3.1 TODO block with actual virtio-console multi-port wiring
- The guest agent (agentd) discovers its port by name via /sys/class/virtio-ports/agent
- Depends on ConsoleBuilder::port() and port_tty() methods added to msb_krun in the libkrun repo

## Changes

- Modified `crates/runtime/lib/vm.rs`: replaced the TODO comment block (3 lines) with a conditional that passes `agent_fd` to `ConsoleBuilder::port("agent", agent_fd, agent_fd)` when present
- No new dependencies or configuration changes
- No breaking changes

## Test Plan

- [x] Run `cargo build` to verify successful compilation
- [ ] End-to-end verification deferred to Phase 3.1c (requires a running VM with agentd to confirm CBOR frames flow over hvc1)