### PR TITLE
fix(filesystem): allow backslash in filename validation

### DIFF
--- a/crates/filesystem/lib/backends/passthrough/tests/test_name_validation.rs
+++ b/crates/filesystem/lib/backends/passthrough/tests/test_name_validation.rs
@@ -22,10 +22,12 @@ fn test_lookup_slash() {
 }
 
 #[test]
-fn test_lookup_backslash() {
+fn test_lookup_backslash_allowed() {
+    // Backslash is a valid filename character on Linux — not rejected.
     let sb = TestSandbox::new();
+    sb.fuse_create_root("a\\b").unwrap();
     let result = sb.lookup_root("a\\b");
-    TestSandbox::assert_errno(result, LINUX_EPERM);
+    assert!(result.is_ok());
 }
 
 #[test]
@@ -120,7 +122,8 @@ fn test_rename_old_dotdot() {
 }
 
 #[test]
-fn test_rename_new_backslash() {
+fn test_rename_new_backslash_allowed() {
+    // Backslash is a valid filename character on Linux — not rejected.
     let sb = TestSandbox::new();
     sb.fuse_create_root("source").unwrap();
     let result = sb.fs.rename(
@@ -131,7 +134,7 @@ fn test_rename_new_backslash() {
         &TestSandbox::cstr("a\\b"),
         0,
     );
-    TestSandbox::assert_errno(result, LINUX_EPERM);
+    assert!(result.is_ok());
 }
 
 #[test]
@@ -158,7 +161,8 @@ fn test_link_name_slash() {
 }
 
 #[test]
-fn test_mknod_backslash() {
+fn test_mknod_backslash_allowed() {
+    // Backslash is a valid filename character on Linux — not rejected.
     let sb = TestSandbox::new();
     let result = sb.fs.mknod(
         sb.ctx(),
@@ -169,5 +173,5 @@ fn test_mknod_backslash() {
         0,
         Extensions::default(),
     );
-    TestSandbox::assert_errno(result, LINUX_EPERM);
+    assert!(result.is_ok());
 }

--- a/crates/filesystem/lib/backends/shared/name_validation.rs
+++ b/crates/filesystem/lib/backends/shared/name_validation.rs
@@ -14,8 +14,11 @@ use super::platform;
 
 /// Validate a directory entry name, blocking traversal attacks.
 ///
-/// Rejects: empty names, `..`, names containing `/` or `\`, and names
-/// containing null bytes.
+/// Rejects: empty names, `..`, and names containing `/`.
+///
+/// Backslash is intentionally allowed — it is a valid filename character on
+/// Linux. The filesystem operates on raw bytes, not path-separator-aware
+/// strings.
 pub(crate) fn validate_name(name: &CStr) -> io::Result<()> {
     let bytes = name.to_bytes();
 
@@ -25,7 +28,7 @@ pub(crate) fn validate_name(name: &CStr) -> io::Result<()> {
     if bytes == b".." {
         return Err(platform::eperm());
     }
-    if bytes.contains(&b'/') || bytes.contains(&b'\\') {
+    if bytes.contains(&b'/') {
         return Err(platform::eperm());
     }
 


### PR DESCRIPTION
## Summary
- Remove backslash from the rejected characters in `validate_name()`, since backslash is a valid filename character on Linux (only `/` is a path separator)
- The previous check incorrectly treated `\` as a path separator, which would reject valid filenames containing backslash
- Update tests to verify that backslash-containing names are accepted in lookup, rename, and mknod operations

## Changes
- `crates/filesystem/lib/backends/shared/name_validation.rs`: Remove `|| bytes.contains(&b'\\')` check from `validate_name()` and update the doc comment to reflect the new behavior
- `crates/filesystem/lib/backends/passthrough/tests/test_name_validation.rs`: Update 3 tests (`test_lookup_backslash_allowed`, `test_rename_new_backslash_allowed`, `test_mknod_backslash_allowed`) to assert success instead of EPERM for backslash-containing filenames

## Test Plan
- Run `cargo test -p microsandbox-filesystem` to verify all name validation tests pass
- Verify that backslash-containing filenames are accepted in lookup, rename, and mknod operations
- Verify that slash, `..`, and empty names are still correctly rejected