### PR TITLE
build: add build and build-signed justfile recipes (#384)

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,6 +54,17 @@ build-libkrunfw:
     cd build
     ln -sf libkrunfw.{{ LIBKRUNFW_ABI }}.dylib libkrunfw.dylib
 
+# Build the msb CLI binary (release mode).
+build: build-deps
+    cargo build --release -p microsandbox-cli
+    mkdir -p build
+    cp target/release/msb build/msb
+
+# Build and sign msb for macOS (hypervisor entitlement required for HVF).
+[macos]
+build-signed: build
+    codesign --entitlements entitlements.plist --force -s - build/msb
+
 # Clean build artifacts.
 clean:
     rm -rf build


### PR DESCRIPTION
## Summary

- Add `just build` and `just build-signed` recipes for building and codesigning the msb CLI binary
- Required for local VM boot testing on macOS, where HVF needs the `com.apple.security.hypervisor` entitlement
- Completes Phase 3.2 of the implementation plan
- Follows existing convention of staging build outputs in `build/`

## Changes

- Added `build` recipe to justfile: runs `cargo build --release -p microsandbox-cli`, then copies the binary to `build/msb`
- Added macOS-only `build-signed` recipe: depends on `build`, then ad-hoc codesigns `build/msb` with `entitlements.plist` for hypervisor access
- Both recipes follow the existing pattern of outputting to the `build/` directory with `mkdir -p build` guard

## Test Plan

- Run `just --dry-run build` to verify recipe dependency chain resolves correctly
- Run `just --dry-run build-signed` on macOS to verify codesign command is correct
- After full `just build-deps` is available, run `just build-signed` end-to-end and verify with `codesign -d --entitlements :- build/msb`