### PR TITLE
feat(filesystem): add passthrough filesystem backend (#390)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,7 +1762,12 @@ dependencies = [
 name = "microsandbox-filesystem"
 version = "0.2.6"
 dependencies = [
+ "libc",
  "microsandbox-utils",
+ "msb_krun",
+ "scopeguard",
+ "tempfile",
+ "tracing",
  "ureq",
 ]
 
@@ -1801,6 +1806,7 @@ dependencies = [
  "clap",
  "libc",
  "microsandbox-db",
+ "microsandbox-filesystem",
  "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -9,6 +9,13 @@ edition.workspace = true
 [lib]
 path = "lib/lib.rs"
 
+[dependencies]
+msb_krun = "0.1.0"
+libc.workspace = true
+tracing.workspace = true
+scopeguard.workspace = true
+tempfile.workspace = true
+
 [features]
 prebuilt = ["dep:ureq"]
 

--- a/crates/filesystem/lib/backends/mod.rs
+++ b/crates/filesystem/lib/backends/mod.rs
@@ -1,0 +1,7 @@
+//! Filesystem backends for microsandbox.
+//!
+//! Currently provides [`PassthroughFs`](passthrough::PassthroughFs) which exposes
+//! a single host directory to the guest VM via virtio-fs with stat virtualization.
+
+pub mod passthrough;
+pub(crate) mod shared;

--- a/crates/filesystem/lib/backends/passthrough/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/create_ops.rs
@@ -1,0 +1,478 @@
+//! Creation operations: create, mkdir, mknod, symlink, link.
+//!
+//! ## Creation Pattern
+//!
+//! All create-type operations follow: validate name → host syscall → set override xattr →
+//! do_lookup. On partial failure (xattr set fails after file creation), the backing file is
+//! unlinked before returning the error to avoid dangling files that could be misinterpreted.
+//!
+//! ## Special File Virtualization
+//!
+//! `mknod` always creates a regular file on the host regardless of requested type. The actual
+//! file type (S_IFBLK, S_IFCHR, S_IFIFO, S_IFSOCK) is stored in the override xattr and
+//! reported to the guest via `patched_stat`. The host process lacks `CAP_MKNOD`.
+//!
+//! ## Symlinks
+//!
+//! On Linux, symlinks are stored as regular files with the target as content and S_IFLNK in
+//! xattr mode (file-backed symlinks), because Linux `user.*` xattrs cannot be set on symlinks.
+//! On macOS, real symlinks are used with `XATTR_NOFOLLOW` for xattr operations.
+
+use std::ffi::CStr;
+use std::io;
+use std::os::fd::FromRawFd;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock};
+
+use super::inode;
+use super::PassthroughFs;
+use crate::backends::shared::handle_table::HandleData;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::name_validation;
+use crate::backends::shared::platform;
+use crate::backends::shared::stat_override;
+use crate::{Context, Entry, Extensions, OpenOptions};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create and open a regular file.
+///
+/// The host file is created with `S_IRUSR | S_IWUSR` (0o600) regardless of the
+/// requested mode — the guest-visible permissions are stored in the override xattr.
+/// This ensures the host process can always read/write the file for I/O operations.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_create(
+    fs: &PassthroughFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    flags: u32,
+    umask: u32,
+    _extensions: Extensions,
+) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+    name_validation::validate_name(name)?;
+
+    if init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_fd = inode::get_inode_fd(fs, parent)?;
+
+    // Apply umask.
+    let file_mode = mode & !umask & 0o7777;
+
+    let mut open_flags = flags as i32;
+    // Strip O_NOFOLLOW: this openat is by name (not through open_inode_fd), so
+    // O_NOFOLLOW would reject creating over an existing file-backed symlink.
+    open_flags &= !libc::O_NOFOLLOW;
+    open_flags |= libc::O_CREAT | libc::O_CLOEXEC;
+
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            name.as_ptr(),
+            open_flags,
+            (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,
+        )
+    };
+    if fd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    // Set override xattr with requested permissions.
+    let full_mode = libc::S_IFREG as u32 | file_mode;
+    if let Err(e) = stat_override::set_override(fd, ctx.uid, ctx.gid, full_mode, 0) {
+        unsafe { libc::close(fd) };
+        unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+        return Err(e);
+    }
+
+    // Close the fd we used for xattr, then do a proper lookup.
+    unsafe { libc::close(fd) };
+
+    let entry = inode::do_lookup(fs, parent, name)?;
+
+    // Reopen for the handle — strip O_CREAT since the file already exists.
+    // open_inode_fd adds O_NOFOLLOW and O_CLOEXEC itself.
+    let open_fd = inode::open_inode_fd(fs, entry.inode, open_flags & !libc::O_CREAT)?;
+    let file = unsafe { std::fs::File::from_raw_fd(open_fd) };
+
+    let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let data = Arc::new(HandleData {
+        file: RwLock::new(file),
+    });
+    fs.handles.write().unwrap().insert(handle, data);
+
+    Ok((entry, Some(handle), fs.cache_open_options()))
+}
+
+/// Create a directory.
+pub(crate) fn do_mkdir(
+    fs: &PassthroughFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    umask: u32,
+    _extensions: Extensions,
+) -> io::Result<Entry> {
+    name_validation::validate_name(name)?;
+
+    if init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_fd = inode::get_inode_fd(fs, parent)?;
+    let dir_mode = mode & !umask & 0o7777;
+
+    let ret = unsafe {
+        libc::mkdirat(
+            parent_fd,
+            name.as_ptr(),
+            (libc::S_IRWXU) as libc::mode_t,
+        )
+    };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    // Set override xattr.
+    let full_mode = libc::S_IFDIR as u32 | dir_mode;
+    if let Err(e) = stat_override::set_override_at(parent_fd, name, ctx.uid, ctx.gid, full_mode, 0)
+    {
+        unsafe { libc::unlinkat(parent_fd, name.as_ptr(), libc::AT_REMOVEDIR) };
+        return Err(e);
+    }
+
+    inode::do_lookup(fs, parent, name)
+}
+
+/// Create a file node (regular file, device, fifo, socket).
+///
+/// On the host, always creates a regular file. The actual file type is stored
+/// in the override xattr mode bits.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_mknod(
+    fs: &PassthroughFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    rdev: u32,
+    umask: u32,
+    _extensions: Extensions,
+) -> io::Result<Entry> {
+    name_validation::validate_name(name)?;
+
+    if init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_fd = inode::get_inode_fd(fs, parent)?;
+    let perm_mode = mode & !umask & 0o7777;
+    let file_type = mode & libc::S_IFMT as u32;
+
+    // Always create a regular file on host.
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            name.as_ptr(),
+            libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY | libc::O_CLOEXEC,
+            (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,
+        )
+    };
+    if fd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    // Store the requested type and permissions in xattr.
+    let full_mode = file_type | perm_mode;
+    if let Err(e) = stat_override::set_override(fd, ctx.uid, ctx.gid, full_mode, rdev) {
+        unsafe { libc::close(fd) };
+        unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+        return Err(e);
+    }
+    unsafe { libc::close(fd) };
+
+    inode::do_lookup(fs, parent, name)
+}
+
+/// Create a symbolic link.
+///
+/// On Linux, creates a file-backed symlink (regular file with target as content
+/// and S_IFLNK in xattr mode) because Linux cannot set user xattrs on symlinks.
+/// On macOS, creates a real symlink and sets xattr with XATTR_NOFOLLOW.
+pub(crate) fn do_symlink(
+    fs: &PassthroughFs,
+    ctx: Context,
+    linkname: &CStr,
+    parent: u64,
+    name: &CStr,
+    _extensions: Extensions,
+) -> io::Result<Entry> {
+    name_validation::validate_name(name)?;
+
+    if init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_fd = inode::get_inode_fd(fs, parent)?;
+
+    #[cfg(target_os = "linux")]
+    {
+        // File-backed symlink: create a regular file with the target as content.
+        let fd = unsafe {
+            libc::openat(
+                parent_fd,
+                name.as_ptr(),
+                libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY | libc::O_CLOEXEC,
+                (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,
+            )
+        };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+
+        // Write the symlink target as file content.
+        let target = linkname.to_bytes();
+        let written = unsafe { libc::write(fd, target.as_ptr() as *const libc::c_void, target.len()) };
+        if written < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            return Err(platform::linux_error(err));
+        }
+        if (written as usize) != target.len() {
+            unsafe { libc::close(fd) };
+            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            return Err(platform::eio());
+        }
+
+        // Set override xattr with S_IFLNK.
+        let mode = libc::S_IFLNK as u32 | 0o777;
+        if let Err(e) = stat_override::set_override(fd, ctx.uid, ctx.gid, mode, 0) {
+            unsafe { libc::close(fd) };
+            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            return Err(e);
+        }
+        unsafe { libc::close(fd) };
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // Real symlink on macOS.
+        let ret = unsafe { libc::symlinkat(linkname.as_ptr(), parent_fd, name.as_ptr()) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+
+        // Set xattr on the symlink itself using XATTR_NOFOLLOW.
+        let mode = libc::S_IFLNK as u32 | 0o777;
+        // Build path for lsetxattr equivalent.
+        let ovr = stat_override::OverrideStat {
+            version: 1,
+            _pad: [0; 3],
+            uid: ctx.uid,
+            gid: ctx.gid,
+            mode,
+            rdev: 0,
+        };
+        let buf = unsafe {
+            std::slice::from_raw_parts(
+                &ovr as *const stat_override::OverrideStat as *const u8,
+                std::mem::size_of::<stat_override::OverrideStat>(),
+            )
+        };
+
+        // Use path-based xattr with XATTR_NOFOLLOW on macOS.
+        // We need the full path, so open the parent and construct it.
+        let fd = unsafe {
+            libc::openat(
+                parent_fd,
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+            )
+        };
+        if fd < 0 {
+            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+
+        let xattr_ret = unsafe {
+            libc::fsetxattr(
+                fd,
+                stat_override::OVERRIDE_XATTR_KEY.as_ptr(),
+                buf.as_ptr() as *const libc::c_void,
+                buf.len(),
+                0,
+                libc::XATTR_NOFOLLOW,
+            )
+        };
+        unsafe { libc::close(fd) };
+
+        if xattr_ret < 0 {
+            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    inode::do_lookup(fs, parent, name)
+}
+
+/// Create a hard link.
+///
+/// On Linux, uses `/proc/self/fd/N` with `AT_SYMLINK_FOLLOW` to link by fd reference.
+/// On macOS, uses `/.vol/dev/ino` to reference the source inode by identity.
+pub(crate) fn do_link(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    newparent: u64,
+    newname: &CStr,
+) -> io::Result<Entry> {
+    name_validation::validate_name(newname)?;
+
+    if init_binary::is_init_name(newname.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    if inode == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let inode_fd = inode::get_inode_fd(fs, inode)?;
+        let newparent_fd = inode::get_inode_fd(fs, newparent)?;
+
+        let path = format!("/proc/self/fd/{inode_fd}\0");
+        let ret = unsafe {
+            libc::linkat(
+                libc::AT_FDCWD,
+                path.as_ptr() as *const libc::c_char,
+                newparent_fd,
+                newname.as_ptr(),
+                libc::AT_SYMLINK_FOLLOW,
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let inodes = fs.inodes.read().unwrap();
+        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+        let src_path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+        let newparent_fd = inode::get_inode_fd(fs, newparent)?;
+
+        let ret = unsafe {
+            libc::linkat(
+                libc::AT_FDCWD,
+                src_path.as_ptr() as *const libc::c_char,
+                newparent_fd,
+                newname.as_ptr(),
+                0,
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    inode::do_lookup(fs, newparent, newname)
+}
+
+/// Read the target of a symbolic link.
+///
+/// On Linux, first checks if the inode is a real host symlink (rare — only if symlinks
+/// preexist in the exported directory). For file-backed symlinks, verifies the override
+/// xattr has S_IFLNK before reading file content. This type guard prevents a guest from
+/// reading arbitrary file content via readlink on a regular file.
+///
+/// On macOS, verifies the inode is actually a symlink via `stat_inode` (which applies
+/// xattr patching) before calling readlinkat.
+pub(crate) fn do_readlink(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+) -> io::Result<Vec<u8>> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::einval());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let inode_fd = inode::get_inode_fd(fs, ino)?;
+        let st = platform::fstat(inode_fd)?;
+
+        // Real symlink on host — use readlinkat.
+        if st.st_mode & libc::S_IFMT == libc::S_IFLNK {
+            let mut buf = vec![0u8; libc::PATH_MAX as usize];
+            let path = format!("/proc/self/fd/{inode_fd}\0");
+            let ret = unsafe {
+                libc::readlinkat(
+                    libc::AT_FDCWD,
+                    path.as_ptr() as *const libc::c_char,
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+            buf.truncate(ret as usize);
+            return Ok(buf);
+        }
+
+        // Verify override xattr says S_IFLNK before reading file content.
+        // Without this check, a guest could read any regular file's content via readlink.
+        match stat_override::get_override(inode_fd)? {
+            Some(ovr) if ovr.mode & libc::S_IFMT as u32 == libc::S_IFLNK as u32 => {}
+            _ => return Err(platform::einval()),
+        }
+
+        // File-backed symlink — read the file content.
+        let fd = inode::open_inode_fd(fs, ino, libc::O_RDONLY)?;
+        let mut buf = vec![0u8; libc::PATH_MAX as usize];
+        let ret = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        unsafe { libc::close(fd) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        buf.truncate(ret as usize);
+        Ok(buf)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // On macOS we create real symlinks, so verify it's actually a symlink first.
+        let st = inode::stat_inode(fs, ino)?;
+        if st.st_mode as u32 & libc::S_IFMT as u32 != libc::S_IFLNK as u32 {
+            return Err(platform::einval());
+        }
+
+        let inodes = fs.inodes.read().unwrap();
+        let data = inodes.get(&ino).ok_or_else(platform::ebadf)?;
+        let path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+
+        let mut buf = vec![0u8; libc::PATH_MAX as usize];
+        let ret = unsafe {
+            libc::readlinkat(
+                libc::AT_FDCWD,
+                path.as_ptr() as *const libc::c_char,
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        buf.truncate(ret as usize);
+        Ok(buf)
+    }
+}

--- a/crates/filesystem/lib/backends/passthrough/dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/dir_ops.rs
@@ -1,0 +1,340 @@
+//! Directory operations: opendir, readdir, readdirplus, releasedir.
+//!
+//! ## Memory Strategy: Bounded Leak
+//!
+//! `DynFileSystem::readdir` returns `Vec<DirEntry<'static>>` where names are `&'static [u8]`.
+//! Since the trait requires `'static` lifetimes, we cannot return borrowed data. Instead, we
+//! collect all entry names into a single contiguous `Vec<u8>`, leak it once per readdir call,
+//! and slice `&'static [u8]` references from it. This bounds the leak to one allocation per
+//! readdir call (not per entry), which is acceptable for the FUSE usage pattern.
+//!
+//! ## d_type Correction
+//!
+//! File-backed symlinks and virtual device nodes report `DT_REG` from the kernel's `getdents64`.
+//! Correcting d_type in plain `readdir` would require opening every `DT_REG` entry to check its
+//! override xattr (3 syscalls per entry). Instead, correction is deferred to `readdirplus`, where
+//! each entry already gets a full `do_lookup` that reads the override xattr — making d_type
+//! correction free.
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock};
+
+use super::inode;
+use super::PassthroughFs;
+use crate::backends::shared::handle_table::HandleData;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, DirEntry, Entry, OpenOptions};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Open a directory and return a handle.
+pub(crate) fn do_opendir(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    _flags: u32,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    let fd = inode::open_inode_fd(fs, inode, libc::O_RDONLY | libc::O_DIRECTORY)?;
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+
+    let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let data = Arc::new(HandleData {
+        file: RwLock::new(file),
+    });
+
+    fs.handles.write().unwrap().insert(handle, data);
+    Ok((Some(handle), fs.cache_dir_options()))
+}
+
+/// Read directory entries.
+///
+/// On Linux, uses raw `getdents64` syscall with buffer sized by the FUSE
+/// `size` parameter (clamped to 1KB–64KB). This avoids reading the entire
+/// directory when the kernel only needs a small response.
+///
+/// Names are collected into a single contiguous buffer that is leaked once
+/// per call (bounded leak) rather than leaking individual allocations per entry.
+///
+/// d_type correction for file-backed symlinks is NOT done here — it's
+/// deferred to [`do_readdirplus`] where the lookup already provides the
+/// correct stat, making the correction free (see module-level doc).
+pub(crate) fn do_readdir(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    size: u32,
+    offset: u64,
+) -> io::Result<Vec<DirEntry<'static>>> {
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    // Write lock: lseek in read_dir_entries modifies fd seek position.
+    #[allow(clippy::readonly_write_lock)]
+    let f = data.file.write().unwrap();
+    let fd = f.as_raw_fd();
+
+    let mut entries = read_dir_entries(fd, offset, size)?;
+
+    // Inject init.krun into root directory listing.
+    if inode == 1 {
+        inject_init_entry(&mut entries);
+    }
+
+    Ok(entries)
+}
+
+/// Read directory entries with attributes (readdirplus).
+///
+/// d_type is corrected from the lookup result's `st_mode`, which catches
+/// file-backed symlinks and virtual device nodes at zero extra cost (the
+/// lookup already reads the override xattr). `.` and `..` are filtered out
+/// entirely — the kernel handles them itself.
+pub(crate) fn do_readdirplus(
+    fs: &PassthroughFs,
+    ctx: Context,
+    inode: u64,
+    handle: u64,
+    size: u32,
+    offset: u64,
+) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+    let dir_entries = do_readdir(fs, ctx, inode, handle, size, offset)?;
+    let mut result = Vec::with_capacity(dir_entries.len());
+
+    for de in dir_entries {
+        let name_bytes = de.name;
+        // Skip . and .. — the kernel handles these itself.
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+
+        // For init.krun, return the synthetic entry.
+        if name_bytes == init_binary::INIT_FILENAME {
+            let entry = init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+            result.push((de, entry));
+            continue;
+        }
+
+        // Look up the entry to get full attributes.
+        let name_cstr = match std::ffi::CString::new(name_bytes.to_vec()) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        match inode::do_lookup(fs, inode, &name_cstr) {
+            Ok(entry) => {
+                // Correct d_type from the lookup's stat (free: no extra syscalls).
+                let mut de = de;
+                let file_type = entry.attr.st_mode as u32 & libc::S_IFMT as u32;
+                de.type_ = mode_to_dtype(file_type);
+                result.push((de, entry));
+            }
+            Err(_) => continue, // Entry may have been removed between readdir and lookup.
+        }
+    }
+
+    Ok(result)
+}
+
+/// Release an open directory handle.
+pub(crate) fn do_releasedir(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    _inode: u64,
+    _flags: u32,
+    handle: u64,
+) -> io::Result<()> {
+    fs.handles.write().unwrap().remove(&handle);
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Inject the init.krun entry into a directory listing if not already present.
+fn inject_init_entry(entries: &mut Vec<DirEntry<'static>>) {
+    let already_present = entries
+        .iter()
+        .any(|e| e.name == init_binary::INIT_FILENAME);
+
+    if !already_present {
+        let next_offset = entries.last().map(|e| e.offset + 1).unwrap_or(1);
+        let name: &'static [u8] = init_binary::INIT_FILENAME;
+        entries.push(DirEntry {
+            ino: init_binary::INIT_INODE,
+            offset: next_offset,
+            type_: libc::DT_REG as u32,
+            name,
+        });
+    }
+}
+
+/// Convert a file mode type to a directory entry type.
+fn mode_to_dtype(mode_type: u32) -> u32 {
+    match mode_type {
+        m if m == libc::S_IFLNK as u32 => libc::DT_LNK as u32,
+        m if m == libc::S_IFDIR as u32 => libc::DT_DIR as u32,
+        m if m == libc::S_IFCHR as u32 => libc::DT_CHR as u32,
+        m if m == libc::S_IFBLK as u32 => libc::DT_BLK as u32,
+        m if m == libc::S_IFIFO as u32 => libc::DT_FIFO as u32,
+        m if m == libc::S_IFSOCK as u32 => libc::DT_SOCK as u32,
+        _ => libc::DT_REG as u32,
+    }
+}
+
+/// Read directory entries using `getdents64` with FUSE size as buffer hint.
+///
+/// Names are collected into a single contiguous buffer, leaked once, and
+/// sliced into `&'static [u8]` references. This replaces the previous
+/// approach of leaking N individual `Box<[u8]>` allocations.
+#[cfg(target_os = "linux")]
+fn read_dir_entries(fd: i32, offset: u64, size: u32) -> io::Result<Vec<DirEntry<'static>>> {
+    // Seek to the requested offset.
+    if offset > 0 {
+        let ret = unsafe { libc::lseek64(fd, offset as i64, libc::SEEK_SET) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    // Use FUSE size as a hint for the getdents buffer.
+    let buf_size = (size as usize).clamp(1024, 65536);
+    let mut buf = vec![0u8; buf_size];
+
+    // Collect raw entry data and names into a contiguous buffer.
+    let mut raw_entries: Vec<(u64, u64, u8, usize, usize)> = Vec::new();
+    let mut names_buf: Vec<u8> = Vec::new();
+
+    loop {
+        let nread =
+            unsafe { libc::syscall(libc::SYS_getdents64, fd, buf.as_mut_ptr(), buf.len()) };
+
+        if nread < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        if nread == 0 {
+            break;
+        }
+
+        let mut pos = 0usize;
+        while pos < nread as usize {
+            // SAFETY: getdents64 returns properly aligned linux_dirent64 structs.
+            let d_ino = u64::from_ne_bytes(buf[pos..pos + 8].try_into().unwrap());
+            let d_off = u64::from_ne_bytes(buf[pos + 8..pos + 16].try_into().unwrap());
+            let d_reclen = u16::from_ne_bytes(buf[pos + 16..pos + 18].try_into().unwrap());
+            let d_type = buf[pos + 18];
+
+            // Name starts at offset 19, null-terminated.
+            let name_start = pos + 19;
+            let name_end = pos + d_reclen as usize;
+            let name_slice = &buf[name_start..name_end];
+            let name_len = name_slice.iter().position(|&b| b == 0).unwrap_or(name_slice.len());
+            let name_bytes = &name_slice[..name_len];
+
+            let name_offset = names_buf.len();
+            names_buf.extend_from_slice(name_bytes);
+
+            raw_entries.push((d_ino, d_off, d_type, name_offset, name_len));
+
+            pos += d_reclen as usize;
+        }
+    }
+
+    if raw_entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Leak one contiguous buffer for all names (bounded: one per readdir call).
+    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
+
+    let entries = raw_entries
+        .into_iter()
+        .map(|(ino, off, typ, start, len)| DirEntry {
+            ino,
+            offset: off,
+            type_: typ as u32,
+            name: &leaked[start..start + len],
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+/// Read directory entries from a file descriptor using readdir on macOS.
+///
+/// Names are collected into a single contiguous buffer, leaked once.
+#[cfg(target_os = "macos")]
+fn read_dir_entries(fd: i32, offset: u64, _size: u32) -> io::Result<Vec<DirEntry<'static>>> {
+    // Duplicate the fd so fdopendir can take ownership without closing ours.
+    let dup_fd = unsafe { libc::dup(fd) };
+    if dup_fd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    let dirp = unsafe { libc::fdopendir(dup_fd) };
+    if dirp.is_null() {
+        unsafe { libc::close(dup_fd) };
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    // Seek to offset if needed.
+    if offset > 0 {
+        unsafe { libc::seekdir(dirp, offset as libc::c_long) };
+    }
+
+    let mut raw_entries: Vec<(u64, u64, u32, usize, usize)> = Vec::new();
+    let mut names_buf: Vec<u8> = Vec::new();
+
+    loop {
+        // Clear errno before readdir to distinguish EOF from error.
+        unsafe { *libc::__error() = 0 };
+
+        let ent = unsafe { libc::readdir(dirp) };
+        if ent.is_null() {
+            let errno = unsafe { *libc::__error() };
+            if errno != 0 {
+                unsafe { libc::closedir(dirp) };
+                return Err(platform::linux_error(io::Error::from_raw_os_error(errno)));
+            }
+            break; // EOF
+        }
+
+        let d = unsafe { &*ent };
+        let name_len = d.d_namlen as usize;
+        let name_bytes = unsafe {
+            std::slice::from_raw_parts(d.d_name.as_ptr() as *const u8, name_len)
+        };
+
+        let name_offset = names_buf.len();
+        names_buf.extend_from_slice(name_bytes);
+
+        let tell_offset = unsafe { libc::telldir(dirp) };
+
+        raw_entries.push((d.d_ino, tell_offset as u64, d.d_type as u32, name_offset, name_len));
+    }
+
+    unsafe { libc::closedir(dirp) };
+
+    if raw_entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Leak one contiguous buffer for all names (bounded: one per readdir call).
+    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
+
+    let entries = raw_entries
+        .into_iter()
+        .map(|(ino, off, typ, start, len)| DirEntry {
+            ino,
+            offset: off,
+            type_: typ,
+            name: &leaked[start..start + len],
+        })
+        .collect();
+
+    Ok(entries)
+}

--- a/crates/filesystem/lib/backends/passthrough/file_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/file_ops.rs
@@ -1,0 +1,153 @@
+//! File operations: open, read, write, flush, release.
+//!
+//! ## I/O Path
+//!
+//! Read and write use the `ZeroCopyWriter`/`ZeroCopyReader` traits from msb_krun, which
+//! bridge FUSE transport buffers directly to file I/O via `preadv64`/`pwritev64`. These take
+//! an explicit offset and do NOT modify the fd seek position, so `HandleData.file` only needs
+//! a `RwLock` read lock for I/O — the write lock is reserved for `lseek`, `fsync`, `ftruncate`.
+//!
+//! ## Writeback Cache
+//!
+//! When writeback caching is negotiated, the kernel may read from write-only files for cache
+//! coherency. `do_open` adjusts `O_WRONLY` → `O_RDWR` and strips `O_APPEND` (which races with
+//! the kernel's cached view of the file).
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock};
+
+use super::inode;
+use super::PassthroughFs;
+use crate::backends::shared::handle_table::HandleData;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Open a file and return a handle.
+pub(crate) fn do_open(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    flags: u32,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    if inode == init_binary::INIT_INODE {
+        return Ok((Some(init_binary::INIT_HANDLE), OpenOptions::KEEP_CACHE));
+    }
+
+    let mut open_flags = flags as i32;
+
+    // Writeback cache: kernel may issue reads on O_WRONLY fds for cache coherency,
+    // so widen to O_RDWR. Strip O_APPEND because it races with the kernel's cached
+    // write position.
+    if fs.writeback.load(Ordering::Relaxed) {
+        if open_flags & libc::O_WRONLY != 0 {
+            open_flags = (open_flags & !libc::O_WRONLY) | libc::O_RDWR;
+        }
+        open_flags &= !libc::O_APPEND;
+    }
+
+    // open_inode_fd adds O_NOFOLLOW and O_CLOEXEC itself for security
+    // (prevents procfd magic-link following), so no need to set them here.
+    let fd = inode::open_inode_fd(fs, inode, open_flags)?;
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+
+    let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let data = Arc::new(HandleData {
+        file: RwLock::new(file),
+    });
+
+    fs.handles.write().unwrap().insert(handle, data);
+    Ok((Some(handle), fs.cache_open_options()))
+}
+
+/// Read data from a file.
+pub(crate) fn do_read(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    w: &mut dyn ZeroCopyWriter,
+    size: u32,
+    offset: u64,
+) -> io::Result<usize> {
+    // Virtual init.krun binary.
+    if inode == init_binary::INIT_INODE {
+        return init_binary::read_init(w, &fs.init_file, size, offset);
+    }
+
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    let f = data.file.read().unwrap();
+    w.write_from(&f, size as usize, offset)
+}
+
+/// Write data to a file.
+pub(crate) fn do_write(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    r: &mut dyn ZeroCopyReader,
+    size: u32,
+    offset: u64,
+) -> io::Result<usize> {
+    if inode == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    let f = data.file.read().unwrap();
+    r.read_to(&f, size as usize, offset)
+}
+
+/// Flush pending data for a file handle.
+///
+/// Emulates POSIX close semantics by duplicating and closing the fd.
+/// Called on every guest `close()` (may fire multiple times if the fd was `dup`'d).
+/// The dup+close flushes pending data and surfaces I/O errors without releasing the handle.
+pub(crate) fn do_flush(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+) -> io::Result<()> {
+    if inode == init_binary::INIT_INODE {
+        return Ok(());
+    }
+
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    let f = data.file.read().unwrap();
+
+    let newfd = unsafe { libc::dup(f.as_raw_fd()) };
+    if newfd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    let ret = unsafe { libc::close(newfd) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Release an open file handle.
+pub(crate) fn do_release(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+) -> io::Result<()> {
+    if inode == init_binary::INIT_INODE {
+        return Ok(());
+    }
+
+    fs.handles.write().unwrap().remove(&handle);
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/passthrough/inode.rs
+++ b/crates/filesystem/lib/backends/passthrough/inode.rs
@@ -1,0 +1,391 @@
+//! Inode management: lookup, forget, and reference counting.
+//!
+//! ## Lookup Strategy
+//!
+//! Linux lookup uses a "collapse" optimization: open → statx(AT_EMPTY_PATH) → getxattr,
+//! yielding 3 syscalls instead of the naive 4 (fstatat + statx + open + getxattr). The stat
+//! is taken on the *opened* fd, eliminating TOCTOU between stat and open.
+//!
+//! macOS lookup uses fstatat → inode table check → register, with a separate fd open
+//! via `/.vol/dev/ino` for xattr access (since macOS doesn't store per-inode O_PATH fds).
+//!
+//! ## Security: Procfd Reopen
+//!
+//! `open_inode_fd` reopens inodes for I/O via `openat(proc_self_fd, "N", O_NOFOLLOW)`.
+//! This prevents procfd magic-link symlink following: without O_NOFOLLOW, `open("/proc/self/fd/N")`
+//! on an O_PATH fd pointing to a real host symlink would follow the target, potentially
+//! escaping the exported root. Using `openat` relative to `/proc/self/fd` with `O_NOFOLLOW`
+//! ensures the kernel resolves the fd reference without following any symlinks.
+
+use std::ffi::CStr;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::PassthroughFs;
+use crate::backends::shared::inode_table::{InodeAltKey, InodeData, MultikeyBTreeMap};
+use crate::backends::shared::platform;
+use crate::{stat64, Entry};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Look up a child name in a parent directory and return an [`Entry`].
+///
+/// If the inode is already in the table (matched by host identity), its
+/// refcount is incremented and the existing inode number is returned.
+/// Otherwise a new inode is allocated.
+pub(crate) fn do_lookup(fs: &PassthroughFs, parent: u64, name: &CStr) -> io::Result<Entry> {
+    crate::backends::shared::name_validation::validate_name(name)?;
+
+    let parent_fd = get_inode_fd(fs, parent)?;
+
+    #[cfg(target_os = "linux")]
+    return do_lookup_linux(fs, parent_fd, name);
+
+    #[cfg(target_os = "macos")]
+    return do_lookup_macos(fs, parent_fd, name);
+}
+
+/// Linux lookup: open → statx(AT_EMPTY_PATH) → patched_stat (3 syscalls).
+///
+/// This is more efficient than the fstatat + statx + open path (4 syscalls),
+/// and also more correct: the stat is on the *opened* fd, eliminating TOCTOU
+/// between stat and open.
+///
+/// The open uses `RESOLVE_BENEATH` (Linux 5.6+) for kernel-enforced containment,
+/// which atomically blocks `..` traversal, absolute symlinks, and handles concurrent
+/// rename races. Falls back to `openat(O_NOFOLLOW)` on older kernels.
+#[cfg(target_os = "linux")]
+fn do_lookup_linux(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Result<Entry> {
+    use std::os::fd::FromRawFd;
+
+    // Syscall 1: Open with RESOLVE_BENEATH containment.
+    let fd = platform::open_beneath(
+        parent_fd,
+        name.as_ptr(),
+        libc::O_PATH | libc::O_NOFOLLOW,
+        fs.has_openat2.load(Ordering::Relaxed),
+    );
+    if fd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    // Syscall 2: statx with AT_EMPTY_PATH on the opened fd.
+    // Gets stat data + mnt_id in one call.
+    let mut stx: libc::statx = unsafe { std::mem::zeroed() };
+    let ret = unsafe {
+        libc::statx(
+            fd,
+            c"".as_ptr(),
+            libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW | libc::AT_STATX_SYNC_AS_STAT,
+            libc::STATX_BASIC_STATS | libc::STATX_MNT_ID,
+            &mut stx,
+        )
+    };
+    if ret < 0 {
+        let err = platform::linux_error(io::Error::last_os_error());
+        unsafe { libc::close(fd) };
+        return Err(err);
+    }
+
+    let st = platform::statx_to_stat64(&stx);
+    let mnt_id = stx.stx_mnt_id;
+    let alt_key = InodeAltKey::new(st.st_ino, st.st_dev, mnt_id);
+
+    // Check if this host file is already tracked.
+    {
+        let inodes = fs.inodes.read().unwrap();
+        if let Some(data) = inodes.get_alt(&alt_key) {
+            data.refcount.fetch_add(1, Ordering::Acquire);
+            // Close the fd — we already have one for this inode.
+            unsafe { libc::close(fd) };
+            // Syscall 3: getxattr for override stat.
+            let patched = crate::backends::shared::stat_override::patched_stat(
+                inode_raw_fd(data),
+                st,
+            )?;
+            return Ok(Entry {
+                inode: data.inode,
+                generation: 0,
+                attr: patched,
+                attr_flags: 0,
+                attr_timeout: fs.cfg.attr_timeout,
+                entry_timeout: fs.cfg.entry_timeout,
+            });
+        }
+    }
+
+    // New inode — take ownership of the fd.
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let inode_num = fs.next_inode.fetch_add(1, Ordering::Relaxed);
+
+    let data = Arc::new(InodeData {
+        inode: inode_num,
+        ino: st.st_ino,
+        dev: st.st_dev,
+        refcount: std::sync::atomic::AtomicU64::new(1),
+        file,
+        mnt_id,
+    });
+
+    let raw_fd = inode_raw_fd(&data);
+    // Syscall 3: getxattr for override stat.
+    let patched = crate::backends::shared::stat_override::patched_stat(raw_fd, st)?;
+
+    {
+        let mut inodes = fs.inodes.write().unwrap();
+        inodes.insert(inode_num, alt_key, data);
+    }
+
+    Ok(Entry {
+        inode: inode_num,
+        generation: 0,
+        attr: patched,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+/// macOS lookup: fstatat → check table → register.
+///
+/// Opens a real fd via `/.vol/dev/ino` for xattr access since macOS
+/// doesn't store per-inode fds (inode_raw_fd returns -1). The `/.vol/`
+/// path scheme references files by device+inode identity, making it
+/// stable across renames — similar to Linux's `/proc/self/fd/N`.
+#[cfg(target_os = "macos")]
+fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Result<Entry> {
+    let st = platform::fstatat_nofollow(parent_fd, name)?;
+    let alt_key = InodeAltKey::new(st.st_ino as u64, st.st_dev as u64);
+
+    // Open a real fd for xattr access via /.vol/dev/ino.
+    let patched = open_and_patch_stat_macos(st.st_dev as u64, st.st_ino as u64, st)?;
+
+    // Check if this host file is already tracked.
+    {
+        let inodes = fs.inodes.read().unwrap();
+        if let Some(data) = inodes.get_alt(&alt_key) {
+            data.refcount.fetch_add(1, Ordering::Acquire);
+            return Ok(Entry {
+                inode: data.inode,
+                generation: 0,
+                attr: patched,
+                attr_flags: 0,
+                attr_timeout: fs.cfg.attr_timeout,
+                entry_timeout: fs.cfg.entry_timeout,
+            });
+        }
+    }
+
+    let inode_num = fs.next_inode.fetch_add(1, Ordering::Relaxed);
+
+    let data = Arc::new(InodeData {
+        inode: inode_num,
+        ino: st.st_ino as u64,
+        dev: st.st_dev as u64,
+        refcount: std::sync::atomic::AtomicU64::new(1),
+    });
+
+    {
+        let mut inodes = fs.inodes.write().unwrap();
+        inodes.insert(inode_num, alt_key, data);
+    }
+
+    Ok(Entry {
+        inode: inode_num,
+        generation: 0,
+        attr: patched,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+/// Open a real fd via `/.vol/dev/ino` for xattr access and apply stat patching.
+///
+/// Tries O_RDONLY first, then O_RDONLY|O_DIRECTORY (for directories that reject
+/// plain O_RDONLY), falls back to unpatched stat if neither succeeds. This is
+/// necessary because macOS doesn't store per-inode fds, so we must open a
+/// temporary fd solely for `fgetxattr` to read the override stat.
+#[cfg(target_os = "macos")]
+fn open_and_patch_stat_macos(dev: u64, ino: u64, st: stat64) -> io::Result<stat64> {
+    let path = format!("/.vol/{}/{}\0", dev, ino);
+
+    // Try regular file open.
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr() as *const libc::c_char,
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd >= 0 {
+        let result = crate::backends::shared::stat_override::patched_stat(fd, st);
+        unsafe { libc::close(fd) };
+        return result;
+    }
+
+    // Try directory open.
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr() as *const libc::c_char,
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY,
+        )
+    };
+    if fd >= 0 {
+        let result = crate::backends::shared::stat_override::patched_stat(fd, st);
+        unsafe { libc::close(fd) };
+        return result;
+    }
+
+    // Can't open — return unpatched stat.
+    Ok(st)
+}
+
+/// Decrement the reference count for an inode. Remove it from the table
+/// when the count reaches zero.
+pub(crate) fn forget_one(fs: &PassthroughFs, inode: u64, count: u64) {
+    let mut inodes = fs.inodes.write().unwrap();
+    forget_one_locked(&mut inodes, inode, count);
+}
+
+/// Decrement the reference count under an already-held write lock.
+///
+/// Used by [`super::PassthroughFs::batch_forget`] to process all entries
+/// under a single lock acquisition (O(1) lock ops vs O(n) for per-entry locking).
+///
+/// Uses a CAS loop to handle the race where a concurrent `lookup` may increment
+/// the refcount between our load and compare_exchange. `saturating_sub` prevents
+/// underflow if the kernel sends a forget count larger than the current refcount.
+pub(crate) fn forget_one_locked(
+    inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
+    inode: u64,
+    count: u64,
+) {
+    if let Some(data) = inodes.get(&inode) {
+        loop {
+            let old = data.refcount.load(Ordering::Relaxed);
+            let new = old.saturating_sub(count);
+            if data
+                .refcount
+                .compare_exchange(old, new, Ordering::Release, Ordering::Relaxed)
+                .is_ok()
+            {
+                if new == 0 {
+                    inodes.remove(&inode);
+                }
+                break;
+            }
+        }
+    }
+}
+
+/// Get the raw fd for an inode. On Linux this is the O_PATH fd.
+/// On macOS this opens via `/.vol/dev/ino`.
+pub(crate) fn get_inode_fd(fs: &PassthroughFs, inode: u64) -> io::Result<i32> {
+    // Root inode uses the stored root fd.
+    if inode == 1 {
+        return Ok(fs.root_fd.as_raw_fd());
+    }
+
+    let inodes = fs.inodes.read().unwrap();
+    let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+
+    Ok(inode_raw_fd(data))
+}
+
+/// Get the raw fd from an InodeData.
+#[cfg(target_os = "linux")]
+fn inode_raw_fd(data: &InodeData) -> i32 {
+    data.file.as_raw_fd()
+}
+
+/// Get the raw fd from an InodeData on macOS.
+/// On macOS we don't store fds per inode; we open via `/.vol/dev/ino`.
+/// For the simple case, we return -1 and callers use path-based operations.
+#[cfg(target_os = "macos")]
+fn inode_raw_fd(_data: &InodeData) -> i32 {
+    // On macOS, we use path-based xattr operations.
+    // Return -1 to signal that path-based access is needed.
+    -1
+}
+
+/// Open a file for I/O by inode. Returns a real file descriptor (not O_PATH).
+///
+/// On Linux, uses `openat(proc_self_fd, "N", flags | O_NOFOLLOW)` to prevent
+/// procfd magic-link symlink following, which could escape the exported root.
+pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::Result<i32> {
+    #[cfg(target_os = "linux")]
+    {
+        let inode_fd = get_inode_fd(fs, inode)?;
+        let mut buf = [0u8; 20];
+        let fd_str = format_fd_cstr(inode_fd, &mut buf);
+        let fd = unsafe {
+            libc::openat(
+                fs.proc_self_fd.as_raw_fd(),
+                fd_str.as_ptr(),
+                flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        Ok(fd)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let inodes = fs.inodes.read().unwrap();
+        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+        let path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+        let fd = unsafe {
+            libc::open(
+                path.as_ptr() as *const libc::c_char,
+                flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        Ok(fd)
+    }
+}
+
+/// Format a file descriptor number as a null-terminated C string into a stack buffer.
+///
+/// Avoids the heap allocation of `format!("/proc/self/fd/{fd}")` on the hot
+/// reopen path. A 20-byte stack buffer is sufficient for any i32 fd number
+/// plus null terminator.
+#[cfg(target_os = "linux")]
+fn format_fd_cstr(fd: i32, buf: &mut [u8; 20]) -> *const libc::c_char {
+    use std::io::Write;
+    let mut cursor = std::io::Cursor::new(&mut buf[..]);
+    write!(cursor, "{}\0", fd).unwrap();
+    buf.as_ptr() as *const libc::c_char
+}
+
+/// Stat an inode (with override xattr applied).
+pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
+    #[cfg(target_os = "linux")]
+    {
+        let fd = get_inode_fd(fs, inode)?;
+        let st = platform::fstat(fd)?;
+        crate::backends::shared::stat_override::patched_stat(fd, st)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let inodes = fs.inodes.read().unwrap();
+        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+        let path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+        let path_cstr = unsafe { CStr::from_ptr(path.as_ptr() as *const _) };
+        let mut st = unsafe { std::mem::zeroed::<stat64>() };
+        let ret = unsafe { libc::lstat(path_cstr.as_ptr(), &mut st) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        open_and_patch_stat_macos(data.dev, data.ino, st)
+    }
+}

--- a/crates/filesystem/lib/backends/passthrough/metadata.rs
+++ b/crates/filesystem/lib/backends/passthrough/metadata.rs
@@ -1,0 +1,196 @@
+//! Attribute operations: getattr, setattr, access.
+//!
+//! ## Stat Virtualization
+//!
+//! All stat results pass through `patched_stat` which applies the override xattr. The guest
+//! sees virtualized uid/gid/mode/rdev, while size/timestamps/blocks come from the real host file.
+//!
+//! ## setattr
+//!
+//! UID/GID/mode changes are stored in the override xattr — never via real `fchown`/`fchmod`
+//! (the host process lacks `CAP_CHOWN`). Size changes use real `ftruncate`, and timestamp
+//! changes use real `futimens`.
+
+use std::io;
+use std::time::Duration;
+
+use super::inode;
+use super::PassthroughFs;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::backends::shared::stat_override;
+use crate::{stat64, Context, SetattrValid};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Get attributes for an inode.
+pub(crate) fn do_getattr(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+    _handle: Option<u64>,
+) -> io::Result<(stat64, Duration)> {
+    if ino == init_binary::INIT_INODE {
+        return Ok((init_binary::init_stat(), fs.cfg.attr_timeout));
+    }
+
+    let st = inode::stat_inode(fs, ino)?;
+    Ok((st, fs.cfg.attr_timeout))
+}
+
+/// Set attributes on an inode.
+pub(crate) fn do_setattr(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+    attr: stat64,
+    _handle: Option<u64>,
+    valid: SetattrValid,
+) -> io::Result<(stat64, Duration)> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    // Open with O_RDWR when truncation is needed, O_RDONLY otherwise.
+    // ftruncate(2) requires write permission on the fd; opening O_RDONLY
+    // would cause EINVAL on Linux when SIZE is in the valid mask.
+    let open_flags = if valid.contains(SetattrValid::SIZE) {
+        libc::O_RDWR
+    } else {
+        libc::O_RDONLY
+    };
+    let fd = inode::open_inode_fd(fs, ino, open_flags)?;
+    let close_fd = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+
+    // Handle uid/gid/mode changes via xattr (not real chown/chmod).
+    if valid.intersects(SetattrValid::UID | SetattrValid::GID | SetattrValid::MODE) {
+        let current = stat_override::get_override(*close_fd)?;
+        let (cur_uid, cur_gid, cur_mode, cur_rdev) = match current {
+            Some(ovr) => (ovr.uid, ovr.gid, ovr.mode, ovr.rdev),
+            None => {
+                let st = platform::fstat(*close_fd)?;
+                #[cfg(target_os = "linux")]
+                let mode = st.st_mode;
+                #[cfg(target_os = "macos")]
+                let mode = st.st_mode as u32;
+                (st.st_uid, st.st_gid, mode, 0)
+            }
+        };
+
+        let new_uid = if valid.contains(SetattrValid::UID) { attr.st_uid } else { cur_uid };
+        let new_gid = if valid.contains(SetattrValid::GID) { attr.st_gid } else { cur_gid };
+        let new_mode = if valid.contains(SetattrValid::MODE) {
+            #[cfg(target_os = "linux")]
+            let attr_mode = attr.st_mode;
+            #[cfg(target_os = "macos")]
+            let attr_mode = attr.st_mode as u32;
+            (cur_mode & libc::S_IFMT as u32) | (attr_mode & !libc::S_IFMT as u32)
+        } else {
+            cur_mode
+        };
+
+        stat_override::set_override(*close_fd, new_uid, new_gid, new_mode, cur_rdev)?;
+    }
+
+    // Handle size changes via ftruncate.
+    if valid.contains(SetattrValid::SIZE) {
+        let ret = unsafe { libc::ftruncate(*close_fd, attr.st_size) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    // Handle timestamp changes.
+    if valid.intersects(SetattrValid::ATIME | SetattrValid::MTIME) {
+        let mut times = [libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT }; 2];
+
+        if valid.contains(SetattrValid::ATIME) {
+            if valid.contains(SetattrValid::ATIME_NOW) {
+                times[0].tv_nsec = libc::UTIME_NOW;
+            } else {
+                times[0].tv_sec = attr.st_atime;
+                times[0].tv_nsec = attr.st_atime_nsec;
+            }
+        }
+
+        if valid.contains(SetattrValid::MTIME) {
+            if valid.contains(SetattrValid::MTIME_NOW) {
+                times[1].tv_nsec = libc::UTIME_NOW;
+            } else {
+                times[1].tv_sec = attr.st_mtime;
+                times[1].tv_nsec = attr.st_mtime_nsec;
+            }
+        }
+
+        let ret = unsafe { libc::futimens(*close_fd, times.as_ptr()) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    drop(close_fd);
+
+    // Return updated attributes.
+    let st = inode::stat_inode(fs, ino)?;
+    Ok((st, fs.cfg.attr_timeout))
+}
+
+/// Check file access permissions using virtualized uid/gid/mode.
+///
+/// Uses `stat_inode` (which applies the override xattr) so permission checks honor
+/// the guest-visible ownership and mode bits, not the real host file permissions.
+/// Root (uid 0) bypasses read/write checks but still needs at least one execute bit.
+pub(crate) fn do_access(
+    fs: &PassthroughFs,
+    ctx: Context,
+    ino: u64,
+    mask: u32,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        // init.krun is always readable and executable.
+        return Ok(());
+    }
+
+    let st = inode::stat_inode(fs, ino)?;
+
+    // F_OK: just check existence.
+    if mask == libc::F_OK as u32 {
+        return Ok(());
+    }
+
+    // Get mode as u32 for uniform handling.
+    #[cfg(target_os = "linux")]
+    let st_mode = st.st_mode;
+    #[cfg(target_os = "macos")]
+    let st_mode = st.st_mode as u32;
+
+    // Root (uid 0) bypasses read/write checks.
+    if ctx.uid == 0 {
+        if mask & libc::X_OK as u32 != 0 && st_mode & 0o111 == 0 {
+            return Err(platform::eacces());
+        }
+        return Ok(());
+    }
+
+    let bits = if st.st_uid == ctx.uid {
+        (st_mode >> 6) & 0o7
+    } else if st.st_gid == ctx.gid {
+        (st_mode >> 3) & 0o7
+    } else {
+        st_mode & 0o7
+    };
+
+    if mask & libc::R_OK as u32 != 0 && bits & 0o4 == 0 {
+        return Err(platform::eacces());
+    }
+    if mask & libc::W_OK as u32 != 0 && bits & 0o2 == 0 {
+        return Err(platform::eacces());
+    }
+    if mask & libc::X_OK as u32 != 0 && bits & 0o1 == 0 {
+        return Err(platform::eacces());
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/passthrough/mod.rs
+++ b/crates/filesystem/lib/backends/passthrough/mod.rs
@@ -1,0 +1,617 @@
+//! Passthrough filesystem backend.
+//!
+//! Exposes a single host directory to the guest VM via virtio-fs, with
+//! stat virtualization (uid/gid/mode via xattr), init.krun injection,
+//! and name validation.
+
+mod create_ops;
+mod dir_ops;
+mod file_ops;
+pub(crate) mod inode;
+mod metadata;
+mod remove_ops;
+mod special;
+mod xattr_ops;
+
+use std::collections::BTreeMap;
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use crate::backends::shared::handle_table::HandleData;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::inode_table::{InodeAltKey, InodeData, MultikeyBTreeMap};
+use crate::backends::shared::platform;
+use crate::backends::shared::stat_override;
+use crate::{
+    stat64, statvfs64, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Cache policy for the passthrough filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachePolicy {
+    /// Never cache — every access goes to the host filesystem.
+    Never,
+    /// Let the kernel decide (default).
+    Auto,
+    /// Aggressively cache — assume the host filesystem is static.
+    Always,
+}
+
+/// Configuration for the passthrough filesystem backend.
+#[derive(Debug, Clone)]
+pub struct PassthroughConfig {
+    /// Path to the root directory on the host.
+    pub root_dir: PathBuf,
+
+    /// Whether to use xattr-based stat virtualization.
+    pub xattr: bool,
+
+    /// Whether to fail mount if xattr support is unavailable.
+    pub strict: bool,
+
+    /// FUSE entry cache timeout.
+    pub entry_timeout: Duration,
+
+    /// FUSE attribute cache timeout.
+    pub attr_timeout: Duration,
+
+    /// Cache policy.
+    pub cache_policy: CachePolicy,
+
+    /// Whether to enable writeback caching.
+    pub writeback: bool,
+}
+
+/// Passthrough filesystem backend.
+///
+/// Implements [`DynFileSystem`] by mapping guest filesystem operations to
+/// the host filesystem, with stat virtualization via xattr.
+pub struct PassthroughFs {
+    /// Configuration.
+    pub(crate) cfg: PassthroughConfig,
+
+    /// Open file descriptor for the root directory.
+    pub(crate) root_fd: File,
+
+    /// Inode table with dual-key lookup (FUSE inode + host identity).
+    pub(crate) inodes: RwLock<MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>>,
+
+    /// Next FUSE inode number to allocate (starts at 3, after root=1 and init=2).
+    pub(crate) next_inode: AtomicU64,
+
+    /// Open file handle table.
+    pub(crate) handles: RwLock<BTreeMap<u64, Arc<HandleData>>>,
+
+    /// Next file handle number to allocate (starts at 1, after init_handle=0).
+    pub(crate) next_handle: AtomicU64,
+
+    /// Whether writeback caching is negotiated.
+    pub(crate) writeback: AtomicBool,
+
+    /// File containing the init binary bytes (memfd on Linux, tmpfile on macOS).
+    pub(crate) init_file: File,
+
+    /// Whether `openat2` with `RESOLVE_BENEATH` is available (Linux 5.6+).
+    #[cfg(target_os = "linux")]
+    pub(crate) has_openat2: AtomicBool,
+
+    /// Open fd to /proc/self/fd (Linux only).
+    ///
+    /// Used by `open_inode_fd` for secure inode reopening: `openat(proc_self_fd, "N", O_NOFOLLOW)`
+    /// prevents procfd magic-link symlink following that could escape the exported root.
+    #[cfg(target_os = "linux")]
+    pub(crate) proc_self_fd: File,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PassthroughFs {
+    /// Create a new passthrough filesystem backend.
+    ///
+    /// Opens the root directory and optionally probes for xattr support.
+    pub fn new(cfg: PassthroughConfig) -> io::Result<Self> {
+        // Open the root directory.
+        let root_path = std::ffi::CString::new(
+            cfg.root_dir
+                .to_str()
+                .ok_or_else(platform::einval)?
+                .as_bytes(),
+        )
+        .map_err(|_| platform::einval())?;
+
+        let root_fd_raw = unsafe {
+            libc::open(
+                root_path.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY,
+            )
+        };
+        if root_fd_raw < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        let root_fd = unsafe { File::from_raw_fd(root_fd_raw) };
+
+        // Probe xattr support if strict mode is enabled.
+        if cfg.strict && cfg.xattr {
+            let supported = stat_override::probe_xattr_support(root_fd.as_raw_fd())?;
+            if !supported {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "xattr not supported on root filesystem and strict mode is enabled",
+                ));
+            }
+        }
+
+        // Create the init binary file.
+        let init_file = init_binary::create_init_file()?;
+
+        // Probe openat2 / RESOLVE_BENEATH availability (Linux 5.6+).
+        #[cfg(target_os = "linux")]
+        let has_openat2 = AtomicBool::new(platform::probe_openat2());
+
+        // Open /proc/self/fd on Linux for efficient path resolution.
+        #[cfg(target_os = "linux")]
+        let proc_self_fd = {
+            let path = std::ffi::CString::new("/proc/self/fd").unwrap();
+            let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+            if fd < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+            unsafe { File::from_raw_fd(fd) }
+        };
+
+        Ok(Self {
+            cfg,
+            root_fd,
+            inodes: RwLock::new(MultikeyBTreeMap::new()),
+            next_inode: AtomicU64::new(3), // 1=root, 2=init
+            handles: RwLock::new(BTreeMap::new()),
+            next_handle: AtomicU64::new(1), // 0=init handle
+            writeback: AtomicBool::new(false),
+            init_file,
+            #[cfg(target_os = "linux")]
+            has_openat2,
+            #[cfg(target_os = "linux")]
+            proc_self_fd,
+        })
+    }
+}
+
+impl PassthroughFs {
+    /// Get the `OpenOptions` for file opens based on cache policy.
+    pub(crate) fn cache_open_options(&self) -> OpenOptions {
+        match self.cfg.cache_policy {
+            CachePolicy::Never => OpenOptions::DIRECT_IO,
+            CachePolicy::Auto => OpenOptions::empty(),
+            CachePolicy::Always => OpenOptions::KEEP_CACHE,
+        }
+    }
+
+    /// Get the `OpenOptions` for directory opens based on cache policy.
+    pub(crate) fn cache_dir_options(&self) -> OpenOptions {
+        match self.cfg.cache_policy {
+            CachePolicy::Never => OpenOptions::DIRECT_IO,
+            CachePolicy::Auto => OpenOptions::empty(),
+            CachePolicy::Always => OpenOptions::CACHE_DIR,
+        }
+    }
+}
+
+impl Default for PassthroughConfig {
+    fn default() -> Self {
+        Self {
+            root_dir: PathBuf::new(),
+            xattr: true,
+            strict: true,
+            entry_timeout: Duration::from_secs(5),
+            attr_timeout: Duration::from_secs(5),
+            cache_policy: CachePolicy::Auto,
+            writeback: false,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DynFileSystem for PassthroughFs {
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        let mut opts = FsOptions::empty();
+
+        // DONT_MASK: we handle umask ourselves in create/mkdir/mknod.
+        if capable.contains(FsOptions::DONT_MASK) {
+            opts |= FsOptions::DONT_MASK;
+        }
+        if capable.contains(FsOptions::BIG_WRITES) {
+            opts |= FsOptions::BIG_WRITES;
+        }
+        if capable.contains(FsOptions::ASYNC_READ) {
+            opts |= FsOptions::ASYNC_READ;
+        }
+        if capable.contains(FsOptions::PARALLEL_DIROPS) {
+            opts |= FsOptions::PARALLEL_DIROPS;
+        }
+        if capable.contains(FsOptions::MAX_PAGES) {
+            opts |= FsOptions::MAX_PAGES;
+        }
+        if capable.contains(FsOptions::HANDLE_KILLPRIV_V2) {
+            opts |= FsOptions::HANDLE_KILLPRIV_V2;
+        }
+        // READDIRPLUS_AUTO: let kernel decide when to use readdirplus vs plain readdir.
+        // readdirplus returns attrs with entries, saving per-entry getattr calls.
+        if capable.contains(FsOptions::DO_READDIRPLUS) {
+            opts |= FsOptions::DO_READDIRPLUS | FsOptions::READDIRPLUS_AUTO;
+        }
+
+        // Enable writeback cache if requested and supported.
+        if self.cfg.writeback && capable.contains(FsOptions::WRITEBACK_CACHE) {
+            opts |= FsOptions::WRITEBACK_CACHE;
+            self.writeback.store(true, Ordering::Relaxed);
+        }
+
+        Ok(opts)
+    }
+
+    fn destroy(&self) {
+        self.handles.write().unwrap().clear();
+        self.inodes.write().unwrap().clear();
+    }
+
+    fn lookup(&self, _ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        // Handle init.krun lookup in root directory.
+        if parent == 1 && init_binary::is_init_name(name.to_bytes()) {
+            return Ok(init_binary::init_entry(
+                self.cfg.entry_timeout,
+                self.cfg.attr_timeout,
+            ));
+        }
+        inode::do_lookup(self, parent, name)
+    }
+
+    fn forget(&self, _ctx: Context, ino: u64, count: u64) {
+        if ino == init_binary::INIT_INODE {
+            return;
+        }
+        inode::forget_one(self, ino, count);
+    }
+
+    fn batch_forget(&self, _ctx: Context, requests: Vec<(u64, u64)>) {
+        // Single lock acquisition for all entries (O(1) instead of O(n) locks).
+        // batch_forget is called with hundreds of entries after directory traversals.
+        let mut inodes = self.inodes.write().unwrap();
+        for (ino, count) in requests {
+            if ino == init_binary::INIT_INODE {
+                continue;
+            }
+            inode::forget_one_locked(&mut inodes, ino, count);
+        }
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: Option<u64>,
+    ) -> io::Result<(stat64, Duration)> {
+        metadata::do_getattr(self, ctx, ino, handle)
+    }
+
+    fn setattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        attr: stat64,
+        handle: Option<u64>,
+        valid: SetattrValid,
+    ) -> io::Result<(stat64, Duration)> {
+        metadata::do_setattr(self, ctx, ino, attr, handle, valid)
+    }
+
+    fn readlink(&self, ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
+        create_ops::do_readlink(self, ctx, ino)
+    }
+
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: u64,
+        name: &CStr,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_symlink(self, ctx, linkname, parent, name, extensions)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_mknod(self, ctx, parent, name, mode, rdev, umask, extensions)
+    }
+
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_mkdir(self, ctx, parent, name, mode, umask, extensions)
+    }
+
+    fn unlink(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        remove_ops::do_unlink(self, ctx, parent, name)
+    }
+
+    fn rmdir(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        remove_ops::do_rmdir(self, ctx, parent, name)
+    }
+
+    fn rename(
+        &self,
+        ctx: Context,
+        olddir: u64,
+        oldname: &CStr,
+        newdir: u64,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        remove_ops::do_rename(self, ctx, olddir, oldname, newdir, newname, flags)
+    }
+
+    fn link(
+        &self,
+        ctx: Context,
+        ino: u64,
+        newparent: u64,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        create_ops::do_link(self, ctx, ino, newparent, newname)
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        file_ops::do_open(self, ctx, ino, flags)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        flags: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+        create_ops::do_create(self, ctx, parent, name, mode, flags, umask, extensions)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        file_ops::do_read(self, ctx, ino, handle, w, size, offset)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _delayed_write: bool,
+        _kill_priv: bool,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        file_ops::do_write(self, ctx, ino, handle, r, size, offset)
+    }
+
+    fn flush(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        _lock_owner: u64,
+    ) -> io::Result<()> {
+        file_ops::do_flush(self, ctx, ino, handle)
+    }
+
+    fn fsync(
+        &self,
+        ctx: Context,
+        ino: u64,
+        datasync: bool,
+        handle: u64,
+    ) -> io::Result<()> {
+        special::do_fsync(self, ctx, ino, datasync, handle)
+    }
+
+    fn fallocate(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        special::do_fallocate(self, ctx, ino, handle, mode, offset, length)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn release(
+        &self,
+        ctx: Context,
+        ino: u64,
+        _flags: u32,
+        handle: u64,
+        _flush: bool,
+        _flock_release: bool,
+        _lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        file_ops::do_release(self, ctx, ino, handle)
+    }
+
+    fn statfs(&self, ctx: Context, ino: u64) -> io::Result<statvfs64> {
+        special::do_statfs(self, ctx, ino)
+    }
+
+    fn setxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        xattr_ops::do_setxattr(self, ctx, ino, name, value, flags)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        xattr_ops::do_getxattr(self, ctx, ino, name, size)
+    }
+
+    fn listxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        size: u32,
+    ) -> io::Result<ListxattrReply> {
+        xattr_ops::do_listxattr(self, ctx, ino, size)
+    }
+
+    fn removexattr(&self, ctx: Context, ino: u64, name: &CStr) -> io::Result<()> {
+        xattr_ops::do_removexattr(self, ctx, ino, name)
+    }
+
+    fn opendir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        dir_ops::do_opendir(self, ctx, ino, flags)
+    }
+
+    fn readdir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<DirEntry<'static>>> {
+        dir_ops::do_readdir(self, ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+        dir_ops::do_readdirplus(self, ctx, ino, handle, size, offset)
+    }
+
+    fn fsyncdir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        datasync: bool,
+        handle: u64,
+    ) -> io::Result<()> {
+        special::do_fsyncdir(self, ctx, ino, datasync, handle)
+    }
+
+    fn releasedir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+        handle: u64,
+    ) -> io::Result<()> {
+        dir_ops::do_releasedir(self, ctx, ino, flags, handle)
+    }
+
+    fn access(&self, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
+        metadata::do_access(self, ctx, ino, mask)
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        special::do_lseek(self, ctx, ino, handle, offset, whence)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn copyfilerange(
+        &self,
+        ctx: Context,
+        inode_in: u64,
+        handle_in: u64,
+        offset_in: u64,
+        inode_out: u64,
+        handle_out: u64,
+        offset_out: u64,
+        len: u64,
+        flags: u64,
+    ) -> io::Result<usize> {
+        special::do_copyfilerange(
+            self, ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len,
+            flags,
+        )
+    }
+}

--- a/crates/filesystem/lib/backends/passthrough/remove_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/remove_ops.rs
@@ -1,0 +1,143 @@
+//! Removal operations: unlink, rmdir, rename.
+//!
+//! All operations validate names and protect `init.krun` from deletion/renaming.
+//! On Linux, `renameat2` is used for flag support (RENAME_NOREPLACE, RENAME_EXCHANGE).
+//! On macOS, `renameatx_np` is used with translated flag values.
+
+use std::ffi::CStr;
+use std::io;
+
+use super::inode;
+use super::PassthroughFs;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::name_validation;
+use crate::backends::shared::platform;
+use crate::Context;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Remove a file.
+pub(crate) fn do_unlink(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    parent: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    name_validation::validate_name(name)?;
+
+    // Protect init.krun from deletion.
+    if init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_fd = inode::get_inode_fd(fs, parent)?;
+    let ret = unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Remove a directory.
+pub(crate) fn do_rmdir(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    parent: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    name_validation::validate_name(name)?;
+
+    if init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_fd = inode::get_inode_fd(fs, parent)?;
+    let ret = unsafe { libc::unlinkat(parent_fd, name.as_ptr(), libc::AT_REMOVEDIR) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Rename a file or directory.
+pub(crate) fn do_rename(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    olddir: u64,
+    oldname: &CStr,
+    newdir: u64,
+    newname: &CStr,
+    flags: u32,
+) -> io::Result<()> {
+    name_validation::validate_name(oldname)?;
+    name_validation::validate_name(newname)?;
+
+    // Protect init.krun from being renamed or overwritten.
+    if init_binary::is_init_name(oldname.to_bytes())
+        || init_binary::is_init_name(newname.to_bytes())
+    {
+        return Err(platform::eacces());
+    }
+
+    let old_fd = inode::get_inode_fd(fs, olddir)?;
+    let new_fd = inode::get_inode_fd(fs, newdir)?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let ret = unsafe {
+            libc::syscall(
+                libc::SYS_renameat2,
+                old_fd,
+                oldname.as_ptr(),
+                new_fd,
+                newname.as_ptr(),
+                flags,
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if flags == 0 {
+            let ret = unsafe {
+                libc::renameat(old_fd, oldname.as_ptr(), new_fd, newname.as_ptr())
+            };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+        } else {
+            // macOS uses renamex_np for RENAME_SWAP and RENAME_EXCL.
+            // Map Linux flags to macOS equivalents.
+            let mut macos_flags: libc::c_uint = 0;
+
+            // Linux RENAME_NOREPLACE = 1, macOS RENAME_EXCL = 0x00000004
+            if flags & 1 != 0 {
+                macos_flags |= 0x00000004; // RENAME_EXCL
+            }
+            // Linux RENAME_EXCHANGE = 2, macOS RENAME_SWAP = 0x00000002
+            if flags & 2 != 0 {
+                macos_flags |= 0x00000002; // RENAME_SWAP
+            }
+
+            let ret = unsafe {
+                libc::renameatx_np(
+                    old_fd,
+                    oldname.as_ptr(),
+                    new_fd,
+                    newname.as_ptr(),
+                    macos_flags,
+                )
+            };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/passthrough/special.rs
+++ b/crates/filesystem/lib/backends/passthrough/special.rs
@@ -1,0 +1,253 @@
+//! Special operations: fsync, fsyncdir, fallocate, lseek, statfs, copyfilerange.
+//!
+//! ## copyfilerange
+//!
+//! Implemented on Linux using `copy_file_range(2)`, which enables server-side file copies
+//! that stay within the host kernel — avoiding the FUSE round-trip of read+write through
+//! guest memory. Returns `ENOSYS` on macOS; the guest kernel falls back to read+write.
+//!
+//! ## fallocate
+//!
+//! On macOS, uses `fcntl(F_PREALLOCATE)` + `ftruncate` since `fallocate64` doesn't exist.
+//! Tries contiguous allocation first, falls back to non-contiguous.
+
+use std::io;
+use std::os::fd::AsRawFd;
+
+use super::PassthroughFs;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{statvfs64, Context};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Synchronize file contents.
+pub(crate) fn do_fsync(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    datasync: bool,
+    handle: u64,
+) -> io::Result<()> {
+    if inode == init_binary::INIT_INODE {
+        return Ok(());
+    }
+
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    // Write lock: fsync/fdatasync modify fd state.
+    #[allow(clippy::readonly_write_lock)]
+    let f = data.file.write().unwrap();
+    let fd = f.as_raw_fd();
+
+    #[cfg(target_os = "linux")]
+    let ret = if datasync {
+        unsafe { libc::fdatasync(fd) }
+    } else {
+        unsafe { libc::fsync(fd) }
+    };
+
+    #[cfg(target_os = "macos")]
+    let ret = {
+        let _ = datasync;
+        unsafe { libc::fsync(fd) }
+    };
+
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Synchronize directory contents.
+pub(crate) fn do_fsyncdir(
+    fs: &PassthroughFs,
+    ctx: Context,
+    inode: u64,
+    datasync: bool,
+    handle: u64,
+) -> io::Result<()> {
+    do_fsync(fs, ctx, inode, datasync, handle)
+}
+
+/// Allocate space for a file.
+pub(crate) fn do_fallocate(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    mode: u32,
+    offset: u64,
+    length: u64,
+) -> io::Result<()> {
+    if inode == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    // Write lock: fallocate modifies file state.
+    #[allow(clippy::readonly_write_lock)]
+    let f = data.file.write().unwrap();
+    let fd = f.as_raw_fd();
+
+    #[cfg(target_os = "linux")]
+    {
+        let ret = unsafe { libc::fallocate64(fd, mode as i32, offset as i64, length as i64) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // macOS uses fcntl with F_PREALLOCATE + ftruncate.
+        let _ = mode; // mode flags not directly supported on macOS.
+
+        let mut store = libc::fstore_t {
+            fst_flags: libc::F_ALLOCATECONTIG,
+            fst_posmode: libc::F_PEOFPOSMODE,
+            fst_offset: 0,
+            fst_length: length as i64,
+            fst_bytesalloc: 0,
+        };
+
+        let ret = unsafe { libc::fcntl(fd, libc::F_PREALLOCATE, &mut store) };
+        if ret < 0 {
+            // Try non-contiguous allocation.
+            store.fst_flags = libc::F_ALLOCATEALL;
+            let ret = unsafe { libc::fcntl(fd, libc::F_PREALLOCATE, &mut store) };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+        }
+
+        // Extend file size if needed.
+        let new_size = offset + length;
+        let ret = unsafe { libc::ftruncate(fd, new_size as i64) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Reposition read/write file offset (seek for sparse files).
+pub(crate) fn do_lseek(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+    handle: u64,
+    offset: u64,
+    whence: u32,
+) -> io::Result<u64> {
+    if inode == init_binary::INIT_INODE {
+        return Err(platform::enosys());
+    }
+
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    // Write lock: lseek modifies fd seek position.
+    #[allow(clippy::readonly_write_lock)]
+    let f = data.file.write().unwrap();
+    let fd = f.as_raw_fd();
+
+    let ret = unsafe { libc::lseek(fd, offset as i64, whence as i32) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    Ok(ret as u64)
+}
+
+/// Copy a range of data from one file to another using the kernel's
+/// `copy_file_range(2)` syscall (Linux only).
+///
+/// On macOS, returns `ENOSYS` — the guest kernel will fall back to read+write.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_copyfilerange(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode_in: u64,
+    handle_in: u64,
+    offset_in: u64,
+    inode_out: u64,
+    handle_out: u64,
+    offset_out: u64,
+    len: u64,
+    flags: u64,
+) -> io::Result<usize> {
+    if inode_in == init_binary::INIT_INODE || inode_out == init_binary::INIT_INODE {
+        return Err(platform::enosys());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let handles = fs.handles.read().unwrap();
+        let data_in = handles.get(&handle_in).ok_or_else(platform::ebadf)?;
+        let data_out = handles.get(&handle_out).ok_or_else(platform::ebadf)?;
+        let f_in = data_in.file.read().unwrap();
+        let f_out = data_out.file.read().unwrap();
+
+        let mut off_in = offset_in as i64;
+        let mut off_out = offset_out as i64;
+
+        let ret = unsafe {
+            libc::copy_file_range(
+                f_in.as_raw_fd(),
+                &mut off_in,
+                f_out.as_raw_fd(),
+                &mut off_out,
+                len as usize,
+                flags as u32,
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        Ok(ret as usize)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (fs, offset_in, inode_out, handle_in, handle_out, offset_out, len, flags);
+        Err(platform::enosys())
+    }
+}
+
+/// Get filesystem statistics.
+pub(crate) fn do_statfs(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    inode: u64,
+) -> io::Result<statvfs64> {
+    // For init binary and root, use root fd.
+    let fd = if inode == init_binary::INIT_INODE || inode == 1 {
+        fs.root_fd.as_raw_fd()
+    } else {
+        super::inode::get_inode_fd(fs, inode)?
+    };
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut st = unsafe { std::mem::zeroed::<statvfs64>() };
+        let ret = unsafe { libc::fstatvfs64(fd, &mut st) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        Ok(st)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut st = unsafe { std::mem::zeroed::<statvfs64>() };
+        let ret = unsafe { libc::fstatvfs(fd, &mut st) };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        Ok(st)
+    }
+}

--- a/crates/filesystem/lib/backends/passthrough/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/xattr_ops.rs
@@ -1,0 +1,362 @@
+//! Extended attribute operations: setxattr, getxattr, listxattr, removexattr.
+//!
+//! The `user.containers.override_stat` xattr is hidden from the guest: get/set/remove
+//! return `EACCES`, and it is filtered from listxattr results. This is secure because the
+//! FUSE protocol guarantees ALL guest xattr operations go through these handlers — there is
+//! no direct path from the guest to the host filesystem.
+//!
+//! ## Errno Safety
+//!
+//! All error paths capture `io::Error::last_os_error()` *before* calling `libc::close(fd)`,
+//! since `close()` may clobber errno on some systems. The captured error is then returned.
+//!
+//! ## listxattr size=0
+//!
+//! When `size=0` (query byte count), the response is computed by doing a full listxattr,
+//! filtering out the hidden key, and returning the filtered byte count. Returning the raw
+//! kernel count would leak the hidden xattr's existence (the guest could compare the
+//! unfiltered count with the filtered list to infer the xattr exists).
+
+use std::ffi::CStr;
+use std::io;
+
+use super::inode;
+use super::PassthroughFs;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::backends::shared::stat_override;
+use crate::{Context, GetxattrReply, ListxattrReply};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Set an extended attribute.
+pub(crate) fn do_setxattr(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+    name: &CStr,
+    value: &[u8],
+    flags: u32,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    // Block writes to the override xattr.
+    if name == stat_override::OVERRIDE_XATTR_KEY {
+        return Err(platform::eacces());
+    }
+
+    let fd = inode::open_inode_fd(fs, ino, libc::O_RDONLY)?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let path = format!("/proc/self/fd/{fd}\0");
+        let ret = unsafe {
+            libc::setxattr(
+                path.as_ptr() as *const libc::c_char,
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                flags as i32,
+            )
+        };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let ret = unsafe {
+            libc::fsetxattr(
+                fd,
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                0,
+                flags as i32,
+            )
+        };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+    }
+
+    Ok(())
+}
+
+/// Get an extended attribute.
+pub(crate) fn do_getxattr(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+    name: &CStr,
+    size: u32,
+) -> io::Result<GetxattrReply> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::enodata());
+    }
+
+    // Block reads of the override xattr.
+    if name == stat_override::OVERRIDE_XATTR_KEY {
+        return Err(platform::eacces());
+    }
+
+    let fd = inode::open_inode_fd(fs, ino, libc::O_RDONLY)?;
+
+    if size == 0 {
+        // Query size.
+        #[cfg(target_os = "linux")]
+        let ret = {
+            let path = format!("/proc/self/fd/{fd}\0");
+            unsafe {
+                libc::getxattr(
+                    path.as_ptr() as *const libc::c_char,
+                    name.as_ptr(),
+                    std::ptr::null_mut(),
+                    0,
+                )
+            }
+        };
+
+        #[cfg(target_os = "macos")]
+        let ret = unsafe {
+            libc::fgetxattr(fd, name.as_ptr(), std::ptr::null_mut(), 0, 0, 0)
+        };
+
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+        Ok(GetxattrReply::Count(ret as u32))
+    } else {
+        let mut buf = vec![0u8; size as usize];
+
+        #[cfg(target_os = "linux")]
+        let ret = {
+            let path = format!("/proc/self/fd/{fd}\0");
+            unsafe {
+                libc::getxattr(
+                    path.as_ptr() as *const libc::c_char,
+                    name.as_ptr(),
+                    buf.as_mut_ptr() as *mut libc::c_void,
+                    buf.len(),
+                )
+            }
+        };
+
+        #[cfg(target_os = "macos")]
+        let ret = unsafe {
+            libc::fgetxattr(
+                fd,
+                name.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len(),
+                0,
+                0,
+            )
+        };
+
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+        buf.truncate(ret as usize);
+        Ok(GetxattrReply::Value(buf))
+    }
+}
+
+/// List extended attribute names.
+///
+/// Filters out the `user.containers.override_stat` key from the returned list.
+pub(crate) fn do_listxattr(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+    size: u32,
+) -> io::Result<ListxattrReply> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::enodata());
+    }
+
+    let fd = inode::open_inode_fd(fs, ino, libc::O_RDONLY)?;
+
+    if size == 0 {
+        // Do a full listxattr, filter, and return the filtered byte count.
+        // Returning the raw kernel count would leak the hidden xattr's existence.
+        #[cfg(target_os = "linux")]
+        let raw_size = {
+            let path = format!("/proc/self/fd/{fd}\0");
+            unsafe { libc::listxattr(path.as_ptr() as *const libc::c_char, std::ptr::null_mut(), 0) }
+        };
+
+        #[cfg(target_os = "macos")]
+        let raw_size = unsafe { libc::flistxattr(fd, std::ptr::null_mut(), 0, 0) };
+
+        if raw_size < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+
+        if raw_size == 0 {
+            unsafe { libc::close(fd) };
+            return Ok(ListxattrReply::Count(0));
+        }
+
+        // Read the full list to compute filtered size.
+        let mut buf = vec![0u8; raw_size as usize];
+
+        #[cfg(target_os = "linux")]
+        let ret = {
+            let path = format!("/proc/self/fd/{fd}\0");
+            unsafe {
+                libc::listxattr(
+                    path.as_ptr() as *const libc::c_char,
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            }
+        };
+
+        #[cfg(target_os = "macos")]
+        let ret = unsafe {
+            libc::flistxattr(fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len(), 0)
+        };
+
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+        buf.truncate(ret as usize);
+
+        let hidden_key = stat_override::OVERRIDE_XATTR_KEY.to_bytes_with_nul();
+        let filtered = filter_xattr_names(&buf, hidden_key);
+        Ok(ListxattrReply::Count(filtered.len() as u32))
+    } else {
+        let mut buf = vec![0u8; size as usize];
+
+        #[cfg(target_os = "linux")]
+        let ret = {
+            let path = format!("/proc/self/fd/{fd}\0");
+            unsafe {
+                libc::listxattr(
+                    path.as_ptr() as *const libc::c_char,
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            }
+        };
+
+        #[cfg(target_os = "macos")]
+        let ret = unsafe {
+            libc::flistxattr(
+                fd,
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+                0,
+            )
+        };
+
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+        buf.truncate(ret as usize);
+
+        // Filter out the override xattr key from the list.
+        let hidden_key = stat_override::OVERRIDE_XATTR_KEY.to_bytes_with_nul();
+        let filtered = filter_xattr_names(&buf, hidden_key);
+
+        Ok(ListxattrReply::Names(filtered))
+    }
+}
+
+/// Remove an extended attribute.
+pub(crate) fn do_removexattr(
+    fs: &PassthroughFs,
+    _ctx: Context,
+    ino: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    // Block removal of the override xattr.
+    if name == stat_override::OVERRIDE_XATTR_KEY {
+        return Err(platform::eacces());
+    }
+
+    let fd = inode::open_inode_fd(fs, ino, libc::O_RDONLY)?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let path = format!("/proc/self/fd/{fd}\0");
+        let ret = unsafe {
+            libc::removexattr(
+                path.as_ptr() as *const libc::c_char,
+                name.as_ptr(),
+            )
+        };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let ret = unsafe { libc::fremovexattr(fd, name.as_ptr(), 0) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(platform::linux_error(err));
+        }
+        unsafe { libc::close(fd) };
+    }
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Filter a nul-separated xattr name list, removing any entry matching `hidden`.
+fn filter_xattr_names(names: &[u8], hidden: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(names.len());
+
+    for entry in names.split(|&b| b == 0) {
+        if entry.is_empty() {
+            continue;
+        }
+        // Compare entry + nul against hidden.
+        let mut with_nul = entry.to_vec();
+        with_nul.push(0);
+        if with_nul != hidden {
+            result.extend_from_slice(&with_nul);
+        }
+    }
+
+    result
+}

--- a/crates/filesystem/lib/backends/shared/handle_table.rs
+++ b/crates/filesystem/lib/backends/shared/handle_table.rs
@@ -1,0 +1,18 @@
+//! Handle table for open file descriptors.
+
+use std::fs::File;
+use std::sync::RwLock;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Data associated with an open file handle.
+pub(crate) struct HandleData {
+    /// The real host file descriptor.
+    ///
+    /// Wrapped in `RwLock` because `preadv64`/`pwritev64` only need a shared
+    /// lock (they take an explicit offset), while `lseek`, `fsync`, and
+    /// `ftruncate` need exclusive access.
+    pub file: RwLock<File>,
+}

--- a/crates/filesystem/lib/backends/shared/init_binary.rs
+++ b/crates/filesystem/lib/backends/shared/init_binary.rs
@@ -1,0 +1,139 @@
+//! Virtual init.krun file serving the embedded agentd binary.
+//!
+//! The init binary appears at the root of every filesystem backend as
+//! `/init.krun` (inode `ROOT_ID + 1`, handle `0`). It is read-only,
+//! cannot be deleted or modified, and is immune to whiteouts.
+//!
+//! ## Storage
+//!
+//! The binary is stored in a memfd (Linux) or tmpfile (macOS) created at init time.
+//! Reads use `ZeroCopyWriter::write_from` for zero-copy transfer from the backing file
+//! to the FUSE response buffer, avoiding intermediate copies of the binary data.
+
+use std::fs::File;
+use std::io;
+use std::time::Duration;
+
+use crate::agentd::AGENTD_BYTES;
+use crate::{stat64, Entry, ZeroCopyWriter};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// The filename of the virtual init binary as it appears in the guest.
+pub(crate) const INIT_FILENAME: &[u8] = b"init.krun";
+
+/// Reserved FUSE inode for the init binary (ROOT_ID + 1 = 2).
+pub(crate) const INIT_INODE: u64 = 2;
+
+/// Reserved FUSE handle for init binary reads.
+pub(crate) const INIT_HANDLE: u64 = 0;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build a synthetic `stat64` for the init binary.
+pub(crate) fn init_stat() -> stat64 {
+    let mut st: stat64 = unsafe { std::mem::zeroed() };
+
+    #[cfg(target_os = "linux")]
+    {
+        st.st_ino = INIT_INODE;
+        st.st_nlink = 1;
+        st.st_mode = libc::S_IFREG as u32 | 0o755;
+        st.st_uid = 0;
+        st.st_gid = 0;
+        st.st_size = AGENTD_BYTES.len() as i64;
+        st.st_blocks = ((AGENTD_BYTES.len() as i64) + 511) / 512;
+        st.st_blksize = 4096;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        st.st_ino = INIT_INODE;
+        st.st_nlink = 1;
+        st.st_mode = libc::S_IFREG | 0o755;
+        st.st_uid = 0;
+        st.st_gid = 0;
+        st.st_size = AGENTD_BYTES.len() as i64;
+        st.st_blocks = ((AGENTD_BYTES.len() as i64) + 511) / 512;
+        st.st_blksize = 4096;
+    }
+
+    st
+}
+
+/// Build a FUSE `Entry` for the init binary.
+pub(crate) fn init_entry(entry_timeout: Duration, attr_timeout: Duration) -> Entry {
+    Entry {
+        inode: INIT_INODE,
+        generation: 0,
+        attr: init_stat(),
+        attr_flags: 0,
+        attr_timeout,
+        entry_timeout,
+    }
+}
+
+/// Create a `File` backed by a memfd (Linux) or tmpfile (macOS) containing AGENTD_BYTES.
+///
+/// This file is stored in `PassthroughFs` and used by `read_init` via `write_from`.
+pub(crate) fn create_init_file() -> io::Result<File> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::FromRawFd;
+
+        let name = std::ffi::CString::new("init.krun").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let data = AGENTD_BYTES;
+        let written = unsafe { libc::write(fd, data.as_ptr() as *const libc::c_void, data.len()) };
+        if written < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(err);
+        }
+        if (written as usize) != data.len() {
+            unsafe { libc::close(fd) };
+            return Err(super::platform::eio());
+        }
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::io::Write;
+        let mut file = tempfile::tempfile()?;
+        file.write_all(AGENTD_BYTES)?;
+        Ok(file)
+    }
+}
+
+/// Handle a read request for the virtual init binary.
+///
+/// Uses `write_from` with the pre-created init file to transfer bytes
+/// via the zero-copy FUSE buffer path.
+pub(crate) fn read_init(
+    w: &mut dyn ZeroCopyWriter,
+    init_file: &File,
+    size: u32,
+    offset: u64,
+) -> io::Result<usize> {
+    let data_len = AGENTD_BYTES.len() as u64;
+
+    if offset >= data_len {
+        return Ok(0);
+    }
+
+    let count = std::cmp::min(size as u64, data_len - offset) as usize;
+    w.write_from(init_file, count, offset)
+}
+
+/// Check if a name matches the init binary filename.
+pub(crate) fn is_init_name(name: &[u8]) -> bool {
+    name == INIT_FILENAME
+}

--- a/crates/filesystem/lib/backends/shared/inode_table.rs
+++ b/crates/filesystem/lib/backends/shared/inode_table.rs
@@ -1,0 +1,161 @@
+//! Inode table with dual-key lookup for filesystem backends.
+//!
+//! Provides [`MultikeyBTreeMap`] (a BTreeMap with two key types), [`InodeData`]
+//! for per-inode state, and [`InodeAltKey`] for host-identity-based deduplication.
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A BTreeMap that supports 2 types of keys per value.
+///
+/// There is a 1:1 relationship between the two key types: for each `K1` in the
+/// map there is exactly one `K2` and vice versa.
+///
+/// Copied from msb_krun's `src/devices/src/virtio/fs/multikey.rs` to avoid
+/// depending on msb_krun internals.
+#[derive(Default)]
+pub(crate) struct MultikeyBTreeMap<K1, K2, V>
+where
+    K1: Ord,
+    K2: Ord,
+{
+    main: BTreeMap<K1, (K2, V)>,
+    alt: BTreeMap<K2, K1>,
+}
+
+/// Alternate key for inode lookup based on host filesystem identity.
+///
+/// On Linux, includes `mnt_id` from `statx` to prevent cross-mount collisions.
+/// On macOS, uses `(ino, dev)` which is sufficient since there are no bind mounts.
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug)]
+pub(crate) struct InodeAltKey {
+    pub ino: u64,
+    pub dev: u64,
+    #[cfg(target_os = "linux")]
+    pub mnt_id: u64,
+}
+
+/// Per-inode data tracked by the filesystem backend.
+pub(crate) struct InodeData {
+    /// Synthetic FUSE inode number (monotonically increasing, never reused).
+    pub inode: u64,
+
+    /// Host inode number.
+    pub ino: u64,
+
+    /// Host device ID.
+    pub dev: u64,
+
+    /// FUSE lookup reference count. When this reaches 0, the inode is removed.
+    pub refcount: AtomicU64,
+
+    /// O_PATH file descriptor pinning this inode on the host filesystem.
+    #[cfg(target_os = "linux")]
+    pub file: std::fs::File,
+
+    /// Mount ID from statx (Linux only, for cross-mount deduplication).
+    #[cfg(target_os = "linux")]
+    pub mnt_id: u64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl<K1, K2, V> MultikeyBTreeMap<K1, K2, V>
+where
+    K1: Clone + Ord,
+    K2: Clone + Ord,
+{
+    /// Create a new empty MultikeyBTreeMap.
+    pub fn new() -> Self {
+        MultikeyBTreeMap {
+            main: BTreeMap::default(),
+            alt: BTreeMap::default(),
+        }
+    }
+
+    /// Returns a reference to the value corresponding to the primary key.
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K1: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.main.get(key).map(|(_, v)| v)
+    }
+
+    /// Returns a reference to the value corresponding to the alternate key.
+    ///
+    /// Performs 2 lookups: alt → primary key, then primary key → value.
+    pub fn get_alt<Q2>(&self, key: &Q2) -> Option<&V>
+    where
+        K2: Borrow<Q2>,
+        Q2: Ord + ?Sized,
+    {
+        if let Some(k) = self.alt.get(key) {
+            self.get(k)
+        } else {
+            None
+        }
+    }
+
+    /// Insert a new entry with both keys. Returns the old value if either key
+    /// was already present.
+    pub fn insert(&mut self, k1: K1, k2: K2, v: V) -> Option<V> {
+        let oldval = if let Some(oldkey) = self.alt.insert(k2.clone(), k1.clone()) {
+            self.main.remove(&oldkey)
+        } else {
+            None
+        };
+        self.main
+            .insert(k1, (k2.clone(), v))
+            .or(oldval)
+            .map(|(oldk2, v)| {
+                if oldk2 != k2 {
+                    self.alt.remove(&oldk2);
+                }
+                v
+            })
+    }
+
+    /// Remove an entry by its primary key.
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K1: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.main.remove(key).map(|(k2, v)| {
+            self.alt.remove(&k2);
+            v
+        })
+    }
+
+    /// Clear all entries.
+    pub fn clear(&mut self) {
+        self.alt.clear();
+        self.main.clear();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl InodeAltKey {
+    /// Create a new alternate key from stat fields.
+    #[cfg(target_os = "linux")]
+    pub fn new(ino: u64, dev: u64, mnt_id: u64) -> Self {
+        Self { ino, dev, mnt_id }
+    }
+
+    /// Create a new alternate key from stat fields.
+    #[cfg(target_os = "macos")]
+    pub fn new(ino: u64, dev: u64) -> Self {
+        Self { ino, dev }
+    }
+}

--- a/crates/filesystem/lib/backends/shared/mod.rs
+++ b/crates/filesystem/lib/backends/shared/mod.rs
@@ -1,0 +1,11 @@
+//! Shared infrastructure for filesystem backends.
+//!
+//! Contains data structures and utilities used by both [`PassthroughFs`](super::passthrough)
+//! and the future `OverlayFs`.
+
+pub(crate) mod handle_table;
+pub(crate) mod init_binary;
+pub(crate) mod inode_table;
+pub(crate) mod name_validation;
+pub(crate) mod platform;
+pub(crate) mod stat_override;

--- a/crates/filesystem/lib/backends/shared/name_validation.rs
+++ b/crates/filesystem/lib/backends/shared/name_validation.rs
@@ -1,0 +1,33 @@
+//! Name validation for filesystem operations.
+//!
+//! Every operation that accepts a guest-provided directory entry name must
+//! call [`validate_name`] to prevent path traversal attacks.
+
+use std::ffi::CStr;
+use std::io;
+
+use super::platform;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Validate a directory entry name, blocking traversal attacks.
+///
+/// Rejects: empty names, `..`, names containing `/` or `\`, and names
+/// containing null bytes.
+pub(crate) fn validate_name(name: &CStr) -> io::Result<()> {
+    let bytes = name.to_bytes();
+
+    if bytes.is_empty() {
+        return Err(platform::einval());
+    }
+    if bytes == b".." {
+        return Err(platform::eperm());
+    }
+    if bytes.contains(&b'/') || bytes.contains(&b'\\') {
+        return Err(platform::eperm());
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/shared/platform.rs
+++ b/crates/filesystem/lib/backends/shared/platform.rs
@@ -1,0 +1,426 @@
+//! Platform abstractions for filesystem backends.
+//!
+//! Provides errno translation (macOS → Linux), stat wrappers, and error helpers.
+//!
+//! ## Errno Translation
+//!
+//! The FUSE protocol always expects Linux errno values. On Linux, errors pass through
+//! unchanged. On macOS, BSD errno values are mapped to their Linux equivalents via
+//! `linux_error()`. All filesystem operations must wrap OS errors with `linux_error()`
+//! before returning them through the FUSE interface.
+//!
+//! ## RESOLVE_BENEATH
+//!
+//! `openat2(RESOLVE_BENEATH)` (Linux 5.6+) provides kernel-enforced path containment
+//! that blocks `..` traversal, absolute symlinks, and handles concurrent rename races
+//! atomically. Availability is probed at init time and cached in `PassthroughFs::has_openat2`.
+//! Falls back to `openat(O_NOFOLLOW)` on older kernels.
+
+use std::io;
+use std::os::fd::RawFd;
+
+use crate::stat64;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const LINUX_EPERM: i32 = 1;
+const LINUX_ENOENT: i32 = 2;
+const LINUX_ESRCH: i32 = 3;
+const LINUX_EINTR: i32 = 4;
+const LINUX_EIO: i32 = 5;
+const LINUX_ENXIO: i32 = 6;
+const LINUX_ENOEXEC: i32 = 8;
+const LINUX_EBADF: i32 = 9;
+const LINUX_ECHILD: i32 = 10;
+const LINUX_EAGAIN: i32 = 11;
+const LINUX_ENOMEM: i32 = 12;
+const LINUX_EACCES: i32 = 13;
+const LINUX_EFAULT: i32 = 14;
+const LINUX_ENOTBLK: i32 = 15;
+const LINUX_EBUSY: i32 = 16;
+const LINUX_EEXIST: i32 = 17;
+const LINUX_EXDEV: i32 = 18;
+const LINUX_ENODEV: i32 = 19;
+const LINUX_ENOTDIR: i32 = 20;
+const LINUX_EISDIR: i32 = 21;
+const LINUX_EINVAL: i32 = 22;
+const LINUX_ENFILE: i32 = 23;
+const LINUX_EMFILE: i32 = 24;
+const LINUX_ENOTTY: i32 = 25;
+const LINUX_ETXTBSY: i32 = 26;
+const LINUX_EFBIG: i32 = 27;
+const LINUX_ENOSPC: i32 = 28;
+const LINUX_ESPIPE: i32 = 29;
+const LINUX_EROFS: i32 = 30;
+const LINUX_EMLINK: i32 = 31;
+const LINUX_EPIPE: i32 = 32;
+const LINUX_EDOM: i32 = 33;
+#[allow(dead_code)]
+pub(crate) const LINUX_ERANGE: i32 = 34;
+const LINUX_EDEADLK: i32 = 35;
+const LINUX_ENAMETOOLONG: i32 = 36;
+const LINUX_ENOLCK: i32 = 37;
+pub(crate) const LINUX_ENOSYS: i32 = 38;
+const LINUX_ENOTEMPTY: i32 = 39;
+const LINUX_ELOOP: i32 = 40;
+const LINUX_ENOMSG: i32 = 42;
+const LINUX_EIDRM: i32 = 43;
+const LINUX_ENOSTR: i32 = 60;
+pub(crate) const LINUX_ENODATA: i32 = 61;
+const LINUX_ETIME: i32 = 62;
+const LINUX_ENOSR: i32 = 63;
+const LINUX_EREMOTE: i32 = 66;
+const LINUX_ENOLINK: i32 = 67;
+const LINUX_EPROTO: i32 = 71;
+const LINUX_EMULTIHOP: i32 = 72;
+const LINUX_EBADMSG: i32 = 74;
+const LINUX_EOVERFLOW: i32 = 75;
+const LINUX_EILSEQ: i32 = 84;
+const LINUX_EUSERS: i32 = 87;
+const LINUX_ENOTSOCK: i32 = 88;
+const LINUX_EDESTADDRREQ: i32 = 89;
+const LINUX_EMSGSIZE: i32 = 90;
+const LINUX_EPROTOTYPE: i32 = 91;
+const LINUX_ENOPROTOOPT: i32 = 92;
+const LINUX_EPROTONOSUPPORT: i32 = 93;
+const LINUX_ESOCKTNOSUPPORT: i32 = 94;
+const LINUX_EOPNOTSUPP: i32 = 95;
+const LINUX_EPFNOSUPPORT: i32 = 96;
+const LINUX_EAFNOSUPPORT: i32 = 97;
+const LINUX_EADDRINUSE: i32 = 98;
+const LINUX_EADDRNOTAVAIL: i32 = 99;
+const LINUX_ENETDOWN: i32 = 100;
+const LINUX_ENETUNREACH: i32 = 101;
+const LINUX_ENETRESET: i32 = 102;
+const LINUX_ECONNABORTED: i32 = 103;
+const LINUX_ECONNRESET: i32 = 104;
+const LINUX_ENOBUFS: i32 = 105;
+const LINUX_EISCONN: i32 = 106;
+const LINUX_ENOTCONN: i32 = 107;
+const LINUX_ESHUTDOWN: i32 = 108;
+const LINUX_ETOOMANYREFS: i32 = 109;
+const LINUX_ETIMEDOUT: i32 = 110;
+const LINUX_ECONNREFUSED: i32 = 111;
+const LINUX_EHOSTDOWN: i32 = 112;
+const LINUX_EHOSTUNREACH: i32 = 113;
+const LINUX_EALREADY: i32 = 114;
+const LINUX_EINPROGRESS: i32 = 115;
+const LINUX_ESTALE: i32 = 116;
+const LINUX_EDQUOT: i32 = 122;
+const LINUX_ECANCELED: i32 = 125;
+const LINUX_EOWNERDEAD: i32 = 130;
+const LINUX_ENOTRECOVERABLE: i32 = 131;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Translate a native OS error to a Linux errno value.
+///
+/// On Linux this is an identity function. On macOS, BSD errno values are
+/// mapped to their Linux equivalents, since the FUSE protocol always
+/// expects Linux errno values.
+#[cfg(target_os = "linux")]
+pub(crate) fn linux_error(error: io::Error) -> io::Error {
+    error
+}
+
+/// Translate a native OS error to a Linux errno value.
+#[cfg(target_os = "macos")]
+pub(crate) fn linux_error(error: io::Error) -> io::Error {
+    io::Error::from_raw_os_error(linux_errno_raw(error.raw_os_error().unwrap_or(libc::EIO)))
+}
+
+/// Map a native errno to its Linux equivalent.
+#[cfg(target_os = "macos")]
+fn linux_errno_raw(errno: i32) -> i32 {
+    match errno {
+        libc::EPERM => LINUX_EPERM,
+        libc::ENOENT => LINUX_ENOENT,
+        libc::ESRCH => LINUX_ESRCH,
+        libc::EINTR => LINUX_EINTR,
+        libc::EIO => LINUX_EIO,
+        libc::ENXIO => LINUX_ENXIO,
+        libc::ENOEXEC => LINUX_ENOEXEC,
+        libc::EBADF => LINUX_EBADF,
+        libc::ECHILD => LINUX_ECHILD,
+        libc::EDEADLK => LINUX_EDEADLK,
+        libc::ENOMEM => LINUX_ENOMEM,
+        libc::EACCES => LINUX_EACCES,
+        libc::EFAULT => LINUX_EFAULT,
+        libc::ENOTBLK => LINUX_ENOTBLK,
+        libc::EBUSY => LINUX_EBUSY,
+        libc::EEXIST => LINUX_EEXIST,
+        libc::EXDEV => LINUX_EXDEV,
+        libc::ENODEV => LINUX_ENODEV,
+        libc::ENOTDIR => LINUX_ENOTDIR,
+        libc::EISDIR => LINUX_EISDIR,
+        libc::EINVAL => LINUX_EINVAL,
+        libc::ENFILE => LINUX_ENFILE,
+        libc::EMFILE => LINUX_EMFILE,
+        libc::ENOTTY => LINUX_ENOTTY,
+        libc::ETXTBSY => LINUX_ETXTBSY,
+        libc::EFBIG => LINUX_EFBIG,
+        libc::ENOSPC => LINUX_ENOSPC,
+        libc::ESPIPE => LINUX_ESPIPE,
+        libc::EROFS => LINUX_EROFS,
+        libc::EMLINK => LINUX_EMLINK,
+        libc::EPIPE => LINUX_EPIPE,
+        libc::EDOM => LINUX_EDOM,
+        libc::EAGAIN => LINUX_EAGAIN,
+        libc::EINPROGRESS => LINUX_EINPROGRESS,
+        libc::EALREADY => LINUX_EALREADY,
+        libc::ENOTSOCK => LINUX_ENOTSOCK,
+        libc::EDESTADDRREQ => LINUX_EDESTADDRREQ,
+        libc::EMSGSIZE => LINUX_EMSGSIZE,
+        libc::EPROTOTYPE => LINUX_EPROTOTYPE,
+        libc::ENOPROTOOPT => LINUX_ENOPROTOOPT,
+        libc::EPROTONOSUPPORT => LINUX_EPROTONOSUPPORT,
+        libc::ESOCKTNOSUPPORT => LINUX_ESOCKTNOSUPPORT,
+        libc::EPFNOSUPPORT => LINUX_EPFNOSUPPORT,
+        libc::EAFNOSUPPORT => LINUX_EAFNOSUPPORT,
+        libc::EADDRINUSE => LINUX_EADDRINUSE,
+        libc::EADDRNOTAVAIL => LINUX_EADDRNOTAVAIL,
+        libc::ENETDOWN => LINUX_ENETDOWN,
+        libc::ENETUNREACH => LINUX_ENETUNREACH,
+        libc::ENETRESET => LINUX_ENETRESET,
+        libc::ECONNABORTED => LINUX_ECONNABORTED,
+        libc::ECONNRESET => LINUX_ECONNRESET,
+        libc::ENOBUFS => LINUX_ENOBUFS,
+        libc::EISCONN => LINUX_EISCONN,
+        libc::ENOTCONN => LINUX_ENOTCONN,
+        libc::ESHUTDOWN => LINUX_ESHUTDOWN,
+        libc::ETOOMANYREFS => LINUX_ETOOMANYREFS,
+        libc::ETIMEDOUT => LINUX_ETIMEDOUT,
+        libc::ECONNREFUSED => LINUX_ECONNREFUSED,
+        libc::ELOOP => LINUX_ELOOP,
+        libc::ENAMETOOLONG => LINUX_ENAMETOOLONG,
+        libc::EHOSTDOWN => LINUX_EHOSTDOWN,
+        libc::EHOSTUNREACH => LINUX_EHOSTUNREACH,
+        libc::ENOTEMPTY => LINUX_ENOTEMPTY,
+        libc::EUSERS => LINUX_EUSERS,
+        libc::EDQUOT => LINUX_EDQUOT,
+        libc::ESTALE => LINUX_ESTALE,
+        libc::EREMOTE => LINUX_EREMOTE,
+        libc::ENOLCK => LINUX_ENOLCK,
+        libc::ENOSYS => LINUX_ENOSYS,
+        libc::EOVERFLOW => LINUX_EOVERFLOW,
+        libc::ECANCELED => LINUX_ECANCELED,
+        libc::EIDRM => LINUX_EIDRM,
+        libc::ENOMSG => LINUX_ENOMSG,
+        libc::EILSEQ => LINUX_EILSEQ,
+        libc::ENOATTR => LINUX_ENODATA,
+        libc::EBADMSG => LINUX_EBADMSG,
+        libc::EMULTIHOP => LINUX_EMULTIHOP,
+        libc::ENODATA => LINUX_ENODATA,
+        libc::ENOLINK => LINUX_ENOLINK,
+        libc::ENOSR => LINUX_ENOSR,
+        libc::ENOSTR => LINUX_ENOSTR,
+        libc::EPROTO => LINUX_EPROTO,
+        libc::ETIME => LINUX_ETIME,
+        libc::EOPNOTSUPP => LINUX_EOPNOTSUPP,
+        libc::ENOTRECOVERABLE => LINUX_ENOTRECOVERABLE,
+        libc::EOWNERDEAD => LINUX_EOWNERDEAD,
+        _ => LINUX_EIO,
+    }
+}
+
+/// Create an `io::Error` with Linux `EIO`.
+pub(crate) fn eio() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EIO)
+}
+
+/// Create an `io::Error` with Linux `EBADF`.
+pub(crate) fn ebadf() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EBADF)
+}
+
+/// Create an `io::Error` with Linux `EINVAL`.
+pub(crate) fn einval() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EINVAL)
+}
+
+/// Create an `io::Error` with Linux `EACCES`.
+pub(crate) fn eacces() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EACCES)
+}
+
+/// Create an `io::Error` with Linux `EPERM`.
+pub(crate) fn eperm() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EPERM)
+}
+
+/// Create an `io::Error` with Linux `ENOSYS`.
+pub(crate) fn enosys() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENOSYS)
+}
+
+/// Create an `io::Error` with Linux `ENOENT`.
+#[allow(dead_code)]
+pub(crate) fn enoent() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENOENT)
+}
+
+/// Create an `io::Error` with Linux `ENODATA`.
+pub(crate) fn enodata() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENODATA)
+}
+
+/// Create an `io::Error` with Linux `ENOTEMPTY`.
+#[allow(dead_code)]
+pub(crate) fn enotempty() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENOTEMPTY)
+}
+
+/// Call `fstat` on a raw file descriptor and return a `stat64`.
+pub(crate) fn fstat(fd: RawFd) -> io::Result<stat64> {
+    let mut st = unsafe { std::mem::zeroed::<stat64>() };
+
+    #[cfg(target_os = "linux")]
+    let ret = unsafe { libc::fstat64(fd, &mut st) };
+
+    #[cfg(target_os = "macos")]
+    let ret = unsafe { libc::fstat(fd, &mut st) };
+
+    if ret < 0 {
+        Err(linux_error(io::Error::last_os_error()))
+    } else {
+        Ok(st)
+    }
+}
+
+/// Struct for the `openat2` syscall (Linux 5.6+).
+#[cfg(target_os = "linux")]
+#[repr(C)]
+pub(crate) struct OpenHow {
+    pub flags: u64,
+    pub mode: u64,
+    pub resolve: u64,
+}
+
+/// `RESOLVE_BENEATH` flag — prevent path resolution from escaping the directory tree.
+#[cfg(target_os = "linux")]
+pub(crate) const RESOLVE_BENEATH: u64 = 0x08;
+
+/// Syscall number for `openat2` (same on x86_64 and aarch64).
+#[cfg(target_os = "linux")]
+const SYS_OPENAT2: libc::c_long = 437;
+
+/// Probe whether the `openat2` syscall is available (Linux 5.6+).
+///
+/// Attempts a minimal openat2 call on the current directory. Returns `true`
+/// if the syscall succeeds or returns any error other than `ENOSYS`.
+#[cfg(target_os = "linux")]
+pub(crate) fn probe_openat2() -> bool {
+    let how = OpenHow {
+        flags: libc::O_CLOEXEC as u64 | libc::O_PATH as u64,
+        mode: 0,
+        resolve: RESOLVE_BENEATH,
+    };
+    let ret = unsafe {
+        libc::syscall(
+            SYS_OPENAT2,
+            libc::AT_FDCWD,
+            c".".as_ptr(),
+            &how as *const OpenHow,
+            std::mem::size_of::<OpenHow>(),
+        )
+    };
+    if ret >= 0 {
+        unsafe { libc::close(ret as i32) };
+        true
+    } else {
+        io::Error::last_os_error().raw_os_error() != Some(libc::ENOSYS)
+    }
+}
+
+/// Open a file relative to a directory with `RESOLVE_BENEATH` if available.
+///
+/// Falls back to regular `openat` if `openat2` is not available.
+#[cfg(target_os = "linux")]
+pub(crate) fn open_beneath(
+    dirfd: RawFd,
+    name: *const libc::c_char,
+    flags: i32,
+    use_openat2: bool,
+) -> RawFd {
+    if use_openat2 {
+        let how = OpenHow {
+            flags: (flags | libc::O_CLOEXEC) as u64,
+            mode: 0,
+            resolve: RESOLVE_BENEATH,
+        };
+        let ret = unsafe {
+            libc::syscall(
+                SYS_OPENAT2,
+                dirfd,
+                name,
+                &how as *const OpenHow,
+                std::mem::size_of::<OpenHow>(),
+            ) as i32
+        };
+        if ret >= 0 || io::Error::last_os_error().raw_os_error() != Some(libc::ENOSYS) {
+            return ret;
+        }
+        // ENOSYS fallthrough to regular openat.
+    }
+    unsafe { libc::openat(dirfd, name, flags | libc::O_CLOEXEC) }
+}
+
+/// Convert a `libc::statx` struct to a `stat64` struct (Linux only).
+///
+/// Used in the lookup collapse optimization where `statx` with `AT_EMPTY_PATH`
+/// provides both stat data and `mnt_id` in a single syscall.
+#[cfg(target_os = "linux")]
+pub(crate) fn statx_to_stat64(stx: &libc::statx) -> stat64 {
+    let mut st: stat64 = unsafe { std::mem::zeroed() };
+    st.st_dev = makedev(stx.stx_dev_major, stx.stx_dev_minor);
+    st.st_ino = stx.stx_ino;
+    st.st_nlink = stx.stx_nlink as _;
+    st.st_mode = stx.stx_mode as _;
+    st.st_uid = stx.stx_uid;
+    st.st_gid = stx.stx_gid;
+    st.st_rdev = makedev(stx.stx_rdev_major, stx.stx_rdev_minor);
+    st.st_size = stx.stx_size as _;
+    st.st_blksize = stx.stx_blksize as _;
+    st.st_blocks = stx.stx_blocks as _;
+    st.st_atime = stx.stx_atime.tv_sec;
+    st.st_atime_nsec = stx.stx_atime.tv_nsec as _;
+    st.st_mtime = stx.stx_mtime.tv_sec;
+    st.st_mtime_nsec = stx.stx_mtime.tv_nsec as _;
+    st.st_ctime = stx.stx_ctime.tv_sec;
+    st.st_ctime_nsec = stx.stx_ctime.tv_nsec as _;
+    st
+}
+
+/// Compute a `dev_t` from major and minor numbers (Linux glibc formula).
+#[cfg(target_os = "linux")]
+fn makedev(major: u32, minor: u32) -> u64 {
+    ((major as u64 & 0xfffff000) << 32)
+        | ((major as u64 & 0x00000fff) << 8)
+        | ((minor as u64 & 0xffffff00) << 12)
+        | (minor as u64 & 0x000000ff)
+}
+
+/// Call `fstatat` (no follow) on a name relative to a directory fd.
+pub(crate) fn fstatat_nofollow(dirfd: RawFd, name: &std::ffi::CStr) -> io::Result<stat64> {
+    let mut st = unsafe { std::mem::zeroed::<stat64>() };
+
+    #[cfg(target_os = "linux")]
+    let ret = unsafe {
+        libc::fstatat64(dirfd, name.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW)
+    };
+
+    #[cfg(target_os = "macos")]
+    let ret = unsafe {
+        libc::fstatat(dirfd, name.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW)
+    };
+
+    if ret < 0 {
+        Err(linux_error(io::Error::last_os_error()))
+    } else {
+        Ok(st)
+    }
+}

--- a/crates/filesystem/lib/backends/shared/stat_override.rs
+++ b/crates/filesystem/lib/backends/shared/stat_override.rs
@@ -1,0 +1,335 @@
+//! Stat virtualization via the `user.containers.override_stat` extended attribute.
+//!
+//! The host process runs unprivileged and cannot `chown`, create device nodes,
+//! or set xattrs on symlinks (Linux). All ownership/permissions/type information
+//! is stored in a 20-byte binary xattr that [`patched_stat`] applies on top of
+//! the real host `stat`.
+//!
+//! ## Format
+//!
+//! The xattr stores a fixed-size 20-byte `#[repr(C, packed)]` struct with version byte,
+//! uid, gid, mode (including file type bits S_IFMT), and rdev. Reading/writing is a single
+//! `memcpy` — no text parsing needed. Unknown version bytes trigger `EIO` (hard fail).
+//!
+//! ## Linux Symlink Exception
+//!
+//! Real symlinks on Linux cannot have `user.*` xattrs on most filesystems. `patched_stat`
+//! skips the xattr read for real host symlinks (detected via `S_IFLNK` in the unpatched stat).
+//! File-backed symlinks (regular files with S_IFLNK in xattr) are handled normally.
+
+use std::ffi::CStr;
+use std::io;
+use std::os::fd::RawFd;
+
+use crate::stat64;
+
+use super::platform;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Xattr key for the override stat, as a null-terminated C string.
+pub(crate) const OVERRIDE_XATTR_KEY: &CStr = c"user.containers.override_stat";
+
+/// Current version of the binary override format.
+const OVERRIDE_VERSION: u8 = 1;
+
+/// Size of the binary override struct.
+const OVERRIDE_SIZE: usize = std::mem::size_of::<OverrideStat>();
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Binary layout of the override xattr value (20 bytes).
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub(crate) struct OverrideStat {
+    pub version: u8,
+    pub _pad: [u8; 3],
+    pub uid: u32,
+    pub gid: u32,
+    pub mode: u32,
+    pub rdev: u32,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Read the override xattr and patch the given stat with virtualized fields.
+///
+/// If no override xattr is present, returns the stat unmodified.
+/// Returns `EIO` if the xattr is corrupt (wrong version, short read).
+pub(crate) fn patched_stat(fd: RawFd, mut st: stat64) -> io::Result<stat64> {
+    // Real symlinks on host cannot have user xattrs on Linux.
+    #[cfg(target_os = "linux")]
+    if st.st_mode & libc::S_IFMT == libc::S_IFLNK {
+        return Ok(st);
+    }
+
+    match read_override(fd) {
+        Ok(Some(ovr)) => {
+            st.st_uid = ovr.uid;
+            st.st_gid = ovr.gid;
+
+            #[cfg(target_os = "linux")]
+            {
+                st.st_mode = ovr.mode;
+            }
+            #[cfg(target_os = "macos")]
+            {
+                st.st_mode = ovr.mode as u16;
+            }
+
+            if ovr.mode & libc::S_IFMT as u32 == libc::S_IFBLK as u32
+                || ovr.mode & libc::S_IFMT as u32 == libc::S_IFCHR as u32
+            {
+                #[cfg(target_os = "linux")]
+                {
+                    st.st_rdev = ovr.rdev as u64;
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    st.st_rdev = ovr.rdev as i32;
+                }
+            }
+            Ok(st)
+        }
+        Ok(None) => Ok(st), // No override xattr
+        Err(e) => Err(e),
+    }
+}
+
+/// Read the override xattr from a file descriptor.
+///
+/// Returns `None` if the xattr does not exist (ENODATA/ENOATTR).
+/// Returns `Err(EIO)` for corrupt data.
+fn read_override(fd: RawFd) -> io::Result<Option<OverrideStat>> {
+    let mut buf = [0u8; OVERRIDE_SIZE];
+
+    #[cfg(target_os = "linux")]
+    let path = format!("/proc/self/fd/{fd}");
+
+    #[cfg(target_os = "linux")]
+    let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
+
+    #[cfg(target_os = "linux")]
+    let ret = unsafe {
+        libc::getxattr(
+            path_cstr.as_ptr(),
+            OVERRIDE_XATTR_KEY.as_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_void,
+            OVERRIDE_SIZE,
+        )
+    };
+
+    #[cfg(target_os = "macos")]
+    let ret = unsafe {
+        libc::fgetxattr(
+            fd,
+            OVERRIDE_XATTR_KEY.as_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_void,
+            OVERRIDE_SIZE,
+            0,
+            0,
+        )
+    };
+
+    if ret < 0 {
+        let err = io::Error::last_os_error();
+        let errno = err.raw_os_error().unwrap_or(0);
+
+        // ENODATA (Linux) or ENOATTR (macOS) means no xattr set.
+        #[cfg(target_os = "linux")]
+        if errno == libc::ENODATA {
+            return Ok(None);
+        }
+        #[cfg(target_os = "macos")]
+        if errno == libc::ENOATTR {
+            return Ok(None);
+        }
+
+        // EOPNOTSUPP means the filesystem doesn't support xattrs.
+        if errno == libc::EOPNOTSUPP {
+            return Ok(None);
+        }
+
+        return Err(platform::linux_error(err));
+    }
+
+    let size = ret as usize;
+    if size < OVERRIDE_SIZE {
+        return Err(platform::eio());
+    }
+
+    // SAFETY: buf is fully initialized and OVERRIDE_SIZE bytes long.
+    let ovr: OverrideStat = unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const OverrideStat) };
+
+    if ovr.version != OVERRIDE_VERSION {
+        return Err(platform::eio());
+    }
+
+    Ok(Some(ovr))
+}
+
+/// Set the override xattr on a file descriptor.
+pub(crate) fn set_override(fd: RawFd, uid: u32, gid: u32, mode: u32, rdev: u32) -> io::Result<()> {
+    let ovr = OverrideStat {
+        version: OVERRIDE_VERSION,
+        _pad: [0; 3],
+        uid,
+        gid,
+        mode,
+        rdev,
+    };
+
+    let buf =
+        unsafe { std::slice::from_raw_parts(&ovr as *const OverrideStat as *const u8, OVERRIDE_SIZE) };
+
+    #[cfg(target_os = "linux")]
+    {
+        let path = format!("/proc/self/fd/{fd}");
+        let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
+        let ret = unsafe {
+            libc::setxattr(
+                path_cstr.as_ptr(),
+                OVERRIDE_XATTR_KEY.as_ptr(),
+                buf.as_ptr() as *const libc::c_void,
+                OVERRIDE_SIZE,
+                0,
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let ret = unsafe {
+            libc::fsetxattr(
+                fd,
+                OVERRIDE_XATTR_KEY.as_ptr(),
+                buf.as_ptr() as *const libc::c_void,
+                OVERRIDE_SIZE,
+                0,
+                0,
+            )
+        };
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Set the override xattr on a path (for use when we don't have an fd).
+pub(crate) fn set_override_at(
+    dirfd: RawFd,
+    name: &CStr,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+    rdev: u32,
+) -> io::Result<()> {
+    // Open the file to get an fd, then delegate.
+    let fd = unsafe {
+        libc::openat(
+            dirfd,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        // For directories, use O_RDONLY | O_DIRECTORY.
+        let fd = unsafe {
+            libc::openat(
+                dirfd,
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY,
+            )
+        };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        let result = set_override(fd, uid, gid, mode, rdev);
+        unsafe { libc::close(fd) };
+        return result;
+    }
+    let result = set_override(fd, uid, gid, mode, rdev);
+    unsafe { libc::close(fd) };
+    result
+}
+
+/// Read the current override xattr values from a file descriptor.
+///
+/// Returns `None` if no override is set.
+pub(crate) fn get_override(fd: RawFd) -> io::Result<Option<OverrideStat>> {
+    read_override(fd)
+}
+
+/// Check if the xattr system is functional by probing the given directory.
+///
+/// Returns `Ok(true)` if xattrs work, `Ok(false)` if not supported.
+pub(crate) fn probe_xattr_support(dirfd: RawFd) -> io::Result<bool> {
+    let probe_key = c"user.containers._probe";
+    let probe_val: [u8; 1] = [1];
+
+    #[cfg(target_os = "linux")]
+    {
+        let path = format!("/proc/self/fd/{dirfd}");
+        let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
+        let ret = unsafe {
+            libc::setxattr(
+                path_cstr.as_ptr(),
+                probe_key.as_ptr(),
+                probe_val.as_ptr() as *const libc::c_void,
+                1,
+                0,
+            )
+        };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            let errno = err.raw_os_error().unwrap_or(0);
+            if errno == libc::EOPNOTSUPP || errno == libc::ENOTSUP {
+                return Ok(false);
+            }
+            return Err(platform::linux_error(err));
+        }
+        // Clean up the probe xattr.
+        unsafe {
+            libc::removexattr(path_cstr.as_ptr(), probe_key.as_ptr());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let ret = unsafe {
+            libc::fsetxattr(
+                dirfd,
+                probe_key.as_ptr(),
+                probe_val.as_ptr() as *const libc::c_void,
+                1,
+                0,
+                0,
+            )
+        };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            let errno = err.raw_os_error().unwrap_or(0);
+            if errno == libc::EOPNOTSUPP || errno == libc::ENOTSUP {
+                return Ok(false);
+            }
+            return Err(platform::linux_error(err));
+        }
+        // Clean up the probe xattr.
+        unsafe {
+            libc::fremovexattr(dirfd, probe_key.as_ptr(), 0);
+        }
+    }
+
+    Ok(true)
+}

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -1,5 +1,5 @@
-//! `microsandbox-filesystem` provides filesystem utilities for microsandbox,
-//! including the embedded agentd binary.
+//! `microsandbox-filesystem` provides filesystem backends and utilities for microsandbox,
+//! including the embedded agentd binary and the passthrough filesystem backend.
 
 #![warn(missing_docs)]
 
@@ -8,3 +8,15 @@
 //--------------------------------------------------------------------------------------------------
 
 pub mod agentd;
+pub mod backends;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use backends::passthrough::{CachePolicy, PassthroughConfig, PassthroughFs};
+pub use msb_krun::backends::fs::{
+    stat64, statvfs64, Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions,
+    GetxattrReply, ListxattrReply, OpenOptions, RemovemappingOne, SetattrValid, ZeroCopyReader,
+    ZeroCopyWriter,
+};

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 microsandbox-db = { path = "../db" }
+microsandbox-filesystem = { path = "../filesystem" }
 microsandbox-protocol = { path = "../protocol" }
 microsandbox-utils = { path = "../utils" }
 msb_krun = { version = "0.1.0", features = ["net"] }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -7,6 +7,7 @@
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 use std::path::PathBuf;
 
+use microsandbox_filesystem::{PassthroughConfig, PassthroughFs};
 use msb_krun::{NetBackend, VmBuilder};
 
 //--------------------------------------------------------------------------------------------------
@@ -84,20 +85,30 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
         })
         .kernel(|k| k.krunfw_path(&config.libkrunfw_path));
 
-    // Root filesystem — single layer uses passthrough via virtio-fs.
-    // TODO(Phase 7): Multiple layers should use OverlayFs via `fs.custom(Box::new(overlay))`
+    // Root filesystem — single layer uses passthrough via virtio-fs with stat virtualization.
+    // TODO: Multiple layers should use OverlayFs via `fs.custom(Box::new(overlay))`
     // from the microsandbox-filesystem crate (DynFileSystem backend with COW and whiteouts).
     if let Some(first_layer) = config.rootfs_layers.first() {
-        let path = first_layer.clone();
-        builder = builder.fs(|fs| fs.root(path));
+        let cfg = PassthroughConfig {
+            root_dir: first_layer.clone(),
+            ..Default::default()
+        };
+        let backend = PassthroughFs::new(cfg)?;
+        builder = builder
+            .fs(move |fs| fs.tag("/dev/root").custom(Box::new(backend)));
     }
 
     // Additional mounts (tag:host_path format).
     for mount_spec in &config.mounts {
         if let Some((tag, path)) = mount_spec.split_once(':') {
             let tag = tag.to_string();
-            let path = PathBuf::from(path);
-            builder = builder.fs(move |fs| fs.tag(&tag).path(path));
+            let cfg = PassthroughConfig {
+                root_dir: PathBuf::from(path),
+                ..Default::default()
+            };
+            let backend = PassthroughFs::new(cfg)?;
+            builder = builder
+                .fs(move |fs| fs.tag(&tag).custom(Box::new(backend)));
         } else {
             tracing::warn!(mount = %mount_spec, "skipping malformed mount spec (expected tag:path)");
         }


### PR DESCRIPTION
## Summary
- Add a `PassthroughFs` backend implementing the `DynFileSystem` trait for virtio-fs with stat virtualization (uid/gid/permissions overrides)
- Provide shared filesystem utilities (inode table, handle table, stat override layer, platform helpers, init binary injection, name validation) to be reused by the upcoming OverlayFs backend
- Wire `PassthroughFs` into the runtime VM builder for both root filesystems and additional mounts, replacing the built-in passthrough path
- This is part of Phase 7 (Filesystem Backends) of the microsandbox implementation plan

## Changes
- **crates/filesystem/lib/backends/passthrough/**: New `PassthroughFs` backend split into focused modules:
  - `mod.rs` (617 lines): Core `PassthroughFs` struct, `PassthroughConfig`, `CachePolicy`, and `DynFileSystem` trait implementation
  - `inode.rs`: Inode management with `InodeData`, `InodeStore`, and file handle caching
  - `create_ops.rs`: File/directory/symlink/mknod/link creation operations
  - `dir_ops.rs`: Directory listing (`readdir`/`readdirplus`) with stat override integration
  - `file_ops.rs`: File read/write via `ZeroCopyReader`/`ZeroCopyWriter`
  - `remove_ops.rs`: Unlink and rmdir operations
  - `metadata.rs`: Getattr/setattr with stat virtualization
  - `special.rs`: Symlink readlink, rename, fallocate, copy_file_range
  - `xattr_ops.rs`: Extended attribute get/set/list/remove operations
- **crates/filesystem/lib/backends/shared/**: Shared utilities for filesystem backends:
  - `inode_table.rs`: Thread-safe inode-to-data mapping
  - `handle_table.rs`: Thread-safe file/dir handle management
  - `stat_override.rs`: Virtualizes uid, gid, and permissions on stat results
  - `platform.rs`: Platform-specific syscall wrappers (openat, fstatat, renameat2, etc.)
  - `init_binary.rs`: Injects the embedded agentd binary as `/init.krun` in the guest filesystem
  - `name_validation.rs`: Validates filenames against reserved names
- **crates/filesystem/Cargo.toml**: Added dependencies: `msb_krun`, `libc`, `tracing`, `scopeguard`, `tempfile`
- **crates/filesystem/lib/lib.rs**: Added `backends` module and re-exports for `PassthroughFs`, `PassthroughConfig`, `CachePolicy`, and `DynFileSystem` trait types
- **crates/runtime/Cargo.toml**: Added `microsandbox-filesystem` dependency
- **crates/runtime/lib/vm.rs**: Updated root filesystem and additional mount wiring to use `PassthroughFs::new(cfg)` with `fs.custom(Box::new(backend))` instead of `fs.root(path)` / `fs.path(path)`

## Test Plan
- Run `cargo build` to verify successful compilation across the workspace
- Run `cargo check --all-targets` to ensure all targets compile
- Manually test VM boot with a single root filesystem layer to verify passthrough operations work correctly
- Verify additional mounts (tag:path format) work with the new PassthroughFs backend
- Confirm stat virtualization is applied (uid/gid should appear as root inside the guest)