### PR TITLE
feat(microsandbox): add filesystem and volume management (#388)

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -15,9 +15,11 @@ use microsandbox_protocol::exec::{
     ExecExited, ExecRequest, ExecResize, ExecSignal, ExecStarted, ExecStdin, ExecStdout,
     ExecStderr,
 };
+use microsandbox_protocol::fs::{FsData, FsRequest};
 use microsandbox_protocol::message::{Message, MessageType};
 
 use crate::error::{AgentdError, AgentdResult};
+use crate::fs::FsWriteSession;
 use crate::heartbeat::{heartbeat_dir_exists, write_heartbeat};
 use crate::serial::{AGENT_PORT_NAME, find_serial_port};
 use crate::session::{ExecSession, SessionOutput};
@@ -69,8 +71,11 @@ pub async fn run() -> AgentdResult<()> {
     let mut serial_in_buf = Vec::new();
     let mut serial_out_buf = Vec::new();
 
-    // Active sessions.
+    // Active exec sessions.
     let mut sessions: HashMap<u32, ExecSession> = HashMap::new();
+
+    // Active filesystem write sessions.
+    let mut write_sessions: HashMap<u32, FsWriteSession> = HashMap::new();
 
     // Channel for session output events.
     let (session_tx, mut session_rx) = mpsc::unbounded_channel::<(u32, SessionOutput)>();
@@ -111,6 +116,7 @@ pub async fn run() -> AgentdResult<()> {
                                 handle_message(
                                     msg,
                                     &mut sessions,
+                                    &mut write_sessions,
                                     &session_tx,
                                     &mut serial_out_buf,
                                 ).await?;
@@ -155,6 +161,10 @@ pub async fn run() -> AgentdResult<()> {
                             .map_err(|e| AgentdError::ExecSession(format!("encode exited frame: {e}")))?;
                         sessions.remove(&id);
                     }
+                    SessionOutput::Raw(frame_bytes) => {
+                        // Pre-encoded frame — write directly to output buffer.
+                        serial_out_buf.extend_from_slice(&frame_bytes);
+                    }
                 }
 
                 if !serial_out_buf.is_empty() {
@@ -185,6 +195,7 @@ pub async fn run() -> AgentdResult<()> {
 async fn handle_message(
     msg: Message,
     sessions: &mut HashMap<u32, ExecSession>,
+    write_sessions: &mut HashMap<u32, FsWriteSession>,
     session_tx: &mpsc::UnboundedSender<(u32, SessionOutput)>,
     out_buf: &mut Vec<u8>,
 ) -> AgentdResult<()> {
@@ -252,11 +263,57 @@ async fn handle_message(
             }
         }
 
+        MessageType::FsRequest => {
+            let req: FsRequest = msg
+                .payload()
+                .map_err(|e| AgentdError::ExecSession(format!("decode fs request: {e}")))?;
+            match crate::fs::handle_fs_request(msg.id, req, out_buf, session_tx).await {
+                Ok(Some(ws)) => {
+                    write_sessions.insert(msg.id, ws);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    eprintln!("fs request error for {}: {e}", msg.id);
+                }
+            }
+        }
+
+        MessageType::FsData => {
+            let data: FsData = msg
+                .payload()
+                .map_err(|e| AgentdError::ExecSession(format!("decode fs data: {e}")))?;
+            if let Some(session) = write_sessions.get_mut(&msg.id) {
+                match crate::fs::handle_fs_data(msg.id, data, session, out_buf).await {
+                    Ok(true) => {
+                        // Session complete — remove it.
+                        write_sessions.remove(&msg.id);
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        eprintln!("fs data error for {}: {e}", msg.id);
+                        write_sessions.remove(&msg.id);
+                    }
+                }
+            } else {
+                // No write session for this ID — send error response.
+                let resp = microsandbox_protocol::fs::FsResponse {
+                    ok: false,
+                    error: Some(format!("unknown write session: {}", msg.id)),
+                    data: None,
+                };
+                let reply = Message::with_payload(MessageType::FsResponse, msg.id, &resp)
+                    .map_err(|e| AgentdError::ExecSession(format!("encode fs error: {e}")))?;
+                encode_to_buf(&reply, out_buf)
+                    .map_err(|e| AgentdError::ExecSession(format!("encode fs error frame: {e}")))?;
+            }
+        }
+
         MessageType::Shutdown => {
             // Graceful shutdown — signal all sessions and break from main loop.
             for (_, session) in sessions.drain() {
                 let _ = session.send_signal(15); // SIGTERM
             }
+            write_sessions.clear();
             return Err(AgentdError::Shutdown);
         }
 

--- a/crates/agentd/lib/fs.rs
+++ b/crates/agentd/lib/fs.rs
@@ -1,0 +1,475 @@
+//! Guest-side filesystem operation handlers.
+//!
+//! Handles `core.fs.*` protocol messages by performing filesystem operations
+//! using `std::fs` and `tokio::fs`, then sending responses back to the host.
+
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+use microsandbox_protocol::codec::encode_to_buf;
+use microsandbox_protocol::fs::{
+    FsData, FsEntryInfo, FsOp, FsRequest, FsResponse, FsResponseData, FS_CHUNK_SIZE,
+};
+use microsandbox_protocol::message::{Message, MessageType};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::mpsc;
+
+use crate::session::SessionOutput;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Tracks an in-progress streaming write operation.
+pub struct FsWriteSession {
+    file: tokio::fs::File,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handles an incoming `FsRequest` message.
+///
+/// For simple request/response ops (stat, list, mkdir, remove, copy, rename),
+/// the response is encoded directly into `out_buf`.
+///
+/// For streaming read, a background task is spawned that sends `FsData` chunks
+/// via `session_tx`, followed by a terminal `FsResponse`.
+///
+/// For streaming write, a `FsWriteSession` is created and returned for the
+/// caller to insert into the write sessions map.
+pub async fn handle_fs_request(
+    id: u32,
+    req: FsRequest,
+    out_buf: &mut Vec<u8>,
+    session_tx: &mpsc::UnboundedSender<(u32, SessionOutput)>,
+) -> Result<Option<FsWriteSession>, String> {
+    match req.op {
+        FsOp::Stat { path } => {
+            let resp = handle_stat(&path).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+        FsOp::List { path } => {
+            let resp = handle_list(&path).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+        FsOp::Read { path } => {
+            let tx = session_tx.clone();
+            tokio::spawn(async move {
+                handle_read_stream(id, &path, &tx).await;
+            });
+            Ok(None)
+        }
+        FsOp::Write { path, mode } => {
+            match handle_write_open(&path, mode).await {
+                Ok(session) => Ok(Some(session)),
+                Err(e) => {
+                    let resp = FsResponse {
+                        ok: false,
+                        error: Some(e),
+                        data: None,
+                    };
+                    encode_response(id, resp, out_buf)?;
+                    Ok(None)
+                }
+            }
+        }
+        FsOp::Mkdir { path } => {
+            let resp = handle_mkdir(&path).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+        FsOp::Remove { path } => {
+            let resp = handle_remove(&path).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+        FsOp::RemoveDir { path } => {
+            let resp = handle_remove_dir(&path).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+        FsOp::Copy { src, dst } => {
+            let resp = handle_copy(&src, &dst).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+        FsOp::Rename { src, dst } => {
+            let resp = handle_rename(&src, &dst).await;
+            encode_response(id, resp, out_buf)?;
+            Ok(None)
+        }
+    }
+}
+
+/// Handles an incoming `FsData` message for a streaming write session.
+///
+/// If `data` is empty, the file is closed and a terminal `FsResponse` is sent.
+/// Returns `true` if the session should be removed (EOF received).
+pub async fn handle_fs_data(
+    id: u32,
+    data: FsData,
+    session: &mut FsWriteSession,
+    out_buf: &mut Vec<u8>,
+) -> Result<bool, String> {
+    if data.data.is_empty() {
+        // EOF — flush and close the file.
+        if let Err(e) = session.file.flush().await {
+            let resp = FsResponse {
+                ok: false,
+                error: Some(format!("flush: {e}")),
+                data: None,
+            };
+            encode_response(id, resp, out_buf)?;
+            return Ok(true);
+        }
+
+        let resp = FsResponse {
+            ok: true,
+            error: None,
+            data: None,
+        };
+        encode_response(id, resp, out_buf)?;
+        Ok(true)
+    } else {
+        // Write chunk to file.
+        if let Err(e) = session.file.write_all(&data.data).await {
+            let resp = FsResponse {
+                ok: false,
+                error: Some(format!("write: {e}")),
+                data: None,
+            };
+            encode_response(id, resp, out_buf)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Encode a `FsResponse` message into the output buffer.
+fn encode_response(id: u32, resp: FsResponse, out_buf: &mut Vec<u8>) -> Result<(), String> {
+    let msg = Message::with_payload(MessageType::FsResponse, id, &resp)
+        .map_err(|e| format!("encode fs response: {e}"))?;
+    encode_to_buf(&msg, out_buf).map_err(|e| format!("encode fs response frame: {e}"))?;
+    Ok(())
+}
+
+/// Stat a path and return the response.
+async fn handle_stat(path: &str) -> FsResponse {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(meta) => FsResponse {
+            ok: true,
+            error: None,
+            data: Some(FsResponseData::Stat(metadata_to_entry_info(
+                path, &meta,
+            ))),
+        },
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("stat: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// List directory contents and return the response.
+async fn handle_list(path: &str) -> FsResponse {
+    match tokio::fs::read_dir(path).await {
+        Ok(mut dir) => {
+            let mut entries = Vec::new();
+            loop {
+                match dir.next_entry().await {
+                    Ok(Some(entry)) => {
+                        let entry_path = entry.path();
+                        let path_str = entry_path.to_string_lossy().to_string();
+                        match tokio::fs::symlink_metadata(&entry_path).await {
+                            Ok(meta) => {
+                                entries.push(metadata_to_entry_info(&path_str, &meta));
+                            }
+                            Err(_) => {
+                                // Skip entries we can't stat.
+                                entries.push(FsEntryInfo {
+                                    path: path_str,
+                                    kind: "other".to_string(),
+                                    size: 0,
+                                    mode: 0,
+                                    modified: None,
+                                });
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        return FsResponse {
+                            ok: false,
+                            error: Some(format!("readdir: {e}")),
+                            data: None,
+                        };
+                    }
+                }
+            }
+            FsResponse {
+                ok: true,
+                error: None,
+                data: Some(FsResponseData::List(entries)),
+            }
+        }
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("opendir: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// Stream file contents as `FsData` chunks, then send terminal `FsResponse`.
+async fn handle_read_stream(
+    id: u32,
+    path: &str,
+    tx: &mpsc::UnboundedSender<(u32, SessionOutput)>,
+) {
+    let file = match tokio::fs::File::open(path).await {
+        Ok(f) => f,
+        Err(e) => {
+            send_raw_response(id, false, Some(format!("open: {e}")), None, tx);
+            return;
+        }
+    };
+
+    let mut reader = tokio::io::BufReader::new(file);
+    let mut chunk = vec![0u8; FS_CHUNK_SIZE];
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let data = FsData {
+                    data: chunk[..n].to_vec(),
+                };
+                let msg = match Message::with_payload(MessageType::FsData, id, &data) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        send_raw_response(id, false, Some(format!("encode chunk: {e}")), None, tx);
+                        return;
+                    }
+                };
+                buf.clear();
+                if let Err(e) = encode_to_buf(&msg, &mut buf) {
+                    send_raw_response(id, false, Some(format!("encode chunk frame: {e}")), None, tx);
+                    return;
+                }
+                if tx.send((id, SessionOutput::Raw(buf.clone()))).is_err() {
+                    return;
+                }
+            }
+            Err(e) => {
+                send_raw_response(id, false, Some(format!("read: {e}")), None, tx);
+                return;
+            }
+        }
+    }
+
+    // Terminal success response.
+    send_raw_response(id, true, None, None, tx);
+}
+
+/// Encode and send a `FsResponse` as a raw pre-encoded frame via the session channel.
+fn send_raw_response(
+    id: u32,
+    ok: bool,
+    error: Option<String>,
+    data: Option<FsResponseData>,
+    tx: &mpsc::UnboundedSender<(u32, SessionOutput)>,
+) {
+    let resp = FsResponse {
+        ok,
+        error,
+        data,
+    };
+    match Message::with_payload(MessageType::FsResponse, id, &resp) {
+        Ok(msg) => {
+            let mut buf = Vec::new();
+            match encode_to_buf(&msg, &mut buf) {
+                Ok(()) => {
+                    let _ = tx.send((id, SessionOutput::Raw(buf)));
+                }
+                Err(e) => {
+                    eprintln!("failed to encode fs response frame for {id}: {e}");
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("failed to encode fs response for {id}: {e}");
+        }
+    }
+}
+
+/// Open a file for writing and return a write session.
+async fn handle_write_open(path: &str, mode: Option<u32>) -> Result<FsWriteSession, String> {
+    // Ensure parent directory exists.
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| format!("mkdir parent: {e}"))?;
+        }
+    }
+
+    let file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .await
+        .map_err(|e| format!("open for write: {e}"))?;
+
+    // Set permissions if specified.
+    if let Some(mode) = mode {
+        let perms = std::fs::Permissions::from_mode(mode);
+        file.set_permissions(perms)
+            .await
+            .map_err(|e| format!("set permissions: {e}"))?;
+    }
+
+    Ok(FsWriteSession { file })
+}
+
+/// Create a directory (and parents).
+async fn handle_mkdir(path: &str) -> FsResponse {
+    match tokio::fs::create_dir_all(path).await {
+        Ok(()) => FsResponse {
+            ok: true,
+            error: None,
+            data: None,
+        },
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("mkdir: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// Remove a file.
+async fn handle_remove(path: &str) -> FsResponse {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => FsResponse {
+            ok: true,
+            error: None,
+            data: None,
+        },
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("remove: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// Remove a directory recursively.
+async fn handle_remove_dir(path: &str) -> FsResponse {
+    match tokio::fs::remove_dir_all(path).await {
+        Ok(()) => FsResponse {
+            ok: true,
+            error: None,
+            data: None,
+        },
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("remove_dir: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// Copy a file within the guest.
+async fn handle_copy(src: &str, dst: &str) -> FsResponse {
+    // Ensure parent directory of destination exists.
+    if let Some(parent) = std::path::Path::new(dst).parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                return FsResponse {
+                    ok: false,
+                    error: Some(format!("mkdir parent: {e}")),
+                    data: None,
+                };
+            }
+        }
+    }
+
+    match tokio::fs::copy(src, dst).await {
+        Ok(_) => FsResponse {
+            ok: true,
+            error: None,
+            data: None,
+        },
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("copy: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// Rename/move a file or directory.
+async fn handle_rename(src: &str, dst: &str) -> FsResponse {
+    // Ensure parent directory of destination exists.
+    if let Some(parent) = std::path::Path::new(dst).parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                return FsResponse {
+                    ok: false,
+                    error: Some(format!("mkdir parent: {e}")),
+                    data: None,
+                };
+            }
+        }
+    }
+
+    match tokio::fs::rename(src, dst).await {
+        Ok(()) => FsResponse {
+            ok: true,
+            error: None,
+            data: None,
+        },
+        Err(e) => FsResponse {
+            ok: false,
+            error: Some(format!("rename: {e}")),
+            data: None,
+        },
+    }
+}
+
+/// Convert `std::fs::Metadata` to `FsEntryInfo`.
+fn metadata_to_entry_info(path: &str, meta: &std::fs::Metadata) -> FsEntryInfo {
+    let kind = if meta.is_file() {
+        "file"
+    } else if meta.is_dir() {
+        "dir"
+    } else if meta.is_symlink() {
+        "symlink"
+    } else {
+        "other"
+    };
+
+    let modified = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64);
+
+    FsEntryInfo {
+        path: path.to_string(),
+        kind: kind.to_string(),
+        size: meta.len(),
+        mode: meta.mode(),
+        modified,
+    }
+}

--- a/crates/agentd/lib/lib.rs
+++ b/crates/agentd/lib/lib.rs
@@ -10,6 +10,7 @@ mod error;
 //--------------------------------------------------------------------------------------------------
 
 pub mod agent;
+pub mod fs;
 pub mod heartbeat;
 pub mod init;
 pub mod serial;

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -25,9 +25,6 @@ use crate::error::{AgentdError, AgentdResult};
 /// Output reading is handled by a background task that sends events
 /// via the `mpsc` channel provided at spawn time.
 pub struct ExecSession {
-    /// The correlation ID for this session.
-    id: u32,
-
     /// The PID of the spawned process.
     pid: i32,
 
@@ -36,9 +33,6 @@ pub struct ExecSession {
 
     /// The child's stdin (only for pipe mode).
     stdin: Option<tokio::process::ChildStdin>,
-
-    /// Whether this session uses a PTY.
-    is_tty: bool,
 }
 
 /// Output from a session that the agent loop should forward to the host.
@@ -51,6 +45,12 @@ pub enum SessionOutput {
 
     /// The process has exited with the given code.
     Exited(i32),
+
+    /// Pre-encoded frame bytes to write directly to the serial output buffer.
+    ///
+    /// Used by filesystem streaming operations that encode their own
+    /// `FsData`/`FsResponse` messages.
+    Raw(Vec<u8>),
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -74,19 +74,9 @@ impl ExecSession {
         }
     }
 
-    /// Returns the session correlation ID.
-    pub fn id(&self) -> u32 {
-        self.id
-    }
-
     /// Returns the PID of the spawned process (as u32 for the protocol).
     pub fn pid(&self) -> u32 {
         self.pid as u32
-    }
-
-    /// Returns whether this session uses a PTY.
-    pub fn is_tty(&self) -> bool {
-        self.is_tty
     }
 
     /// Writes data to the process's stdin (or PTY master).
@@ -286,11 +276,9 @@ impl ExecSession {
         tokio::spawn(pty_reader_task(id, pid, reader_fd, tx));
 
         Ok(Self {
-            id,
             pid,
             pty_master: Some(pty.master),
             stdin: None,
-            is_tty: true,
         })
     }
 
@@ -341,11 +329,9 @@ impl ExecSession {
         tokio::spawn(pipe_reader_task(id, child, stdout, stderr, tx));
 
         Ok(Self {
-            id,
             pid,
             pty_master: None,
             stdin,
-            is_tty: false,
         })
     }
 }

--- a/crates/microsandbox/lib/agent/bridge.rs
+++ b/crates/microsandbox/lib/agent/bridge.rs
@@ -158,7 +158,7 @@ async fn reader_loop<R: AsyncRead + Unpin>(
             msg.id
         };
 
-        let is_terminal = msg.t == MessageType::ExecExited;
+        let is_terminal = matches!(msg.t, MessageType::ExecExited | MessageType::FsResponse);
 
         let mut map = pending.lock().await;
         if let Some(tx) = map.get(&dispatch_id) {

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -66,6 +66,18 @@ pub enum MicrosandboxError {
     #[error("terminal error: {0}")]
     Terminal(String),
 
+    /// A filesystem operation failed inside the sandbox.
+    #[error("sandbox fs error: {0}")]
+    SandboxFs(String),
+
+    /// The requested volume was not found.
+    #[error("volume not found: {0}")]
+    VolumeNotFound(String),
+
+    /// The volume already exists.
+    #[error("volume already exists: {0}")]
+    VolumeAlreadyExists(String),
+
     /// A custom error message.
     #[error("{0}")]
     Custom(String),

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -16,5 +16,6 @@ pub mod config;
 pub mod runtime;
 pub mod sandbox;
 pub mod setup;
+pub mod volume;
 
 pub use error::*;

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -14,7 +14,7 @@ use tokio::process::Command;
 
 use crate::config;
 use crate::runtime::handle::SupervisorHandle;
-use crate::sandbox::{RootfsSource, SandboxConfig};
+use crate::sandbox::{RootfsSource, SandboxConfig, VolumeMount};
 use crate::MicrosandboxResult;
 
 //--------------------------------------------------------------------------------------------------
@@ -129,6 +129,33 @@ pub async fn spawn_supervisor(
         cmd.arg("--env").arg(format!("{key}={value}"));
     }
 
+    // Volume mounts.
+    for mount in &config.mounts {
+        match mount {
+            VolumeMount::Bind { host, guest, readonly } => {
+                // Format: "tag:host_path[:ro]" where tag is a sanitized guest path.
+                let tag = guest_mount_tag(guest);
+                let mut arg = format!("{tag}:{}", host.display());
+                if *readonly {
+                    arg.push_str(":ro");
+                }
+                cmd.arg("--mount").arg(arg);
+            }
+            VolumeMount::Named { name, guest, readonly } => {
+                let vol_path = config::config().volumes_dir().join(name);
+                let tag = guest_mount_tag(guest);
+                let mut arg = format!("{tag}:{}", vol_path.display());
+                if *readonly {
+                    arg.push_str(":ro");
+                }
+                cmd.arg("--mount").arg(arg);
+            }
+            VolumeMount::Tmpfs { .. } => {
+                // Tmpfs mounts are handled by the guest kernel, not virtiofs.
+            }
+        }
+    }
+
     // Working directory.
     if let Some(ref workdir) = config.workdir {
         cmd.arg("--workdir").arg(workdir);
@@ -237,6 +264,17 @@ fn shutdown_mode_str(mode: &microsandbox_runtime::policy::ShutdownMode) -> &'sta
         ShutdownMode::Terminate => "terminate",
         ShutdownMode::Kill => "kill",
     }
+}
+
+/// Generate a virtiofs tag from a guest mount path.
+///
+/// Replaces `/` with `_` and strips leading underscores to produce a
+/// valid tag name. For example, `/data/cache` becomes `data_cache`.
+fn guest_mount_tag(guest_path: &str) -> String {
+    guest_path
+        .replace('/', "_")
+        .trim_start_matches('_')
+        .to_string()
 }
 
 /// Convert ExitAction to CLI arg string.

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -3,7 +3,7 @@
 use microsandbox_runtime::policy::ShutdownMode;
 
 use super::config::SandboxConfig;
-use super::types::RootfsSource;
+use super::types::{MountBuilder, RootfsSource};
 use crate::MicrosandboxResult;
 
 //--------------------------------------------------------------------------------------------------
@@ -121,6 +121,24 @@ impl SandboxBuilder {
     /// Set the idle timeout in seconds.
     pub fn idle_timeout(mut self, secs: u64) -> Self {
         self.config.supervisor_policy.idle_timeout_secs = Some(secs);
+        self
+    }
+
+    /// Add a volume mount using a closure-based builder.
+    ///
+    /// ```ignore
+    /// .volume("/data", |m| m.bind("/host/data"))
+    /// .volume("/config", |m| m.bind("/host/config").readonly())
+    /// .volume("/cache", |m| m.named("my-cache"))
+    /// .volume("/tmp", |m| m.tmpfs().size_mib(100))
+    /// ```
+    pub fn volume(
+        mut self,
+        guest_path: impl Into<String>,
+        f: impl FnOnce(MountBuilder) -> MountBuilder,
+    ) -> Self {
+        let mount = f(MountBuilder::new(guest_path)).build();
+        self.config.mounts.push(mount);
         self
     }
 

--- a/crates/microsandbox/lib/sandbox/fs.rs
+++ b/crates/microsandbox/lib/sandbox/fs.rs
@@ -1,0 +1,537 @@
+//! Filesystem operations on a running sandbox.
+//!
+//! [`SandboxFs`] provides methods to read, write, list, and manipulate files
+//! inside a running sandbox via the `core.fs.*` protocol messages.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use microsandbox_protocol::fs::{
+    FsData, FsEntryInfo, FsOp, FsRequest, FsResponse, FsResponseData, FS_CHUNK_SIZE,
+};
+use microsandbox_protocol::message::{Message, MessageType};
+use tokio::sync::mpsc;
+
+use crate::MicrosandboxError;
+use crate::MicrosandboxResult;
+use crate::agent::AgentBridge;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Filesystem operations handle for a running sandbox.
+///
+/// All operations go through the agent protocol (`core.fs.*` messages),
+/// which are handled by agentd inside the guest VM.
+pub struct SandboxFs<'a> {
+    bridge: &'a Arc<AgentBridge>,
+}
+
+/// A filesystem entry returned from listing or stat operations.
+#[derive(Debug, Clone)]
+pub struct FsEntry {
+    /// Path of the entry.
+    pub path: String,
+
+    /// Kind of entry.
+    pub kind: FsEntryKind,
+
+    /// Size in bytes.
+    pub size: u64,
+
+    /// Unix permission bits.
+    pub mode: u32,
+
+    /// Last modification time.
+    pub modified: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Kind of filesystem entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsEntryKind {
+    /// Regular file.
+    File,
+
+    /// Directory.
+    Directory,
+
+    /// Symbolic link.
+    Symlink,
+
+    /// Other (device, socket, etc.).
+    Other,
+}
+
+/// Metadata about a filesystem entry.
+#[derive(Debug, Clone)]
+pub struct FsMetadata {
+    /// Kind of entry.
+    pub kind: FsEntryKind,
+
+    /// Size in bytes.
+    pub size: u64,
+
+    /// Unix permission bits.
+    pub mode: u32,
+
+    /// Whether the entry is read-only.
+    pub readonly: bool,
+
+    /// Last modification time.
+    pub modified: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// A streaming reader for file data from the sandbox.
+pub struct FsReadStream {
+    rx: mpsc::UnboundedReceiver<Message>,
+}
+
+/// A streaming writer for file data to the sandbox.
+pub struct FsWriteSink {
+    id: u32,
+    bridge: Arc<AgentBridge>,
+    rx: mpsc::UnboundedReceiver<Message>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl<'a> SandboxFs<'a> {
+    /// Create a new filesystem handle.
+    pub(crate) fn new(bridge: &'a Arc<AgentBridge>) -> Self {
+        Self { bridge }
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Read Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// Read a file to bytes.
+    pub async fn read(&self, path: &str) -> MicrosandboxResult<Bytes> {
+        let id = self.bridge.next_id();
+        let mut rx = self.bridge.subscribe(id).await;
+
+        let req = FsRequest {
+            op: FsOp::Read {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, id, &req)?;
+        self.bridge.send(&msg).await?;
+
+        // Collect FsData chunks until FsResponse (terminal).
+        let mut data = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            match msg.t {
+                MessageType::FsData => {
+                    let chunk: FsData = msg.payload()?;
+                    data.extend_from_slice(&chunk.data);
+                }
+                MessageType::FsResponse => {
+                    let resp: FsResponse = msg.payload()?;
+                    if !resp.ok {
+                        return Err(MicrosandboxError::SandboxFs(
+                            resp.error.unwrap_or_else(|| "unknown error".into()),
+                        ));
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Bytes::from(data))
+    }
+
+    /// Read a file to string.
+    pub async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String> {
+        let data = self.read(path).await?;
+        String::from_utf8(Vec::from(data))
+            .map_err(|e| MicrosandboxError::SandboxFs(format!("invalid utf-8: {e}")))
+    }
+
+    /// Read a file with streaming.
+    ///
+    /// Returns an [`FsReadStream`] that yields chunks of data as they arrive.
+    pub async fn read_stream(&self, path: &str) -> MicrosandboxResult<FsReadStream> {
+        let id = self.bridge.next_id();
+        let rx = self.bridge.subscribe(id).await;
+
+        let req = FsRequest {
+            op: FsOp::Read {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, id, &req)?;
+        self.bridge.send(&msg).await?;
+
+        Ok(FsReadStream { rx })
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Write Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// Write bytes to a file.
+    pub async fn write(
+        &self,
+        path: &str,
+        data: impl AsRef<[u8]>,
+    ) -> MicrosandboxResult<()> {
+        let data = data.as_ref();
+        let id = self.bridge.next_id();
+        let mut rx = self.bridge.subscribe(id).await;
+
+        // Send write request.
+        let req = FsRequest {
+            op: FsOp::Write {
+                path: path.to_string(),
+                mode: None,
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, id, &req)?;
+        self.bridge.send(&msg).await?;
+
+        // Send data chunks.
+        for chunk in data.chunks(FS_CHUNK_SIZE) {
+            let fs_data = FsData {
+                data: chunk.to_vec(),
+            };
+            let msg = Message::with_payload(MessageType::FsData, id, &fs_data)?;
+            self.bridge.send(&msg).await?;
+        }
+
+        // Send EOF.
+        let eof = FsData { data: Vec::new() };
+        let msg = Message::with_payload(MessageType::FsData, id, &eof)?;
+        self.bridge.send(&msg).await?;
+
+        // Wait for terminal response.
+        wait_for_ok_response(&mut rx).await
+    }
+
+    /// Write with streaming.
+    ///
+    /// Returns an [`FsWriteSink`] for writing data in chunks. Call
+    /// [`FsWriteSink::close`] when done writing.
+    pub async fn write_stream(&self, path: &str) -> MicrosandboxResult<FsWriteSink> {
+        let id = self.bridge.next_id();
+
+        // Subscribe before sending to avoid race.
+        let rx = self.bridge.subscribe(id).await;
+
+        let req = FsRequest {
+            op: FsOp::Write {
+                path: path.to_string(),
+                mode: None,
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, id, &req)?;
+        self.bridge.send(&msg).await?;
+
+        Ok(FsWriteSink {
+            id,
+            bridge: Arc::clone(self.bridge),
+            rx,
+        })
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Directory Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// List directory contents.
+    pub async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>> {
+        let req = FsRequest {
+            op: FsOp::List {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        let resp: FsResponse = resp_msg.payload()?;
+
+        if !resp.ok {
+            return Err(MicrosandboxError::SandboxFs(
+                resp.error.unwrap_or_else(|| "unknown error".into()),
+            ));
+        }
+
+        match resp.data {
+            Some(FsResponseData::List(entries)) => {
+                Ok(entries.into_iter().map(entry_info_to_fs_entry).collect())
+            }
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    /// Create a directory (and parents).
+    pub async fn mkdir(&self, path: &str) -> MicrosandboxResult<()> {
+        let req = FsRequest {
+            op: FsOp::Mkdir {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        check_response(resp_msg)
+    }
+
+    /// Remove a directory recursively.
+    pub async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()> {
+        let req = FsRequest {
+            op: FsOp::RemoveDir {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        check_response(resp_msg)
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // File Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// Remove a file.
+    pub async fn remove(&self, path: &str) -> MicrosandboxResult<()> {
+        let req = FsRequest {
+            op: FsOp::Remove {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        check_response(resp_msg)
+    }
+
+    /// Copy a file within the sandbox.
+    pub async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()> {
+        let req = FsRequest {
+            op: FsOp::Copy {
+                src: from.to_string(),
+                dst: to.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        check_response(resp_msg)
+    }
+
+    /// Rename/move a file or directory.
+    pub async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()> {
+        let req = FsRequest {
+            op: FsOp::Rename {
+                src: from.to_string(),
+                dst: to.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        check_response(resp_msg)
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Metadata
+    //----------------------------------------------------------------------------------------------
+
+    /// Get file/directory metadata.
+    pub async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata> {
+        let req = FsRequest {
+            op: FsOp::Stat {
+                path: path.to_string(),
+            },
+        };
+        let msg = Message::with_payload(MessageType::FsRequest, 0, &req)?;
+        let resp_msg = self.bridge.request(msg).await?;
+        let resp: FsResponse = resp_msg.payload()?;
+
+        if !resp.ok {
+            return Err(MicrosandboxError::SandboxFs(
+                resp.error.unwrap_or_else(|| "unknown error".into()),
+            ));
+        }
+
+        match resp.data {
+            Some(FsResponseData::Stat(info)) => Ok(entry_info_to_metadata(&info)),
+            _ => Err(MicrosandboxError::SandboxFs(
+                "unexpected response data for stat".into(),
+            )),
+        }
+    }
+
+    /// Check if a path exists.
+    pub async fn exists(&self, path: &str) -> MicrosandboxResult<bool> {
+        match self.stat(path).await {
+            Ok(_) => Ok(true),
+            Err(MicrosandboxError::SandboxFs(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Host Transfer
+    //----------------------------------------------------------------------------------------------
+
+    /// Copy a file from the host into the sandbox.
+    pub async fn copy_from_host(
+        &self,
+        host_path: impl AsRef<Path>,
+        guest_path: &str,
+    ) -> MicrosandboxResult<()> {
+        let data = tokio::fs::read(host_path.as_ref()).await?;
+        self.write(guest_path, &data).await
+    }
+
+    /// Copy a file from the sandbox to the host.
+    pub async fn copy_to_host(
+        &self,
+        guest_path: &str,
+        host_path: impl AsRef<Path>,
+    ) -> MicrosandboxResult<()> {
+        let data = self.read(guest_path).await?;
+        tokio::fs::write(host_path.as_ref(), &data).await?;
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: FsReadStream
+//--------------------------------------------------------------------------------------------------
+
+impl FsReadStream {
+    /// Receive the next chunk of data.
+    ///
+    /// Returns `None` when the stream is complete (after `FsResponse`).
+    /// Returns an error if the guest reported a failure.
+    pub async fn recv(&mut self) -> MicrosandboxResult<Option<Bytes>> {
+        while let Some(msg) = self.rx.recv().await {
+            match msg.t {
+                MessageType::FsData => {
+                    let chunk: FsData = msg.payload()?;
+                    if !chunk.data.is_empty() {
+                        return Ok(Some(Bytes::from(chunk.data)));
+                    }
+                }
+                MessageType::FsResponse => {
+                    let resp: FsResponse = msg.payload()?;
+                    if !resp.ok {
+                        return Err(MicrosandboxError::SandboxFs(
+                            resp.error.unwrap_or_else(|| "unknown error".into()),
+                        ));
+                    }
+                    return Ok(None);
+                }
+                _ => {}
+            }
+        }
+        Ok(None)
+    }
+
+    /// Collect all remaining data into bytes.
+    pub async fn collect(mut self) -> MicrosandboxResult<Bytes> {
+        let mut data = Vec::new();
+        while let Some(chunk) = self.recv().await? {
+            data.extend_from_slice(&chunk);
+        }
+        Ok(Bytes::from(data))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: FsWriteSink
+//--------------------------------------------------------------------------------------------------
+
+impl FsWriteSink {
+    /// Write a chunk of data.
+    pub async fn write(&self, data: impl AsRef<[u8]>) -> MicrosandboxResult<()> {
+        let fs_data = FsData {
+            data: data.as_ref().to_vec(),
+        };
+        let msg = Message::with_payload(MessageType::FsData, self.id, &fs_data)?;
+        self.bridge.send(&msg).await
+    }
+
+    /// Close the write stream (sends EOF) and wait for confirmation.
+    ///
+    /// This must be called to finalize the write operation. Returns an
+    /// error if the guest reports a write failure.
+    pub async fn close(mut self) -> MicrosandboxResult<()> {
+        let eof = FsData { data: Vec::new() };
+        let msg = Message::with_payload(MessageType::FsData, self.id, &eof)?;
+        self.bridge.send(&msg).await?;
+
+        // Wait for the terminal FsResponse from the guest.
+        wait_for_ok_response(&mut self.rx).await
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Parse a kind string from the wire protocol into an `FsEntryKind`.
+fn parse_kind(s: &str) -> FsEntryKind {
+    match s {
+        "file" => FsEntryKind::File,
+        "dir" => FsEntryKind::Directory,
+        "symlink" => FsEntryKind::Symlink,
+        _ => FsEntryKind::Other,
+    }
+}
+
+/// Parse an optional Unix timestamp into a `DateTime<Utc>`.
+fn parse_modified(ts: Option<i64>) -> Option<chrono::DateTime<chrono::Utc>> {
+    ts.map(|t| chrono::DateTime::from_timestamp(t, 0).unwrap_or_default())
+}
+
+/// Parse an `FsEntryInfo` into an `FsEntry`.
+fn entry_info_to_fs_entry(info: FsEntryInfo) -> FsEntry {
+    FsEntry {
+        kind: parse_kind(&info.kind),
+        modified: parse_modified(info.modified),
+        path: info.path,
+        size: info.size,
+        mode: info.mode,
+    }
+}
+
+/// Convert an `FsEntryInfo` to `FsMetadata`.
+fn entry_info_to_metadata(info: &FsEntryInfo) -> FsMetadata {
+    FsMetadata {
+        kind: parse_kind(&info.kind),
+        modified: parse_modified(info.modified),
+        size: info.size,
+        mode: info.mode,
+        readonly: info.mode & 0o200 == 0,
+    }
+}
+
+/// Deserialize and check a simple ok/error `FsResponse`.
+fn check_response(msg: Message) -> MicrosandboxResult<()> {
+    let resp: FsResponse = msg.payload()?;
+    if resp.ok {
+        Ok(())
+    } else {
+        Err(MicrosandboxError::SandboxFs(
+            resp.error.unwrap_or_else(|| "unknown error".into()),
+        ))
+    }
+}
+
+/// Wait for and check a terminal `FsResponse` from a subscription channel.
+async fn wait_for_ok_response(
+    rx: &mut mpsc::UnboundedReceiver<Message>,
+) -> MicrosandboxResult<()> {
+    while let Some(msg) = rx.recv().await {
+        if msg.t == MessageType::FsResponse {
+            return check_response(msg);
+        }
+    }
+    Err(MicrosandboxError::SandboxFs(
+        "channel closed before response".into(),
+    ))
+}

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -9,6 +9,7 @@ mod attach;
 mod builder;
 mod config;
 pub mod exec;
+pub mod fs;
 mod types;
 
 use std::process::ExitStatus;
@@ -42,7 +43,11 @@ pub use config::SandboxConfig;
 pub use exec::{
     ExecOptionsBuilder, ExitStatus as ExecExitStatus, Rlimit, RlimitResource, SizeExt,
 };
-pub use types::*;
+pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, SandboxFs};
+pub use types::{
+    MountBuilder, NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig,
+    VolumeMount,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -172,6 +177,11 @@ impl Sandbox {
     /// Get the agent bridge for low-level communication with agentd.
     pub fn bridge(&self) -> &AgentBridge {
         &self.bridge
+    }
+
+    /// Access the filesystem API for this sandbox.
+    pub fn fs(&self) -> fs::SandboxFs<'_> {
+        fs::SandboxFs::new(&self.bridge)
     }
 
     /// Stop the sandbox gracefully by sending `core.shutdown` to agentd.

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -1,8 +1,6 @@
-//! Stub types for sandbox configuration.
+//! Types for sandbox configuration.
 //!
-//! These types are referenced by [`SandboxConfig`](super::SandboxConfig) but
-//! will be fully implemented in later phases. They carry enough structure
-//! for Phase 4 to compile and for configs to round-trip through serde.
+//! These types are referenced by [`SandboxConfig`](super::SandboxConfig).
 
 use std::path::PathBuf;
 
@@ -22,43 +20,150 @@ pub enum RootfsSource {
     Oci(String),
 }
 
-/// A volume mount mapping a host source to a guest path.
+/// A volume mount specification for a sandbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct VolumeMount {
-    /// Source identifier (host path or named volume).
-    pub source: String,
+#[serde(tag = "type")]
+pub enum VolumeMount {
+    /// Bind mount a host directory into the guest.
+    Bind {
+        /// Host path to bind mount.
+        host: PathBuf,
+        /// Guest mount path.
+        guest: String,
+        /// Whether the mount is read-only.
+        #[serde(default)]
+        readonly: bool,
+    },
 
-    /// Mount target path inside the guest.
-    pub target: String,
+    /// Mount a named volume into the guest.
+    Named {
+        /// Volume name.
+        name: String,
+        /// Guest mount path.
+        guest: String,
+        /// Whether the mount is read-only.
+        #[serde(default)]
+        readonly: bool,
+    },
 
-    /// Whether the mount is read-only.
-    #[serde(default)]
-    pub read_only: bool,
+    /// Temporary filesystem (memory-backed).
+    Tmpfs {
+        /// Guest mount path.
+        guest: String,
+        /// Size limit in MiB.
+        #[serde(default)]
+        size_mib: Option<u32>,
+    },
+}
+
+/// Builder for constructing a [`VolumeMount`].
+pub struct MountBuilder {
+    guest: String,
+    mount: MountKind,
+    readonly: bool,
+    size_mib: Option<u32>,
+}
+
+/// Internal kind for the mount builder.
+enum MountKind {
+    Bind(PathBuf),
+    Named(String),
+    Tmpfs,
+    Unset,
 }
 
 /// A rootfs patch applied as an overlay layer before VM start.
 ///
-/// Fully implemented in Phase 8 (Image Management).
+/// Fully implemented in Phase 13 (Patches).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Patch {}
 
 /// Network configuration for a sandbox.
 ///
-/// Fully implemented in Phase 6 (Networking).
+/// Fully implemented in Phase 9 (Network).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NetworkConfig {}
 
 /// Secrets configuration for a sandbox.
 ///
-/// Fully implemented in Phase 7 (Secrets Management).
+/// Fully implemented in Phase 11 (Secrets).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SecretsConfig {}
 
 /// SSH configuration for a sandbox.
 ///
-/// Fully implemented in Phase 9 (SSH).
+/// Fully implemented in Phase 14 (Polish).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SshConfig {}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MountBuilder {
+    /// Create a new mount builder for the given guest path.
+    pub fn new(guest: impl Into<String>) -> Self {
+        Self {
+            guest: guest.into(),
+            mount: MountKind::Unset,
+            readonly: false,
+            size_mib: None,
+        }
+    }
+
+    /// Bind mount from a host path.
+    pub fn bind(mut self, host: impl Into<PathBuf>) -> Self {
+        self.mount = MountKind::Bind(host.into());
+        self
+    }
+
+    /// Use a named volume.
+    pub fn named(mut self, name: impl Into<String>) -> Self {
+        self.mount = MountKind::Named(name.into());
+        self
+    }
+
+    /// Use tmpfs (memory-backed).
+    pub fn tmpfs(mut self) -> Self {
+        self.mount = MountKind::Tmpfs;
+        self
+    }
+
+    /// Make the mount read-only.
+    pub fn readonly(mut self) -> Self {
+        self.readonly = true;
+        self
+    }
+
+    /// Set size limit in MiB (for tmpfs).
+    pub fn size_mib(mut self, size: u32) -> Self {
+        self.size_mib = Some(size);
+        self
+    }
+
+    /// Build the volume mount.
+    ///
+    /// Panics if no mount type was set (bind, named, or tmpfs).
+    pub fn build(self) -> VolumeMount {
+        match self.mount {
+            MountKind::Bind(host) => VolumeMount::Bind {
+                host,
+                guest: self.guest,
+                readonly: self.readonly,
+            },
+            MountKind::Named(name) => VolumeMount::Named {
+                name,
+                guest: self.guest,
+                readonly: self.readonly,
+            },
+            MountKind::Tmpfs => VolumeMount::Tmpfs {
+                guest: self.guest,
+                size_mib: self.size_mib,
+            },
+            MountKind::Unset => panic!("MountBuilder: no mount type set (call .bind(), .named(), or .tmpfs())"),
+        }
+    }
+}
 
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations

--- a/crates/microsandbox/lib/volume/fs.rs
+++ b/crates/microsandbox/lib/volume/fs.rs
@@ -1,0 +1,287 @@
+//! Direct host-side filesystem operations on a named volume.
+//!
+//! Unlike [`SandboxFs`](crate::sandbox::fs::SandboxFs) which operates through the
+//! agent protocol, [`VolumeFs`] operates directly on the host-side volume
+//! directory using `tokio::fs`.
+
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+
+use crate::MicrosandboxError;
+use crate::MicrosandboxResult;
+use crate::sandbox::fs::{FsEntry, FsEntryKind, FsMetadata};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Filesystem operations on a volume's host-side directory.
+pub struct VolumeFs<'a> {
+    volume: &'a super::Volume,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl<'a> VolumeFs<'a> {
+    /// Create a new volume filesystem handle.
+    pub(crate) fn new(volume: &'a super::Volume) -> Self {
+        Self { volume }
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Read Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// Read a file to bytes.
+    pub async fn read(&self, path: &str) -> MicrosandboxResult<Bytes> {
+        let full = self.resolve(path)?;
+        let data = tokio::fs::read(&full).await?;
+        Ok(Bytes::from(data))
+    }
+
+    /// Read a file to string.
+    pub async fn read_to_string(&self, path: &str) -> MicrosandboxResult<String> {
+        let full = self.resolve(path)?;
+        let data = tokio::fs::read_to_string(&full).await?;
+        Ok(data)
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Write Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// Write bytes to a file.
+    pub async fn write(
+        &self,
+        path: &str,
+        data: impl AsRef<[u8]>,
+    ) -> MicrosandboxResult<()> {
+        let full = self.resolve(path)?;
+
+        // Ensure parent directory exists.
+        if let Some(parent) = full.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        tokio::fs::write(&full, data.as_ref()).await?;
+        Ok(())
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Directory Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// List directory contents.
+    pub async fn list(&self, path: &str) -> MicrosandboxResult<Vec<FsEntry>> {
+        let full = self.resolve(path)?;
+        let mut dir = tokio::fs::read_dir(&full).await?;
+        let mut entries = Vec::new();
+
+        while let Some(entry) = dir.next_entry().await? {
+            let entry_path = entry.path();
+            let rel_path = entry_path
+                .strip_prefix(self.volume.path())
+                .unwrap_or(&entry_path);
+
+            match entry.metadata().await {
+                Ok(meta) => {
+                    entries.push(metadata_to_entry(
+                        &format!("/{}", rel_path.display()),
+                        &meta,
+                    ));
+                }
+                Err(_) => {
+                    entries.push(FsEntry {
+                        path: format!("/{}", rel_path.display()),
+                        kind: FsEntryKind::Other,
+                        size: 0,
+                        mode: 0,
+                        modified: None,
+                    });
+                }
+            }
+        }
+
+        Ok(entries)
+    }
+
+    /// Create a directory (and parents).
+    pub async fn mkdir(&self, path: &str) -> MicrosandboxResult<()> {
+        let full = self.resolve(path)?;
+        tokio::fs::create_dir_all(&full).await?;
+        Ok(())
+    }
+
+    /// Remove a directory recursively.
+    pub async fn remove_dir(&self, path: &str) -> MicrosandboxResult<()> {
+        let full = self.resolve(path)?;
+        tokio::fs::remove_dir_all(&full).await?;
+        Ok(())
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // File Operations
+    //----------------------------------------------------------------------------------------------
+
+    /// Remove a file.
+    pub async fn remove(&self, path: &str) -> MicrosandboxResult<()> {
+        let full = self.resolve(path)?;
+        tokio::fs::remove_file(&full).await?;
+        Ok(())
+    }
+
+    /// Copy a file within the volume.
+    pub async fn copy(&self, from: &str, to: &str) -> MicrosandboxResult<()> {
+        let src = self.resolve(from)?;
+        let dst = self.resolve(to)?;
+
+        if let Some(parent) = dst.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        tokio::fs::copy(&src, &dst).await?;
+        Ok(())
+    }
+
+    /// Rename/move a file or directory.
+    pub async fn rename(&self, from: &str, to: &str) -> MicrosandboxResult<()> {
+        let src = self.resolve(from)?;
+        let dst = self.resolve(to)?;
+
+        if let Some(parent) = dst.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        tokio::fs::rename(&src, &dst).await?;
+        Ok(())
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Metadata
+    //----------------------------------------------------------------------------------------------
+
+    /// Get file/directory metadata.
+    pub async fn stat(&self, path: &str) -> MicrosandboxResult<FsMetadata> {
+        let full = self.resolve(path)?;
+        let meta = tokio::fs::symlink_metadata(&full).await?;
+        Ok(std_metadata_to_fs(&meta))
+    }
+
+    /// Check if a path exists.
+    pub async fn exists(&self, path: &str) -> MicrosandboxResult<bool> {
+        let full = self.resolve(path)?;
+        Ok(tokio::fs::try_exists(&full).await.unwrap_or(false))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Helpers
+//--------------------------------------------------------------------------------------------------
+
+impl VolumeFs<'_> {
+    /// Resolve a relative path against the volume root, preventing path traversal.
+    fn resolve(&self, path: &str) -> MicrosandboxResult<PathBuf> {
+        let root = self.volume.path();
+
+        // Strip leading slash for joining.
+        let clean = path.strip_prefix('/').unwrap_or(path);
+
+        let joined = root.join(clean);
+
+        // Canonicalize what exists, then check prefix. If the path doesn't exist
+        // yet (for writes), canonicalize the parent and verify.
+        let canonical = if joined.exists() {
+            joined
+                .canonicalize()
+                .map_err(|e| MicrosandboxError::SandboxFs(format!("resolve path: {e}")))?
+        } else {
+            // Find the deepest existing ancestor.
+            let mut ancestor = joined.as_path();
+            loop {
+                if let Some(parent) = ancestor.parent() {
+                    if parent.exists() {
+                        let canon_parent = parent.canonicalize().map_err(|e| {
+                            MicrosandboxError::SandboxFs(format!("resolve parent: {e}"))
+                        })?;
+                        // Reconstruct with remaining components.
+                        let remainder = joined.strip_prefix(parent).unwrap_or(Path::new(""));
+                        break canon_parent.join(remainder);
+                    }
+                    ancestor = parent;
+                } else {
+                    break joined.clone();
+                }
+            }
+        };
+
+        // Ensure the root itself is canonicalized for comparison.
+        let canon_root = if root.exists() {
+            root.canonicalize()
+                .map_err(|e| MicrosandboxError::SandboxFs(format!("resolve root: {e}")))?
+        } else {
+            root.to_path_buf()
+        };
+
+        if !canonical.starts_with(&canon_root) {
+            return Err(MicrosandboxError::SandboxFs(
+                "path traversal outside volume root".into(),
+            ));
+        }
+
+        Ok(canonical)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Determine the `FsEntryKind` from `std::fs::Metadata`.
+fn std_kind(meta: &std::fs::Metadata) -> FsEntryKind {
+    if meta.is_file() {
+        FsEntryKind::File
+    } else if meta.is_dir() {
+        FsEntryKind::Directory
+    } else if meta.is_symlink() {
+        FsEntryKind::Symlink
+    } else {
+        FsEntryKind::Other
+    }
+}
+
+/// Extract the modification time from `std::fs::Metadata`.
+fn std_modified(meta: &std::fs::Metadata) -> Option<chrono::DateTime<chrono::Utc>> {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| chrono::DateTime::from_timestamp(d.as_secs() as i64, 0).unwrap_or_default())
+}
+
+/// Convert `std::fs::Metadata` to an `FsEntry`.
+fn metadata_to_entry(path: &str, meta: &std::fs::Metadata) -> FsEntry {
+    use std::os::unix::fs::MetadataExt;
+
+    FsEntry {
+        path: path.to_string(),
+        kind: std_kind(meta),
+        size: meta.len(),
+        mode: meta.mode(),
+        modified: std_modified(meta),
+    }
+}
+
+/// Convert `std::fs::Metadata` to `FsMetadata`.
+fn std_metadata_to_fs(meta: &std::fs::Metadata) -> FsMetadata {
+    use std::os::unix::fs::MetadataExt;
+
+    FsMetadata {
+        kind: std_kind(meta),
+        size: meta.len(),
+        mode: meta.mode(),
+        readonly: meta.permissions().readonly(),
+        modified: std_modified(meta),
+    }
+}

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -1,0 +1,248 @@
+//! Named volume management.
+//!
+//! Volumes are persistent host-side directories stored under
+//! `~/.microsandbox/volumes/<name>/` with metadata tracked in the database.
+
+pub mod fs;
+
+use std::path::PathBuf;
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, Set,
+};
+use sea_orm::sea_query::OnConflict;
+
+use crate::MicrosandboxError;
+use crate::MicrosandboxResult;
+use crate::db::entity::volume as volume_entity;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A named volume.
+pub struct Volume {
+    name: String,
+    path: PathBuf,
+}
+
+/// Configuration for creating a volume.
+#[derive(Debug, Clone)]
+pub struct VolumeConfig {
+    /// Volume name.
+    pub name: String,
+
+    /// Size quota in MiB (None = unlimited).
+    pub quota_mib: Option<u32>,
+
+    /// Labels for organization (JSON-serialized in DB).
+    pub labels: Vec<(String, String)>,
+}
+
+/// Summary information about a volume (re-exported from entity model).
+pub type VolumeInfo = volume_entity::Model;
+
+/// Builder for creating a volume.
+pub struct VolumeBuilder {
+    config: VolumeConfig,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Static
+//--------------------------------------------------------------------------------------------------
+
+impl Volume {
+    /// Create a builder for a new volume.
+    pub fn builder(name: impl Into<String>) -> VolumeBuilder {
+        VolumeBuilder::new(name)
+    }
+
+    /// Create a volume from a config.
+    pub async fn create(config: VolumeConfig) -> MicrosandboxResult<Self> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        let volumes_dir = crate::config::config().volumes_dir();
+        let path = volumes_dir.join(&config.name);
+
+        // Create the volume directory.
+        tokio::fs::create_dir_all(&path).await?;
+
+        // Serialize labels.
+        let labels_json = if config.labels.is_empty() {
+            None
+        } else {
+            Some(serde_json::to_string(&config.labels)?)
+        };
+
+        let now = chrono::Utc::now().naive_utc();
+        let model = volume_entity::ActiveModel {
+            name: Set(config.name.clone()),
+            quota_mib: Set(config.quota_mib.map(|v| v as i32)),
+            size_bytes: Set(None),
+            labels: Set(labels_json),
+            created_at: Set(Some(now)),
+            updated_at: Set(Some(now)),
+            ..Default::default()
+        };
+
+        volume_entity::Entity::insert(model)
+            .on_conflict(
+                OnConflict::column(volume_entity::Column::Name)
+                    .update_columns([
+                        volume_entity::Column::QuotaMib,
+                        volume_entity::Column::Labels,
+                        volume_entity::Column::UpdatedAt,
+                    ])
+                    .to_owned(),
+            )
+            .exec(db)
+            .await?;
+
+        Ok(Self {
+            name: config.name,
+            path,
+        })
+    }
+
+    /// Get an existing volume by name.
+    pub async fn get(name: &str) -> MicrosandboxResult<Self> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(name))
+            .one(db)
+            .await?
+            .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.into()))?;
+
+        let path = crate::config::config().volumes_dir().join(name);
+
+        Ok(Self {
+            name: name.to_string(),
+            path,
+        })
+    }
+
+    /// List all volumes.
+    pub async fn list() -> MicrosandboxResult<Vec<VolumeInfo>> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        volume_entity::Entity::find()
+            .order_by_desc(volume_entity::Column::CreatedAt)
+            .all(db)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Remove a volume by name.
+    pub async fn remove(name: &str) -> MicrosandboxResult<()> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        let model = volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(name))
+            .one(db)
+            .await?
+            .ok_or_else(|| MicrosandboxError::VolumeNotFound(name.into()))?;
+
+        // Delete the directory.
+        let path = crate::config::config().volumes_dir().join(name);
+        if path.exists() {
+            tokio::fs::remove_dir_all(&path).await?;
+        }
+
+        // Delete the DB record.
+        model.into_active_model().delete(db).await?;
+
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Instance
+//--------------------------------------------------------------------------------------------------
+
+impl Volume {
+    /// Get the volume name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the host-side path of the volume directory.
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Get volume info from the database.
+    pub async fn info(&self) -> MicrosandboxResult<VolumeInfo> {
+        let db = crate::db::init_global(
+            Some(crate::config::config().database.max_connections),
+        ).await?;
+
+        volume_entity::Entity::find()
+            .filter(volume_entity::Column::Name.eq(&self.name))
+            .one(db)
+            .await?
+            .ok_or_else(|| MicrosandboxError::VolumeNotFound(self.name.clone()))
+    }
+
+    /// Access the filesystem API for this volume.
+    pub fn fs(&self) -> fs::VolumeFs<'_> {
+        fs::VolumeFs::new(self)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: VolumeBuilder
+//--------------------------------------------------------------------------------------------------
+
+impl VolumeBuilder {
+    /// Create a new volume builder.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            config: VolumeConfig {
+                name: name.into(),
+                quota_mib: None,
+                labels: Vec::new(),
+            },
+        }
+    }
+
+    /// Set the size quota in MiB.
+    pub fn quota(mut self, mib: u32) -> Self {
+        self.config.quota_mib = Some(mib);
+        self
+    }
+
+    /// Add a label.
+    pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.config.labels.push((key.into(), value.into()));
+        self
+    }
+
+    /// Build the volume config without creating it.
+    pub fn build(self) -> VolumeConfig {
+        self.config
+    }
+
+    /// Create the volume.
+    pub async fn create(self) -> MicrosandboxResult<Volume> {
+        Volume::create(self.config).await
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl From<VolumeConfig> for VolumeBuilder {
+    fn from(config: VolumeConfig) -> Self {
+        Self { config }
+    }
+}

--- a/crates/protocol/lib/fs.rs
+++ b/crates/protocol/lib/fs.rs
@@ -1,0 +1,146 @@
+//! Filesystem-related protocol message payloads.
+
+use serde::{Deserialize, Serialize};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Maximum chunk size for streaming file data (3 MiB).
+///
+/// This stays safely under the 4 MiB frame limit after CBOR envelope overhead.
+pub const FS_CHUNK_SIZE: usize = 3 * 1024 * 1024;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A filesystem operation requested by the host.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FsOp {
+    /// Get metadata for a path.
+    Stat {
+        /// Guest path to stat.
+        path: String,
+    },
+
+    /// List directory contents.
+    List {
+        /// Guest directory path to list.
+        path: String,
+    },
+
+    /// Read a file (streaming: guest replies with FsData chunks then FsResponse).
+    Read {
+        /// Guest file path to read.
+        path: String,
+    },
+
+    /// Write a file (streaming: host sends FsData chunks, guest replies with FsResponse).
+    Write {
+        /// Guest file path to write.
+        path: String,
+        /// Permission bits to set on creation (e.g. 0o644).
+        #[serde(default)]
+        mode: Option<u32>,
+    },
+
+    /// Create a directory (and parents).
+    Mkdir {
+        /// Guest directory path to create.
+        path: String,
+    },
+
+    /// Remove a file.
+    Remove {
+        /// Guest file path to remove.
+        path: String,
+    },
+
+    /// Remove a directory recursively.
+    RemoveDir {
+        /// Guest directory path to remove.
+        path: String,
+    },
+
+    /// Copy a file or directory within the guest.
+    Copy {
+        /// Source path in guest.
+        src: String,
+        /// Destination path in guest.
+        dst: String,
+    },
+
+    /// Rename/move a file or directory.
+    Rename {
+        /// Source path in guest.
+        src: String,
+        /// Destination path in guest.
+        dst: String,
+    },
+}
+
+/// Request to perform a filesystem operation in the guest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FsRequest {
+    /// The operation to perform.
+    pub op: FsOp,
+}
+
+/// Metadata about a filesystem entry (wire format).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FsEntryInfo {
+    /// Path of the entry.
+    pub path: String,
+
+    /// Kind of entry: `"file"`, `"dir"`, `"symlink"`, or `"other"`.
+    pub kind: String,
+
+    /// Size in bytes.
+    pub size: u64,
+
+    /// Unix permission bits.
+    pub mode: u32,
+
+    /// Last modification time as Unix timestamp (seconds since epoch).
+    pub modified: Option<i64>,
+}
+
+/// Data variants that can be included in a filesystem response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FsResponseData {
+    /// Stat result.
+    Stat(FsEntryInfo),
+
+    /// Directory listing result.
+    List(Vec<FsEntryInfo>),
+}
+
+/// Terminal response for a filesystem operation.
+///
+/// This is always the last message sent for a given correlation ID.
+/// For streaming reads, it follows the `FsData` chunks.
+/// For simple operations, it carries the result directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FsResponse {
+    /// Whether the operation succeeded.
+    pub ok: bool,
+
+    /// Error message if `ok` is false.
+    #[serde(default)]
+    pub error: Option<String>,
+
+    /// Optional result data (for stat/list operations).
+    #[serde(default)]
+    pub data: Option<FsResponseData>,
+}
+
+/// A chunk of file data for streaming read/write operations.
+///
+/// An empty `data` field signals EOF (like `ExecStdin` with empty data).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FsData {
+    /// The raw file data.
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -12,6 +12,7 @@ mod error;
 pub mod codec;
 pub mod core;
 pub mod exec;
+pub mod fs;
 pub mod heartbeat;
 pub mod message;
 

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -67,6 +67,15 @@ pub enum MessageType {
 
     /// Host sends signal to process.
     ExecSignal,
+
+    /// Host requests a filesystem operation.
+    FsRequest,
+
+    /// Guest sends a terminal filesystem response.
+    FsResponse,
+
+    /// Streaming file data chunk (bidirectional).
+    FsData,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -116,6 +125,9 @@ impl MessageType {
             Self::ExecExited => "core.exec.exited",
             Self::ExecResize => "core.exec.resize",
             Self::ExecSignal => "core.exec.signal",
+            Self::FsRequest => "core.fs.request",
+            Self::FsResponse => "core.fs.response",
+            Self::FsData => "core.fs.data",
         }
     }
 
@@ -132,6 +144,9 @@ impl MessageType {
             "core.exec.exited" => Some(Self::ExecExited),
             "core.exec.resize" => Some(Self::ExecResize),
             "core.exec.signal" => Some(Self::ExecSignal),
+            "core.fs.request" => Some(Self::FsRequest),
+            "core.fs.response" => Some(Self::FsResponse),
+            "core.fs.data" => Some(Self::FsData),
             _ => None,
         }
     }
@@ -181,6 +196,9 @@ mod tests {
             (MessageType::ExecExited, "core.exec.exited"),
             (MessageType::ExecResize, "core.exec.resize"),
             (MessageType::ExecSignal, "core.exec.signal"),
+            (MessageType::FsRequest, "core.fs.request"),
+            (MessageType::FsResponse, "core.fs.response"),
+            (MessageType::FsData, "core.fs.data"),
         ];
 
         for (mt, expected_str) in &types {
@@ -202,6 +220,9 @@ mod tests {
             MessageType::ExecExited,
             MessageType::ExecResize,
             MessageType::ExecSignal,
+            MessageType::FsRequest,
+            MessageType::FsResponse,
+            MessageType::FsData,
         ];
 
         for mt in &types {


### PR DESCRIPTION
## Summary

- Add Phase 6 filesystem protocol (`core.fs.*`), guest-side handlers, SandboxFs SDK API, Volume CRUD, VolumeFs, and VolumeMount/MountBuilder types
- Enables reading, writing, listing, and manipulating files inside running sandboxes via the agent protocol, and managing persistent named volumes on the host
- 5 new files (1693 lines) and 12 modified files across protocol, agentd, and SDK crates
- Includes code review fixes: proper error propagation, streaming write confirmation, symlink consistency, readonly mount wiring, dead code removal

## Changes

**Protocol (microsandbox-protocol):**
- Add `crates/protocol/lib/fs.rs`: FsOp enum (Stat, List, Read, Write, Mkdir, Remove, RemoveDir, Copy, Rename), FsRequest, FsResponse, FsData, FsEntryInfo, FsResponseData payloads with 3 MiB chunk size
- Add FsRequest, FsResponse, FsData MessageType variants with wire strings in `message.rs`

**Guest agent (microsandbox-agentd):**
- Add `crates/agentd/lib/fs.rs`: handlers for all FsOp variants, streaming read via background task, FsWriteSession for multi-chunk writes, error FsResponse for unknown sessions
- Add FsRequest/FsData dispatch and write_sessions map in `agent.rs`
- Add SessionOutput::Raw variant in `session.rs` for pre-encoded frames
- Remove unused ExecSession id/is_tty fields

**SDK (microsandbox):**
- Add `crates/microsandbox/lib/sandbox/fs.rs`: SandboxFs with read, read_to_string, read_stream, write, write_stream, list, mkdir, remove, remove_dir, copy, rename, stat, exists, copy_from_host, copy_to_host; FsReadStream and FsWriteSink streaming types
- Add `crates/microsandbox/lib/volume/mod.rs`: Volume CRUD (create, get, list, remove) with SeaORM, VolumeBuilder with quota/label fluent API
- Add `crates/microsandbox/lib/volume/fs.rs`: VolumeFs with direct tokio::fs I/O and path traversal prevention
- Replace VolumeMount struct with tagged enum (Bind, Named, Tmpfs) in `types.rs`; add MountBuilder with closure-based API; remove unused AccessMode
- Add `.volume()` method to SandboxBuilder; wire mount specs into supervisor CLI args with `:ro` support in `spawn.rs`
- Add FsResponse to bridge terminal message check; add SandboxFs, VolumeNotFound, VolumeAlreadyExists error variants

## Test Plan

- [x] `cargo build -p microsandbox-protocol` compiles with new types
- [x] `cargo test -p microsandbox-protocol` passes all 11 message roundtrip tests
- [x] `cargo build -p microsandbox-agentd` compiles with fs handlers
- [x] `cargo build -p microsandbox` compiles with all new SDK types
- [x] `cargo test` passes all 29 workspace tests with zero failures