### PR TITLE
feat(microsandbox): add core SDK infrastructure (#386)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,18 +1646,27 @@ dependencies = [
 name = "microsandbox"
 version = "0.2.6"
 dependencies = [
+ "chrono",
  "dirs",
  "futures",
+ "libc",
  "microsandbox-filesystem",
  "microsandbox-migration",
+ "microsandbox-protocol",
+ "microsandbox-runtime",
  "microsandbox-utils",
+ "nix",
  "reqwest",
  "sea-orm",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "typed-builder",
  "ureq",
+ "which",
 ]
 
 [[package]]
@@ -4117,6 +4132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a824aeba0fbb27264f815ada4cff43d65b1741b7a4ed7629ff9089148c4a4e0"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4523,6 +4549,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -32,6 +32,15 @@ enum Commands {
 
 #[tokio::main]
 async fn main() {
+    // Auto-set MSB_PATH so the library can find the msb binary
+    // when spawning supervisor processes.
+    // Safety: called before any threads are spawned (single-threaded at this point).
+    if std::env::var("MSB_PATH").is_err() {
+        if let Ok(exe) = std::env::current_exe() {
+            unsafe { std::env::set_var("MSB_PATH", &exe) };
+        }
+    }
+
     tracing_subscriber::fmt::init();
 
     let cli = Cli::parse();

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -21,14 +21,23 @@ prebuilt = ["microsandbox-filesystem/prebuilt", "dep:ureq"]
 [dependencies]
 microsandbox-filesystem = { path = "../filesystem" }
 microsandbox-migration = { path = "../migration" }
+microsandbox-protocol = { path = "../protocol" }
+microsandbox-runtime = { path = "../runtime" }
 microsandbox-utils = { path = "../utils" }
+chrono.workspace = true
 dirs.workspace = true
 futures.workspace = true
+libc.workspace = true
+nix = { workspace = true, features = ["process", "signal"] }
 reqwest.workspace = true
 sea-orm.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 typed-builder.workspace = true
+which.workspace = true
 
 [build-dependencies]
 microsandbox-utils = { path = "../utils" }

--- a/crates/microsandbox/lib/agent/bridge.rs
+++ b/crates/microsandbox/lib/agent/bridge.rs
@@ -1,0 +1,153 @@
+//! Bridge for host↔agentd communication over virtio-console.
+//!
+//! [`AgentBridge`] manages a background reader task that dispatches incoming
+//! messages to pending request channels by correlation ID. The `core.ready`
+//! message from agentd is dispatched to correlation ID 0.
+
+use std::collections::HashMap;
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use microsandbox_protocol::codec;
+use microsandbox_protocol::message::{Message, MessageType};
+use tokio::io::AsyncRead;
+use tokio::sync::{Mutex, oneshot};
+use tokio::task::JoinHandle;
+
+use crate::MicrosandboxResult;
+
+use super::stream;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Bridge for communicating with agentd in the guest VM.
+///
+/// Provides request/response messaging over the agent FD pair.
+/// A background task reads incoming messages and dispatches them
+/// to pending `oneshot` channels by correlation ID.
+pub struct AgentBridge {
+    writer: Arc<Mutex<stream::FdWriter>>,
+    next_id: AtomicU32,
+    pending: Arc<Mutex<HashMap<u32, oneshot::Sender<Message>>>>,
+    reader_handle: JoinHandle<()>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl AgentBridge {
+    /// Create a new agent bridge from the host-side agent file descriptor.
+    ///
+    /// Spawns a background reader task that dispatches incoming messages.
+    pub fn new(agent_host_fd: RawFd) -> MicrosandboxResult<Self> {
+        let (reader, writer) = stream::from_raw_fd(agent_host_fd)?;
+        let pending: Arc<Mutex<HashMap<u32, oneshot::Sender<Message>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
+
+        Ok(Self {
+            writer: Arc::new(Mutex::new(writer)),
+            next_id: AtomicU32::new(1),
+            pending,
+            reader_handle,
+        })
+    }
+
+    /// Send a message to agentd without waiting for a response.
+    pub async fn send(&self, msg: &Message) -> MicrosandboxResult<()> {
+        let mut writer = self.writer.lock().await;
+        codec::write_message(&mut *writer, msg).await?;
+        Ok(())
+    }
+
+    /// Send a request to agentd and wait for the correlated response.
+    ///
+    /// Assigns a unique correlation ID to the message before sending.
+    pub async fn request(&self, mut msg: Message) -> MicrosandboxResult<Message> {
+        let mut id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        // ID 0 is reserved for core.ready; skip it on wraparound.
+        if id == 0 {
+            id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        }
+        msg.id = id;
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        self.send(&msg).await?;
+
+        rx.await.map_err(|_| {
+            crate::MicrosandboxError::Runtime("agent bridge reader closed before response".into())
+        })
+    }
+
+    /// Wait for agentd to report readiness (`core.ready` message).
+    ///
+    /// The ready message is dispatched to correlation ID 0 by convention.
+    pub async fn wait_ready(&self) -> MicrosandboxResult<()> {
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(0, tx);
+
+        rx.await.map_err(|_| {
+            crate::MicrosandboxError::Runtime("agent bridge closed before ready signal".into())
+        })?;
+
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Background task that reads messages from agentd and dispatches them.
+async fn reader_loop<R: AsyncRead + Unpin>(
+    mut reader: R,
+    pending: Arc<Mutex<HashMap<u32, oneshot::Sender<Message>>>>,
+) {
+    loop {
+        let msg = match codec::read_message(&mut reader).await {
+            Ok(msg) => msg,
+            Err(microsandbox_protocol::ProtocolError::UnexpectedEof) => {
+                tracing::debug!("agent bridge: reader EOF");
+                break;
+            }
+            Err(e) => {
+                tracing::error!("agent bridge: read error: {e}");
+                break;
+            }
+        };
+
+        // Route `core.ready` to correlation ID 0.
+        let dispatch_id = if msg.t == MessageType::Ready {
+            0
+        } else {
+            msg.id
+        };
+
+        if let Some(tx) = pending.lock().await.remove(&dispatch_id) {
+            let _ = tx.send(msg);
+        } else {
+            tracing::trace!("agent bridge: no pending request for id={dispatch_id}");
+        }
+    }
+
+    // When the reader exits, wake all pending requests so they fail gracefully.
+    let mut map = pending.lock().await;
+    map.clear();
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Drop for AgentBridge {
+    fn drop(&mut self) {
+        self.reader_handle.abort();
+    }
+}

--- a/crates/microsandbox/lib/agent/mod.rs
+++ b/crates/microsandbox/lib/agent/mod.rs
@@ -1,0 +1,13 @@
+//! Agent communication with the guest VM.
+//!
+//! The [`AgentBridge`] provides request/response messaging with agentd
+//! over a virtio-console FD pair using the CBOR-based agent protocol.
+
+mod bridge;
+mod stream;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use bridge::AgentBridge;

--- a/crates/microsandbox/lib/agent/stream.rs
+++ b/crates/microsandbox/lib/agent/stream.rs
@@ -1,0 +1,150 @@
+//! Async reader/writer over a raw file descriptor.
+//!
+//! Wraps a Unix file descriptor in `tokio::io::unix::AsyncFd` to provide
+//! non-blocking async I/O. Used by [`AgentBridge`](super::AgentBridge) for
+//! communication with agentd over the virtio-console FD pair.
+
+use std::io;
+use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::unix::AsyncFd;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Async reader wrapping a file descriptor.
+pub struct FdReader {
+    inner: AsyncFd<OwnedFd>,
+}
+
+/// Async writer wrapping a file descriptor.
+pub struct FdWriter {
+    inner: AsyncFd<OwnedFd>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create an async reader/writer pair from a raw file descriptor.
+///
+/// The FD is duplicated so the reader and writer operate independently.
+/// Both copies are set to non-blocking mode.
+///
+/// # Safety
+///
+/// The caller must ensure `raw_fd` is a valid, open file descriptor.
+/// Ownership of `raw_fd` is transferred to the returned `FdReader`.
+pub fn from_raw_fd(raw_fd: RawFd) -> io::Result<(FdReader, FdWriter)> {
+    // Dup the FD so reader and writer are independent.
+    // Safety: raw_fd is valid per precondition.
+    let read_owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+    let write_owned = nix::unistd::dup(&read_owned).map_err(io_from_nix)?;
+
+    // Set both non-blocking.
+    set_nonblocking(&read_owned)?;
+    set_nonblocking(&write_owned)?;
+
+    let reader = FdReader {
+        inner: AsyncFd::new(read_owned)?,
+    };
+    let writer = FdWriter {
+        inner: AsyncFd::new(write_owned)?,
+    };
+
+    Ok((reader, writer))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl AsyncRead for FdReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        loop {
+            let mut guard = match self.inner.poll_read_ready(cx) {
+                Poll::Ready(Ok(guard)) => guard,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            };
+
+            let fd = self.inner.get_ref();
+            let unfilled = buf.initialize_unfilled();
+
+            match nix::unistd::read(fd, unfilled) {
+                Ok(0) => return Poll::Ready(Ok(())),
+                Ok(n) => {
+                    buf.advance(n);
+                    return Poll::Ready(Ok(()));
+                }
+                Err(nix::errno::Errno::EAGAIN) => {
+                    guard.clear_ready();
+                    continue;
+                }
+                Err(e) => return Poll::Ready(Err(io_from_nix(e))),
+            }
+        }
+    }
+}
+
+impl AsyncWrite for FdWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        loop {
+            let mut guard = match self.inner.poll_write_ready(cx) {
+                Poll::Ready(Ok(guard)) => guard,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            };
+
+            let fd = self.inner.get_ref();
+
+            match nix::unistd::write(fd, buf) {
+                Ok(n) => return Poll::Ready(Ok(n)),
+                Err(nix::errno::Errno::EAGAIN) => {
+                    guard.clear_ready();
+                    continue;
+                }
+                Err(e) => return Poll::Ready(Err(io_from_nix(e))),
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Set a file descriptor to non-blocking mode.
+fn set_nonblocking(fd: &OwnedFd) -> io::Result<()> {
+    use nix::fcntl::{FcntlArg, OFlag, fcntl};
+
+    let flags = fcntl(fd, FcntlArg::F_GETFL).map_err(io_from_nix)?;
+    let flags = OFlag::from_bits_truncate(flags);
+    fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK)).map_err(io_from_nix)?;
+    Ok(())
+}
+
+/// Convert a nix::errno::Errno to std::io::Error.
+fn io_from_nix(e: nix::errno::Errno) -> io::Error {
+    io::Error::from_raw_os_error(e as i32)
+}

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -1,0 +1,329 @@
+//! Global configuration for the microsandbox library.
+//!
+//! Configuration is loaded from `~/.microsandbox/config.json` on first access.
+//! All fields have sensible defaults — a missing config file is equivalent to `{}`.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Default number of vCPUs per sandbox.
+const DEFAULT_CPUS: u8 = 1;
+
+/// Default guest memory in MiB.
+const DEFAULT_MEMORY_MIB: u32 = 512;
+
+/// Default database max connections.
+pub(crate) const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Global configuration for the microsandbox library.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GlobalConfig {
+    /// Root directory for all microsandbox data.
+    pub home: Option<PathBuf>,
+
+    /// Log level.
+    pub log_level: String,
+
+    /// Database configuration.
+    pub database: DatabaseConfig,
+
+    /// Path overrides.
+    pub paths: PathsConfig,
+
+    /// Default values for sandbox configuration.
+    pub sandbox_defaults: SandboxDefaults,
+}
+
+/// Database configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DatabaseConfig {
+    /// Database connection URL. `None` uses the default SQLite path.
+    pub url: Option<String>,
+
+    /// Maximum connection pool size.
+    pub max_connections: u32,
+}
+
+/// Path overrides for runtime binaries and data directories.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PathsConfig {
+    /// Path to `msb` binary. Resolution: `MSB_PATH` env → this → PATH lookup.
+    pub msb: Option<PathBuf>,
+
+    /// Path to `libkrunfw.{so,dylib}`.
+    pub libkrunfw: Option<PathBuf>,
+
+    /// Path to `msbnet` binary.
+    pub msbnet: Option<PathBuf>,
+
+    /// Cache directory.
+    pub cache: Option<PathBuf>,
+
+    /// Per-sandbox state directory.
+    pub sandboxes: Option<PathBuf>,
+
+    /// Named volumes directory.
+    pub volumes: Option<PathBuf>,
+
+    /// Logs directory.
+    pub logs: Option<PathBuf>,
+
+    /// Secrets directory.
+    pub secrets: Option<PathBuf>,
+}
+
+/// Default values applied to sandboxes when not overridden per-sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SandboxDefaults {
+    /// Default vCPU count.
+    pub cpus: u8,
+
+    /// Default guest memory in MiB.
+    pub memory_mib: u32,
+
+    /// Default shell for interactive sessions and scripts.
+    pub shell: String,
+
+    /// Default working directory inside the sandbox.
+    pub workdir: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+static CONFIG: OnceLock<GlobalConfig> = OnceLock::new();
+
+impl GlobalConfig {
+    /// Get the resolved home directory.
+    pub fn home(&self) -> PathBuf {
+        self.home
+            .clone()
+            .unwrap_or_else(|| resolve_default_home())
+    }
+
+    /// Resolve the `sandboxes` directory.
+    pub fn sandboxes_dir(&self) -> PathBuf {
+        self.paths
+            .sandboxes
+            .clone()
+            .unwrap_or_else(|| self.home().join(microsandbox_utils::SANDBOXES_SUBDIR))
+    }
+
+    /// Resolve the `volumes` directory.
+    pub fn volumes_dir(&self) -> PathBuf {
+        self.paths
+            .volumes
+            .clone()
+            .unwrap_or_else(|| self.home().join(microsandbox_utils::VOLUMES_SUBDIR))
+    }
+
+    /// Resolve the `logs` directory.
+    pub fn logs_dir(&self) -> PathBuf {
+        self.paths
+            .logs
+            .clone()
+            .unwrap_or_else(|| self.home().join(microsandbox_utils::LOGS_SUBDIR))
+    }
+
+    /// Resolve the `cache` directory.
+    pub fn cache_dir(&self) -> PathBuf {
+        self.paths
+            .cache
+            .clone()
+            .unwrap_or_else(|| self.home().join(microsandbox_utils::CACHE_SUBDIR))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self {
+            home: None,
+            log_level: "info".into(),
+            database: DatabaseConfig::default(),
+            paths: PathsConfig::default(),
+            sandbox_defaults: SandboxDefaults::default(),
+        }
+    }
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            url: None,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+        }
+    }
+}
+
+impl Default for SandboxDefaults {
+    fn default() -> Self {
+        Self {
+            cpus: DEFAULT_CPUS,
+            memory_mib: DEFAULT_MEMORY_MIB,
+            shell: "/bin/sh".into(),
+            workdir: None,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Get the global configuration (lazy-loaded from disk on first call).
+pub fn config() -> &'static GlobalConfig {
+    CONFIG.get_or_init(|| load_config().unwrap_or_default())
+}
+
+/// Override the global configuration programmatically.
+///
+/// Must be called before the first call to [`config()`]. Returns `Err` with the
+/// provided config if the global has already been initialized.
+pub fn set_config(config: GlobalConfig) -> Result<(), GlobalConfig> {
+    CONFIG.set(config)
+}
+
+/// Resolve the path to the `msb` binary.
+///
+/// Resolution order:
+/// 1. `MSB_PATH` environment variable
+/// 2. `config().paths.msb`
+/// 3. `which::which("msb")`
+pub fn resolve_msb_path() -> MicrosandboxResult<PathBuf> {
+    if let Ok(path) = std::env::var("MSB_PATH") {
+        return Ok(PathBuf::from(path));
+    }
+
+    if let Some(path) = &config().paths.msb {
+        return Ok(path.clone());
+    }
+
+    which::which(microsandbox_utils::MSB_BINARY).map_err(|e| {
+        crate::MicrosandboxError::Custom(format!(
+            "msb binary not found: set MSB_PATH env var or add msb to PATH ({e})"
+        ))
+    })
+}
+
+/// Resolve the path to `libkrunfw`.
+///
+/// Resolution order:
+/// 1. `config().paths.libkrunfw`
+/// 2. `{home}/lib/libkrunfw.{so,dylib}`
+pub fn resolve_libkrunfw_path() -> PathBuf {
+    if let Some(path) = &config().paths.libkrunfw {
+        return path.clone();
+    }
+
+    let filename = if cfg!(target_os = "macos") {
+        microsandbox_utils::libkrunfw_filename("macos")
+    } else {
+        microsandbox_utils::libkrunfw_filename("linux")
+    };
+
+    config()
+        .home()
+        .join(microsandbox_utils::LIB_SUBDIR)
+        .join(filename)
+}
+
+/// Resolve the default home directory (`~/.microsandbox`).
+fn resolve_default_home() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(microsandbox_utils::BASE_DIR_NAME)
+}
+
+/// Load config from the default config file path.
+fn load_config() -> Option<GlobalConfig> {
+    let path = resolve_default_home().join(microsandbox_utils::CONFIG_FILENAME);
+    load_config_from(&path)
+}
+
+/// Load config from a specific file path.
+fn load_config_from(path: &Path) -> Option<GlobalConfig> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let cfg = GlobalConfig::default();
+        assert_eq!(cfg.sandbox_defaults.cpus, 1);
+        assert_eq!(cfg.sandbox_defaults.memory_mib, 512);
+        assert_eq!(cfg.sandbox_defaults.shell, "/bin/sh");
+        assert_eq!(cfg.log_level, "info");
+        assert_eq!(cfg.database.max_connections, 5);
+    }
+
+    #[test]
+    fn test_deserialize_empty_json() {
+        let cfg: GlobalConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.sandbox_defaults.cpus, 1);
+        assert!(cfg.home.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_partial_json() {
+        let json = r#"{"sandbox_defaults": {"cpus": 4}}"#;
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.sandbox_defaults.cpus, 4);
+        assert_eq!(cfg.sandbox_defaults.memory_mib, 512);
+    }
+
+    #[test]
+    fn test_home_resolution() {
+        let cfg = GlobalConfig {
+            home: Some(PathBuf::from("/custom/home")),
+            ..Default::default()
+        };
+        assert_eq!(cfg.home(), PathBuf::from("/custom/home"));
+    }
+
+    #[test]
+    fn test_sandboxes_dir_override() {
+        let cfg = GlobalConfig {
+            paths: PathsConfig {
+                sandboxes: Some(PathBuf::from("/custom/sandboxes")),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(cfg.sandboxes_dir(), PathBuf::from("/custom/sandboxes"));
+    }
+
+    #[test]
+    fn test_load_config_from_missing_file() {
+        let result = load_config_from(Path::new("/nonexistent/config.json"));
+        assert!(result.is_none());
+    }
+}

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -16,13 +16,6 @@ use tokio::sync::OnceCell;
 use crate::MicrosandboxResult;
 
 //--------------------------------------------------------------------------------------------------
-// Constants
-//--------------------------------------------------------------------------------------------------
-
-/// Default maximum number of connections in the pool.
-const DEFAULT_MAX_CONNECTIONS: u32 = 5;
-
-//--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
@@ -47,7 +40,7 @@ pub async fn init_global(max_connections: Option<u32>) -> MicrosandboxResult<&'s
                 .join(microsandbox_utils::BASE_DIR_NAME)
                 .join(microsandbox_utils::DB_SUBDIR);
 
-            connect_and_migrate(&db_dir, max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS)).await
+            connect_and_migrate(&db_dir, max_connections.unwrap_or(crate::config::DEFAULT_MAX_CONNECTIONS)).await
         })
         .await
 }
@@ -69,7 +62,7 @@ pub async fn init_project(
                 .join(microsandbox_utils::BASE_DIR_NAME)
                 .join(microsandbox_utils::DB_SUBDIR);
 
-            let conn = connect_and_migrate(&db_dir, max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS)).await?;
+            let conn = connect_and_migrate(&db_dir, max_connections.unwrap_or(crate::config::DEFAULT_MAX_CONNECTIONS)).await?;
             Ok::<_, crate::MicrosandboxError>((requested.clone(), conn))
         })
         .await?;

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -26,6 +26,34 @@ pub enum MicrosandboxError {
     #[error("database error: {0}")]
     Database(#[from] sea_orm::DbErr),
 
+    /// Invalid configuration.
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
+
+    /// The requested sandbox was not found.
+    #[error("sandbox not found: {0}")]
+    SandboxNotFound(String),
+
+    /// The sandbox is not running.
+    #[error("sandbox not running: {0}")]
+    SandboxNotRunning(String),
+
+    /// A runtime error occurred.
+    #[error("runtime error: {0}")]
+    Runtime(String),
+
+    /// A JSON serialization/deserialization error occurred.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// A protocol error occurred.
+    #[error("protocol error: {0}")]
+    Protocol(#[from] microsandbox_protocol::ProtocolError),
+
+    /// A nix/errno error occurred.
+    #[error("nix error: {0}")]
+    Nix(#[from] nix::errno::Errno),
+
     /// A custom error message.
     #[error("{0}")]
     Custom(String),

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -11,6 +11,10 @@ mod error;
 
 #[allow(dead_code)]
 pub(crate) mod db;
+pub mod agent;
+pub mod config;
+pub mod runtime;
+pub mod sandbox;
 pub mod setup;
 
 pub use error::*;

--- a/crates/microsandbox/lib/runtime/handle.rs
+++ b/crates/microsandbox/lib/runtime/handle.rs
@@ -1,0 +1,113 @@
+//! Handle to a running supervisor process.
+//!
+//! [`SupervisorHandle`] holds the PIDs of the supervisor, VM, and msbnet
+//! processes and provides methods for lifecycle management (signals, wait).
+
+use std::process::ExitStatus;
+
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+use tokio::process::Child;
+
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Handle to a running supervisor process and its children.
+pub struct SupervisorHandle {
+    /// PID of the supervisor process (`msb supervisor`).
+    supervisor_pid: u32,
+
+    /// PID of the VM process (`msb microvm`).
+    vm_pid: u32,
+
+    /// PID of the msbnet process (if spawned).
+    msbnet_pid: Option<u32>,
+
+    /// Name of the sandbox this supervisor manages.
+    sandbox_name: String,
+
+    /// The supervisor child process handle.
+    child: Child,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl SupervisorHandle {
+    /// Create a new supervisor handle.
+    pub(crate) fn new(
+        supervisor_pid: u32,
+        vm_pid: u32,
+        msbnet_pid: Option<u32>,
+        sandbox_name: String,
+        child: Child,
+    ) -> Self {
+        Self {
+            supervisor_pid,
+            vm_pid,
+            msbnet_pid,
+            sandbox_name,
+            child,
+        }
+    }
+
+    /// Get the supervisor PID.
+    pub fn supervisor_pid(&self) -> u32 {
+        self.supervisor_pid
+    }
+
+    /// Get the VM PID.
+    pub fn vm_pid(&self) -> u32 {
+        self.vm_pid
+    }
+
+    /// Get the msbnet PID, if running.
+    pub fn msbnet_pid(&self) -> Option<u32> {
+        self.msbnet_pid
+    }
+
+    /// Get the sandbox name.
+    pub fn sandbox_name(&self) -> &str {
+        &self.sandbox_name
+    }
+
+    /// Send SIGKILL to the VM process for immediate termination.
+    pub fn kill_vm(&self) -> MicrosandboxResult<()> {
+        signal::kill(Pid::from_raw(self.vm_pid as i32), Signal::SIGKILL)?;
+        Ok(())
+    }
+
+    /// Send SIGUSR1 to the supervisor to trigger a graceful drain.
+    pub fn drain_supervisor(&self) -> MicrosandboxResult<()> {
+        signal::kill(
+            Pid::from_raw(self.supervisor_pid as i32),
+            Signal::SIGUSR1,
+        )?;
+        Ok(())
+    }
+
+    /// Wait for the supervisor process to exit.
+    pub async fn wait(&mut self) -> MicrosandboxResult<ExitStatus> {
+        let status = self.child.wait().await?;
+        Ok(status)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Drop for SupervisorHandle {
+    fn drop(&mut self) {
+        // Safety net: send SIGTERM to the supervisor so child processes
+        // are cleaned up if the handle is dropped without an explicit stop.
+        let _ = signal::kill(
+            Pid::from_raw(self.supervisor_pid as i32),
+            Signal::SIGTERM,
+        );
+    }
+}

--- a/crates/microsandbox/lib/runtime/mod.rs
+++ b/crates/microsandbox/lib/runtime/mod.rs
@@ -1,0 +1,14 @@
+//! Runtime process management.
+//!
+//! Provides [`SupervisorHandle`] for interacting with a running supervisor
+//! process and [`spawn_supervisor`] for starting one from a [`SandboxConfig`].
+
+pub(crate) mod handle;
+pub(crate) mod spawn;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use handle::SupervisorHandle;
+pub use spawn::spawn_supervisor;

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -1,0 +1,250 @@
+//! Spawning the supervisor process.
+//!
+//! [`spawn_supervisor`] creates a Unix socket pair for the agent channel,
+//! assembles CLI arguments from [`SandboxConfig`], fork+execs `msb supervisor`,
+//! and reads the startup JSON to obtain child PIDs.
+
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use std::path::Path;
+use std::process::Stdio;
+
+use serde::Deserialize;
+use tokio::io::AsyncBufReadExt;
+use tokio::process::Command;
+
+use crate::config;
+use crate::runtime::handle::SupervisorHandle;
+use crate::sandbox::{RootfsSource, SandboxConfig};
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// JSON structure read from supervisor stdout on startup.
+#[derive(Debug, Deserialize)]
+struct StartupInfo {
+    vm_pid: u32,
+    msbnet_pid: Option<u32>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Spawn the supervisor process for a sandbox.
+///
+/// Returns a [`SupervisorHandle`] and the host-side raw FD for the agent
+/// channel (to be wrapped in an [`AgentBridge`](crate::agent::AgentBridge)).
+///
+/// The function:
+/// 1. Creates a Unix socket pair for host↔agentd communication
+/// 2. Resolves the `msb` binary path
+/// 3. Creates sandbox directories (logs, runtime, scripts)
+/// 4. Builds CLI arguments from the config
+/// 5. Spawns `msb supervisor` with the guest FD inherited
+/// 6. Reads startup JSON from stdout to get child PIDs
+pub async fn spawn_supervisor(
+    config: &SandboxConfig,
+) -> MicrosandboxResult<(SupervisorHandle, RawFd)> {
+    // Create the agent socket pair.
+    let (host_fd, guest_fd) = create_socketpair()?;
+    let guest_raw_fd = guest_fd.as_raw_fd();
+
+    // Resolve paths.
+    let msb_path = config::resolve_msb_path()?;
+    let libkrunfw_path = config::resolve_libkrunfw_path();
+    let global = config::config();
+    let sandbox_dir = global.sandboxes_dir().join(&config.name);
+    let log_dir = sandbox_dir.join("logs");
+    let runtime_dir = sandbox_dir.join("runtime");
+    let scripts_dir = runtime_dir.join("scripts");
+    let db_dir = global.home().join(microsandbox_utils::DB_SUBDIR);
+    let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+
+    // Create directories concurrently.
+    tokio::try_join!(
+        tokio::fs::create_dir_all(&log_dir),
+        tokio::fs::create_dir_all(&scripts_dir),
+    )?;
+
+    // Write scripts to the runtime scripts directory.
+    for (name, content) in &config.scripts {
+        // Prevent path traversal: only use the filename component.
+        let safe_name = Path::new(name)
+            .file_name()
+            .ok_or_else(|| crate::MicrosandboxError::InvalidConfig(
+                format!("invalid script name: {name}")
+            ))?;
+        let script_path = scripts_dir.join(safe_name);
+        tokio::fs::write(&script_path, content).await?;
+    }
+
+    // Build the command.
+    let mut cmd = Command::new(&msb_path);
+    cmd.arg("supervisor");
+    cmd.arg("--name").arg(&config.name);
+    cmd.arg("--db-path").arg(&db_path);
+    cmd.arg("--log-dir").arg(&log_dir);
+    cmd.arg("--runtime-dir").arg(&runtime_dir);
+    cmd.arg("--agent-fd").arg(guest_raw_fd.to_string());
+
+    // Supervisor policy args.
+    let sp = &config.supervisor_policy;
+    cmd.arg("--shutdown-mode").arg(shutdown_mode_str(&sp.shutdown_mode));
+    cmd.arg("--grace-secs").arg(sp.grace_secs.to_string());
+    if let Some(max_dur) = sp.max_duration_secs {
+        cmd.arg("--max-duration").arg(max_dur.to_string());
+    }
+    if let Some(idle) = sp.idle_timeout_secs {
+        cmd.arg("--idle-timeout").arg(idle.to_string());
+    }
+
+    // VM child policy args.
+    let vp = &config.child_policies.vm;
+    cmd.arg("--vm-on-exit").arg(exit_action_str(&vp.on_exit));
+    cmd.arg("--vm-max-restarts").arg(vp.max_restarts.to_string());
+    cmd.arg("--vm-restart-delay-ms").arg(vp.restart_delay_ms.to_string());
+    cmd.arg("--vm-restart-window").arg(vp.restart_window_secs.to_string());
+    cmd.arg("--vm-shutdown-timeout-ms").arg(vp.shutdown_timeout_ms.to_string());
+
+    // VM configuration args.
+    cmd.arg("--libkrunfw-path").arg(&libkrunfw_path);
+    cmd.arg("--vcpus").arg(config.cpus.to_string());
+    cmd.arg("--memory-mib").arg(config.memory_mib.to_string());
+
+    // Root filesystem layers.
+    match &config.image {
+        RootfsSource::Bind(path) => {
+            cmd.arg("--rootfs-layer").arg(path);
+        }
+        RootfsSource::Oci(_) => {
+            // OCI image resolution is handled in Phase 8.
+            // For now, this would be resolved to layer paths before calling spawn.
+        }
+    }
+
+    // Environment variables.
+    for (key, value) in &config.env {
+        cmd.arg("--env").arg(format!("{key}={value}"));
+    }
+
+    // Working directory.
+    if let Some(ref workdir) = config.workdir {
+        cmd.arg("--workdir").arg(workdir);
+    }
+
+    // Capture stdout (for startup JSON), inherit stderr.
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::inherit());
+
+    // Clear CLOEXEC on the guest FD so it's inherited by the child.
+    unsafe {
+        cmd.pre_exec(move || {
+            clear_cloexec(guest_raw_fd)?;
+            Ok(())
+        });
+    }
+
+    // Spawn the supervisor.
+    let mut child = cmd.spawn()?;
+    let supervisor_pid = child.id().ok_or_else(|| {
+        crate::MicrosandboxError::Runtime("supervisor process exited immediately".into())
+    })?;
+
+    // Close the guest FD in the parent by dropping it.
+    drop(guest_fd);
+
+    // Read the startup JSON from the supervisor's stdout.
+    let stdout = child.stdout.take().ok_or_else(|| {
+        crate::MicrosandboxError::Runtime("failed to capture supervisor stdout".into())
+    })?;
+
+    let mut reader = tokio::io::BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+
+    let startup: StartupInfo = serde_json::from_str(line.trim())?;
+
+    // Transfer ownership of the host FD to the caller.
+    let host_raw_fd = host_fd.into_raw_fd();
+
+    let handle = SupervisorHandle::new(
+        supervisor_pid,
+        startup.vm_pid,
+        startup.msbnet_pid,
+        config.name.clone(),
+        child,
+    );
+
+    Ok((handle, host_raw_fd))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Create a Unix socket pair, returning (host_fd, guest_fd) as OwnedFds.
+fn create_socketpair() -> MicrosandboxResult<(OwnedFd, OwnedFd)> {
+    let mut fds = [0i32; 2];
+    let ret = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    if ret != 0 {
+        return Err(crate::MicrosandboxError::Io(std::io::Error::last_os_error()));
+    }
+
+    // Wrap immediately so FDs are closed on error.
+    let fd1 = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let fd2 = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+    // Set CLOEXEC on both.
+    set_cloexec(fd1.as_raw_fd())?;
+    set_cloexec(fd2.as_raw_fd())?;
+
+    Ok((fd1, fd2))
+}
+
+/// Set the close-on-exec flag on a file descriptor (preserving existing flags).
+fn set_cloexec(fd: RawFd) -> MicrosandboxResult<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(crate::MicrosandboxError::Io(std::io::Error::last_os_error()));
+    }
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+    if ret == -1 {
+        return Err(crate::MicrosandboxError::Io(std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Clear the close-on-exec flag on a file descriptor (preserving other flags).
+fn clear_cloexec(fd: RawFd) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+    if ret == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Convert ShutdownMode to CLI arg string.
+fn shutdown_mode_str(mode: &microsandbox_runtime::policy::ShutdownMode) -> &'static str {
+    use microsandbox_runtime::policy::ShutdownMode;
+    match mode {
+        ShutdownMode::Graceful => "graceful",
+        ShutdownMode::Terminate => "terminate",
+        ShutdownMode::Kill => "kill",
+    }
+}
+
+/// Convert ExitAction to CLI arg string.
+fn exit_action_str(action: &microsandbox_runtime::policy::ExitAction) -> &'static str {
+    use microsandbox_runtime::policy::ExitAction;
+    match action {
+        ExitAction::ShutdownAll => "shutdown-all",
+        ExitAction::Restart => "restart",
+        ExitAction::Ignore => "ignore",
+    }
+}

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -1,0 +1,171 @@
+//! Fluent builder for [`SandboxConfig`].
+
+use microsandbox_runtime::policy::ShutdownMode;
+
+use super::config::SandboxConfig;
+use super::types::RootfsSource;
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Builder for constructing a [`SandboxConfig`] with a fluent API.
+pub struct SandboxBuilder {
+    config: SandboxConfig,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl SandboxBuilder {
+    /// Create a new builder with the given sandbox name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            config: SandboxConfig {
+                name: name.into(),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Set the root filesystem source.
+    pub fn image(mut self, image: impl Into<RootfsSource>) -> Self {
+        self.config.image = image.into();
+        self
+    }
+
+    /// Set the number of virtual CPUs.
+    pub fn cpus(mut self, count: u8) -> Self {
+        self.config.cpus = count;
+        self
+    }
+
+    /// Set guest memory in MiB.
+    pub fn memory(mut self, mib: u32) -> Self {
+        self.config.memory_mib = mib;
+        self
+    }
+
+    /// Set the working directory inside the sandbox.
+    pub fn workdir(mut self, path: impl Into<String>) -> Self {
+        self.config.workdir = Some(path.into());
+        self
+    }
+
+    /// Set the default shell.
+    pub fn shell(mut self, shell: impl Into<String>) -> Self {
+        self.config.shell = Some(shell.into());
+        self
+    }
+
+    /// Set a custom init binary path.
+    pub fn init(mut self, path: impl Into<String>) -> Self {
+        self.config.init = Some(path.into());
+        self
+    }
+
+    /// Add an environment variable.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.config.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Add multiple environment variables.
+    pub fn envs(
+        mut self,
+        vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        for (k, v) in vars {
+            self.config.env.push((k.into(), v.into()));
+        }
+        self
+    }
+
+    /// Add a named script.
+    pub fn script(mut self, name: impl Into<String>, content: impl Into<String>) -> Self {
+        self.config.scripts.insert(name.into(), content.into());
+        self
+    }
+
+    /// Add multiple scripts.
+    pub fn scripts(
+        mut self,
+        scripts: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        for (name, content) in scripts {
+            self.config.scripts.insert(name.into(), content.into());
+        }
+        self
+    }
+
+    /// Set the shutdown escalation mode.
+    pub fn shutdown_mode(mut self, mode: ShutdownMode) -> Self {
+        self.config.supervisor_policy.shutdown_mode = mode;
+        self
+    }
+
+    /// Set the grace period between escalation steps (in seconds).
+    pub fn grace_period(mut self, secs: u64) -> Self {
+        self.config.supervisor_policy.grace_secs = secs;
+        self
+    }
+
+    /// Set a maximum sandbox lifetime in seconds.
+    pub fn max_duration(mut self, secs: u64) -> Self {
+        self.config.supervisor_policy.max_duration_secs = Some(secs);
+        self
+    }
+
+    /// Set the idle timeout in seconds.
+    pub fn idle_timeout(mut self, secs: u64) -> Self {
+        self.config.supervisor_policy.idle_timeout_secs = Some(secs);
+        self
+    }
+
+    /// Build the configuration without creating the sandbox.
+    pub fn build(self) -> MicrosandboxResult<SandboxConfig> {
+        self.validate()?;
+        Ok(self.config)
+    }
+
+    /// Create the sandbox. Boots the VM with agentd ready.
+    pub async fn create(self) -> MicrosandboxResult<super::Sandbox> {
+        let config = self.build()?;
+        super::Sandbox::create(config).await
+    }
+}
+
+impl SandboxBuilder {
+    /// Validate the configuration before building.
+    fn validate(&self) -> MicrosandboxResult<()> {
+        if self.config.name.is_empty() {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "sandbox name is required".into(),
+            ));
+        }
+
+        // Check that image is set (non-empty OCI string or Bind path).
+        match &self.config.image {
+            RootfsSource::Oci(s) if s.is_empty() => {
+                return Err(crate::MicrosandboxError::InvalidConfig(
+                    "image source is required".into(),
+                ));
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl From<SandboxConfig> for SandboxBuilder {
+    fn from(config: SandboxConfig) -> Self {
+        Self { config }
+    }
+}

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -1,0 +1,121 @@
+//! Sandbox configuration.
+
+use std::collections::HashMap;
+
+use microsandbox_runtime::policy::{ChildPolicies, SupervisorPolicy};
+use serde::{Deserialize, Serialize};
+
+use super::types::{NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig, VolumeMount};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+fn default_cpus() -> u8 {
+    crate::config::config().sandbox_defaults.cpus
+}
+
+fn default_memory_mib() -> u32 {
+    crate::config::config().sandbox_defaults.memory_mib
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Configuration for a sandbox.
+///
+/// All config structs derive `Default` for direct construction and
+/// `Serialize`/`Deserialize` for file-based configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxConfig {
+    /// Unique sandbox name (required).
+    pub name: String,
+
+    /// Root filesystem source (required).
+    #[serde(default)]
+    pub image: RootfsSource,
+
+    /// Number of virtual CPUs.
+    #[serde(default = "default_cpus")]
+    pub cpus: u8,
+
+    /// Guest memory in MiB.
+    #[serde(default = "default_memory_mib")]
+    pub memory_mib: u32,
+
+    /// Working directory inside the sandbox.
+    #[serde(default)]
+    pub workdir: Option<String>,
+
+    /// Default shell for scripts and interactive sessions.
+    #[serde(default)]
+    pub shell: Option<String>,
+
+    /// Custom init binary path. `None` uses the embedded init.
+    #[serde(default)]
+    pub init: Option<String>,
+
+    /// Named scripts available at `/.msb/scripts/<name>` in the guest.
+    #[serde(default)]
+    pub scripts: HashMap<String, String>,
+
+    /// Environment variables.
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+
+    /// Volume mounts.
+    #[serde(default)]
+    pub mounts: Vec<VolumeMount>,
+
+    /// Rootfs patches applied as overlay layers before VM start.
+    #[serde(default)]
+    pub patches: Vec<Patch>,
+
+    /// Network configuration.
+    #[serde(default)]
+    pub network: NetworkConfig,
+
+    /// Secrets configuration.
+    #[serde(default)]
+    pub secrets: SecretsConfig,
+
+    /// SSH configuration.
+    #[serde(default)]
+    pub ssh: SshConfig,
+
+    /// Supervisor lifecycle policy.
+    #[serde(default)]
+    pub supervisor_policy: SupervisorPolicy,
+
+    /// Per-child process policies.
+    #[serde(default)]
+    pub child_policies: ChildPolicies,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for SandboxConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            image: RootfsSource::default(),
+            cpus: default_cpus(),
+            memory_mib: default_memory_mib(),
+            workdir: None,
+            shell: None,
+            init: None,
+            scripts: HashMap::new(),
+            env: Vec::new(),
+            mounts: Vec::new(),
+            patches: Vec::new(),
+            network: NetworkConfig::default(),
+            secrets: SecretsConfig::default(),
+            ssh: SshConfig::default(),
+            supervisor_policy: SupervisorPolicy::default(),
+            child_policies: ChildPolicies::default(),
+        }
+    }
+}

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -1,0 +1,252 @@
+//! Sandbox lifecycle management.
+//!
+//! The [`Sandbox`] struct represents a running sandbox. It is created via
+//! [`Sandbox::builder`] or [`Sandbox::create`], and provides lifecycle
+//! methods (stop, kill, drain, wait) and access to the [`AgentBridge`]
+//! for guest communication.
+
+mod builder;
+mod config;
+mod types;
+
+use std::process::ExitStatus;
+use std::sync::Arc;
+
+use microsandbox_protocol::message::{Message, MessageType};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, Set,
+};
+use sea_orm::sea_query::{Expr, OnConflict};
+use tokio::sync::Mutex;
+
+use crate::agent::AgentBridge;
+use crate::db::entity::sandbox as sandbox_entity;
+use crate::runtime::{SupervisorHandle, spawn_supervisor};
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use builder::SandboxBuilder;
+pub use config::SandboxConfig;
+pub use types::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A running sandbox.
+///
+/// Created via [`Sandbox::builder`] or [`Sandbox::create`]. Provides
+/// lifecycle management and access to the agent bridge for guest communication.
+pub struct Sandbox {
+    config: SandboxConfig,
+    handle: Arc<Mutex<SupervisorHandle>>,
+    bridge: Arc<AgentBridge>,
+}
+
+/// Summary information about a sandbox (re-exported from entity model).
+pub type SandboxInfo = sandbox_entity::Model;
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Static
+//--------------------------------------------------------------------------------------------------
+
+impl Sandbox {
+    /// Create a builder for a new sandbox.
+    pub fn builder(name: impl Into<String>) -> SandboxBuilder {
+        SandboxBuilder::new(name)
+    }
+
+    /// Create a sandbox from a config.
+    ///
+    /// Boots the VM with agentd ready to accept commands. Does not run
+    /// any user workload — use `exec()`, `shell()`, etc. afterward.
+    pub async fn create(config: SandboxConfig) -> MicrosandboxResult<Self> {
+        // Initialize the database.
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        // Upsert sandbox record.
+        upsert_sandbox_record(db, &config).await?;
+
+        // Spawn supervisor + create bridge. On failure, mark the sandbox
+        // as stopped so it doesn't appear as a phantom "Running" entry.
+        match Self::create_inner(&config).await {
+            Ok(sandbox) => Ok(sandbox),
+            Err(e) => {
+                let _ = update_sandbox_status(db, &config.name, "Stopped").await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Inner create logic separated for error-cleanup wrapper.
+    async fn create_inner(config: &SandboxConfig) -> MicrosandboxResult<Self> {
+        let (handle, agent_host_fd) = spawn_supervisor(config).await?;
+        let bridge = AgentBridge::new(agent_host_fd)?;
+        bridge.wait_ready().await?;
+
+        Ok(Self {
+            config: config.clone(),
+            handle: Arc::new(Mutex::new(handle)),
+            bridge: Arc::new(bridge),
+        })
+    }
+
+    /// Get sandbox info by name from the database.
+    pub async fn get(name: &str) -> MicrosandboxResult<SandboxInfo> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        sandbox_entity::Entity::find()
+            .filter(sandbox_entity::Column::Name.eq(name))
+            .one(db)
+            .await?
+            .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))
+    }
+
+    /// List all sandboxes from the database.
+    pub async fn list() -> MicrosandboxResult<Vec<SandboxInfo>> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        sandbox_entity::Entity::find()
+            .order_by_desc(sandbox_entity::Column::CreatedAt)
+            .all(db)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Remove a stopped sandbox from the database.
+    pub async fn remove(name: &str) -> MicrosandboxResult<()> {
+        // Check if the sandbox exists and its status.
+        let model = Self::get(name).await?;
+        if model.status == "Running" {
+            return Err(crate::MicrosandboxError::SandboxNotRunning(
+                format!("cannot remove sandbox '{name}': still running"),
+            ));
+        }
+
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        model.into_active_model().delete(db).await?;
+
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Instance
+//--------------------------------------------------------------------------------------------------
+
+impl Sandbox {
+    /// Get the sandbox name.
+    pub fn name(&self) -> &str {
+        &self.config.name
+    }
+
+    /// Get the sandbox configuration.
+    pub fn config(&self) -> &SandboxConfig {
+        &self.config
+    }
+
+    /// Get the agent bridge for low-level communication with agentd.
+    pub fn bridge(&self) -> &AgentBridge {
+        &self.bridge
+    }
+
+    /// Stop the sandbox gracefully by sending `core.shutdown` to agentd.
+    pub async fn stop(&self) -> MicrosandboxResult<()> {
+        let msg = Message::new(MessageType::Shutdown, 0, Vec::new());
+        self.bridge.send(&msg).await
+    }
+
+    /// Kill the sandbox immediately (SIGKILL to VM process).
+    pub async fn kill(&self) -> MicrosandboxResult<()> {
+        self.handle.lock().await.kill_vm()
+    }
+
+    /// Trigger a graceful drain (SIGUSR1 to supervisor).
+    pub async fn drain(&self) -> MicrosandboxResult<()> {
+        self.handle.lock().await.drain_supervisor()
+    }
+
+    /// Wait for the supervisor process to exit.
+    ///
+    /// Updates the sandbox status in the database to `Stopped` after exit.
+    pub async fn wait(&self) -> MicrosandboxResult<ExitStatus> {
+        let status = self.handle.lock().await.wait().await?;
+
+        // Update the DB status now that the supervisor has exited.
+        if let Ok(db) = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await {
+            let _ = update_sandbox_status(db, &self.config.name, "Stopped").await;
+        }
+
+        Ok(status)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Update the sandbox status in the database.
+async fn update_sandbox_status(
+    db: &sea_orm::DatabaseConnection,
+    name: &str,
+    status: &str,
+) -> MicrosandboxResult<()> {
+    sandbox_entity::Entity::update_many()
+        .col_expr(sandbox_entity::Column::Status, Expr::value(status))
+        .col_expr(
+            sandbox_entity::Column::UpdatedAt,
+            Expr::value(chrono::Utc::now().naive_utc()),
+        )
+        .filter(sandbox_entity::Column::Name.eq(name))
+        .exec(db)
+        .await?;
+
+    Ok(())
+}
+
+/// Insert or update the sandbox record in the database.
+async fn upsert_sandbox_record(
+    db: &sea_orm::DatabaseConnection,
+    config: &SandboxConfig,
+) -> MicrosandboxResult<()> {
+    let now = chrono::Utc::now().naive_utc();
+    let config_json = serde_json::to_string(config)?;
+
+    let model = sandbox_entity::ActiveModel {
+        name: Set(config.name.clone()),
+        config: Set(config_json),
+        status: Set("Running".to_string()),
+        created_at: Set(Some(now)),
+        updated_at: Set(Some(now)),
+        ..Default::default()
+    };
+
+    sandbox_entity::Entity::insert(model)
+        .on_conflict(
+            OnConflict::column(sandbox_entity::Column::Name)
+                .update_columns([
+                    sandbox_entity::Column::Status,
+                    sandbox_entity::Column::Config,
+                    sandbox_entity::Column::UpdatedAt,
+                ])
+                .to_owned(),
+        )
+        .exec(db)
+        .await?;
+
+    Ok(())
+}

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -1,0 +1,89 @@
+//! Stub types for sandbox configuration.
+//!
+//! These types are referenced by [`SandboxConfig`](super::SandboxConfig) but
+//! will be fully implemented in later phases. They carry enough structure
+//! for Phase 4 to compile and for configs to round-trip through serde.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Root filesystem source for a sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RootfsSource {
+    /// Use a host directory directly as the root filesystem.
+    Bind(PathBuf),
+
+    /// Use an OCI image reference (e.g. `python:3.12`).
+    Oci(String),
+}
+
+/// A volume mount mapping a host source to a guest path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VolumeMount {
+    /// Source identifier (host path or named volume).
+    pub source: String,
+
+    /// Mount target path inside the guest.
+    pub target: String,
+
+    /// Whether the mount is read-only.
+    #[serde(default)]
+    pub read_only: bool,
+}
+
+/// A rootfs patch applied as an overlay layer before VM start.
+///
+/// Fully implemented in Phase 8 (Image Management).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Patch {}
+
+/// Network configuration for a sandbox.
+///
+/// Fully implemented in Phase 6 (Networking).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NetworkConfig {}
+
+/// Secrets configuration for a sandbox.
+///
+/// Fully implemented in Phase 7 (Secrets Management).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SecretsConfig {}
+
+/// SSH configuration for a sandbox.
+///
+/// Fully implemented in Phase 9 (SSH).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SshConfig {}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for RootfsSource {
+    fn default() -> Self {
+        Self::Oci(String::new())
+    }
+}
+
+impl From<&str> for RootfsSource {
+    fn from(s: &str) -> Self {
+        Self::Oci(s.to_string())
+    }
+}
+
+impl From<String> for RootfsSource {
+    fn from(s: String) -> Self {
+        Self::Oci(s)
+    }
+}
+
+impl From<PathBuf> for RootfsSource {
+    fn from(p: PathBuf) -> Self {
+        Self::Bind(p)
+    }
+}

--- a/crates/runtime/lib/policy.rs
+++ b/crates/runtime/lib/policy.rs
@@ -1,13 +1,14 @@
 //! Child process and supervisor lifecycle policies.
 
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
 /// Action taken when a child process exits.
-#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 pub enum ExitAction {
     /// Kill all other children and shut down the supervisor.
     ShutdownAll,
@@ -20,7 +21,7 @@ pub enum ExitAction {
 }
 
 /// Policy for a single child process (VM or msbnet).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChildPolicy {
     /// Action to take when the child exits.
     pub on_exit: ExitAction,
@@ -39,7 +40,7 @@ pub struct ChildPolicy {
 }
 
 /// Shutdown mode for the supervisor drain sequence.
-#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 pub enum ShutdownMode {
     /// Wait for voluntary exit, then SIGTERM, then SIGKILL.
     Graceful,
@@ -52,7 +53,7 @@ pub enum ShutdownMode {
 }
 
 /// Supervisor-level lifecycle policy.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SupervisorPolicy {
     /// How to shut down children when drain is triggered.
     pub shutdown_mode: ShutdownMode,
@@ -68,7 +69,7 @@ pub struct SupervisorPolicy {
 }
 
 /// Combined child policies for all managed processes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChildPolicies {
     /// Policy for the VM process.
     pub vm: ChildPolicy,
@@ -130,5 +131,69 @@ impl Default for SupervisorPolicy {
             max_duration_secs: None,
             idle_timeout_secs: None,
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supervisor_policy_serde_roundtrip() {
+        let policy = SupervisorPolicy {
+            shutdown_mode: ShutdownMode::Terminate,
+            grace_secs: 30,
+            max_duration_secs: Some(3600),
+            idle_timeout_secs: Some(120),
+        };
+
+        let json = serde_json::to_string(&policy).unwrap();
+        let decoded: SupervisorPolicy = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.shutdown_mode, ShutdownMode::Terminate);
+        assert_eq!(decoded.grace_secs, 30);
+        assert_eq!(decoded.max_duration_secs, Some(3600));
+        assert_eq!(decoded.idle_timeout_secs, Some(120));
+    }
+
+    #[test]
+    fn test_child_policies_serde_roundtrip() {
+        let policies = ChildPolicies::default();
+
+        let json = serde_json::to_string(&policies).unwrap();
+        let decoded: ChildPolicies = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.vm.on_exit, ExitAction::ShutdownAll);
+        assert_eq!(decoded.vm.shutdown_timeout_ms, 5000);
+        assert_eq!(decoded.msbnet.on_exit, ExitAction::Restart);
+        assert_eq!(decoded.msbnet.max_restarts, 3);
+    }
+
+    #[test]
+    fn test_default_supervisor_policy() {
+        let policy = SupervisorPolicy::default();
+        assert_eq!(policy.shutdown_mode, ShutdownMode::Graceful);
+        assert_eq!(policy.grace_secs, 15);
+        assert!(policy.max_duration_secs.is_none());
+        assert!(policy.idle_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn test_default_child_policies() {
+        let policies = ChildPolicies::default();
+
+        // VM default: ShutdownAll, no restarts.
+        assert_eq!(policies.vm.on_exit, ExitAction::ShutdownAll);
+        assert_eq!(policies.vm.max_restarts, 0);
+
+        // msbnet default: Restart, up to 3 times.
+        assert_eq!(policies.msbnet.on_exit, ExitAction::Restart);
+        assert_eq!(policies.msbnet.max_restarts, 3);
+        assert_eq!(policies.msbnet.restart_delay_ms, 1000);
+        assert_eq!(policies.msbnet.restart_window_secs, 60);
     }
 }


### PR DESCRIPTION
## Summary

- Implement Phase 4 of the microsandbox crate: the public Rust SDK for sandbox lifecycle management
- Add four new modules (agent, config, runtime, sandbox) totaling ~1650 lines across 11 new files
- Enable the host process to spawn a supervisor, communicate with agentd in the guest VM, and manage sandbox lifecycle via a builder API
- DB operations use SeaORM entity queries (type-safe, compile-checked) rather than raw SQL

## Changes

### New modules

**agent** (`agent/bridge.rs`, `agent/stream.rs`, `agent/mod.rs`)
- `AgentBridge`: async request/response messaging over the agent FD pair with background reader task and correlation-ID dispatch
- `FdReader`/`FdWriter`: async reader/writer over Unix FD using `tokio::io::unix::AsyncFd<OwnedFd>`

**config** (`config/mod.rs`)
- `GlobalConfig` with lazy loading from `~/.microsandbox/config.json` and serde defaults
- `resolve_msb_path()` (env -> config -> PATH) and `resolve_libkrunfw_path()`
- 6 unit tests for config loading and defaults

**runtime** (`runtime/handle.rs`, `runtime/spawn.rs`, `runtime/mod.rs`)
- `SupervisorHandle`: holds PIDs + tokio Child, provides `kill_vm()` (SIGKILL), `drain_supervisor()` (SIGUSR1), `wait()`
- `spawn_supervisor()`: creates Unix socketpair, resolves paths, writes scripts, builds CLI args, fork+execs `msb supervisor`, reads startup JSON

**sandbox** (`sandbox/mod.rs`, `sandbox/builder.rs`, `sandbox/config.rs`, `sandbox/types.rs`)
- `Sandbox` struct with static methods (`create`, `get`, `list`, `remove`) and instance methods (`stop`, `kill`, `drain`, `wait`)
- `SandboxBuilder` with fluent API and validation
- `SandboxConfig` with supervisor/child policy configuration
- DB operations via SeaORM entity queries (find, insert with on_conflict, update_many, delete)
- Stub types (`RootfsSource`, `VolumeMount`, `NetworkConfig`, etc.) for future phases

### Modified files

- **error.rs**: Add `InvalidConfig`, `SandboxNotFound`, `SandboxNotRunning`, `Runtime`, `Json`, `Protocol`, `Nix` variants
- **db/mod.rs**: Remove duplicate `DEFAULT_MAX_CONNECTIONS`, reference `config::DEFAULT_MAX_CONNECTIONS`
- **policy.rs** (runtime crate): Add `Serialize`/`Deserialize` derives to all policy types + 4 serde round-trip tests
- **main.rs** (CLI): Auto-set `MSB_PATH` env var before tracing init
- **Cargo.toml**: Add dependencies (microsandbox-protocol, microsandbox-runtime, chrono, libc, nix, serde, serde_json, tracing, which)
- **lib.rs**: Export new `agent`, `config`, `runtime`, `sandbox` modules

## Test Plan

- [x] `cargo check -p microsandbox -p microsandbox-cli` compiles cleanly
- [x] `cargo test -p microsandbox` passes all 8 tests (6 config + 2 db)
- [x] `cargo test -p microsandbox-runtime` passes all 4 policy serde tests