### PR TITLE
feat(microsandbox): add exec, attach, and streaming execution (#387)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +605,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -683,6 +719,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -732,6 +769,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1579,6 +1625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,7 +1698,9 @@ dependencies = [
 name = "microsandbox"
 version = "0.2.6"
 dependencies = [
+ "bytes",
  "chrono",
+ "crossterm",
  "dirs",
  "futures",
  "libc",
@@ -1657,6 +1711,7 @@ dependencies = [
  "microsandbox-utils",
  "nix",
  "reqwest",
+ "scopeguard",
  "sea-orm",
  "serde",
  "serde_json",
@@ -1776,6 +1831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3037,6 +3093,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,6 +3883,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/agentd/bin/main.rs
+++ b/crates/agentd/bin/main.rs
@@ -21,9 +21,13 @@ fn main() {
         .expect("agentd: failed to build tokio runtime");
 
     rt.block_on(async {
-        if let Err(e) = microsandbox_agentd::agent::run().await {
-            eprintln!("agentd: agent loop error: {e}");
-            std::process::exit(1);
+        match microsandbox_agentd::agent::run().await {
+            Ok(()) => {}
+            Err(microsandbox_agentd::AgentdError::Shutdown) => {}
+            Err(e) => {
+                eprintln!("agentd: agent loop error: {e}");
+                std::process::exit(1);
+            }
         }
     });
 

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -224,8 +224,13 @@ async fn handle_message(
             let stdin: ExecStdin = msg
                 .payload()
                 .map_err(|e| AgentdError::ExecSession(format!("decode stdin: {e}")))?;
-            if let Some(session) = sessions.get(&msg.id) {
-                let _ = session.write_stdin(&stdin.data).await;
+            if let Some(session) = sessions.get_mut(&msg.id) {
+                if stdin.data.is_empty() {
+                    // Empty data signals EOF — close stdin.
+                    session.close_stdin();
+                } else {
+                    let _ = session.write_stdin(&stdin.data).await;
+                }
             }
         }
 
@@ -248,11 +253,11 @@ async fn handle_message(
         }
 
         MessageType::Shutdown => {
-            // Graceful shutdown — kill all sessions, then exit.
+            // Graceful shutdown — signal all sessions and break from main loop.
             for (_, session) in sessions.drain() {
                 let _ = session.send_signal(15); // SIGTERM
             }
-            std::process::exit(0);
+            return Err(AgentdError::Shutdown);
         }
 
         _ => {

--- a/crates/agentd/lib/error.rs
+++ b/crates/agentd/lib/error.rs
@@ -39,4 +39,8 @@ pub enum AgentdError {
     /// An init error.
     #[error("init error: {0}")]
     Init(String),
+
+    /// Graceful shutdown requested.
+    #[error("shutdown")]
+    Shutdown,
 }

--- a/crates/agentd/lib/serial.rs
+++ b/crates/agentd/lib/serial.rs
@@ -13,7 +13,7 @@ use crate::error::{AgentdError, AgentdResult};
 const VIRTIO_PORTS_PATH: &str = "/sys/class/virtio-ports";
 
 /// The expected port name for the agent channel.
-pub const AGENT_PORT_NAME: &str = "msb-agent";
+pub const AGENT_PORT_NAME: &str = "agent";
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -125,6 +125,14 @@ impl ExecSession {
         kill(Pid::from_raw(self.pid), sig)?;
         Ok(())
     }
+
+    /// Closes the process's stdin.
+    ///
+    /// For pipe mode, drops the `ChildStdin` handle which closes the fd.
+    /// For PTY mode, this is a no-op (the PTY master stays open for output).
+    pub fn close_stdin(&mut self) {
+        self.stdin.take();
+    }
 }
 
 impl ExecSession {
@@ -194,6 +202,9 @@ impl ExecSession {
             .transpose()
             .map_err(|e| AgentdError::ExecSession(format!("invalid cwd: {e}")))?;
 
+        // Pre-parse rlimits before fork (no allocations in child).
+        let parsed_rlimits = parse_rlimits(req);
+
         // Fork.
         let pid = unsafe { libc::fork() };
         if pid < 0 {
@@ -242,6 +253,13 @@ impl ExecSession {
             if let Some(ref dir) = c_cwd {
                 unsafe {
                     libc::chdir(dir.as_ptr());
+                }
+            }
+
+            // Apply resource limits.
+            for (resource, limit) in &parsed_rlimits {
+                if unsafe { libc::setrlimit(*resource as _, limit) } != 0 {
+                    unsafe { libc::_exit(1) };
                 }
             }
 
@@ -298,6 +316,21 @@ impl ExecSession {
             cmd.current_dir(dir);
         }
 
+        // Apply resource limits in the child before exec.
+        let parsed_rlimits = parse_rlimits(req);
+        if !parsed_rlimits.is_empty() {
+            unsafe {
+                cmd.pre_exec(move || {
+                    for (resource, limit) in &parsed_rlimits {
+                        if libc::setrlimit(*resource as _, limit) != 0 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                    }
+                    Ok(())
+                });
+            }
+        }
+
         let mut child = cmd.spawn()?;
         let pid = child.id().unwrap_or(0) as i32;
         let stdin = child.stdin.take();
@@ -321,17 +354,73 @@ impl ExecSession {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Writes data to a raw fd using a blocking task.
+/// Parses a resource limit name into the corresponding `RLIMIT_*` constant.
+///
+/// Uses raw constants for Linux-specific limits that aren't in libc's cross-platform API.
+fn parse_rlimit_resource(name: &str) -> Option<libc::c_int> {
+    // Linux x86_64 RLIMIT_* values for resources not exposed by libc on all platforms.
+    const RLIMIT_LOCKS: libc::c_int = 10;
+    const RLIMIT_SIGPENDING: libc::c_int = 11;
+    const RLIMIT_MSGQUEUE: libc::c_int = 12;
+    const RLIMIT_NICE: libc::c_int = 13;
+    const RLIMIT_RTPRIO: libc::c_int = 14;
+    const RLIMIT_RTTIME: libc::c_int = 15;
+
+    match name {
+        "cpu" => Some(libc::RLIMIT_CPU as _),
+        "fsize" => Some(libc::RLIMIT_FSIZE as _),
+        "data" => Some(libc::RLIMIT_DATA as _),
+        "stack" => Some(libc::RLIMIT_STACK as _),
+        "core" => Some(libc::RLIMIT_CORE as _),
+        "rss" => Some(libc::RLIMIT_RSS as _),
+        "nproc" => Some(libc::RLIMIT_NPROC as _),
+        "nofile" => Some(libc::RLIMIT_NOFILE as _),
+        "memlock" => Some(libc::RLIMIT_MEMLOCK as _),
+        "as" => Some(libc::RLIMIT_AS as _),
+        "locks" => Some(RLIMIT_LOCKS),
+        "sigpending" => Some(RLIMIT_SIGPENDING),
+        "msgqueue" => Some(RLIMIT_MSGQUEUE),
+        "nice" => Some(RLIMIT_NICE),
+        "rtprio" => Some(RLIMIT_RTPRIO),
+        "rttime" => Some(RLIMIT_RTTIME),
+        _ => None,
+    }
+}
+
+/// Pre-parses rlimits from the exec request into `(resource_id, rlimit)` tuples
+/// that can be applied in the child process via `setrlimit()`.
+fn parse_rlimits(
+    req: &ExecRequest,
+) -> Vec<(libc::c_int, libc::rlimit)> {
+    req.rlimits
+        .iter()
+        .filter_map(|rl| {
+            let resource = parse_rlimit_resource(&rl.resource)?;
+            Some((
+                resource,
+                libc::rlimit {
+                    rlim_cur: rl.soft,
+                    rlim_max: rl.hard,
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Writes data to a raw fd using a blocking task, handling short writes.
 async fn blocking_write_fd(fd: RawFd, data: &[u8]) -> AgentdResult<()> {
     let data = data.to_vec();
     tokio::task::spawn_blocking(move || {
-        let ret =
-            unsafe { libc::write(fd, data.as_ptr() as *const libc::c_void, data.len()) };
-        if ret < 0 {
-            Err(AgentdError::Io(std::io::Error::last_os_error()))
-        } else {
-            Ok(())
+        let mut written = 0;
+        while written < data.len() {
+            let ptr = unsafe { data.as_ptr().add(written) as *const libc::c_void };
+            let ret = unsafe { libc::write(fd, ptr, data.len() - written) };
+            if ret < 0 {
+                return Err(AgentdError::Io(std::io::Error::last_os_error()));
+            }
+            written += ret as usize;
         }
+        Ok(())
     })
     .await
     .map_err(|e| AgentdError::ExecSession(format!("stdin write join error: {e}")))?

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -24,12 +24,15 @@ microsandbox-migration = { path = "../migration" }
 microsandbox-protocol = { path = "../protocol" }
 microsandbox-runtime = { path = "../runtime" }
 microsandbox-utils = { path = "../utils" }
+bytes.workspace = true
 chrono.workspace = true
+crossterm.workspace = true
 dirs.workspace = true
 futures.workspace = true
 libc.workspace = true
 nix = { workspace = true, features = ["process", "signal"] }
 reqwest.workspace = true
+scopeguard.workspace = true
 sea-orm.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/microsandbox/lib/agent/bridge.rs
+++ b/crates/microsandbox/lib/agent/bridge.rs
@@ -1,8 +1,12 @@
 //! Bridge for host↔agentd communication over virtio-console.
 //!
 //! [`AgentBridge`] manages a background reader task that dispatches incoming
-//! messages to pending request channels by correlation ID. The `core.ready`
-//! message from agentd is dispatched to correlation ID 0.
+//! messages to pending channels by correlation ID. The `core.ready` message
+//! from agentd is dispatched to correlation ID 0.
+//!
+//! All handlers use `mpsc::UnboundedSender<Message>`. Single-response callers
+//! (`request()`, `wait_ready()`) simply read one message and drop the receiver.
+//! Multi-message callers (`subscribe()`) keep reading until the session ends.
 
 use std::collections::HashMap;
 use std::os::unix::io::RawFd;
@@ -12,7 +16,7 @@ use std::sync::Arc;
 use microsandbox_protocol::codec;
 use microsandbox_protocol::message::{Message, MessageType};
 use tokio::io::AsyncRead;
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::MicrosandboxResult;
@@ -25,13 +29,13 @@ use super::stream;
 
 /// Bridge for communicating with agentd in the guest VM.
 ///
-/// Provides request/response messaging over the agent FD pair.
-/// A background task reads incoming messages and dispatches them
-/// to pending `oneshot` channels by correlation ID.
+/// Provides request/response and streaming messaging over the agent FD pair.
+/// A background task reads incoming messages and dispatches them to pending
+/// channels by correlation ID.
 pub struct AgentBridge {
     writer: Arc<Mutex<stream::FdWriter>>,
     next_id: AtomicU32,
-    pending: Arc<Mutex<HashMap<u32, oneshot::Sender<Message>>>>,
+    pending: Arc<Mutex<HashMap<u32, mpsc::UnboundedSender<Message>>>>,
     reader_handle: JoinHandle<()>,
 }
 
@@ -44,8 +48,9 @@ impl AgentBridge {
     ///
     /// Spawns a background reader task that dispatches incoming messages.
     pub fn new(agent_host_fd: RawFd) -> MicrosandboxResult<Self> {
-        let (reader, writer) = stream::from_raw_fd(agent_host_fd)?;
-        let pending: Arc<Mutex<HashMap<u32, oneshot::Sender<Message>>>> =
+        // Safety: agent_host_fd is a valid fd from spawn_supervisor.
+        let (reader, writer) = unsafe { stream::from_raw_fd(agent_host_fd) }?;
+        let pending: Arc<Mutex<HashMap<u32, mpsc::UnboundedSender<Message>>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
         let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
@@ -56,6 +61,17 @@ impl AgentBridge {
             pending,
             reader_handle,
         })
+    }
+
+    /// Allocate a new unique correlation ID.
+    ///
+    /// ID 0 is reserved for `core.ready`; it is skipped on wraparound.
+    pub fn next_id(&self) -> u32 {
+        let mut id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        if id == 0 {
+            id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        }
+        id
     }
 
     /// Send a message to agentd without waiting for a response.
@@ -69,31 +85,43 @@ impl AgentBridge {
     ///
     /// Assigns a unique correlation ID to the message before sending.
     pub async fn request(&self, mut msg: Message) -> MicrosandboxResult<Message> {
-        let mut id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        // ID 0 is reserved for core.ready; skip it on wraparound.
-        if id == 0 {
-            id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        }
+        let id = self.next_id();
         msg.id = id;
 
-        let (tx, rx) = oneshot::channel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
         self.pending.lock().await.insert(id, tx);
 
-        self.send(&msg).await?;
+        if let Err(e) = self.send(&msg).await {
+            self.pending.lock().await.remove(&id);
+            return Err(e);
+        }
 
-        rx.await.map_err(|_| {
+        rx.recv().await.ok_or_else(|| {
             crate::MicrosandboxError::Runtime("agent bridge reader closed before response".into())
         })
+    }
+
+    /// Register a channel for the given correlation ID.
+    ///
+    /// Returns a receiver that will receive all messages dispatched to this ID.
+    /// The subscription is automatically removed when a terminal message
+    /// (`ExecExited`) is received or when the receiver is dropped.
+    ///
+    /// Call this **before** sending the request to ensure no messages are lost.
+    pub async fn subscribe(&self, id: u32) -> mpsc::UnboundedReceiver<Message> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.pending.lock().await.insert(id, tx);
+        rx
     }
 
     /// Wait for agentd to report readiness (`core.ready` message).
     ///
     /// The ready message is dispatched to correlation ID 0 by convention.
     pub async fn wait_ready(&self) -> MicrosandboxResult<()> {
-        let (tx, rx) = oneshot::channel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
         self.pending.lock().await.insert(0, tx);
 
-        rx.await.map_err(|_| {
+        rx.recv().await.ok_or_else(|| {
             crate::MicrosandboxError::Runtime("agent bridge closed before ready signal".into())
         })?;
 
@@ -102,13 +130,13 @@ impl AgentBridge {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Functions: Helpers
+// Functions
 //--------------------------------------------------------------------------------------------------
 
 /// Background task that reads messages from agentd and dispatches them.
 async fn reader_loop<R: AsyncRead + Unpin>(
     mut reader: R,
-    pending: Arc<Mutex<HashMap<u32, oneshot::Sender<Message>>>>,
+    pending: Arc<Mutex<HashMap<u32, mpsc::UnboundedSender<Message>>>>,
 ) {
     loop {
         let msg = match codec::read_message(&mut reader).await {
@@ -130,14 +158,23 @@ async fn reader_loop<R: AsyncRead + Unpin>(
             msg.id
         };
 
-        if let Some(tx) = pending.lock().await.remove(&dispatch_id) {
-            let _ = tx.send(msg);
+        let is_terminal = msg.t == MessageType::ExecExited;
+
+        let mut map = pending.lock().await;
+        if let Some(tx) = map.get(&dispatch_id) {
+            if tx.send(msg).is_err() {
+                // Receiver dropped — clean up.
+                map.remove(&dispatch_id);
+            } else if is_terminal {
+                // Terminal message sent successfully — remove subscription.
+                map.remove(&dispatch_id);
+            }
         } else {
-            tracing::trace!("agent bridge: no pending request for id={dispatch_id}");
+            tracing::trace!("agent bridge: no pending handler for id={dispatch_id}");
         }
     }
 
-    // When the reader exits, wake all pending requests so they fail gracefully.
+    // When the reader exits, drop all senders so receivers get None.
     let mut map = pending.lock().await;
     map.clear();
 }

--- a/crates/microsandbox/lib/agent/stream.rs
+++ b/crates/microsandbox/lib/agent/stream.rs
@@ -39,7 +39,7 @@ pub struct FdWriter {
 ///
 /// The caller must ensure `raw_fd` is a valid, open file descriptor.
 /// Ownership of `raw_fd` is transferred to the returned `FdReader`.
-pub fn from_raw_fd(raw_fd: RawFd) -> io::Result<(FdReader, FdWriter)> {
+pub unsafe fn from_raw_fd(raw_fd: RawFd) -> io::Result<(FdReader, FdWriter)> {
     // Dup the FD so reader and writer are independent.
     // Safety: raw_fd is valid per precondition.
     let read_owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -54,6 +54,18 @@ pub enum MicrosandboxError {
     #[error("nix error: {0}")]
     Nix(#[from] nix::errno::Errno),
 
+    /// Command execution timed out.
+    #[error("exec timed out after {0:?}")]
+    ExecTimeout(std::time::Duration),
+
+    /// The requested script was not found in sandbox configuration.
+    #[error("script not found: {0}")]
+    ScriptNotFound(String),
+
+    /// A terminal operation failed.
+    #[error("terminal error: {0}")]
+    Terminal(String),
+
     /// A custom error message.
     #[error("{0}")]
     Custom(String),

--- a/crates/microsandbox/lib/sandbox/attach.rs
+++ b/crates/microsandbox/lib/sandbox/attach.rs
@@ -1,0 +1,342 @@
+//! Interactive attach types for terminal bridging with sandboxes.
+
+use crate::MicrosandboxResult;
+
+use super::exec::Rlimit;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Configuration for attaching to a sandbox with an interactive session.
+///
+/// The host terminal is set to raw mode for the duration of the attach session.
+/// The guest process runs in a PTY, enabling terminal features (colors, line
+/// editing, Ctrl+C → SIGINT).
+#[derive(Debug, Clone, Default)]
+pub struct AttachConfig {
+    /// Command to run (default: sandbox's configured shell).
+    pub cmd: Option<String>,
+
+    /// Arguments.
+    pub args: Vec<String>,
+
+    /// Environment variables (merged with sandbox env).
+    pub env: Vec<(String, String)>,
+
+    /// Working directory (default: sandbox's workdir).
+    pub cwd: Option<String>,
+
+    /// Detach key sequence (default: `"ctrl-]"`).
+    ///
+    /// Uses Docker-style syntax: `"ctrl-<char>"` for control keys,
+    /// comma-separated for multi-key sequences (e.g., `"ctrl-p,ctrl-q"`).
+    pub detach_keys: Option<String>,
+
+    /// Resource limits.
+    pub rlimits: Vec<Rlimit>,
+}
+
+/// Builder for [`AttachConfig`].
+pub struct AttachBuilder {
+    config: AttachConfig,
+}
+
+/// Trait for types that can be converted to [`AttachConfig`].
+///
+/// Enables ergonomic calling patterns:
+/// - `sandbox.attach(())` — default shell
+/// - `sandbox.attach("bash")` — specific command
+/// - `sandbox.attach(|a| a.cmd("zsh").env("TERM", "xterm"))` — closure
+/// - `sandbox.attach(config)` — pre-built AttachConfig
+pub trait IntoAttachConfig {
+    /// Convert into attach configuration.
+    fn into_attach_config(self) -> AttachConfig;
+}
+
+/// Parsed detach key sequence.
+///
+/// Matches raw stdin bytes against the configured detach sequence.
+pub(crate) struct DetachKeys {
+    /// The byte sequence that triggers detach.
+    sequence: Vec<u8>,
+}
+
+/// Information about an active session (stub — deferred).
+///
+/// Session listing and reconnection require protocol extensions
+/// (`core.sessions.list`, `core.session.attach`) that are not yet implemented.
+pub struct SessionInfo {
+    /// Unique session ID.
+    pub id: String,
+
+    /// Command being executed.
+    pub cmd: String,
+
+    /// When the session was started.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+
+    /// Whether session has TTY.
+    pub tty: bool,
+
+    /// Process ID in guest.
+    pub pid: Option<u32>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl AttachBuilder {
+    /// Set the command to run.
+    pub fn cmd(mut self, cmd: impl Into<String>) -> Self {
+        self.config.cmd = Some(cmd.into());
+        self
+    }
+
+    /// Add a single argument.
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.config.args.push(arg.into());
+        self
+    }
+
+    /// Add multiple arguments.
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.config.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the working directory.
+    pub fn cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.config.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Add an environment variable.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.config.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Add multiple environment variables.
+    pub fn envs(
+        mut self,
+        vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.config
+            .env
+            .extend(vars.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self
+    }
+
+    /// Set the detach key sequence.
+    pub fn detach_keys(mut self, keys: impl Into<String>) -> Self {
+        self.config.detach_keys = Some(keys.into());
+        self
+    }
+
+    /// Set a resource limit (soft = hard).
+    pub fn rlimit(mut self, resource: super::exec::RlimitResource, limit: u64) -> Self {
+        self.config.rlimits.push(Rlimit {
+            resource,
+            soft: limit,
+            hard: limit,
+        });
+        self
+    }
+
+    /// Set a resource limit with different soft/hard values.
+    pub fn rlimit_range(
+        mut self,
+        resource: super::exec::RlimitResource,
+        soft: u64,
+        hard: u64,
+    ) -> Self {
+        self.config.rlimits.push(Rlimit {
+            resource,
+            soft,
+            hard,
+        });
+        self
+    }
+
+    /// Build the configuration.
+    pub fn build(self) -> AttachConfig {
+        self.config
+    }
+}
+
+impl DetachKeys {
+    /// Default detach key: Ctrl+] (0x1D).
+    const DEFAULT: u8 = 0x1d;
+
+    /// Parse a detach key specification string.
+    ///
+    /// Supports Docker-style syntax:
+    /// - `"ctrl-]"` → `[0x1D]`
+    /// - `"ctrl-a"` → `[0x01]`
+    /// - `"ctrl-p,ctrl-q"` → `[0x10, 0x11]`
+    pub fn parse(spec: &str) -> MicrosandboxResult<Self> {
+        let mut sequence = Vec::new();
+        for part in spec.split(',') {
+            let part = part.trim();
+            if let Some(ch) = part.strip_prefix("ctrl-") {
+                let byte = match ch {
+                    "]" => 0x1d,
+                    "[" => 0x1b,
+                    "\\" => 0x1c,
+                    "^" => 0x1e,
+                    "_" => 0x1f,
+                    "@" => 0x00,
+                    c if c.len() == 1 => {
+                        let b = c.as_bytes()[0];
+                        if b.is_ascii_lowercase() {
+                            b - b'a' + 1
+                        } else if b.is_ascii_uppercase() {
+                            b - b'A' + 1
+                        } else {
+                            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                                "invalid detach key: {part}"
+                            )));
+                        }
+                    }
+                    _ => {
+                        return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                            "invalid detach key: {part}"
+                        )));
+                    }
+                };
+                sequence.push(byte);
+            } else if part.len() == 1 {
+                sequence.push(part.as_bytes()[0]);
+            } else {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "invalid detach key: {part}"
+                )));
+            }
+        }
+
+        if sequence.is_empty() {
+            sequence.push(Self::DEFAULT);
+        }
+
+        Ok(Self { sequence })
+    }
+
+    /// Create the default detach keys (Ctrl+]).
+    pub fn default_keys() -> Self {
+        Self {
+            sequence: vec![Self::DEFAULT],
+        }
+    }
+
+    /// Returns the detach key sequence bytes.
+    pub fn sequence(&self) -> &[u8] {
+        &self.sequence
+    }
+
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for AttachBuilder {
+    fn default() -> Self {
+        Self {
+            config: AttachConfig::default(),
+        }
+    }
+}
+
+/// Unit type for default shell: `sandbox.attach(())`
+impl IntoAttachConfig for () {
+    fn into_attach_config(self) -> AttachConfig {
+        AttachConfig::default()
+    }
+}
+
+/// Closure pattern: `sandbox.attach(|a| a.cmd("zsh").env("TERM", "xterm"))`
+impl<F> IntoAttachConfig for F
+where
+    F: FnOnce(AttachBuilder) -> AttachBuilder,
+{
+    fn into_attach_config(self) -> AttachConfig {
+        self(AttachBuilder::default()).build()
+    }
+}
+
+/// Direct config: `sandbox.attach(config)`
+impl IntoAttachConfig for AttachConfig {
+    fn into_attach_config(self) -> AttachConfig {
+        self
+    }
+}
+
+/// Simple string for command: `sandbox.attach("bash")`
+impl IntoAttachConfig for &str {
+    fn into_attach_config(self) -> AttachConfig {
+        AttachConfig {
+            cmd: Some(self.to_string()),
+            ..Default::default()
+        }
+    }
+}
+
+/// String for command: `sandbox.attach(String::from("bash"))`
+impl IntoAttachConfig for String {
+    fn into_attach_config(self) -> AttachConfig {
+        AttachConfig {
+            cmd: Some(self),
+            ..Default::default()
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detach_keys_default() {
+        let keys = DetachKeys::default_keys();
+        assert_eq!(keys.sequence(), &[0x1d]);
+    }
+
+    #[test]
+    fn test_detach_keys_ctrl_bracket() {
+        let keys = DetachKeys::parse("ctrl-]").unwrap();
+        assert_eq!(keys.sequence(), &[0x1d]);
+    }
+
+    #[test]
+    fn test_detach_keys_ctrl_letter() {
+        let keys = DetachKeys::parse("ctrl-a").unwrap();
+        assert_eq!(keys.sequence(), &[0x01]);
+
+        let keys = DetachKeys::parse("ctrl-z").unwrap();
+        assert_eq!(keys.sequence(), &[0x1a]);
+    }
+
+    #[test]
+    fn test_detach_keys_multi_sequence() {
+        let keys = DetachKeys::parse("ctrl-p,ctrl-q").unwrap();
+        assert_eq!(keys.sequence(), &[0x10, 0x11]);
+    }
+
+    #[test]
+    fn test_detach_keys_single_char() {
+        let keys = DetachKeys::parse("q").unwrap();
+        assert_eq!(keys.sequence(), &[b'q']);
+    }
+
+    #[test]
+    fn test_detach_keys_invalid() {
+        assert!(DetachKeys::parse("ctrl-").is_err());
+        assert!(DetachKeys::parse("ctrl-ab").is_err());
+    }
+}

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -1,0 +1,521 @@
+//! Execution types for running commands inside sandboxes.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use microsandbox_protocol::exec::{ExecSignal, ExecStdin};
+use microsandbox_protocol::message::{Message, MessageType};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::MicrosandboxResult;
+use crate::agent::AgentBridge;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Options for command execution (everything except the command itself).
+#[derive(Debug, Clone, Default)]
+pub struct ExecOptions {
+    /// Arguments.
+    pub args: Vec<String>,
+
+    /// Working directory (overrides sandbox default).
+    pub cwd: Option<String>,
+
+    /// Environment variables (merged with sandbox env).
+    pub env: Vec<(String, String)>,
+
+    /// Execution timeout. On expiry, SIGKILL is sent.
+    pub timeout: Option<Duration>,
+
+    /// Stdin mode.
+    pub stdin: StdinMode,
+
+    /// Allocate a PTY (pseudo-terminal).
+    pub tty: bool,
+
+    /// Resource limits applied before exec via `setrlimit()`.
+    pub rlimits: Vec<Rlimit>,
+}
+
+/// Builder for [`ExecOptions`].
+pub struct ExecOptionsBuilder {
+    options: ExecOptions,
+}
+
+/// How stdin is provided to the command.
+#[derive(Debug, Clone, Default)]
+pub enum StdinMode {
+    /// No stdin (`/dev/null`).
+    #[default]
+    Null,
+
+    /// Pipe stdin via [`ExecSink`].
+    Pipe,
+
+    /// Provide fixed bytes as stdin.
+    Bytes(Vec<u8>),
+}
+
+/// Output of a completed command execution.
+pub struct ExecOutput {
+    /// Exit status.
+    pub status: ExitStatus,
+
+    /// Captured stdout.
+    pub stdout: Bytes,
+
+    /// Captured stderr.
+    pub stderr: Bytes,
+}
+
+/// Process exit status.
+#[derive(Debug, Clone, Copy)]
+pub struct ExitStatus {
+    /// Exit code.
+    pub code: i32,
+
+    /// Whether the process exited successfully (code == 0).
+    pub success: bool,
+}
+
+/// Handle to a streaming exec session.
+pub struct ExecHandle {
+    /// Correlation ID for this session.
+    pub(crate) id: u32,
+
+    /// Event receiver.
+    events: mpsc::UnboundedReceiver<ExecEvent>,
+
+    /// Stdin sink (only if `StdinMode::Pipe` was used).
+    stdin: Option<ExecSink>,
+
+    /// Bridge reference for sending signals/stdin.
+    bridge: Arc<AgentBridge>,
+}
+
+/// Events emitted by a streaming exec session.
+#[derive(Debug)]
+pub enum ExecEvent {
+    /// Process started.
+    Started {
+        /// Guest PID.
+        pid: u32,
+    },
+
+    /// Stdout data.
+    Stdout(Bytes),
+
+    /// Stderr data.
+    Stderr(Bytes),
+
+    /// Process exited.
+    Exited {
+        /// Exit code.
+        code: i32,
+    },
+}
+
+/// Sink for writing to a running process's stdin.
+pub struct ExecSink {
+    id: u32,
+    bridge: Arc<AgentBridge>,
+}
+
+/// A POSIX resource limit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rlimit {
+    /// Resource type.
+    pub resource: RlimitResource,
+
+    /// Soft limit (can be raised up to hard limit by the process).
+    pub soft: u64,
+
+    /// Hard limit (ceiling, requires privileges to raise).
+    pub hard: u64,
+}
+
+/// POSIX resource limit identifiers (maps to `RLIMIT_*` constants).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RlimitResource {
+    /// Max CPU time in seconds (`RLIMIT_CPU`).
+    Cpu,
+    /// Max file size in bytes (`RLIMIT_FSIZE`).
+    Fsize,
+    /// Max data segment size (`RLIMIT_DATA`).
+    Data,
+    /// Max stack size (`RLIMIT_STACK`).
+    Stack,
+    /// Max core file size (`RLIMIT_CORE`).
+    Core,
+    /// Max resident set size (`RLIMIT_RSS`).
+    Rss,
+    /// Max number of processes (`RLIMIT_NPROC`).
+    Nproc,
+    /// Max open file descriptors (`RLIMIT_NOFILE`).
+    Nofile,
+    /// Max locked memory (`RLIMIT_MEMLOCK`).
+    Memlock,
+    /// Max address space size (`RLIMIT_AS`).
+    As,
+    /// Max file locks (`RLIMIT_LOCKS`).
+    Locks,
+    /// Max pending signals (`RLIMIT_SIGPENDING`).
+    Sigpending,
+    /// Max bytes in POSIX message queues (`RLIMIT_MSGQUEUE`).
+    Msgqueue,
+    /// Max nice priority (`RLIMIT_NICE`).
+    Nice,
+    /// Max real-time priority (`RLIMIT_RTPRIO`).
+    Rtprio,
+    /// Max real-time timeout (`RLIMIT_RTTIME`).
+    Rttime,
+}
+
+/// Trait for types that can be converted to [`ExecOptions`].
+///
+/// Enables ergonomic calling patterns:
+/// - `sandbox.exec("ls", ["-la"])` — args array
+/// - `sandbox.exec("python", |e| e.args(["-c", "print('hi')"]))` — closure
+/// - `sandbox.exec("cat", ())` — no options
+/// - `sandbox.exec("my-app", options)` — pre-built ExecOptions
+pub trait IntoExecOptions {
+    /// Convert into exec options.
+    fn into_exec_options(self) -> ExecOptions;
+}
+
+/// Helper trait for readable byte sizes.
+pub trait SizeExt {
+    /// Convert to kibibytes.
+    fn kib(self) -> u64;
+    /// Convert to mebibytes.
+    fn mib(self) -> u64;
+    /// Convert to gibibytes.
+    fn gib(self) -> u64;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ExecOptionsBuilder {
+    /// Add a single argument.
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.options.args.push(arg.into());
+        self
+    }
+
+    /// Add multiple arguments.
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.options.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the working directory.
+    pub fn cwd(mut self, cwd: impl Into<String>) -> Self {
+        self.options.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Add an environment variable.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Add multiple environment variables.
+    pub fn envs(
+        mut self,
+        vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.options
+            .env
+            .extend(vars.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self
+    }
+
+    /// Set execution timeout.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.options.timeout = Some(timeout);
+        self
+    }
+
+    /// Set stdin mode to null (`/dev/null`).
+    pub fn stdin_null(mut self) -> Self {
+        self.options.stdin = StdinMode::Null;
+        self
+    }
+
+    /// Set stdin mode to pipe (use `ExecHandle::stdin()`).
+    pub fn stdin_pipe(mut self) -> Self {
+        self.options.stdin = StdinMode::Pipe;
+        self
+    }
+
+    /// Set stdin to fixed bytes.
+    pub fn stdin_bytes(mut self, data: impl Into<Vec<u8>>) -> Self {
+        self.options.stdin = StdinMode::Bytes(data.into());
+        self
+    }
+
+    /// Allocate a PTY.
+    pub fn tty(mut self, enabled: bool) -> Self {
+        self.options.tty = enabled;
+        self
+    }
+
+    /// Set a resource limit (soft = hard).
+    pub fn rlimit(mut self, resource: RlimitResource, limit: u64) -> Self {
+        self.options.rlimits.push(Rlimit {
+            resource,
+            soft: limit,
+            hard: limit,
+        });
+        self
+    }
+
+    /// Set a resource limit with different soft/hard values.
+    pub fn rlimit_range(
+        mut self,
+        resource: RlimitResource,
+        soft: u64,
+        hard: u64,
+    ) -> Self {
+        self.options.rlimits.push(Rlimit {
+            resource,
+            soft,
+            hard,
+        });
+        self
+    }
+
+    /// Build the options.
+    pub fn build(self) -> ExecOptions {
+        self.options
+    }
+}
+
+impl ExecHandle {
+    /// Create a new exec handle.
+    pub(crate) fn new(
+        id: u32,
+        events: mpsc::UnboundedReceiver<ExecEvent>,
+        stdin: Option<ExecSink>,
+        bridge: Arc<AgentBridge>,
+    ) -> Self {
+        Self {
+            id,
+            events,
+            stdin,
+            bridge,
+        }
+    }
+
+    /// Receive the next exec event.
+    ///
+    /// Returns `None` when the session has ended.
+    pub async fn recv(&mut self) -> Option<ExecEvent> {
+        self.events.recv().await
+    }
+
+    /// Take the stdin sink (if `StdinMode::Pipe` was used).
+    ///
+    /// Returns `None` if stdin was not piped or was already taken.
+    pub fn take_stdin(&mut self) -> Option<ExecSink> {
+        self.stdin.take()
+    }
+
+    /// Wait for the command to complete and return the exit status.
+    pub async fn wait(&mut self) -> MicrosandboxResult<ExitStatus> {
+        while let Some(event) = self.events.recv().await {
+            if let ExecEvent::Exited { code } = event {
+                return Ok(ExitStatus {
+                    code,
+                    success: code == 0,
+                });
+            }
+        }
+
+        Err(crate::MicrosandboxError::Runtime(
+            "exec session ended without exit event".into(),
+        ))
+    }
+
+    /// Wait for completion and collect all stdout/stderr.
+    pub async fn collect(&mut self) -> MicrosandboxResult<ExecOutput> {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut exit_code = -1;
+
+        while let Some(event) = self.events.recv().await {
+            match event {
+                ExecEvent::Stdout(data) => stdout.extend_from_slice(&data),
+                ExecEvent::Stderr(data) => stderr.extend_from_slice(&data),
+                ExecEvent::Exited { code } => {
+                    exit_code = code;
+                    break;
+                }
+                ExecEvent::Started { .. } => {}
+            }
+        }
+
+        Ok(ExecOutput {
+            status: ExitStatus {
+                code: exit_code,
+                success: exit_code == 0,
+            },
+            stdout: Bytes::from(stdout),
+            stderr: Bytes::from(stderr),
+        })
+    }
+
+    /// Send a signal to the running process.
+    pub async fn signal(&self, signal: i32) -> MicrosandboxResult<()> {
+        let payload = ExecSignal { signal };
+        let msg = Message::with_payload(MessageType::ExecSignal, self.id, &payload)?;
+        self.bridge.send(&msg).await
+    }
+
+    /// Send SIGKILL to the running process.
+    pub async fn kill(&self) -> MicrosandboxResult<()> {
+        self.signal(9).await
+    }
+}
+
+impl ExecSink {
+    /// Create a new stdin sink.
+    pub(crate) fn new(id: u32, bridge: Arc<AgentBridge>) -> Self {
+        Self { id, bridge }
+    }
+
+    /// Write data to the process's stdin.
+    pub async fn write(&self, data: impl AsRef<[u8]>) -> MicrosandboxResult<()> {
+        let payload = ExecStdin {
+            data: data.as_ref().to_vec(),
+        };
+        let msg = Message::with_payload(MessageType::ExecStdin, self.id, &payload)?;
+        self.bridge.send(&msg).await
+    }
+
+    /// Close stdin (sends EOF to the process).
+    pub async fn close(&self) -> MicrosandboxResult<()> {
+        let payload = ExecStdin { data: Vec::new() };
+        let msg = Message::with_payload(MessageType::ExecStdin, self.id, &payload)?;
+        self.bridge.send(&msg).await
+    }
+}
+
+impl RlimitResource {
+    /// Returns the lowercase string representation used in the protocol.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Fsize => "fsize",
+            Self::Data => "data",
+            Self::Stack => "stack",
+            Self::Core => "core",
+            Self::Rss => "rss",
+            Self::Nproc => "nproc",
+            Self::Nofile => "nofile",
+            Self::Memlock => "memlock",
+            Self::As => "as",
+            Self::Locks => "locks",
+            Self::Sigpending => "sigpending",
+            Self::Msgqueue => "msgqueue",
+            Self::Nice => "nice",
+            Self::Rtprio => "rtprio",
+            Self::Rttime => "rttime",
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for ExecOptionsBuilder {
+    fn default() -> Self {
+        Self {
+            options: ExecOptions::default(),
+        }
+    }
+}
+
+/// No options: `sandbox.exec("cat", ())`
+impl IntoExecOptions for () {
+    fn into_exec_options(self) -> ExecOptions {
+        ExecOptions::default()
+    }
+}
+
+/// Closure pattern: `sandbox.exec("python", |e| e.args(["-c", "print('hi')"]))`
+impl<F> IntoExecOptions for F
+where
+    F: FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+{
+    fn into_exec_options(self) -> ExecOptions {
+        self(ExecOptionsBuilder::default()).build()
+    }
+}
+
+/// Direct options: `sandbox.exec("my-app", options)`
+impl IntoExecOptions for ExecOptions {
+    fn into_exec_options(self) -> ExecOptions {
+        self
+    }
+}
+
+/// Args array: `sandbox.exec("ls", ["-la", "/tmp"])`
+impl<const N: usize> IntoExecOptions for [&str; N] {
+    fn into_exec_options(self) -> ExecOptions {
+        ExecOptions {
+            args: self.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+}
+
+/// String to `RlimitResource` conversion.
+///
+/// Accepts: `"nofile"`, `"as"`, `"nproc"`, `"cpu"`, etc. (case-insensitive).
+impl TryFrom<&str> for RlimitResource {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "cpu" => Ok(Self::Cpu),
+            "fsize" => Ok(Self::Fsize),
+            "data" => Ok(Self::Data),
+            "stack" => Ok(Self::Stack),
+            "core" => Ok(Self::Core),
+            "rss" => Ok(Self::Rss),
+            "nproc" => Ok(Self::Nproc),
+            "nofile" => Ok(Self::Nofile),
+            "memlock" => Ok(Self::Memlock),
+            "as" => Ok(Self::As),
+            "locks" => Ok(Self::Locks),
+            "sigpending" => Ok(Self::Sigpending),
+            "msgqueue" => Ok(Self::Msgqueue),
+            "nice" => Ok(Self::Nice),
+            "rtprio" => Ok(Self::Rtprio),
+            "rttime" => Ok(Self::Rttime),
+            _ => Err(format!("unknown rlimit resource: {s}")),
+        }
+    }
+}
+
+impl SizeExt for u64 {
+    fn kib(self) -> u64 {
+        self * 1024
+    }
+    fn mib(self) -> u64 {
+        self * 1024 * 1024
+    }
+    fn gib(self) -> u64 {
+        self * 1024 * 1024 * 1024
+    }
+}
+

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -5,31 +5,43 @@
 //! methods (stop, kill, drain, wait) and access to the [`AgentBridge`]
 //! for guest communication.
 
+mod attach;
 mod builder;
 mod config;
+pub mod exec;
 mod types;
 
 use std::process::ExitStatus;
 use std::sync::Arc;
 
+use bytes::Bytes;
+use microsandbox_protocol::exec::{
+    ExecRlimit, ExecRequest, ExecStarted, ExecStdin, ExecStdout, ExecStderr, ExecExited,
+};
 use microsandbox_protocol::message::{Message, MessageType};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, Set,
 };
 use sea_orm::sea_query::{Expr, OnConflict};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
 
 use crate::agent::AgentBridge;
 use crate::db::entity::sandbox as sandbox_entity;
 use crate::runtime::{SupervisorHandle, spawn_supervisor};
 use crate::MicrosandboxResult;
 
+use self::exec::{ExecEvent, ExecHandle, ExecOutput, ExecSink, IntoExecOptions, StdinMode};
+
 //--------------------------------------------------------------------------------------------------
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use attach::{AttachConfig, AttachBuilder, IntoAttachConfig, SessionInfo};
 pub use builder::SandboxBuilder;
 pub use config::SandboxConfig;
+pub use exec::{
+    ExecOptionsBuilder, ExitStatus as ExecExitStatus, Rlimit, RlimitResource, SizeExt,
+};
 pub use types::*;
 
 //--------------------------------------------------------------------------------------------------
@@ -196,8 +208,397 @@ impl Sandbox {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Functions: Helpers
+// Methods: Execution
 //--------------------------------------------------------------------------------------------------
+
+impl Sandbox {
+    /// Execute a command and return a streaming handle.
+    ///
+    /// This is the foundational exec method. All other exec methods delegate to it.
+    pub async fn exec_stream(
+        &self,
+        cmd: impl Into<String>,
+        opts: impl IntoExecOptions,
+    ) -> MicrosandboxResult<ExecHandle> {
+        let cmd = cmd.into();
+        let opts = opts.into_exec_options();
+
+        // Allocate correlation ID and subscribe BEFORE sending.
+        let id = self.bridge.next_id();
+        let rx = self.bridge.subscribe(id).await;
+
+        let req = build_exec_request(
+            &self.config, cmd, opts.args.clone(), opts.cwd.clone(),
+            &opts.env, &opts.rlimits, opts.tty, 24, 80,
+        );
+        let msg = Message::with_payload(MessageType::ExecRequest, id, &req)?;
+        self.bridge.send(&msg).await?;
+
+        // Build stdin sink (if Pipe mode).
+        let stdin = match &opts.stdin {
+            StdinMode::Pipe => Some(ExecSink::new(id, Arc::clone(&self.bridge))),
+            _ => None,
+        };
+
+        // Handle StdinMode::Bytes — send bytes then close.
+        if let StdinMode::Bytes(ref data) = opts.stdin {
+            let data = data.clone();
+            let bridge = Arc::clone(&self.bridge);
+            tokio::spawn(async move {
+                let payload = ExecStdin { data };
+                if let Ok(msg) = Message::with_payload(MessageType::ExecStdin, id, &payload) {
+                    let _ = bridge.send(&msg).await;
+                }
+                // Send empty to signal EOF.
+                let close = ExecStdin { data: Vec::new() };
+                if let Ok(msg) = Message::with_payload(MessageType::ExecStdin, id, &close) {
+                    let _ = bridge.send(&msg).await;
+                }
+            });
+        }
+
+        // Transform raw protocol messages into ExecEvents.
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        tokio::spawn(event_mapper_task(rx, event_tx));
+
+        Ok(ExecHandle::new(id, event_rx, stdin, Arc::clone(&self.bridge)))
+    }
+
+    /// Execute a command and wait for completion.
+    ///
+    /// Returns captured stdout/stderr.
+    ///
+    /// - `sandbox.exec("ls", ["-la"])` — command + args
+    /// - `sandbox.exec("python", |e| e.args(["-c", "print('hi')"]).env("HOME", "/root"))` — closure
+    /// - `sandbox.exec("cat", ())` — no options
+    pub async fn exec(
+        &self,
+        cmd: impl Into<String>,
+        opts: impl IntoExecOptions,
+    ) -> MicrosandboxResult<ExecOutput> {
+        let opts = opts.into_exec_options();
+        let timeout_duration = opts.timeout;
+        let mut handle = self.exec_stream(cmd, opts).await?;
+
+        match timeout_duration {
+            Some(duration) => {
+                match tokio::time::timeout(duration, handle.collect()).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        // Timed out — kill the process and drain remaining events.
+                        let _ = handle.kill().await;
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            handle.collect(),
+                        ).await {
+                            Ok(result) => result,
+                            Err(_) => Err(crate::MicrosandboxError::ExecTimeout(duration)),
+                        }
+                    }
+                }
+            }
+            None => handle.collect().await,
+        }
+    }
+
+    /// Execute a shell command and wait for completion.
+    ///
+    /// Uses the sandbox's configured shell (default: `/bin/sh`).
+    ///
+    /// - `sandbox.shell("echo hello", ())` — no options
+    /// - `sandbox.shell("make test", |e| e.env("CI", "true"))` — with env
+    pub async fn shell(
+        &self,
+        script: impl Into<String>,
+        opts: impl IntoExecOptions,
+    ) -> MicrosandboxResult<ExecOutput> {
+        let shell = self.config.shell.as_deref().unwrap_or("/bin/sh");
+        let mut opts = opts.into_exec_options();
+        opts.args = vec!["-c".to_string(), script.into()];
+        self.exec(shell, opts).await
+    }
+
+    /// Execute a shell command with streaming I/O.
+    pub async fn shell_stream(
+        &self,
+        script: impl Into<String>,
+        opts: impl IntoExecOptions,
+    ) -> MicrosandboxResult<ExecHandle> {
+        let shell = self.config.shell.as_deref().unwrap_or("/bin/sh");
+        let mut opts = opts.into_exec_options();
+        opts.args = vec!["-c".to_string(), script.into()];
+        self.exec_stream(shell, opts).await
+    }
+
+    /// Run a named script (defined via `.script()` in builder).
+    ///
+    /// Scripts are available at `/.msb/scripts/<name>` in the guest.
+    pub async fn run(
+        &self,
+        name: &str,
+        opts: impl IntoExecOptions,
+    ) -> MicrosandboxResult<ExecOutput> {
+        if !self.config.scripts.contains_key(name) {
+            return Err(crate::MicrosandboxError::ScriptNotFound(name.to_string()));
+        }
+        let script_path = format!("/.msb/scripts/{name}");
+        self.shell(&format!("sh {script_path}"), opts).await
+    }
+
+    /// Run a named script with streaming I/O.
+    pub async fn run_stream(
+        &self,
+        name: &str,
+        opts: impl IntoExecOptions,
+    ) -> MicrosandboxResult<ExecHandle> {
+        if !self.config.scripts.contains_key(name) {
+            return Err(crate::MicrosandboxError::ScriptNotFound(name.to_string()));
+        }
+        let script_path = format!("/.msb/scripts/{name}");
+        self.shell_stream(&format!("sh {script_path}"), opts).await
+    }
+
+    /// Start the sandbox by running the `"start"` script.
+    ///
+    /// Returns error if no `"start"` script is defined.
+    pub async fn start(&self) -> MicrosandboxResult<ExecOutput> {
+        self.run("start", ()).await
+    }
+
+    /// Start the sandbox with streaming I/O.
+    pub async fn start_stream(&self) -> MicrosandboxResult<ExecHandle> {
+        self.run_stream("start", ()).await
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Attach
+//--------------------------------------------------------------------------------------------------
+
+impl Sandbox {
+    /// Attach to the sandbox with an interactive terminal session.
+    ///
+    /// Bridges the host terminal to a guest process running in a PTY.
+    /// Returns the exit code when the process exits or the user detaches.
+    ///
+    /// - `sandbox.attach(())` — default shell
+    /// - `sandbox.attach("bash")` — specific command
+    /// - `sandbox.attach(|a| a.cmd("zsh").env("TERM", "xterm"))` — closure
+    pub async fn attach(
+        &self,
+        config: impl attach::IntoAttachConfig,
+    ) -> MicrosandboxResult<i32> {
+        use microsandbox_protocol::exec::ExecResize;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let config = config.into_attach_config();
+        let detach_keys = match &config.detach_keys {
+            Some(spec) => attach::DetachKeys::parse(spec)?,
+            None => attach::DetachKeys::default_keys(),
+        };
+
+        // Resolve command (default to sandbox shell).
+        let cmd = config
+            .cmd
+            .unwrap_or_else(|| self.config.shell.clone().unwrap_or_else(|| "/bin/sh".into()));
+
+        // Get terminal size.
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+
+        // Allocate ID and subscribe.
+        let id = self.bridge.next_id();
+        let mut rx = self.bridge.subscribe(id).await;
+
+        // Build ExecRequest with tty=true.
+        let req = build_exec_request(
+            &self.config, cmd, config.args, config.cwd,
+            &config.env, &config.rlimits, true, rows, cols,
+        );
+        let msg = Message::with_payload(MessageType::ExecRequest, id, &req)?;
+        self.bridge.send(&msg).await?;
+
+        // Enter raw mode.
+        crossterm::terminal::enable_raw_mode()
+            .map_err(|e| crate::MicrosandboxError::Terminal(e.to_string()))?;
+        let _raw_guard = scopeguard::guard((), |_| {
+            let _ = crossterm::terminal::disable_raw_mode();
+        });
+
+        // Set up async I/O.
+        let mut stdin = tokio::io::stdin();
+        let mut stdout = tokio::io::stdout();
+        let mut sigwinch = tokio::signal::unix::signal(
+            tokio::signal::unix::SignalKind::window_change(),
+        ).map_err(|e| crate::MicrosandboxError::Runtime(format!("sigwinch: {e}")))?;
+
+        let mut exit_code: i32 = -1;
+        let detach_seq = detach_keys.sequence();
+        let mut match_pos = 0usize;
+
+        loop {
+            let mut input_buf = [0u8; 1024];
+
+            tokio::select! {
+                // Read stdin from host terminal.
+                result = stdin.read(&mut input_buf) => {
+                    match result {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            let data = &input_buf[..n];
+
+                            // Check for detach key sequence.
+                            let mut detached = false;
+                            for &b in data {
+                                if b == detach_seq[match_pos] {
+                                    match_pos += 1;
+                                    if match_pos == detach_seq.len() {
+                                        detached = true;
+                                        break;
+                                    }
+                                } else {
+                                    match_pos = 0;
+                                    // Check if this byte starts a new match.
+                                    if b == detach_seq[0] {
+                                        match_pos = 1;
+                                    }
+                                }
+                            }
+
+                            if detached {
+                                break;
+                            }
+
+                            // Forward to guest.
+                            let payload = ExecStdin { data: data.to_vec() };
+                            if let Ok(msg) = Message::with_payload(MessageType::ExecStdin, id, &payload) {
+                                let _ = self.bridge.send(&msg).await;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+
+                // Receive output from guest.
+                Some(msg) = rx.recv() => {
+                    match msg.t {
+                        MessageType::ExecStdout => {
+                            if let Ok(out) = msg.payload::<ExecStdout>() {
+                                let _ = stdout.write_all(&out.data).await;
+                                let _ = stdout.flush().await;
+                            }
+                        }
+                        MessageType::ExecExited => {
+                            if let Ok(exited) = msg.payload::<ExecExited>() {
+                                exit_code = exited.code;
+                            }
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Terminal resize.
+                _ = sigwinch.recv() => {
+                    if let Ok((new_cols, new_rows)) = crossterm::terminal::size() {
+                        let payload = ExecResize { rows: new_rows, cols: new_cols };
+                        if let Ok(msg) = Message::with_payload(MessageType::ExecResize, id, &payload) {
+                            let _ = self.bridge.send(&msg).await;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Raw mode restored by scopeguard drop.
+        Ok(exit_code)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build an `ExecRequest` by merging sandbox config with caller-provided overrides.
+fn build_exec_request(
+    config: &SandboxConfig,
+    cmd: String,
+    args: Vec<String>,
+    cwd: Option<String>,
+    env: &[(String, String)],
+    rlimits: &[Rlimit],
+    tty: bool,
+    rows: u16,
+    cols: u16,
+) -> ExecRequest {
+    let env: Vec<String> = config
+        .env
+        .iter()
+        .chain(env.iter())
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect();
+
+    let rlimits: Vec<ExecRlimit> = rlimits
+        .iter()
+        .map(|rl| ExecRlimit {
+            resource: rl.resource.as_str().to_string(),
+            soft: rl.soft,
+            hard: rl.hard,
+        })
+        .collect();
+
+    ExecRequest {
+        cmd,
+        args,
+        env,
+        cwd: cwd.or_else(|| config.workdir.clone()),
+        tty,
+        rows,
+        cols,
+        rlimits,
+    }
+}
+
+/// Background task that converts raw protocol messages into [`ExecEvent`]s.
+async fn event_mapper_task(
+    mut rx: mpsc::UnboundedReceiver<Message>,
+    tx: mpsc::UnboundedSender<ExecEvent>,
+) {
+    while let Some(msg) = rx.recv().await {
+        let event = match msg.t {
+            MessageType::ExecStarted => {
+                if let Ok(started) = msg.payload::<ExecStarted>() {
+                    ExecEvent::Started { pid: started.pid }
+                } else {
+                    continue;
+                }
+            }
+            MessageType::ExecStdout => {
+                if let Ok(out) = msg.payload::<ExecStdout>() {
+                    ExecEvent::Stdout(Bytes::from(out.data))
+                } else {
+                    continue;
+                }
+            }
+            MessageType::ExecStderr => {
+                if let Ok(err) = msg.payload::<ExecStderr>() {
+                    ExecEvent::Stderr(Bytes::from(err.data))
+                } else {
+                    continue;
+                }
+            }
+            MessageType::ExecExited => {
+                if let Ok(exited) = msg.payload::<ExecExited>() {
+                    let _ = tx.send(ExecEvent::Exited { code: exited.code });
+                }
+                break;
+            }
+            _ => continue,
+        };
+        if tx.send(event).is_err() {
+            break;
+        }
+    }
+}
 
 /// Update the sandbox status in the database.
 async fn update_sandbox_status(

--- a/crates/protocol/lib/exec.rs
+++ b/crates/protocol/lib/exec.rs
@@ -35,6 +35,23 @@ pub struct ExecRequest {
     /// Initial terminal columns (only used when `tty` is true).
     #[serde(default = "default_cols")]
     pub cols: u16,
+
+    /// POSIX resource limits to apply to the spawned process via `setrlimit()`.
+    #[serde(default)]
+    pub rlimits: Vec<ExecRlimit>,
+}
+
+/// A POSIX resource limit to apply to a spawned process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecRlimit {
+    /// Resource name (lowercase): "nofile", "nproc", "as", "cpu", etc.
+    pub resource: String,
+
+    /// Soft limit (can be raised up to hard limit by the process).
+    pub soft: u64,
+
+    /// Hard limit (ceiling, requires privileges to raise).
+    pub hard: u64,
 }
 
 /// Confirmation that a command has been started.

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -130,7 +130,7 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
     }
 
     // Agent — wire agent_fd through virtio-console multi-port.
-    // Guest discovers port by name via /sys/class/virtio-ports/agent.
+    // Guest discovers port by name "agent" via /sys/class/virtio-ports/.
     if let Some(agent_fd) = config.agent_fd {
         builder = builder.console(|c| c.port("agent", agent_fd, agent_fd));
     }


### PR DESCRIPTION
## Summary

- Implement Phase 5 (Execution) of the microsandbox SDK: running commands inside sandboxes, streaming stdout/stderr, piping stdin, timeouts, and interactive terminal attach
- Extend the protocol and agentd to support rlimits (POSIX resource limits enforced in the guest via setrlimit) and stdin EOF signaling
- Upgrade AgentBridge from single-response oneshot channels to uniform mpsc streaming, enabling multi-message exec sessions (Started, Stdout x N, Stderr x N, Exited)
- Fix agent port name mismatch bug: agentd searched for "msb-agent" but the VM registered "agent" -- these would never match at runtime

## Changes

### Protocol (crates/protocol)
- Add `ExecRlimit` struct and `rlimits: Vec<ExecRlimit>` field to `ExecRequest` with `#[serde(default)]` for backward compatibility

### Agentd (crates/agentd)
- Add `parse_rlimit_resource()` and `parse_rlimits()` helpers mapping resource name strings to `libc::RLIMIT_*` constants
- Apply rlimits via `libc::setrlimit()` in PTY fork path (between fork and execvp) and pipe path (via `pre_exec` hook)
- Add `close_stdin()` method on `ExecSession` for EOF handling (drops stdin handle in pipe mode, no-op in PTY mode)
- Handle empty `ExecStdin.data` as EOF signal in the agent message handler
- Add `Shutdown` error variant for clean exit on guest shutdown
- Fix port name: `AGENT_PORT_NAME` changed from `"msb-agent"` to `"agent"`

### AgentBridge (crates/microsandbox/lib/agent)
- Replace `oneshot::Sender<Message>` with uniform `mpsc::UnboundedSender<Message>` for all pending handlers
- Add `subscribe(id)` method for multi-message exec session streaming
- Add public `next_id()` for correlation ID allocation before subscribing
- Clean up subscriptions on terminal messages (`ExecExited`) or receiver drop
- Mark `from_raw_fd` as unsafe (was missing)

### Exec types (new: crates/microsandbox/lib/sandbox/exec.rs)
- `ExecOptions` and `ExecOptionsBuilder` with fluent API (arg, args, cwd, env, timeout, stdin modes, tty, rlimits)
- `IntoExecOptions` trait with impls for `()`, closures, `ExecOptions`, `[&str; N]`
- `StdinMode` enum (Null, Pipe, Bytes), `ExecOutput`, `ExitStatus`
- `ExecHandle` with `recv()`, `wait()`, `collect()`, `signal()`, `kill()`, `take_stdin()`
- `ExecSink` for stdin piping (write, close via empty ExecStdin)
- `Rlimit`, `RlimitResource` (16 POSIX variants with `as_str()` and `From<&str>`), `SizeExt` trait

### Attach types (new: crates/microsandbox/lib/sandbox/attach.rs)
- `AttachConfig`, `AttachBuilder` with fluent API
- `IntoAttachConfig` trait with impls for `()`, `&str`, `String`, `AttachConfig`, closures
- `DetachKeys` parser supporting Docker-style syntax (ctrl-], ctrl-p,ctrl-q)
- `SessionInfo` stub type (session listing deferred)
- Unit tests for DetachKeys parsing

### Sandbox methods (crates/microsandbox/lib/sandbox/mod.rs)
- `exec()` / `exec_stream()` with timeout support (SIGKILL on expiry, then collect)
- `shell()` / `shell_stream()` via configured shell (sh -c)
- `run()` / `run_stream()` for named scripts at /.msb/scripts/
- `start()` / `start_stream()` for the "start" script
- `attach()` with crossterm raw mode, SIGWINCH handling, detach key matching, scopeguard terminal restore
- Internal `event_mapper_task` converting protocol Messages to ExecEvents

### Other
- Add `bytes`, `crossterm`, `scopeguard` dependencies to microsandbox Cargo.toml
- Add `ExecTimeout`, `ScriptNotFound`, `Terminal` error variants
- Fix vm.rs comment to match actual port name

## Test Plan

- Run `cargo build` to verify all 10 workspace crates compile
- Run `cargo test -p microsandbox-protocol` to verify ExecRequest serialization with rlimits
- Run `cargo test -p microsandbox` to verify DetachKeys parsing, RlimitResource conversion, SizeExt, and IntoExecOptions impls
- Full integration test (exec a command, verify stdout/stderr collected) requires a running VM -- deferred to first Linux boot