### PR TITLE
fix: resolve VM boot hang and macOS passthrough filesystem issues

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -52,22 +52,19 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64) -> AgentdResult<()> {
     // Discover serial port.
     let port_path = find_serial_port(AGENT_PORT_NAME)?;
 
-    // Open the port for reading and writing using separate file descriptors.
-    let read_file = OpenOptions::new()
+    // Open the port once with read+write. Virtio-console multiport devices
+    // only allow a single open; a second open returns EBUSY.
+    let port_file = OpenOptions::new()
         .read(true)
-        .open(&port_path)?;
-    let write_file = OpenOptions::new()
         .write(true)
         .open(&port_path)?;
 
     // Set non-blocking for async I/O.
-    let read_fd = read_file.as_raw_fd();
-    let write_fd = write_file.as_raw_fd();
-    set_nonblocking(read_fd)?;
-    set_nonblocking(write_fd)?;
+    let port_fd = port_file.as_raw_fd();
+    set_nonblocking(port_fd)?;
 
-    let async_read = AsyncFd::new(read_file)?;
-    let async_write = AsyncFd::new(write_file)?;
+    // A single AsyncFd tracks both readable and writable readiness.
+    let async_port = AsyncFd::new(port_file)?;
 
     // Buffer for serial reads.
     let mut read_buf = vec![0u8; SERIAL_READ_BUF_SIZE];
@@ -101,15 +98,15 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64) -> AgentdResult<()> {
     .map_err(|e| AgentdError::ExecSession(format!("encode ready: {e}")))?;
     encode_to_buf(&ready_msg, &mut serial_out_buf)
         .map_err(|e| AgentdError::ExecSession(format!("encode ready frame: {e}")))?;
-    flush_write_buf(&async_write, &mut serial_out_buf).await?;
+    flush_write_buf(&async_port, &mut serial_out_buf).await?;
 
     // Main loop.
     loop {
         tokio::select! {
             // Read from serial port.
-            result = async_read_ready(&async_read) => {
+            result = async_read_ready(&async_port) => {
                 if result.is_ok() {
-                    match read_from_fd(read_fd, &mut read_buf) {
+                    match read_from_fd(port_fd, &mut read_buf) {
                         Ok(n) if n > 0 => {
                             serial_in_buf.extend_from_slice(&read_buf[..n]);
                             last_activity = Utc::now();
@@ -136,7 +133,7 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64) -> AgentdResult<()> {
 
                             // Flush any outgoing messages.
                             if !serial_out_buf.is_empty() {
-                                flush_write_buf(&async_write, &mut serial_out_buf).await?;
+                                flush_write_buf(&async_port, &mut serial_out_buf).await?;
                             }
                         }
                         Ok(_) => {
@@ -180,7 +177,7 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64) -> AgentdResult<()> {
                 }
 
                 if !serial_out_buf.is_empty() {
-                    flush_write_buf(&async_write, &mut serial_out_buf).await?;
+                    flush_write_buf(&async_port, &mut serial_out_buf).await?;
                 }
             }
 

--- a/crates/agentd/lib/heartbeat.rs
+++ b/crates/agentd/lib/heartbeat.rs
@@ -12,7 +12,7 @@ use crate::error::AgentdResult;
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-/// Path to the heartbeat JSON file.
+/// Path to the heartbeat JSON file (under [`microsandbox_protocol::RUNTIME_MOUNT_POINT`]).
 const HEARTBEAT_PATH: &str = "/.msb/heartbeat.json";
 
 /// Path to the temporary heartbeat file (for atomic rename).
@@ -41,7 +41,7 @@ pub async fn write_heartbeat(
     Ok(())
 }
 
-/// Returns `true` if the heartbeat directory exists (i.e., `/.msb` is mounted).
+/// Returns `true` if the heartbeat directory exists (i.e., the runtime mount is available).
 pub fn heartbeat_dir_exists() -> bool {
-    Path::new("/.msb").is_dir()
+    Path::new(microsandbox_protocol::RUNTIME_MOUNT_POINT).is_dir()
 }

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -118,12 +118,12 @@ mod linux {
         Ok(())
     }
 
-    /// Mounts the virtiofs runtime filesystem at `/.msb`.
+    /// Mounts the virtiofs runtime filesystem at the canonical mount point.
     pub fn mount_runtime() -> AgentdResult<()> {
-        mkdir_ignore_exists("/.msb")?;
+        mkdir_ignore_exists(microsandbox_protocol::RUNTIME_MOUNT_POINT)?;
         mount_ignore_busy(
-            Some("msb_runtime"),
-            "/.msb",
+            Some(microsandbox_protocol::RUNTIME_FS_TAG),
+            microsandbox_protocol::RUNTIME_MOUNT_POINT,
             Some("virtiofs"),
             MsFlags::empty(),
             None::<&str>,

--- a/crates/agentd/lib/serial.rs
+++ b/crates/agentd/lib/serial.rs
@@ -12,8 +12,8 @@ use crate::error::{AgentdError, AgentdResult};
 /// The sysfs path where virtio ports are listed.
 const VIRTIO_PORTS_PATH: &str = "/sys/class/virtio-ports";
 
-/// The expected port name for the agent channel.
-pub const AGENT_PORT_NAME: &str = "agent";
+/// Re-export the canonical agent port name from the protocol crate.
+pub use microsandbox_protocol::AGENT_PORT_NAME;
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/build.rs
+++ b/crates/filesystem/build.rs
@@ -7,6 +7,10 @@ use microsandbox_utils::agentd_download_url;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../utils/lib/lib.rs");
+    // Invalidate the embedded agentd when its source changes.
+    // This won't auto-rebuild agentd (that requires `just build-agentd`),
+    // but it forces cargo to re-check that `build/agentd` is fresh.
+    println!("cargo:rerun-if-changed=../agentd");
 
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
@@ -41,6 +45,21 @@ fn build_agentd(workspace_root: &Path, out_dir: &Path) {
                  Run `just build-deps` first.",
                 source.display()
             );
+        }
+
+        // Warn if the binary is older than the agentd source directory.
+        let agentd_src = workspace_root.join("crates/agentd");
+        if let (Ok(bin_meta), Ok(src_meta)) =
+            (std::fs::metadata(&source), std::fs::metadata(&agentd_src))
+        {
+            if let (Ok(bin_time), Ok(src_time)) = (bin_meta.modified(), src_meta.modified()) {
+                if src_time > bin_time {
+                    println!(
+                        "cargo:warning=build/{AGENTD_BINARY} is older than crates/agentd source. \
+                         Run `just build-agentd` to rebuild."
+                    );
+                }
+            }
         }
 
         let dest = out_dir.join(AGENTD_BINARY);

--- a/crates/filesystem/lib/backends/passthrough/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/create_ops.rs
@@ -49,6 +49,7 @@ pub(crate) fn do_create(
     parent: u64,
     name: &CStr,
     mode: u32,
+    kill_priv: bool,
     flags: u32,
     umask: u32,
     _extensions: Extensions,
@@ -64,15 +65,12 @@ pub(crate) fn do_create(
     // Apply umask.
     let file_mode = mode & !umask & 0o7777;
 
-    let mut open_flags = flags as i32;
-    // Strip O_NOFOLLOW: this openat is by name (not through open_inode_fd), so
-    // O_NOFOLLOW would reject creating over an existing file-backed symlink.
-    open_flags &= !libc::O_NOFOLLOW;
-    open_flags |= libc::O_CREAT | libc::O_CLOEXEC;
+    let mut open_flags = inode::translate_open_flags(flags as i32);
+    open_flags |= libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW;
 
     let fd = unsafe {
         libc::openat(
-            parent_fd,
+            parent_fd.raw(),
             name.as_ptr(),
             open_flags,
             (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,
@@ -86,7 +84,7 @@ pub(crate) fn do_create(
     let full_mode = libc::S_IFREG as u32 | file_mode;
     if let Err(e) = stat_override::set_override(fd, ctx.uid, ctx.gid, full_mode, 0) {
         unsafe { libc::close(fd) };
-        unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+        unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
         return Err(e);
     }
 
@@ -98,6 +96,17 @@ pub(crate) fn do_create(
     // Reopen for the handle — strip O_CREAT since the file already exists.
     // open_inode_fd adds O_NOFOLLOW and O_CLOEXEC itself.
     let open_fd = inode::open_inode_fd(fs, entry.inode, open_flags & !libc::O_CREAT)?;
+
+    // Clear SUID/SGID on create+truncate of existing file (HANDLE_KILLPRIV_V2).
+    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
+        if let Ok(Some(ovr)) = stat_override::get_override(open_fd) {
+            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+            if new_mode != ovr.mode {
+                let _ = stat_override::set_override(open_fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
+            }
+        }
+    }
+
     let file = unsafe { std::fs::File::from_raw_fd(open_fd) };
 
     let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
@@ -130,7 +139,7 @@ pub(crate) fn do_mkdir(
 
     let ret = unsafe {
         libc::mkdirat(
-            parent_fd,
+            parent_fd.raw(),
             name.as_ptr(),
             (libc::S_IRWXU) as libc::mode_t,
         )
@@ -141,9 +150,10 @@ pub(crate) fn do_mkdir(
 
     // Set override xattr.
     let full_mode = libc::S_IFDIR as u32 | dir_mode;
-    if let Err(e) = stat_override::set_override_at(parent_fd, name, ctx.uid, ctx.gid, full_mode, 0)
+    if let Err(e) =
+        stat_override::set_override_at(parent_fd.raw(), name, ctx.uid, ctx.gid, full_mode, 0)
     {
-        unsafe { libc::unlinkat(parent_fd, name.as_ptr(), libc::AT_REMOVEDIR) };
+        unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), libc::AT_REMOVEDIR) };
         return Err(e);
     }
 
@@ -178,7 +188,7 @@ pub(crate) fn do_mknod(
     // Always create a regular file on host.
     let fd = unsafe {
         libc::openat(
-            parent_fd,
+            parent_fd.raw(),
             name.as_ptr(),
             libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY | libc::O_CLOEXEC,
             (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,
@@ -192,7 +202,7 @@ pub(crate) fn do_mknod(
     let full_mode = file_type | perm_mode;
     if let Err(e) = stat_override::set_override(fd, ctx.uid, ctx.gid, full_mode, rdev) {
         unsafe { libc::close(fd) };
-        unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+        unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
         return Err(e);
     }
     unsafe { libc::close(fd) };
@@ -226,7 +236,7 @@ pub(crate) fn do_symlink(
         // File-backed symlink: create a regular file with the target as content.
         let fd = unsafe {
             libc::openat(
-                parent_fd,
+                parent_fd.raw(),
                 name.as_ptr(),
                 libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY | libc::O_CLOEXEC,
                 (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,
@@ -242,12 +252,12 @@ pub(crate) fn do_symlink(
         if written < 0 {
             let err = io::Error::last_os_error();
             unsafe { libc::close(fd) };
-            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
             return Err(platform::linux_error(err));
         }
         if (written as usize) != target.len() {
             unsafe { libc::close(fd) };
-            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
             return Err(platform::eio());
         }
 
@@ -255,7 +265,7 @@ pub(crate) fn do_symlink(
         let mode = libc::S_IFLNK as u32 | 0o777;
         if let Err(e) = stat_override::set_override(fd, ctx.uid, ctx.gid, mode, 0) {
             unsafe { libc::close(fd) };
-            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
             return Err(e);
         }
         unsafe { libc::close(fd) };
@@ -264,7 +274,7 @@ pub(crate) fn do_symlink(
     #[cfg(target_os = "macos")]
     {
         // Real symlink on macOS.
-        let ret = unsafe { libc::symlinkat(linkname.as_ptr(), parent_fd, name.as_ptr()) };
+        let ret = unsafe { libc::symlinkat(linkname.as_ptr(), parent_fd.raw(), name.as_ptr()) };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
@@ -291,13 +301,13 @@ pub(crate) fn do_symlink(
         // We need the full path, so open the parent and construct it.
         let fd = unsafe {
             libc::openat(
-                parent_fd,
+                parent_fd.raw(),
                 name.as_ptr(),
                 libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
             )
         };
         if fd < 0 {
-            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
 
@@ -314,7 +324,7 @@ pub(crate) fn do_symlink(
         unsafe { libc::close(fd) };
 
         if xattr_ret < 0 {
-            unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+            unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
     }
@@ -348,12 +358,12 @@ pub(crate) fn do_link(
         let inode_fd = inode::get_inode_fd(fs, inode)?;
         let newparent_fd = inode::get_inode_fd(fs, newparent)?;
 
-        let path = format!("/proc/self/fd/{inode_fd}\0");
+        let path = format!("/proc/self/fd/{}\0", inode_fd.raw());
         let ret = unsafe {
             libc::linkat(
                 libc::AT_FDCWD,
                 path.as_ptr() as *const libc::c_char,
-                newparent_fd,
+                newparent_fd.raw(),
                 newname.as_ptr(),
                 libc::AT_SYMLINK_FOLLOW,
             )
@@ -374,7 +384,7 @@ pub(crate) fn do_link(
             libc::linkat(
                 libc::AT_FDCWD,
                 src_path.as_ptr() as *const libc::c_char,
-                newparent_fd,
+                newparent_fd.raw(),
                 newname.as_ptr(),
                 0,
             )
@@ -408,12 +418,12 @@ pub(crate) fn do_readlink(
     #[cfg(target_os = "linux")]
     {
         let inode_fd = inode::get_inode_fd(fs, ino)?;
-        let st = platform::fstat(inode_fd)?;
+        let st = platform::fstat(inode_fd.raw())?;
 
         // Real symlink on host — use readlinkat.
         if st.st_mode & libc::S_IFMT == libc::S_IFLNK {
             let mut buf = vec![0u8; libc::PATH_MAX as usize];
-            let path = format!("/proc/self/fd/{inode_fd}\0");
+            let path = format!("/proc/self/fd/{}\0", inode_fd.raw());
             let ret = unsafe {
                 libc::readlinkat(
                     libc::AT_FDCWD,
@@ -431,7 +441,7 @@ pub(crate) fn do_readlink(
 
         // Verify override xattr says S_IFLNK before reading file content.
         // Without this check, a guest could read any regular file's content via readlink.
-        match stat_override::get_override(inode_fd)? {
+        match stat_override::get_override(inode_fd.raw())? {
             Some(ovr) if ovr.mode & libc::S_IFMT as u32 == libc::S_IFLNK as u32 => {}
             _ => return Err(platform::einval()),
         }

--- a/crates/filesystem/lib/backends/passthrough/file_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/file_ops.rs
@@ -23,6 +23,7 @@ use super::PassthroughFs;
 use crate::backends::shared::handle_table::HandleData;
 use crate::backends::shared::init_binary;
 use crate::backends::shared::platform;
+use crate::backends::shared::stat_override;
 use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
 
 //--------------------------------------------------------------------------------------------------
@@ -30,17 +31,21 @@ use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
 //--------------------------------------------------------------------------------------------------
 
 /// Open a file and return a handle.
+///
+/// When `kill_priv` is true and the open includes `O_TRUNC`, clears SUID/SGID
+/// bits from the override xattr — truncating a setuid binary should remove setuid.
 pub(crate) fn do_open(
     fs: &PassthroughFs,
     _ctx: Context,
     inode: u64,
+    kill_priv: bool,
     flags: u32,
 ) -> io::Result<(Option<u64>, OpenOptions)> {
     if inode == init_binary::INIT_INODE {
         return Ok((Some(init_binary::INIT_HANDLE), OpenOptions::KEEP_CACHE));
     }
 
-    let mut open_flags = flags as i32;
+    let mut open_flags = inode::translate_open_flags(flags as i32);
 
     // Writeback cache: kernel may issue reads on O_WRONLY fds for cache coherency,
     // so widen to O_RDWR. Strip O_APPEND because it races with the kernel's cached
@@ -55,6 +60,17 @@ pub(crate) fn do_open(
     // open_inode_fd adds O_NOFOLLOW and O_CLOEXEC itself for security
     // (prevents procfd magic-link following), so no need to set them here.
     let fd = inode::open_inode_fd(fs, inode, open_flags)?;
+
+    // Clear SUID/SGID on open+truncate (HANDLE_KILLPRIV_V2).
+    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
+        if let Ok(Some(ovr)) = stat_override::get_override(fd) {
+            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+            if new_mode != ovr.mode {
+                let _ = stat_override::set_override(fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
+            }
+        }
+    }
+
     let file = unsafe { std::fs::File::from_raw_fd(fd) };
 
     let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
@@ -88,6 +104,10 @@ pub(crate) fn do_read(
 }
 
 /// Write data to a file.
+///
+/// When `kill_priv` is true (HANDLE_KILLPRIV_V2 negotiated), clears SUID/SGID
+/// bits from the override xattr after a successful write — the guest kernel
+/// expects the filesystem to handle this.
 pub(crate) fn do_write(
     fs: &PassthroughFs,
     _ctx: Context,
@@ -96,6 +116,7 @@ pub(crate) fn do_write(
     r: &mut dyn ZeroCopyReader,
     size: u32,
     offset: u64,
+    kill_priv: bool,
 ) -> io::Result<usize> {
     if inode == init_binary::INIT_INODE {
         return Err(platform::eacces());
@@ -104,7 +125,19 @@ pub(crate) fn do_write(
     let handles = fs.handles.read().unwrap();
     let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
     let f = data.file.read().unwrap();
-    r.read_to(&f, size as usize, offset)
+    let written = r.read_to(&f, size as usize, offset)?;
+
+    if kill_priv {
+        let fd = f.as_raw_fd();
+        if let Ok(Some(ovr)) = stat_override::get_override(fd) {
+            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+            if new_mode != ovr.mode {
+                let _ = stat_override::set_override(fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
+            }
+        }
+    }
+
+    Ok(written)
 }
 
 /// Flush pending data for a file handle.

--- a/crates/filesystem/lib/backends/passthrough/inode.rs
+++ b/crates/filesystem/lib/backends/passthrough/inode.rs
@@ -29,8 +29,97 @@ use crate::backends::shared::platform;
 use crate::{stat64, Entry};
 
 //--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Owned-or-borrowed fd for inode operations.
+///
+/// On Linux, borrows the O_PATH fd from InodeData (no close on drop).
+/// On macOS, may own a temporary fd opened via `/.vol/` (closed on drop).
+pub(crate) struct InodeFd {
+    fd: i32,
+    #[cfg(target_os = "macos")]
+    owned: bool,
+}
+
+impl InodeFd {
+    pub(crate) fn raw(&self) -> i32 {
+        self.fd
+    }
+}
+
+impl Drop for InodeFd {
+    fn drop(&mut self) {
+        #[cfg(target_os = "macos")]
+        if self.owned && self.fd >= 0 {
+            unsafe { libc::close(self.fd) };
+        }
+    }
+}
+
+/// Linux guest open flag constants.
+///
+/// The guest kernel sends Linux flag values over virtio-fs. On Linux hosts these
+/// match `libc` constants, but on macOS the numeric values differ (e.g. Linux
+/// `O_TRUNC` 0x200 = macOS `O_CREAT` 0x200). This module defines the Linux
+/// values so we can translate them to host values on macOS.
+#[cfg(target_os = "macos")]
+mod linux_flags {
+    pub const O_APPEND: i32 = 0x400;
+    pub const O_CREAT: i32 = 0x40;
+    pub const O_TRUNC: i32 = 0x200;
+    pub const O_EXCL: i32 = 0x80;
+    pub const O_NOFOLLOW: i32 = 0x20000;
+    pub const O_NONBLOCK: i32 = 0x800;
+    pub const O_CLOEXEC: i32 = 0x80000;
+    pub const O_DIRECTORY: i32 = 0x10000;
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Translate Linux guest open flags to host open flags.
+///
+/// On Linux this is a no-op (flags match). On macOS, maps Linux numeric values
+/// to the corresponding macOS `libc` constants. Without this translation,
+/// Linux `O_TRUNC` (0x200) becomes macOS `O_CREAT` (0x200), and Linux
+/// `O_APPEND` (0x400) becomes macOS `O_TRUNC` (0x400).
+#[cfg(target_os = "linux")]
+pub(crate) fn translate_open_flags(flags: i32) -> i32 {
+    flags
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn translate_open_flags(linux_flags_val: i32) -> i32 {
+    // Access mode (O_RDONLY=0, O_WRONLY=1, O_RDWR=2) — same on both platforms.
+    let mut flags = linux_flags_val & 0b11;
+    if linux_flags_val & linux_flags::O_APPEND != 0 {
+        flags |= libc::O_APPEND;
+    }
+    if linux_flags_val & linux_flags::O_CREAT != 0 {
+        flags |= libc::O_CREAT;
+    }
+    if linux_flags_val & linux_flags::O_TRUNC != 0 {
+        flags |= libc::O_TRUNC;
+    }
+    if linux_flags_val & linux_flags::O_EXCL != 0 {
+        flags |= libc::O_EXCL;
+    }
+    if linux_flags_val & linux_flags::O_NOFOLLOW != 0 {
+        flags |= libc::O_NOFOLLOW;
+    }
+    if linux_flags_val & linux_flags::O_NONBLOCK != 0 {
+        flags |= libc::O_NONBLOCK;
+    }
+    if linux_flags_val & linux_flags::O_CLOEXEC != 0 {
+        flags |= libc::O_CLOEXEC;
+    }
+    if linux_flags_val & linux_flags::O_DIRECTORY != 0 {
+        flags |= libc::O_DIRECTORY;
+    }
+    flags
+}
 
 /// Look up a child name in a parent directory and return an [`Entry`].
 ///
@@ -43,10 +132,10 @@ pub(crate) fn do_lookup(fs: &PassthroughFs, parent: u64, name: &CStr) -> io::Res
     let parent_fd = get_inode_fd(fs, parent)?;
 
     #[cfg(target_os = "linux")]
-    return do_lookup_linux(fs, parent_fd, name);
+    return do_lookup_linux(fs, parent_fd.raw(), name);
 
     #[cfg(target_os = "macos")]
-    return do_lookup_macos(fs, parent_fd, name);
+    return do_lookup_macos(fs, parent_fd.raw(), name);
 }
 
 /// Linux lookup: open → statx(AT_EMPTY_PATH) → patched_stat (3 syscalls).
@@ -187,6 +276,8 @@ fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Resul
         ino: st.st_ino as u64,
         dev: st.st_dev as u64,
         refcount: std::sync::atomic::AtomicU64::new(1),
+        #[cfg(target_os = "macos")]
+        unlinked_fd: std::sync::atomic::AtomicI64::new(-1),
     });
 
     {
@@ -274,6 +365,14 @@ pub(crate) fn forget_one_locked(
                 .is_ok()
             {
                 if new == 0 {
+                    // Close the unlinked fd if one was preserved.
+                    #[cfg(target_os = "macos")]
+                    {
+                        let ufd = data.unlinked_fd.load(Ordering::Acquire);
+                        if ufd >= 0 {
+                            unsafe { libc::close(ufd as i32) };
+                        }
+                    }
                     inodes.remove(&inode);
                 }
                 break;
@@ -282,34 +381,75 @@ pub(crate) fn forget_one_locked(
     }
 }
 
-/// Get the raw fd for an inode. On Linux this is the O_PATH fd.
-/// On macOS this opens via `/.vol/dev/ino`.
-pub(crate) fn get_inode_fd(fs: &PassthroughFs, inode: u64) -> io::Result<i32> {
+/// Get an fd for an inode suitable for `*at()` syscalls.
+///
+/// On Linux, returns the borrowed O_PATH fd from InodeData (no close on drop).
+/// On macOS, opens a temporary fd via `/.vol/<dev>/<ino>` (closed on drop).
+/// Root inode (1) always borrows the stored root fd.
+pub(crate) fn get_inode_fd(fs: &PassthroughFs, inode: u64) -> io::Result<InodeFd> {
     // Root inode uses the stored root fd.
     if inode == 1 {
-        return Ok(fs.root_fd.as_raw_fd());
+        return Ok(InodeFd {
+            fd: fs.root_fd.as_raw_fd(),
+            #[cfg(target_os = "macos")]
+            owned: false,
+        });
     }
 
     let inodes = fs.inodes.read().unwrap();
     let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
 
-    Ok(inode_raw_fd(data))
+    #[cfg(target_os = "linux")]
+    {
+        Ok(InodeFd {
+            fd: data.file.as_raw_fd(),
+        })
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let fd = open_vol_fd(data.dev, data.ino)?;
+        Ok(InodeFd { fd, owned: true })
+    }
 }
 
-/// Get the raw fd from an InodeData.
+/// Get the raw fd from an InodeData (Linux only).
 #[cfg(target_os = "linux")]
 fn inode_raw_fd(data: &InodeData) -> i32 {
     data.file.as_raw_fd()
 }
 
-/// Get the raw fd from an InodeData on macOS.
-/// On macOS we don't store fds per inode; we open via `/.vol/dev/ino`.
-/// For the simple case, we return -1 and callers use path-based operations.
+/// Open a temporary fd via `/.vol/<dev>/<ino>` on macOS.
+///
+/// Tries `O_RDONLY | O_DIRECTORY` first (most callers need a parent directory fd),
+/// then falls back to plain `O_RDONLY` for non-directory inodes.
 #[cfg(target_os = "macos")]
-fn inode_raw_fd(_data: &InodeData) -> i32 {
-    // On macOS, we use path-based xattr operations.
-    // Return -1 to signal that path-based access is needed.
-    -1
+fn open_vol_fd(dev: u64, ino: u64) -> io::Result<i32> {
+    let path = format!("/.vol/{}/{}\0", dev, ino);
+
+    // Try directory open first (most callers want a parent fd).
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr() as *const libc::c_char,
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY,
+        )
+    };
+    if fd >= 0 {
+        return Ok(fd);
+    }
+
+    // Fall back to regular open.
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr() as *const libc::c_char,
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd >= 0 {
+        return Ok(fd);
+    }
+
+    Err(platform::linux_error(io::Error::last_os_error()))
 }
 
 /// Open a file for I/O by inode. Returns a real file descriptor (not O_PATH).
@@ -321,7 +461,7 @@ pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::R
     {
         let inode_fd = get_inode_fd(fs, inode)?;
         let mut buf = [0u8; 20];
-        let fd_str = format_fd_cstr(inode_fd, &mut buf);
+        let fd_str = format_fd_cstr(inode_fd.raw(), &mut buf);
         let fd = unsafe {
             libc::openat(
                 fs.proc_self_fd.as_raw_fd(),
@@ -339,6 +479,17 @@ pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::R
     {
         let inodes = fs.inodes.read().unwrap();
         let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+
+        // If the file was unlinked, dup the preserved fd instead of using /.vol/ path.
+        let ufd = data.unlinked_fd.load(Ordering::Acquire);
+        if ufd >= 0 {
+            let fd = unsafe { libc::fcntl(ufd as i32, libc::F_DUPFD_CLOEXEC, 0) };
+            if fd >= 0 {
+                return Ok(fd);
+            }
+            // Fall through to /.vol/ path if dup fails.
+        }
+
         let path = format!("/.vol/{}/{}\0", data.dev, data.ino);
         let fd = unsafe {
             libc::open(
@@ -371,8 +522,8 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
     #[cfg(target_os = "linux")]
     {
         let fd = get_inode_fd(fs, inode)?;
-        let st = platform::fstat(fd)?;
-        crate::backends::shared::stat_override::patched_stat(fd, st)
+        let st = platform::fstat(fd.raw())?;
+        crate::backends::shared::stat_override::patched_stat(fd.raw(), st)
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/filesystem/lib/backends/passthrough/mod.rs
+++ b/crates/filesystem/lib/backends/passthrough/mod.rs
@@ -242,6 +242,8 @@ impl PassthroughFs {
             },
             #[cfg(target_os = "linux")]
             mnt_id,
+            #[cfg(target_os = "macos")]
+            unlinked_fd: std::sync::atomic::AtomicI64::new(-1),
         });
 
         let mut inodes = self.inodes.write().unwrap();
@@ -463,9 +465,10 @@ impl DynFileSystem for PassthroughFs {
         &self,
         ctx: Context,
         ino: u64,
+        kill_priv: bool,
         flags: u32,
     ) -> io::Result<(Option<u64>, OpenOptions)> {
-        file_ops::do_open(self, ctx, ino, flags)
+        file_ops::do_open(self, ctx, ino, kill_priv, flags)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -475,11 +478,12 @@ impl DynFileSystem for PassthroughFs {
         parent: u64,
         name: &CStr,
         mode: u32,
+        kill_priv: bool,
         flags: u32,
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
-        create_ops::do_create(self, ctx, parent, name, mode, flags, umask, extensions)
+        create_ops::do_create(self, ctx, parent, name, mode, kill_priv, flags, umask, extensions)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -508,10 +512,10 @@ impl DynFileSystem for PassthroughFs {
         offset: u64,
         _lock_owner: Option<u64>,
         _delayed_write: bool,
-        _kill_priv: bool,
+        kill_priv: bool,
         _flags: u32,
     ) -> io::Result<usize> {
-        file_ops::do_write(self, ctx, ino, handle, r, size, offset)
+        file_ops::do_write(self, ctx, ino, handle, r, size, offset, kill_priv)
     }
 
     fn flush(
@@ -681,5 +685,43 @@ impl DynFileSystem for PassthroughFs {
             self, ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len,
             flags,
         )
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test: after `init()`, `getattr` on root inode (inode 1) must succeed.
+    ///
+    /// The passthrough filesystem previously failed to register the root inode on
+    /// macOS, causing the guest kernel to panic with `Requested init /init.krun
+    /// failed (error -2)` because GETATTR(ROOT_ID) immediately after FUSE_INIT
+    /// returned ENOENT.
+    #[test]
+    fn test_root_inode_accessible_after_init() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = PassthroughConfig {
+            root_dir: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+        let fs = PassthroughFs::new(cfg).unwrap();
+        fs.init(FsOptions::empty()).unwrap();
+
+        // ROOT_ID = 1. getattr must succeed after init.
+        let ctx = Context {
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let result = fs.getattr(ctx, 1, None);
+        assert!(
+            result.is_ok(),
+            "getattr on root inode must succeed after init: {result:?}"
+        );
     }
 }

--- a/crates/filesystem/lib/backends/passthrough/remove_ops.rs
+++ b/crates/filesystem/lib/backends/passthrough/remove_ops.rs
@@ -19,6 +19,10 @@ use crate::Context;
 //--------------------------------------------------------------------------------------------------
 
 /// Remove a file.
+///
+/// On macOS, opens an fd to the file before unlinking so that open handles
+/// can still access the data after the directory entry is removed (the
+/// `/.vol/<dev>/<ino>` path becomes invalid after unlink).
 pub(crate) fn do_unlink(
     fs: &PassthroughFs,
     _ctx: Context,
@@ -33,10 +37,52 @@ pub(crate) fn do_unlink(
     }
 
     let parent_fd = inode::get_inode_fd(fs, parent)?;
-    let ret = unsafe { libc::unlinkat(parent_fd, name.as_ptr(), 0) };
+
+    // On macOS, grab an fd before unlink to keep the file data alive.
+    #[cfg(target_os = "macos")]
+    let pre_unlink_fd = {
+        let fd = unsafe {
+            libc::openat(
+                parent_fd.raw(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd >= 0 { Some(fd) } else { None }
+    };
+
+    let ret = unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
     if ret < 0 {
+        #[cfg(target_os = "macos")]
+        if let Some(fd) = pre_unlink_fd {
+            unsafe { libc::close(fd) };
+        }
         return Err(platform::linux_error(io::Error::last_os_error()));
     }
+
+    // Store the fd in InodeData so open_inode_fd can use it.
+    #[cfg(target_os = "macos")]
+    if let Some(fd) = pre_unlink_fd {
+        // Look up the inode by stat identity from the pre-unlink fd.
+        let st = platform::fstat(fd);
+        if let Ok(st) = st {
+            let alt_key = crate::backends::shared::inode_table::InodeAltKey::new(
+                st.st_ino as u64,
+                st.st_dev as u64,
+            );
+            let inodes = fs.inodes.read().unwrap();
+            if let Some(data) = inodes.get_alt(&alt_key) {
+                use std::sync::atomic::Ordering;
+                data.unlinked_fd.store(fd as i64, Ordering::Release);
+            } else {
+                // No tracked inode — close the fd.
+                unsafe { libc::close(fd) };
+            }
+        } else {
+            unsafe { libc::close(fd) };
+        }
+    }
+
     Ok(())
 }
 
@@ -54,7 +100,7 @@ pub(crate) fn do_rmdir(
     }
 
     let parent_fd = inode::get_inode_fd(fs, parent)?;
-    let ret = unsafe { libc::unlinkat(parent_fd, name.as_ptr(), libc::AT_REMOVEDIR) };
+    let ret = unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), libc::AT_REMOVEDIR) };
     if ret < 0 {
         return Err(platform::linux_error(io::Error::last_os_error()));
     }
@@ -89,9 +135,9 @@ pub(crate) fn do_rename(
         let ret = unsafe {
             libc::syscall(
                 libc::SYS_renameat2,
-                old_fd,
+                old_fd.raw(),
                 oldname.as_ptr(),
-                new_fd,
+                new_fd.raw(),
                 newname.as_ptr(),
                 flags,
             )
@@ -105,7 +151,7 @@ pub(crate) fn do_rename(
     {
         if flags == 0 {
             let ret = unsafe {
-                libc::renameat(old_fd, oldname.as_ptr(), new_fd, newname.as_ptr())
+                libc::renameat(old_fd.raw(), oldname.as_ptr(), new_fd.raw(), newname.as_ptr())
             };
             if ret < 0 {
                 return Err(platform::linux_error(io::Error::last_os_error()));
@@ -126,9 +172,9 @@ pub(crate) fn do_rename(
 
             let ret = unsafe {
                 libc::renameatx_np(
-                    old_fd,
+                    old_fd.raw(),
                     oldname.as_ptr(),
-                    new_fd,
+                    new_fd.raw(),
                     newname.as_ptr(),
                     macos_flags,
                 )

--- a/crates/filesystem/lib/backends/passthrough/special.rs
+++ b/crates/filesystem/lib/backends/passthrough/special.rs
@@ -228,7 +228,7 @@ pub(crate) fn do_statfs(
     let fd = if inode == init_binary::INIT_INODE || inode == 1 {
         fs.root_fd.as_raw_fd()
     } else {
-        super::inode::get_inode_fd(fs, inode)?
+        super::inode::get_inode_fd(fs, inode)?.raw()
     };
 
     #[cfg(target_os = "linux")]

--- a/crates/filesystem/lib/backends/shared/inode_table.rs
+++ b/crates/filesystem/lib/backends/shared/inode_table.rs
@@ -6,6 +6,8 @@
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::sync::atomic::AtomicU64;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::AtomicI64;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -61,6 +63,14 @@ pub(crate) struct InodeData {
     /// Mount ID from statx (Linux only, for cross-mount deduplication).
     #[cfg(target_os = "linux")]
     pub mnt_id: u64,
+
+    /// Fd grabbed before unlink, keeping the file accessible after deletion.
+    ///
+    /// On macOS, `/.vol/<dev>/<ino>` may become invalid after unlink. This fd
+    /// (set by `do_unlink`) keeps the file data alive for open handles. -1 means
+    /// the file has not been unlinked.
+    #[cfg(target_os = "macos")]
+    pub unlinked_fd: AtomicI64,
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -213,10 +213,12 @@ pub fn set_config(config: GlobalConfig) -> Result<(), GlobalConfig> {
 /// 4. `which::which("msb")`
 pub fn resolve_msb_path() -> MicrosandboxResult<PathBuf> {
     if let Ok(path) = std::env::var("MSB_PATH") {
+        tracing::debug!(path = %path, source = "MSB_PATH env", "resolved msb binary");
         return Ok(PathBuf::from(path));
     }
 
     if let Some(path) = &config().paths.msb {
+        tracing::debug!(path = %path.display(), source = "config.paths.msb", "resolved msb binary");
         return Ok(path.clone());
     }
 
@@ -226,14 +228,17 @@ pub fn resolve_msb_path() -> MicrosandboxResult<PathBuf> {
         .join(microsandbox_utils::BIN_SUBDIR)
         .join(microsandbox_utils::MSB_BINARY);
     if home_bin.is_file() {
+        tracing::debug!(path = %home_bin.display(), source = "~/.microsandbox/bin/msb", "resolved msb binary");
         return Ok(home_bin);
     }
 
-    which::which(microsandbox_utils::MSB_BINARY).map_err(|e| {
+    let path = which::which(microsandbox_utils::MSB_BINARY).map_err(|e| {
         crate::MicrosandboxError::Custom(format!(
             "msb binary not found: set MSB_PATH env var or add msb to PATH ({e})"
         ))
-    })
+    })?;
+    tracing::debug!(path = %path.display(), source = "PATH lookup", "resolved msb binary");
+    Ok(path)
 }
 
 /// Resolve the path to `libkrunfw`.

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -6,6 +6,19 @@
 mod error;
 
 //--------------------------------------------------------------------------------------------------
+// Constants: Host↔Guest Protocol
+//--------------------------------------------------------------------------------------------------
+
+/// Virtio-console port name for the agent channel.
+pub const AGENT_PORT_NAME: &str = "agent";
+
+/// Virtiofs tag for the runtime filesystem (scripts, heartbeat).
+pub const RUNTIME_FS_TAG: &str = "msb_runtime";
+
+/// Guest mount point for the runtime filesystem.
+pub const RUNTIME_MOUNT_POINT: &str = "/.msb";
+
+//--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------
 

--- a/crates/runtime/lib/supervisor.rs
+++ b/crates/runtime/lib/supervisor.rs
@@ -387,6 +387,14 @@ fn spawn_vm_process(
         cmd.arg("--mount").arg(mount);
     }
 
+    // Inject the runtime directory as a virtiofs mount so the guest can access
+    // scripts and write heartbeat at the canonical mount point (/.msb).
+    cmd.arg("--mount").arg(format!(
+        "{}:{}",
+        microsandbox_protocol::RUNTIME_FS_TAG,
+        config.runtime_dir.display()
+    ));
+
     if let Some(ref init_path) = config.vm_config.init_path {
         cmd.arg("--init-path").arg(init_path);
     }
@@ -412,6 +420,11 @@ fn spawn_vm_process(
 
     // Spawn in its own process group for clean signal delivery.
     cmd.process_group(0);
+
+    // Redirect stdin to /dev/null so the VM child never reads from the caller's
+    // terminal. Without this, libkrun's implicit console reads STDIN_FILENO,
+    // and the background process group gets SIGTTIN (stopped).
+    cmd.stdin(Stdio::null());
 
     // Pipe stdout/stderr for log capture.
     cmd.stdout(Stdio::piped());
@@ -540,7 +553,8 @@ where
 {
     let Ok(mut file) = tokio::fs::OpenOptions::new()
         .create(true)
-        .append(true)
+        .write(true)
+        .truncate(true)
         .open(&file_path)
         .await
     else {

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -143,10 +143,17 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
     });
 
     // Agent — wire agent_fd through virtio-console multi-port.
-    // Guest discovers port by name "agent" via /sys/class/virtio-ports/.
-    if let Some(agent_fd) = config.agent_fd {
-        builder = builder.console(|c| c.port("agent", agent_fd, agent_fd));
-    }
+    // Guest discovers port by name via /sys/class/virtio-ports/.
+    // Disable the implicit console — microsandbox VMs are headless and only use
+    // the explicit agent port for host↔guest communication.
+    builder = builder.console(|c| {
+        let c = c.disable_implicit();
+        if let Some(agent_fd) = config.agent_fd {
+            c.port(microsandbox_protocol::AGENT_PORT_NAME, agent_fd, agent_fd)
+        } else {
+            c
+        }
+    });
 
     // Network — use msb_krun's built-in Unixgram backend to relay frames to msbnet.
     if let Some(raw_fd) = config.net_fd {

--- a/justfile
+++ b/justfile
@@ -54,18 +54,16 @@ build-libkrunfw:
     cd build
     ln -sf libkrunfw.{{ LIBKRUNFW_ABI }}.dylib libkrunfw.dylib
 
-# Build the msb CLI binary (release mode). Requires: just build-deps (if not already built).
+# Build the msb CLI binary (release mode). Rebuilds agentd first if needed.
 [linux]
-build:
-    @test -f build/agentd || { echo "error: build/agentd not found. Run 'just build-deps' first."; exit 1; }
+build: build-agentd
     cargo build --release -p microsandbox-cli
     mkdir -p build
     cp target/release/msb build/msb
 
-# Build and sign the msb CLI binary (release mode). Requires: just build-deps (if not already built).
+# Build and sign the msb CLI binary (release mode). Rebuilds agentd first if needed.
 [macos]
-build:
-    @test -f build/agentd || { echo "error: build/agentd not found. Run 'just build-deps' first."; exit 1; }
+build: build-agentd
     cargo build --release -p microsandbox-cli
     mkdir -p build
     cp target/release/msb build/msb


### PR DESCRIPTION
## Summary

- Fix multiple runtime issues that prevented `examples/basic` from completing on macOS: TTY hang from inherited stdin, EBUSY from double-opening virtio port, missing runtime mount, and log file growth
- Fix critical macOS passthrough filesystem bugs: `get_inode_fd` returning -1 for all non-root inodes, Linux-to-macOS open flag value mismatch, missing SUID/SGID clearing on write/open/create, symlink-following window in create, and broken file access after unlink
- Centralize host-guest protocol constants and improve build pipeline with agentd staleness detection
- Thread `kill_priv` through the `DynFileSystem` trait's `open()` and `create()` methods in libkrun to close the HANDLE_KILLPRIV_V2 security gap

## Changes

**VM runtime (supervisor, vm, agentd):**
- `supervisor.rs`: redirect VM stdin to `/dev/null`, inject `msb_runtime` virtiofs mount, truncate logs instead of appending
- `vm.rs`: disable libkrun implicit console via new `ConsoleBuilder::disable_implicit()`, use shared protocol constants for agent port name
- `agent.rs`: single read+write open on virtio-console port to avoid EBUSY from multiport's one-open-at-a-time constraint

**Passthrough filesystem:**
- `inode.rs`: add `InodeFd` RAII type (borrows O_PATH fd on Linux, opens temporary `/.vol/` fd on macOS with close-on-drop); add `translate_open_flags()` mapping Linux guest flag values to macOS host values; check `unlinked_fd` in `open_inode_fd` before falling back to `/.vol/` path; close `unlinked_fd` on forget
- `create_ops.rs`: use `translate_open_flags`, restore `O_NOFOLLOW` on initial `openat`, accept and handle `kill_priv` for truncate-on-existing-file case, update all callers to `parent_fd.raw()`
- `file_ops.rs`: use `translate_open_flags` in `do_open`, add `kill_priv` handling in both `do_open` (O_TRUNC clears SUID/SGID) and `do_write`
- `remove_ops.rs`: grab fd before `unlinkat` on macOS and store in `InodeData.unlinked_fd`; update all callers to `parent_fd.raw()`
- `inode_table.rs`: add `unlinked_fd: AtomicI64` field to `InodeData` (macOS only)
- `mod.rs`: pass `kill_priv` through to `do_open`, `do_create`, `do_write`; add `unlinked_fd` init in root inode registration

**Protocol and infrastructure:**
- `protocol/lib.rs`: add `AGENT_PORT_NAME`, `RUNTIME_FS_TAG`, `RUNTIME_MOUNT_POINT` constants
- `agentd/{serial,init,heartbeat}.rs`: use shared protocol constants instead of local literals
- `filesystem/build.rs`: add `rerun-if-changed` for agentd source, warn if `build/agentd` is stale
- `config/mod.rs`: add `tracing::debug!` to msb binary resolution paths
- `justfile`: make `just build` depend on `build-agentd`

**libkrun (separate repo, already committed):**
- `dyn_filesystem.rs`: add `kill_priv: bool` to `DynFileSystem::open()` and `DynFileSystem::create()` trait methods and adapter
- `builders.rs`: add `disable_implicit` field and method to `ConsoleBuilder`
- `builder.rs`: wire `disable_implicit_console` in VM build

## Test Plan

- Run `cargo check --workspace` to verify compilation across all crates
- Run `cargo test --workspace` to verify all 30 tests pass
- Run `MSB_PATH="$PWD/build/msb" cargo run -p basic-example` on macOS to verify end-to-end VM boot, command execution, and clean exit
- Verify `just build` triggers `build-agentd` before compiling msb