### PR TITLE
feat(filesystem): add memfs, proxyfs, and dualfs backends

### DIFF
--- a/crates/filesystem/lib/backends/dualfs/builder.rs
+++ b/crates/filesystem/lib/backends/dualfs/builder.rs
@@ -1,0 +1,138 @@
+//! Builder for constructing a `DualFs` backend.
+
+use std::sync::Arc;
+
+use super::hooks::DualDispatchHook;
+use super::policies::ReadBackendBWriteBackendA;
+use super::policy::DualDispatchPolicy;
+use super::types::{CachePolicy, DualFsConfig, DualState};
+use crate::backends::shared::init_binary;
+use crate::DynFileSystem;
+
+use std::io;
+use std::time::Duration;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Builder for [`DualFs`](super::DualFs).
+pub struct DualFsBuilder {
+    backend_a: Option<Box<dyn DynFileSystem>>,
+    backend_b: Option<Box<dyn DynFileSystem>>,
+    policy: Option<Arc<dyn DualDispatchPolicy>>,
+    hooks: Vec<Arc<dyn DualDispatchHook>>,
+    entry_timeout: Duration,
+    attr_timeout: Duration,
+    cache_policy: CachePolicy,
+    writeback: bool,
+    copy_chunk_size: usize,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DualFsBuilder {
+    /// Create a new builder with default settings.
+    pub(crate) fn new() -> Self {
+        let defaults = DualFsConfig::default();
+        DualFsBuilder {
+            backend_a: None,
+            backend_b: None,
+            policy: None,
+            hooks: Vec::new(),
+            entry_timeout: defaults.entry_timeout,
+            attr_timeout: defaults.attr_timeout,
+            cache_policy: defaults.cache_policy,
+            writeback: defaults.writeback,
+            copy_chunk_size: defaults.copy_chunk_size,
+        }
+    }
+
+    /// Set the backend_a backend.
+    pub fn backend_a(mut self, fs: impl DynFileSystem + 'static) -> Self {
+        self.backend_a = Some(Box::new(fs));
+        self
+    }
+
+    /// Set the backend_b backend.
+    pub fn backend_b(mut self, fs: impl DynFileSystem + 'static) -> Self {
+        self.backend_b = Some(Box::new(fs));
+        self
+    }
+
+    /// Set the dispatch policy.
+    pub fn policy(mut self, policy: impl DualDispatchPolicy + 'static) -> Self {
+        self.policy = Some(Arc::new(policy));
+        self
+    }
+
+    /// Add a lifecycle hook.
+    pub fn hook(mut self, hook: Arc<dyn DualDispatchHook>) -> Self {
+        self.hooks.push(hook);
+        self
+    }
+
+    /// Set the FUSE entry cache timeout.
+    pub fn entry_timeout(mut self, d: Duration) -> Self {
+        self.entry_timeout = d;
+        self
+    }
+
+    /// Set the FUSE attribute cache timeout.
+    pub fn attr_timeout(mut self, d: Duration) -> Self {
+        self.attr_timeout = d;
+        self
+    }
+
+    /// Set the cache policy.
+    pub fn cache_policy(mut self, p: CachePolicy) -> Self {
+        self.cache_policy = p;
+        self
+    }
+
+    /// Enable writeback caching.
+    pub fn writeback(mut self, v: bool) -> Self {
+        self.writeback = v;
+        self
+    }
+
+    /// Set the materialization chunk size.
+    pub fn copy_chunk_size(mut self, s: usize) -> Self {
+        self.copy_chunk_size = s;
+        self
+    }
+
+    /// Build the `DualFs` backend.
+    pub fn build(self) -> io::Result<super::DualFs> {
+        let backend_a = self.backend_a.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "backend_a is required")
+        })?;
+        let backend_b = self.backend_b.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "backend_b is required")
+        })?;
+
+        let policy: Arc<dyn DualDispatchPolicy> = self
+            .policy
+            .unwrap_or_else(|| Arc::new(ReadBackendBWriteBackendA));
+
+        let init_file = init_binary::create_init_file()?;
+
+        Ok(super::DualFs {
+            backend_a,
+            backend_b,
+            policy,
+            hooks: self.hooks,
+            state: DualState::new(),
+            init_file,
+            cfg: DualFsConfig {
+                entry_timeout: self.entry_timeout,
+                attr_timeout: self.attr_timeout,
+                cache_policy: self.cache_policy,
+                writeback: self.writeback,
+                copy_chunk_size: self.copy_chunk_size,
+            },
+        })
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/create_ops.rs
@@ -1,0 +1,521 @@
+//! Create, mkdir, mknod, symlink, link operations.
+
+use std::ffi::CStr;
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+
+use super::hooks::{
+    CommitEvent, DentryChange, HookCtx, decode_entry, handle_hook_decision, notify_observers,
+    run_decision_hooks,
+};
+use super::lookup::{
+    backend, ensure_backend_presence, get_node, mark_metadata_authority, resolve_backend_inode,
+};
+use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
+use super::types::{AtomicBackendId, BackendId, FileKind, GuestNode, NodeState};
+use super::DualFs;
+use crate::backends::shared::{init_binary, name_validation, platform};
+use crate::{Context, Entry, Extensions, OpenOptions};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle create (file creation with open).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_create(
+    fs: &DualFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    kill_priv: bool,
+    flags: u32,
+    umask: u32,
+    extensions: Extensions,
+) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+    let name_bytes = name.to_bytes();
+    name_validation::validate_name(name)?;
+
+    let parent_node = get_node(&fs.state, parent)?;
+    let node_state = parent_node.state.read().unwrap().clone();
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Create,
+            guest_inode: parent,
+            node_state: node_state.clone(),
+            file_kind: parent_node.kind,
+            flags,
+            name: name_bytes.to_vec(),
+            parent_inode: parent,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    // Full pipeline: hooks + plan.
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_resolve(ctx)),
+        decode_entry,
+    ) {
+        let entry = r?;
+        return Ok((entry, None, OpenOptions::empty()));
+    }
+
+    let view = DualNamespaceView {
+        state: &fs.state,
+    };
+    let plan = fs.policy.plan(&hook_ctx.req, &view, &hook_ctx.hints)?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    // Ensure parent has target presence.
+    ensure_backend_presence(fs, ctx, parent, target)?;
+
+    // Check existence in merged view.
+    check_name_available(fs, parent, name_bytes, target)?;
+
+    // Resolve parent on target.
+    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
+        .ok_or_else(platform::enoent)?;
+
+    // Delegate.
+    let (child_entry, child_handle, opts) = backend(fs, target).create(
+        ctx,
+        parent_target_inode,
+        name,
+        mode,
+        kill_priv,
+        flags,
+        umask,
+        extensions,
+    )?;
+
+    // Clear whiteout if one existed.
+    clear_whiteout(fs, parent, name_bytes, target);
+
+    mark_metadata_authority(&fs.state, parent, target);
+
+    // Register new node.
+    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, FileKind::RegularFile);
+
+    // Create file handle.
+    let child_handle_val = child_handle.unwrap_or(0);
+    let guest_handle = fs.state.next_handle.fetch_add(1, Ordering::Relaxed);
+    let dual_handle = match target {
+        BackendId::BackendA => super::types::DualHandle::BackendA {
+            guest_inode,
+            backend_a_inode: child_entry.inode,
+            backend_a_handle: child_handle_val,
+        },
+        BackendId::BackendB => super::types::DualHandle::BackendB {
+            guest_inode,
+            backend_b_inode: child_entry.inode,
+            backend_b_handle: child_handle_val,
+        },
+    };
+    fs.state
+        .file_handles
+        .write()
+        .unwrap()
+        .insert(guest_handle, Arc::new(dual_handle));
+
+    let mut st = child_entry.attr;
+    st.st_ino = guest_inode;
+
+    let entry = Entry {
+        inode: guest_inode,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    };
+
+    // hooks.after_commit
+    notify_observers(&fs.hooks, |h| {
+        h.after_commit(&CommitEvent {
+            op: OpKind::Create,
+            guest_inode,
+            transition: None,
+            dentry_changes: vec![DentryChange::Added {
+                parent,
+                name: name_bytes.to_vec(),
+                child: guest_inode,
+            }],
+        });
+    });
+
+    Ok((entry, Some(guest_handle), opts))
+}
+
+/// Handle mkdir.
+pub(crate) fn do_mkdir(
+    fs: &DualFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    umask: u32,
+    extensions: Extensions,
+) -> io::Result<Entry> {
+    let name_bytes = name.to_bytes();
+    name_validation::validate_name(name)?;
+
+    let parent_node = get_node(&fs.state, parent)?;
+    let node_state = parent_node.state.read().unwrap().clone();
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Mkdir,
+            guest_inode: parent,
+            node_state,
+            file_kind: parent_node.kind,
+            flags: 0,
+            name: name_bytes.to_vec(),
+            parent_inode: parent,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_resolve(ctx)),
+        decode_entry,
+    ) {
+        return r;
+    }
+
+    let view = DualNamespaceView { state: &fs.state };
+    let plan = fs.policy.plan(&hook_ctx.req, &view, &hook_ctx.hints)?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    ensure_backend_presence(fs, ctx, parent, target)?;
+
+    // Check if a whiteout existed (means a dir was previously deleted here).
+    let had_whiteout = {
+        let wh = fs.state.whiteouts.read().unwrap();
+        wh.contains(&(parent, name_bytes.to_vec(), target.other()))
+    };
+
+    if !had_whiteout {
+        check_name_available(fs, parent, name_bytes, target)?;
+    }
+
+    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
+        .ok_or_else(platform::enoent)?;
+
+    let child_entry = backend(fs, target).mkdir(ctx, parent_target_inode, name, mode, umask, extensions)?;
+
+    clear_whiteout(fs, parent, name_bytes, target);
+    mark_metadata_authority(&fs.state, parent, target);
+
+    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, FileKind::Directory);
+
+    // If recreating over a deleted dir, make opaque against the other backend.
+    if had_whiteout {
+        fs.state
+            .opaque_dirs
+            .write()
+            .unwrap()
+            .insert((guest_inode, target.other()));
+    }
+
+    let mut st = child_entry.attr;
+    st.st_ino = guest_inode;
+
+    Ok(Entry {
+        inode: guest_inode,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+/// Handle mknod.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_mknod(
+    fs: &DualFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    rdev: u32,
+    umask: u32,
+    extensions: Extensions,
+) -> io::Result<Entry> {
+    let name_bytes = name.to_bytes();
+    name_validation::validate_name(name)?;
+
+    let parent_node = get_node(&fs.state, parent)?;
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Mknod,
+        guest_inode: parent,
+        node_state: parent_node.state.read().unwrap().clone(),
+        file_kind: parent_node.kind,
+        flags: 0,
+        name: name_bytes.to_vec(),
+        parent_inode: parent,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    ensure_backend_presence(fs, ctx, parent, target)?;
+    check_name_available(fs, parent, name_bytes, target)?;
+
+    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
+        .ok_or_else(platform::enoent)?;
+
+    let child_entry = backend(fs, target).mknod(ctx, parent_target_inode, name, mode, rdev, umask, extensions)?;
+
+    clear_whiteout(fs, parent, name_bytes, target);
+    mark_metadata_authority(&fs.state, parent, target);
+
+    let kind = FileKind::from_mode(mode);
+    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, kind);
+
+    let mut st = child_entry.attr;
+    st.st_ino = guest_inode;
+
+    Ok(Entry {
+        inode: guest_inode,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+/// Handle symlink.
+pub(crate) fn do_symlink(
+    fs: &DualFs,
+    ctx: Context,
+    linkname: &CStr,
+    parent: u64,
+    name: &CStr,
+    extensions: Extensions,
+) -> io::Result<Entry> {
+    let name_bytes = name.to_bytes();
+    name_validation::validate_name(name)?;
+
+    let parent_node = get_node(&fs.state, parent)?;
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Symlink,
+        guest_inode: parent,
+        node_state: parent_node.state.read().unwrap().clone(),
+        file_kind: parent_node.kind,
+        flags: 0,
+        name: name_bytes.to_vec(),
+        parent_inode: parent,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    ensure_backend_presence(fs, ctx, parent, target)?;
+    check_name_available(fs, parent, name_bytes, target)?;
+
+    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
+        .ok_or_else(platform::enoent)?;
+
+    let child_entry = backend(fs, target).symlink(ctx, linkname, parent_target_inode, name, extensions)?;
+
+    clear_whiteout(fs, parent, name_bytes, target);
+    mark_metadata_authority(&fs.state, parent, target);
+
+    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, FileKind::Symlink);
+
+    let mut st = child_entry.attr;
+    st.st_ino = guest_inode;
+
+    Ok(Entry {
+        inode: guest_inode,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+/// Handle link.
+pub(crate) fn do_link(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    newparent: u64,
+    newname: &CStr,
+) -> io::Result<Entry> {
+    let newname_bytes = newname.to_bytes();
+    name_validation::validate_name(newname)?;
+
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::EPERM));
+    }
+
+    let source_node = get_node(&fs.state, ino)?;
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Link,
+        guest_inode: ino,
+        node_state: source_node.state.read().unwrap().clone(),
+        file_kind: source_node.kind,
+        flags: 0,
+        name: newname_bytes.to_vec(),
+        parent_inode: newparent,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    // Materialize source if not on target.
+    if let Some(current) = source_node.state.read().unwrap().current_backend() {
+        if current != target {
+            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
+        }
+    }
+
+    ensure_backend_presence(fs, ctx, newparent, target)?;
+    check_name_available(fs, newparent, newname_bytes, target)?;
+
+    let source_target_inode = resolve_backend_inode(&fs.state, ino, target)
+        .ok_or_else(platform::einval)?;
+    let newparent_target_inode = resolve_backend_inode(&fs.state, newparent, target)
+        .ok_or_else(platform::enoent)?;
+
+    let child_entry = backend(fs, target).link(ctx, source_target_inode, newparent_target_inode, newname)?;
+
+    mark_metadata_authority(&fs.state, newparent, target);
+
+    // Record new alias.
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .insert((newparent, newname_bytes.to_vec()), ino);
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(ino)
+        .or_default()
+        .insert((newparent, newname_bytes.to_vec()));
+
+    source_node.lookup_refs.fetch_add(1, Ordering::Relaxed);
+
+    let mut st = child_entry.attr;
+    st.st_ino = ino;
+
+    Ok(Entry {
+        inode: ino,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Register a newly created node in the state tables.
+fn register_new_node(
+    fs: &DualFs,
+    child_inode: u64,
+    name: &[u8],
+    parent: u64,
+    target: BackendId,
+    kind: FileKind,
+) -> u64 {
+    let guest_inode = fs.state.next_inode.fetch_add(1, Ordering::Relaxed);
+
+    let node_state = match target {
+        BackendId::BackendA => NodeState::BackendA {
+            backend_a_inode: child_inode,
+            former_backend_b_inode: None,
+        },
+        BackendId::BackendB => NodeState::BackendB {
+            backend_b_inode: child_inode,
+            former_backend_a_inode: None,
+        },
+    };
+
+    let node = Arc::new(GuestNode {
+        guest_inode,
+        kind,
+        lookup_refs: std::sync::atomic::AtomicU64::new(1),
+        anchor_parent: std::sync::atomic::AtomicU64::new(parent),
+        anchor_name: std::sync::RwLock::new(name.to_vec()),
+        metadata_backend: AtomicBackendId::new(target),
+        state: std::sync::RwLock::new(node_state),
+        copy_up_lock: Mutex::new(()),
+    });
+
+    fs.state.nodes.write().unwrap().insert(guest_inode, node);
+    fs.state
+        .inode_map(target)
+        .write()
+        .unwrap()
+        .insert(child_inode, guest_inode);
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .insert((parent, name.to_vec()), guest_inode);
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(guest_inode)
+        .or_default()
+        .insert((parent, name.to_vec()));
+
+    guest_inode
+}
+
+/// Check that a name is available in the merged namespace.
+fn check_name_available(
+    fs: &DualFs,
+    parent: u64,
+    name: &[u8],
+    target: BackendId,
+) -> io::Result<()> {
+    // If whited out against other backend, the name is "deleted" — available.
+    let whited_out = fs
+        .state
+        .whiteouts
+        .read()
+        .unwrap()
+        .contains(&(parent, name.to_vec(), target.other()));
+    if whited_out {
+        return Ok(());
+    }
+
+    // Check dentry table.
+    if fs
+        .state
+        .dentries
+        .read()
+        .unwrap()
+        .contains_key(&(parent, name.to_vec()))
+    {
+        return Err(io::Error::from_raw_os_error(libc::EEXIST));
+    }
+
+    Ok(())
+}
+
+/// Clear a whiteout for a name after successful creation.
+fn clear_whiteout(fs: &DualFs, parent: u64, name: &[u8], target: BackendId) {
+    fs.state
+        .whiteouts
+        .write()
+        .unwrap()
+        .remove(&(parent, name.to_vec(), target.other()));
+}

--- a/crates/filesystem/lib/backends/dualfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/dir_ops.rs
@@ -1,0 +1,559 @@
+//! Opendir, readdir, readdirplus, releasedir, and snapshot building.
+
+use std::collections::HashSet;
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::lookup::{auto_register_readdir, backend, get_node};
+use super::policy::{BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx};
+use super::types::{
+    BackendId, DirSnapshot, DualDirHandle, FileKind, MergedDirEntry, NodeState, ROOT_INODE,
+};
+use super::DualFs;
+use crate::backends::shared::init_binary;
+use crate::{Context, DirEntry, Entry, OpenOptions};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Name of the hidden staging directory (filtered from readdir).
+const STAGING_DIR_NAME: &[u8] = b".dualfs_staging";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle opendir. Compute readdir plan and allocate handle.
+pub(crate) fn do_opendir(
+    fs: &DualFs,
+    _ctx: Context,
+    ino: u64,
+    _flags: u32,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    let node = get_node(&fs.state, ino)?;
+    if node.kind != FileKind::Directory {
+        return Err(io::Error::from_raw_os_error(libc::ENOTDIR));
+    }
+
+    // Determine readdir plan from policy.
+    let node_state = node.state.read().unwrap().clone();
+    let req_ctx = RequestCtx {
+        op: OpKind::Readdir,
+        guest_inode: ino,
+        node_state: node_state.clone(),
+        file_kind: node.kind,
+        flags: 0,
+        name: Vec::new(),
+        parent_inode: 0,
+    };
+    let view = DualNamespaceView {
+        state: &fs.state,
+    };
+    let hints = HintBag::new();
+
+    let readdir_plan = fs.policy.plan(&req_ctx, &view, &hints)?;
+
+    // Validate plan type.
+    match &readdir_plan {
+        DualDispatchPlan::MergeReaddir { .. }
+        | DualDispatchPlan::UseBackendA { .. }
+        | DualDispatchPlan::UseBackendB { .. } => {}
+        _ => return Err(io::Error::from_raw_os_error(libc::EINVAL)),
+    }
+
+    // Extract child inode IDs for the handle.
+    let (backend_a_inode, backend_b_inode) = {
+        let state = node.state.read().unwrap();
+        match &*state {
+            NodeState::Root {
+                backend_a_root,
+                backend_b_root,
+            } => (Some(*backend_a_root), Some(*backend_b_root)),
+            NodeState::BackendA {
+                backend_a_inode, ..
+            } => (Some(*backend_a_inode), None),
+            NodeState::BackendB {
+                backend_b_inode, ..
+            } => (None, Some(*backend_b_inode)),
+            NodeState::MergedDir {
+                backend_a_inode,
+                backend_b_inode,
+            } => (Some(*backend_a_inode), Some(*backend_b_inode)),
+            NodeState::Init => return Err(io::Error::from_raw_os_error(libc::ENOTDIR)),
+        }
+    };
+
+    let handle = fs
+        .state
+        .next_handle
+        .fetch_add(1, Ordering::Relaxed);
+
+    fs.state.dir_handles.write().unwrap().insert(
+        handle,
+        Arc::new(DualDirHandle {
+            guest_inode: ino,
+            backend_a_inode,
+            backend_b_inode,
+            readdir_plan,
+            snapshot: std::sync::Mutex::new(None),
+        }),
+    );
+
+    Ok((Some(handle), OpenOptions::empty()))
+}
+
+/// Handle readdir. Build or serve from snapshot.
+pub(crate) fn do_readdir(
+    fs: &DualFs,
+    ctx: Context,
+    _ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+) -> io::Result<Vec<DirEntry<'static>>> {
+    let dh = get_dir_handle(fs, handle)?;
+    let mut snapshot_guard = dh.snapshot.lock().unwrap();
+
+    // Build snapshot on first call.
+    if snapshot_guard.is_none() {
+        *snapshot_guard = Some(build_readdir_snapshot(fs, ctx, dh.guest_inode, &dh)?);
+    }
+
+    let snapshot = snapshot_guard.as_ref().unwrap();
+    serve_readdir(snapshot, offset)
+}
+
+/// Handle readdirplus.
+pub(crate) fn do_readdirplus(
+    fs: &DualFs,
+    ctx: Context,
+    _ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+    let dh = get_dir_handle(fs, handle)?;
+    let mut snapshot_guard = dh.snapshot.lock().unwrap();
+
+    if snapshot_guard.is_none() {
+        *snapshot_guard = Some(build_readdir_snapshot(fs, ctx, dh.guest_inode, &dh)?);
+    }
+
+    let snapshot = snapshot_guard.as_ref().unwrap();
+    let dir_entries = serve_readdir(snapshot, offset)?;
+
+    let mut result = Vec::with_capacity(dir_entries.len());
+    for de in dir_entries {
+        // Build entry with attrs.
+        let entry = if de.ino == init_binary::INIT_INODE {
+            init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout)
+        } else if let Some(node) = fs.state.nodes.read().unwrap().get(&de.ino).cloned() {
+            node.lookup_refs.fetch_add(1, Ordering::Relaxed);
+            let (backend_id, child_inode) = super::lookup::resolve_active_backend_inode(&node);
+            match backend(fs, backend_id).getattr(ctx, child_inode, None) {
+                Ok((mut st, _)) => {
+                    st.st_ino = de.ino;
+                    Entry {
+                        inode: de.ino,
+                        generation: 0,
+                        attr: st,
+                        attr_flags: 0,
+                        attr_timeout: fs.cfg.attr_timeout,
+                        entry_timeout: fs.cfg.entry_timeout,
+                    }
+                }
+                Err(_) => {
+                    // Fallback: minimal entry.
+                    Entry {
+                        inode: de.ino,
+                        generation: 0,
+                        attr: unsafe { std::mem::zeroed() },
+                        attr_flags: 0,
+                        attr_timeout: fs.cfg.attr_timeout,
+                        entry_timeout: fs.cfg.entry_timeout,
+                    }
+                }
+            }
+        } else {
+            Entry {
+                inode: de.ino,
+                generation: 0,
+                attr: unsafe { std::mem::zeroed() },
+                attr_flags: 0,
+                attr_timeout: fs.cfg.attr_timeout,
+                entry_timeout: fs.cfg.entry_timeout,
+            }
+        };
+
+        result.push((de, entry));
+    }
+
+    Ok(result)
+}
+
+/// Handle releasedir.
+pub(crate) fn do_releasedir(
+    fs: &DualFs,
+    _ctx: Context,
+    _ino: u64,
+    _flags: u32,
+    handle: u64,
+) -> io::Result<()> {
+    fs.state.dir_handles.write().unwrap().remove(&handle);
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Build a merged readdir snapshot.
+fn build_readdir_snapshot(
+    fs: &DualFs,
+    ctx: Context,
+    guest_inode: u64,
+    dh: &DualDirHandle,
+) -> io::Result<DirSnapshot> {
+    let mut seen: HashSet<Vec<u8>> = HashSet::new();
+    let mut entries: Vec<MergedDirEntry> = Vec::new();
+    let mut off = 1u64;
+
+    // Standard "." and ".." entries.
+    entries.push(MergedDirEntry {
+        name: b".".to_vec(),
+        inode: guest_inode,
+        offset: off,
+        file_type: libc::DT_DIR as u32,
+    });
+    off += 1;
+    seen.insert(b".".to_vec());
+
+    // ".." — use parent or self for root.
+    let parent_inode = fs
+        .state
+        .alias_index
+        .read()
+        .unwrap()
+        .get(&guest_inode)
+        .and_then(|s| s.iter().next().map(|(p, _)| *p))
+        .unwrap_or(guest_inode);
+    entries.push(MergedDirEntry {
+        name: b"..".to_vec(),
+        inode: parent_inode,
+        offset: off,
+        file_type: libc::DT_DIR as u32,
+    });
+    off += 1;
+    seen.insert(b"..".to_vec());
+
+    // init.krun injection for root.
+    if guest_inode == ROOT_INODE {
+        entries.push(MergedDirEntry {
+            name: init_binary::INIT_FILENAME.to_vec(),
+            inode: init_binary::INIT_INODE,
+            offset: off,
+            file_type: libc::DT_REG as u32,
+        });
+        off += 1;
+        seen.insert(init_binary::INIT_FILENAME.to_vec());
+    }
+
+    // Collect whiteout/opaque state.
+    let whiteouts = fs.state.whiteouts.read().unwrap();
+    let opaque_dirs = fs.state.opaque_dirs.read().unwrap();
+    let opaque_a = opaque_dirs.contains(&(guest_inode, BackendId::BackendA));
+    let opaque_b = opaque_dirs.contains(&(guest_inode, BackendId::BackendB));
+
+    match &dh.readdir_plan {
+        DualDispatchPlan::MergeReaddir {
+            precedence: BackendChoice::BackendBFirst,
+        } => {
+            // Pass 1: backend_b via readdir.
+            if !opaque_b {
+                if let Some(bb_inode) = dh.backend_b_inode {
+                    collect_backend_entries(
+                        fs,
+                        ctx,
+                        BackendId::BackendB,
+                        bb_inode,
+                        guest_inode,
+                        &mut seen,
+                        &mut entries,
+                        &mut off,
+                        &whiteouts,
+                        BackendId::BackendB,
+                    )?;
+                }
+            }
+
+            // Pass 2: backend_a children from dentries.
+            if !opaque_a {
+                collect_dentry_entries(
+                    fs,
+                    guest_inode,
+                    BackendId::BackendA,
+                    &mut seen,
+                    &mut entries,
+                    &mut off,
+                    &whiteouts,
+                );
+            }
+        }
+
+        DualDispatchPlan::MergeReaddir {
+            precedence: BackendChoice::BackendAFirst,
+        } => {
+            // Pass 1: backend_a via readdir.
+            if !opaque_a {
+                if let Some(ba_inode) = dh.backend_a_inode {
+                    collect_backend_entries(
+                        fs,
+                        ctx,
+                        BackendId::BackendA,
+                        ba_inode,
+                        guest_inode,
+                        &mut seen,
+                        &mut entries,
+                        &mut off,
+                        &whiteouts,
+                        BackendId::BackendA,
+                    )?;
+                }
+            }
+
+            // Pass 2: backend_b via readdir.
+            if !opaque_b {
+                if let Some(bb_inode) = dh.backend_b_inode {
+                    collect_backend_entries(
+                        fs,
+                        ctx,
+                        BackendId::BackendB,
+                        bb_inode,
+                        guest_inode,
+                        &mut seen,
+                        &mut entries,
+                        &mut off,
+                        &whiteouts,
+                        BackendId::BackendB,
+                    )?;
+                }
+            }
+        }
+
+        DualDispatchPlan::UseBackendA { .. } => {
+            if !opaque_a {
+                if let Some(ba_inode) = dh.backend_a_inode {
+                    collect_backend_entries(
+                        fs,
+                        ctx,
+                        BackendId::BackendA,
+                        ba_inode,
+                        guest_inode,
+                        &mut seen,
+                        &mut entries,
+                        &mut off,
+                        &whiteouts,
+                        BackendId::BackendA,
+                    )?;
+                }
+            }
+        }
+
+        DualDispatchPlan::UseBackendB { .. } => {
+            if !opaque_b {
+                if let Some(bb_inode) = dh.backend_b_inode {
+                    collect_backend_entries(
+                        fs,
+                        ctx,
+                        BackendId::BackendB,
+                        bb_inode,
+                        guest_inode,
+                        &mut seen,
+                        &mut entries,
+                        &mut off,
+                        &whiteouts,
+                        BackendId::BackendB,
+                    )?;
+                }
+            }
+        }
+
+        _ => {} // Invalid plan — return what we have.
+    }
+
+    Ok(DirSnapshot { entries })
+}
+
+/// Collect entries from a backend via readdir, auto-registering unknown ones.
+#[allow(clippy::too_many_arguments)]
+fn collect_backend_entries(
+    fs: &DualFs,
+    ctx: Context,
+    backend_id: BackendId,
+    backend_inode: u64,
+    guest_parent: u64,
+    seen: &mut HashSet<Vec<u8>>,
+    entries: &mut Vec<MergedDirEntry>,
+    off: &mut u64,
+    whiteouts: &std::collections::HashSet<(u64, Vec<u8>, BackendId)>,
+    hidden_check_backend: BackendId,
+) -> io::Result<()> {
+    let (dir_handle, _) = backend(fs, backend_id).opendir(ctx, backend_inode, 0)?;
+    let dir_handle_val = dir_handle.unwrap_or(0);
+
+    let child_entries = backend(fs, backend_id).readdir(ctx, backend_inode, dir_handle_val, u32::MAX, 0)?;
+    let _ = backend(fs, backend_id).releasedir(ctx, backend_inode, 0, dir_handle_val);
+
+    for entry in child_entries {
+        let name = entry.name.to_vec();
+
+        // Skip . and ..
+        if name == b"." || name == b".." {
+            continue;
+        }
+
+        // Skip staging dir.
+        if guest_parent == ROOT_INODE && name == STAGING_DIR_NAME {
+            continue;
+        }
+
+        // Already seen?
+        if seen.contains(&name) {
+            continue;
+        }
+
+        // Whited out?
+        if whiteouts.contains(&(guest_parent, name.clone(), hidden_check_backend)) {
+            continue;
+        }
+
+        seen.insert(name.clone());
+
+        // Auto-register if needed.
+        if let Some(guest_ino) = auto_register_readdir(
+            fs,
+            ctx,
+            entry.ino,
+            &name,
+            entry.type_,
+            guest_parent,
+            backend_inode,
+            backend_id,
+        ) {
+            entries.push(MergedDirEntry {
+                name,
+                inode: guest_ino,
+                offset: *off,
+                file_type: entry.type_,
+            });
+            *off += 1;
+        }
+    }
+
+    Ok(())
+}
+
+/// Collect entries from dentries for a specific backend side.
+fn collect_dentry_entries(
+    fs: &DualFs,
+    guest_parent: u64,
+    backend_filter: BackendId,
+    seen: &mut HashSet<Vec<u8>>,
+    entries: &mut Vec<MergedDirEntry>,
+    off: &mut u64,
+    whiteouts: &std::collections::HashSet<(u64, Vec<u8>, BackendId)>,
+) {
+    let dentries = fs.state.dentries.read().unwrap();
+    let nodes = fs.state.nodes.read().unwrap();
+
+    for ((parent, name), &child_ino) in dentries.iter() {
+        if *parent != guest_parent {
+            continue;
+        }
+        if seen.contains(name) {
+            continue;
+        }
+        if whiteouts.contains(&(guest_parent, name.clone(), backend_filter)) {
+            continue;
+        }
+
+        let child_node = match nodes.get(&child_ino) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Only include nodes that are on the filter backend or merged.
+        let state = child_node.state.read().unwrap();
+        let include = match (&*state, backend_filter) {
+            (NodeState::BackendA { .. }, BackendId::BackendA) => true,
+            (NodeState::BackendB { .. }, BackendId::BackendB) => true,
+            (NodeState::MergedDir { .. }, _) => true,
+            _ => false,
+        };
+
+        if include {
+            seen.insert(name.clone());
+            entries.push(MergedDirEntry {
+                name: name.clone(),
+                inode: child_ino,
+                offset: *off,
+                file_type: child_node.kind.to_dtype(),
+            });
+            *off += 1;
+        }
+    }
+}
+
+/// Serve readdir results from a snapshot starting at the given offset.
+fn serve_readdir(
+    snapshot: &DirSnapshot,
+    offset: u64,
+) -> io::Result<Vec<DirEntry<'static>>> {
+    let start = snapshot
+        .entries
+        .iter()
+        .position(|e| e.offset > offset)
+        .unwrap_or(snapshot.entries.len());
+
+    let result_entries = &snapshot.entries[start..];
+    if result_entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Bounded-leak: collect all names into one contiguous buffer.
+    let mut names_buf = Vec::new();
+    let mut offsets_vec = Vec::new();
+
+    for entry in result_entries {
+        let name_start = names_buf.len();
+        names_buf.extend_from_slice(&entry.name);
+        offsets_vec.push((name_start, entry.name.len(), entry.inode, entry.offset, entry.file_type));
+    }
+
+    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
+
+    let result: Vec<DirEntry<'static>> = offsets_vec
+        .into_iter()
+        .map(|(name_start, name_len, ino, offset, file_type)| DirEntry {
+            ino,
+            offset,
+            type_: file_type,
+            name: &leaked[name_start..name_start + name_len],
+        })
+        .collect();
+
+    Ok(result)
+}
+
+/// Get a directory handle by guest handle ID.
+fn get_dir_handle(fs: &DualFs, handle: u64) -> io::Result<Arc<DualDirHandle>> {
+    fs.state
+        .dir_handles
+        .read()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))
+}

--- a/crates/filesystem/lib/backends/dualfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/file_ops.rs
@@ -1,0 +1,586 @@
+//! Open, read, write, flush, release for regular files.
+
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::hooks::{
+    DispatchStep, HookCtx, StepResult, decode_ok, decode_open, handle_hook_decision,
+    notify_observers, run_decision_hooks,
+};
+use super::lookup::{backend, get_node, resolve_backend_inode};
+use super::policy::{DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx};
+use super::types::{BackendId, DualHandle, NodeState};
+use super::DualFs;
+use crate::backends::shared::{init_binary, platform};
+use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle open. Full pipeline with policy routing.
+pub(crate) fn do_open(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    kill_priv: bool,
+    flags: u32,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    if ino == init_binary::INIT_INODE {
+        return Ok((Some(init_binary::INIT_HANDLE), OpenOptions::KEEP_CACHE));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+
+    // Adjust flags for writeback cache.
+    let mut flags = flags;
+    if fs.state.writeback.load(Ordering::Relaxed) {
+        if flags & libc::O_WRONLY as u32 != 0 {
+            flags = (flags & !(libc::O_WRONLY as u32)) | libc::O_RDWR as u32;
+        }
+        flags &= !(libc::O_APPEND as u32);
+    }
+
+    let node_state = node.state.read().unwrap().clone();
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Open,
+            guest_inode: ino,
+            node_state: node_state.clone(),
+            file_kind: node.kind,
+            flags,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    // hooks.before_resolve
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_resolve(ctx)),
+        decode_open,
+    ) {
+        return r;
+    }
+
+    let view = DualNamespaceView {
+        state: &fs.state,
+    };
+
+    // hooks.after_resolve
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.after_resolve(ctx, &view)
+        }),
+        decode_open,
+    ) {
+        return r;
+    }
+
+    // hooks.before_plan
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_plan(ctx)),
+        decode_open,
+    ) {
+        return r;
+    }
+
+    let plan = fs.policy.plan(&hook_ctx.req, &view, &hook_ctx.hints)?;
+
+    // hooks.after_plan
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.after_plan(ctx, &plan)
+        }),
+        decode_open,
+    ) {
+        return r;
+    }
+
+    // Dispatch.
+    match plan {
+        DualDispatchPlan::MaterializeToBackendThen {
+            source,
+            target,
+            ..
+        } => {
+            super::materialize::do_materialize(fs, ctx, ino, source, target)?;
+            open_on_backend(fs, ctx, ino, kill_priv, flags, target, &mut hook_ctx)
+        }
+        DualDispatchPlan::UseBackendA { .. } => {
+            open_on_backend(fs, ctx, ino, kill_priv, flags, BackendId::BackendA, &mut hook_ctx)
+        }
+        DualDispatchPlan::UseBackendB { .. } => {
+            open_on_backend(fs, ctx, ino, kill_priv, flags, BackendId::BackendB, &mut hook_ctx)
+        }
+        DualDispatchPlan::Deny { errno } => Err(io::Error::from_raw_os_error(errno)),
+        _ => Err(platform::einval()),
+    }
+}
+
+/// Handle read. Handle-bound dispatch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_read(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    handle: u64,
+    w: &mut dyn ZeroCopyWriter,
+    size: u32,
+    offset: u64,
+    lock_owner: Option<u64>,
+    flags: u32,
+) -> io::Result<usize> {
+    if ino == init_binary::INIT_INODE {
+        return init_binary::read_init(w, &fs.init_file, size, offset);
+    }
+
+    let fh = get_file_handle(fs, handle)?;
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Read,
+            guest_inode: ino,
+            node_state: NodeState::Init, // Placeholder, handle-bound.
+            file_kind: super::types::FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Read,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        super::hooks::decode_usize,
+    ) {
+        return r;
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => fs.backend_a.read(
+            ctx,
+            *backend_a_inode,
+            *backend_a_handle,
+            w,
+            size,
+            offset,
+            lock_owner,
+            flags,
+        ),
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => fs.backend_b.read(
+            ctx,
+            *backend_b_inode,
+            *backend_b_handle,
+            w,
+            size,
+            offset,
+            lock_owner,
+            flags,
+        ),
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(n) => StepResult::Data(*n),
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle write. Handle-bound dispatch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_write(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    handle: u64,
+    r: &mut dyn ZeroCopyReader,
+    size: u32,
+    offset: u64,
+    lock_owner: Option<u64>,
+    delayed_write: bool,
+    kill_priv: bool,
+    flags: u32,
+) -> io::Result<usize> {
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::EACCES));
+    }
+
+    let fh = get_file_handle(fs, handle)?;
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Write,
+            guest_inode: ino,
+            node_state: NodeState::Init,
+            file_kind: super::types::FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Write,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(result) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        super::hooks::decode_usize,
+    ) {
+        return result;
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => fs.backend_a.write(
+            ctx,
+            *backend_a_inode,
+            *backend_a_handle,
+            r,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            kill_priv,
+            flags,
+        ),
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => fs.backend_b.write(
+            ctx,
+            *backend_b_inode,
+            *backend_b_handle,
+            r,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            kill_priv,
+            flags,
+        ),
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(n) => StepResult::Data(*n),
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle flush. Handle-bound dispatch.
+pub(crate) fn do_flush(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    handle: u64,
+    lock_owner: u64,
+) -> io::Result<()> {
+    let fh = get_file_handle(fs, handle)?;
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Flush,
+            guest_inode: ino,
+            node_state: NodeState::Init,
+            file_kind: super::types::FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Flush,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_ok,
+    ) {
+        return r;
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => fs.backend_a.flush(ctx, *backend_a_inode, *backend_a_handle, lock_owner),
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => fs.backend_b.flush(ctx, *backend_b_inode, *backend_b_handle, lock_owner),
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(()) => StepResult::Ok,
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle release. Remove handle from table and delegate with hooks.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_release(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    flags: u32,
+    handle: u64,
+    flush: bool,
+    flock_release: bool,
+    lock_owner: Option<u64>,
+) -> io::Result<()> {
+    let fh = match fs.state.file_handles.write().unwrap().remove(&handle) {
+        Some(fh) => fh,
+        None => return Ok(()),
+    };
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Release,
+            guest_inode: ino,
+            node_state: NodeState::Init, // Placeholder, handle-bound.
+            file_kind: super::types::FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Release,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_ok,
+    ) {
+        return r;
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => {
+            fs.backend_a.release(
+                ctx,
+                *backend_a_inode,
+                flags,
+                *backend_a_handle,
+                flush,
+                flock_release,
+                lock_owner,
+            )
+        }
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => {
+            fs.backend_b.release(
+                ctx,
+                *backend_b_inode,
+                flags,
+                *backend_b_handle,
+                flush,
+                flock_release,
+                lock_owner,
+            )
+        }
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(()) => StepResult::Ok,
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle readlink. Direct dispatch from node state.
+pub(crate) fn do_readlink(fs: &DualFs, ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::einval());
+    }
+
+    let node = get_node(&fs.state, ino)?;
+    let state = node.state.read().unwrap();
+
+    match &*state {
+        NodeState::BackendA {
+            backend_a_inode, ..
+        } => fs.backend_a.readlink(ctx, *backend_a_inode),
+        NodeState::BackendB {
+            backend_b_inode, ..
+        } => fs.backend_b.readlink(ctx, *backend_b_inode),
+        _ => Err(platform::einval()),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Open a file on a specific backend.
+fn open_on_backend(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    kill_priv: bool,
+    flags: u32,
+    target: BackendId,
+    hook_ctx: &mut HookCtx,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    let target_inode = resolve_backend_inode(&fs.state, ino, target)
+        .ok_or_else(platform::einval)?;
+
+    let step = DispatchStep {
+        backend: target,
+        op: OpKind::Open,
+        inode: target_inode,
+        handle: None,
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_open,
+    ) {
+        return r;
+    }
+
+    let (child_handle, opts) = backend(fs, target).open(ctx, target_inode, kill_priv, flags)?;
+    let child_handle_val = child_handle.unwrap_or(0);
+
+    let guest_handle = fs
+        .state
+        .next_handle
+        .fetch_add(1, Ordering::Relaxed);
+
+    let dual_handle = match target {
+        BackendId::BackendA => DualHandle::BackendA {
+            guest_inode: ino,
+            backend_a_inode: target_inode,
+            backend_a_handle: child_handle_val,
+        },
+        BackendId::BackendB => DualHandle::BackendB {
+            guest_inode: ino,
+            backend_b_inode: target_inode,
+            backend_b_handle: child_handle_val,
+        },
+    };
+
+    fs.state
+        .file_handles
+        .write()
+        .unwrap()
+        .insert(guest_handle, Arc::new(dual_handle));
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            hook_ctx,
+            &step,
+            &StepResult::Handle(guest_handle, opts),
+        );
+    });
+
+    Ok((Some(guest_handle), opts))
+}
+
+/// Get a file handle by guest handle ID.
+fn get_file_handle(fs: &DualFs, handle: u64) -> io::Result<Arc<DualHandle>> {
+    fs.state
+        .file_handles
+        .read()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))
+}

--- a/crates/filesystem/lib/backends/dualfs/hooks.rs
+++ b/crates/filesystem/lib/backends/dualfs/hooks.rs
@@ -1,0 +1,341 @@
+//! Lifecycle hooks for DualFs dispatch pipeline.
+//!
+//! Hooks observe and influence dispatch without doing filesystem work.
+//! They run at defined pipeline points and can add hints, deny operations,
+//! or short-circuit responses.
+
+use std::collections::HashMap;
+use std::io;
+use std::time::Duration;
+
+use super::policy::{DualDispatchPlan, DualNamespaceView, HintBag, Hint, OpKind, RequestCtx};
+use super::types::{BackendId, NodeState};
+use crate::{Entry, OpenOptions, stat64};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Lifecycle hooks for observing and influencing dispatch.
+///
+/// All methods default to `Continue` / no-op. Implement only the methods you need.
+#[allow(unused_variables)]
+pub trait DualDispatchHook: Send + Sync {
+    // ── Decision phases (can deny or short-circuit) ──
+
+    /// Before namespace resolution.
+    fn before_resolve(&self, ctx: &mut HookCtx) -> HookDecision {
+        HookDecision::Continue
+    }
+
+    /// After namespace resolution.
+    fn after_resolve(&self, ctx: &mut HookCtx, view: &DualNamespaceView<'_>) -> HookDecision {
+        HookDecision::Continue
+    }
+
+    /// Before policy.plan(). Can add hints to influence the policy.
+    fn before_plan(&self, ctx: &mut HookCtx) -> HookDecision {
+        HookDecision::Continue
+    }
+
+    /// After policy.plan(). Sees the dispatch plan.
+    fn after_plan(&self, ctx: &mut HookCtx, plan: &DualDispatchPlan) -> HookDecision {
+        HookDecision::Continue
+    }
+
+    /// Before backend dispatch. Last chance to deny or short-circuit.
+    fn before_dispatch(&self, ctx: &mut HookCtx, step: &DispatchStep) -> HookDecision {
+        HookDecision::Continue
+    }
+
+    // ── Observer phases (fire-and-forget) ──
+
+    /// After backend dispatch. Observe-only.
+    fn after_dispatch(&self, ctx: &HookCtx, step: &DispatchStep, out: &StepResult) {}
+
+    /// After state commit. Fire-and-forget.
+    fn after_commit(&self, event: &CommitEvent) {}
+
+    /// Pre-return observer. Fire-and-forget.
+    fn after_response(&self, event: &ResponseEvent) {}
+}
+
+/// Mutable context threaded through the hook chain for a single operation.
+pub struct HookCtx {
+    /// The incoming request.
+    pub req: RequestCtx,
+    /// Hints accumulated so far.
+    pub hints: HintBag,
+    /// Operation-level metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+/// The result of a hook invocation.
+#[derive(Debug)]
+pub enum HookDecision {
+    /// Continue to the next hook / pipeline stage.
+    Continue,
+    /// Deny the operation with an errno.
+    Deny(i32),
+    /// Add a hint for the policy.
+    AddHint(Hint),
+    /// Add multiple hints.
+    AddHints(Vec<Hint>),
+    /// Short-circuit the pipeline with a synthetic response.
+    ShortCircuit(SyntheticResponse),
+}
+
+/// Describes a single backend call about to be made.
+#[derive(Debug)]
+pub struct DispatchStep {
+    /// Which backend.
+    pub backend: BackendId,
+    /// Operation kind.
+    pub op: OpKind,
+    /// Child backend inode.
+    pub inode: u64,
+    /// Child backend handle, if applicable.
+    pub handle: Option<u64>,
+}
+
+/// The result of a single backend call.
+#[allow(missing_docs)]
+pub enum StepResult {
+    Ok,
+    Entry(Entry),
+    Attr(stat64, Duration),
+    Handle(u64, OpenOptions),
+    Data(usize),
+    Err(io::Error),
+}
+
+impl std::fmt::Debug for StepResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StepResult::Ok => write!(f, "Ok"),
+            StepResult::Entry(e) => write!(f, "Entry(inode={})", e.inode),
+            StepResult::Attr(_, ttl) => write!(f, "Attr(ttl={:?})", ttl),
+            StepResult::Handle(h, opts) => write!(f, "Handle({}, {:?})", h, opts),
+            StepResult::Data(n) => write!(f, "Data({})", n),
+            StepResult::Err(e) => write!(f, "Err({:?})", e),
+        }
+    }
+}
+
+/// A pre-built response for operations that don't need backend calls.
+pub enum SyntheticResponse {
+    /// Synthetic Entry.
+    Entry(Entry),
+    /// Synthetic attributes.
+    Attr(stat64, Duration),
+    /// Synthetic open handle.
+    Open(Option<u64>, OpenOptions),
+    /// Synthetic read data.
+    Data(Vec<u8>),
+    /// Synthetic readlink target.
+    LinkTarget(Vec<u8>),
+    /// Empty success.
+    Ok,
+}
+
+impl std::fmt::Debug for SyntheticResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SyntheticResponse::Entry(e) => write!(f, "Entry(inode={})", e.inode),
+            SyntheticResponse::Attr(_, ttl) => write!(f, "Attr(ttl={:?})", ttl),
+            SyntheticResponse::Open(h, opts) => write!(f, "Open({:?}, {:?})", h, opts),
+            SyntheticResponse::Data(d) => write!(f, "Data(len={})", d.len()),
+            SyntheticResponse::LinkTarget(t) => write!(f, "LinkTarget(len={})", t.len()),
+            SyntheticResponse::Ok => write!(f, "Ok"),
+        }
+    }
+}
+
+impl Clone for SyntheticResponse {
+    fn clone(&self) -> Self {
+        match self {
+            SyntheticResponse::Entry(e) => SyntheticResponse::Entry(copy_entry(e)),
+            SyntheticResponse::Attr(st, ttl) => SyntheticResponse::Attr(*st, *ttl),
+            SyntheticResponse::Open(h, opts) => SyntheticResponse::Open(*h, *opts),
+            SyntheticResponse::Data(d) => SyntheticResponse::Data(d.clone()),
+            SyntheticResponse::LinkTarget(t) => SyntheticResponse::LinkTarget(t.clone()),
+            SyntheticResponse::Ok => SyntheticResponse::Ok,
+        }
+    }
+}
+
+/// Describes a state change that was committed.
+#[allow(missing_docs)]
+pub struct CommitEvent {
+    /// Operation kind.
+    pub op: OpKind,
+    /// Guest inode.
+    pub guest_inode: u64,
+    /// State transition that occurred (if any).
+    pub transition: Option<(NodeState, NodeState)>,
+    /// Dentries added/removed.
+    pub dentry_changes: Vec<DentryChange>,
+}
+
+/// A single dentry change.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum DentryChange {
+    Added {
+        parent: u64,
+        name: Vec<u8>,
+        child: u64,
+    },
+    Removed {
+        parent: u64,
+        name: Vec<u8>,
+        child: u64,
+    },
+}
+
+/// Describes the final response sent to the guest.
+pub struct ResponseEvent {
+    /// Operation kind.
+    pub op: OpKind,
+    /// Guest inode.
+    pub guest_inode: u64,
+    /// Ok or errno.
+    pub result: Result<(), i32>,
+    /// Latency of the operation.
+    pub latency: Duration,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Run decision hooks (before_resolve through before_dispatch).
+///
+/// Returns the final decision. `AddHint`/`AddHints` are consumed internally.
+pub(crate) fn run_decision_hooks<F>(
+    hooks: &[std::sync::Arc<dyn DualDispatchHook>],
+    ctx: &mut HookCtx,
+    mut invoke: F,
+) -> HookDecision
+where
+    F: FnMut(&dyn DualDispatchHook, &mut HookCtx) -> HookDecision,
+{
+    for hook in hooks {
+        match invoke(hook.as_ref(), ctx) {
+            HookDecision::Continue => continue,
+            HookDecision::Deny(errno) => return HookDecision::Deny(errno),
+            HookDecision::ShortCircuit(resp) => return HookDecision::ShortCircuit(resp),
+            HookDecision::AddHint(h) => {
+                ctx.hints.push(h);
+                continue;
+            }
+            HookDecision::AddHints(hs) => {
+                ctx.hints.extend(hs);
+                continue;
+            }
+        }
+    }
+    HookDecision::Continue
+}
+
+/// Notify observer hooks (fire-and-forget).
+pub(crate) fn notify_observers<F>(
+    hooks: &[std::sync::Arc<dyn DualDispatchHook>],
+    invoke: F,
+) where
+    F: Fn(&dyn DualDispatchHook),
+{
+    for hook in hooks {
+        invoke(hook.as_ref());
+    }
+}
+
+/// Handle a hook decision, returning `ControlFlow` for the caller.
+///
+/// `Continue` -> the caller should proceed.
+/// `Deny` -> return an error.
+/// `ShortCircuit` -> return the synthetic response decoded by `decode`.
+pub(crate) fn handle_hook_decision<T, D>(
+    decision: HookDecision,
+    decode: D,
+) -> std::ops::ControlFlow<io::Result<T>>
+where
+    D: FnOnce(SyntheticResponse) -> io::Result<T>,
+{
+    match decision {
+        HookDecision::Continue => std::ops::ControlFlow::Continue(()),
+        HookDecision::Deny(errno) => {
+            std::ops::ControlFlow::Break(Err(io::Error::from_raw_os_error(errno)))
+        }
+        HookDecision::ShortCircuit(resp) => std::ops::ControlFlow::Break(decode(resp)),
+        // AddHint/AddHints should have been consumed by run_decision_hooks.
+        HookDecision::AddHint(_) | HookDecision::AddHints(_) => std::ops::ControlFlow::Continue(()),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Decoders
+//--------------------------------------------------------------------------------------------------
+
+/// Decode a SyntheticResponse into an Entry.
+pub(crate) fn decode_entry(resp: SyntheticResponse) -> io::Result<Entry> {
+    match resp {
+        SyntheticResponse::Entry(e) => Ok(e),
+        _ => Err(crate::backends::shared::platform::einval()),
+    }
+}
+
+/// Decode a SyntheticResponse into (stat64, Duration).
+pub(crate) fn decode_attr(resp: SyntheticResponse) -> io::Result<(stat64, Duration)> {
+    match resp {
+        SyntheticResponse::Attr(st, ttl) => Ok((st, ttl)),
+        _ => Err(crate::backends::shared::platform::einval()),
+    }
+}
+
+/// Decode a SyntheticResponse into (Option<u64>, OpenOptions).
+pub(crate) fn decode_open(resp: SyntheticResponse) -> io::Result<(Option<u64>, OpenOptions)> {
+    match resp {
+        SyntheticResponse::Open(h, opts) => Ok((h, opts)),
+        _ => Err(crate::backends::shared::platform::einval()),
+    }
+}
+
+/// Decode a SyntheticResponse into Vec<u8>.
+#[allow(dead_code)]
+pub(crate) fn decode_data(resp: SyntheticResponse) -> io::Result<Vec<u8>> {
+    match resp {
+        SyntheticResponse::Data(d) => Ok(d),
+        SyntheticResponse::LinkTarget(d) => Ok(d),
+        _ => Err(crate::backends::shared::platform::einval()),
+    }
+}
+
+/// Decode a SyntheticResponse into ().
+pub(crate) fn decode_ok(resp: SyntheticResponse) -> io::Result<()> {
+    match resp {
+        SyntheticResponse::Ok => Ok(()),
+        _ => Err(crate::backends::shared::platform::einval()),
+    }
+}
+
+/// Decode a SyntheticResponse into usize (for read/write byte counts).
+pub(crate) fn decode_usize(resp: SyntheticResponse) -> io::Result<usize> {
+    match resp {
+        SyntheticResponse::Data(d) => Ok(d.len()),
+        SyntheticResponse::Ok => Ok(0),
+        _ => Err(crate::backends::shared::platform::einval()),
+    }
+}
+
+/// Copy an Entry (all fields are individually Copy but Entry doesn't derive Clone).
+pub(crate) fn copy_entry(e: &Entry) -> Entry {
+    Entry {
+        inode: e.inode,
+        generation: e.generation,
+        attr: e.attr,
+        attr_flags: e.attr_flags,
+        attr_timeout: e.attr_timeout,
+        entry_timeout: e.entry_timeout,
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/lookup.rs
+++ b/crates/filesystem/lib/backends/dualfs/lookup.rs
@@ -1,0 +1,904 @@
+//! Lookup pipeline, REGISTER, whiteout/opaque checking, and backend pin management.
+
+use std::ffi::CStr;
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+
+use super::hooks::{
+    CommitEvent, DentryChange, DispatchStep, HookCtx, StepResult,
+    decode_entry, handle_hook_decision, notify_observers, run_decision_hooks,
+};
+use super::policy::{
+    BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx,
+};
+use super::types::{
+    AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE,
+};
+use super::DualFs;
+use crate::backends::shared::{init_binary, name_validation, platform};
+use crate::{Context, Entry};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Name of the hidden staging directory.
+const STAGING_DIR_NAME: &[u8] = b".dualfs_staging";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the full lookup pipeline.
+pub(crate) fn do_lookup(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+    let name_bytes = name.to_bytes();
+
+    // Handle reserved names at root.
+    if parent == ROOT_INODE {
+        if init_binary::is_init_name(name_bytes) {
+            return Ok(init_binary::init_entry(
+                fs.cfg.entry_timeout,
+                fs.cfg.attr_timeout,
+            ));
+        }
+        if name_bytes == STAGING_DIR_NAME {
+            return Err(platform::enoent());
+        }
+    }
+
+    // Validate name.
+    name_validation::validate_name(name)?;
+
+    // Get parent node.
+    let parent_node = get_node(&fs.state, parent)?;
+    if parent_node.kind != FileKind::Directory {
+        return Err(platform::enotdir());
+    }
+
+    // Dentry cache check.
+    if let Some(entry) = dentry_lookup(fs, parent, name_bytes)? {
+        return Ok(entry);
+    }
+
+    // Build hook context.
+    let node_state = parent_node.state.read().unwrap().clone();
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Lookup,
+            guest_inode: parent,
+            node_state: node_state.clone(),
+            file_kind: parent_node.kind,
+            flags: 0,
+            name: name_bytes.to_vec(),
+            parent_inode: parent,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    // hooks.before_resolve (already resolved dentry above)
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_resolve(ctx)),
+        decode_entry,
+    ) {
+        return r;
+    }
+
+    // hooks.after_resolve
+    let view = DualNamespaceView {
+        state: &fs.state,
+    };
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.after_resolve(ctx, &view)
+        }),
+        decode_entry,
+    ) {
+        return r;
+    }
+
+    // hooks.before_plan
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_plan(ctx)),
+        decode_entry,
+    ) {
+        return r;
+    }
+
+    // Plan.
+    let plan = fs.policy.plan(&hook_ctx.req, &view, &hook_ctx.hints)?;
+
+    // hooks.after_plan
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.after_plan(ctx, &plan)
+        }),
+        decode_entry,
+    ) {
+        return r;
+    }
+
+    // Dispatch.
+    let result = match plan {
+        DualDispatchPlan::MergeLookup { precedence } => {
+            execute_merge_lookup(fs, ctx, parent, name, precedence, &mut hook_ctx)
+        }
+        DualDispatchPlan::UseBackendA { .. } => {
+            // Single-backend lookup (e.g., BackendAOnly policy).
+            execute_single_backend_lookup(
+                fs,
+                ctx,
+                parent,
+                name,
+                BackendId::BackendA,
+                &mut hook_ctx,
+            )
+        }
+        DualDispatchPlan::UseBackendB { .. } => {
+            execute_single_backend_lookup(
+                fs,
+                ctx,
+                parent,
+                name,
+                BackendId::BackendB,
+                &mut hook_ctx,
+            )
+        }
+        DualDispatchPlan::Deny { errno } => Err(io::Error::from_raw_os_error(errno)),
+        _ => Err(platform::einval()),
+    };
+
+    // hooks.after_response
+    notify_observers(&fs.hooks, |h| {
+        h.after_response(&super::hooks::ResponseEvent {
+            op: OpKind::Lookup,
+            guest_inode: parent,
+            result: result.as_ref().map(|_| ()).map_err(|e| {
+                e.raw_os_error().unwrap_or(libc::EIO)
+            }),
+            latency: std::time::Duration::ZERO,
+        });
+    });
+
+    result
+}
+
+/// Handle forget for a single inode.
+pub(crate) fn do_forget(fs: &DualFs, _ctx: Context, ino: u64, count: u64) {
+    if ino == init_binary::INIT_INODE {
+        return;
+    }
+    forget_one(fs, ino, count);
+}
+
+/// Handle batch forget.
+pub(crate) fn do_batch_forget(fs: &DualFs, _ctx: Context, requests: Vec<(u64, u64)>) {
+    for (ino, count) in requests {
+        if ino == init_binary::INIT_INODE {
+            continue;
+        }
+        forget_one(fs, ino, count);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Get a GuestNode by guest inode.
+pub(crate) fn get_node(state: &DualState, ino: u64) -> io::Result<Arc<GuestNode>> {
+    state
+        .nodes
+        .read()
+        .unwrap()
+        .get(&ino)
+        .cloned()
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))
+}
+
+/// Resolve a child backend inode for a given backend.
+pub(crate) fn resolve_backend_inode(state: &DualState, guest_inode: u64, backend: BackendId) -> Option<u64> {
+    let nodes = state.nodes.read().unwrap();
+    let node = nodes.get(&guest_inode)?;
+    node.state.read().unwrap().backend_inode(backend)
+}
+
+/// Resolve the active backend inode for read-only direct-dispatch ops.
+pub(crate) fn resolve_active_backend_inode(node: &GuestNode) -> (BackendId, u64) {
+    let metadata = node.metadata_backend.load(Ordering::Relaxed);
+    let state = node.state.read().unwrap();
+    match &*state {
+        NodeState::Root {
+            backend_a_root,
+            backend_b_root,
+        } => {
+            if metadata == BackendId::BackendB {
+                (BackendId::BackendB, *backend_b_root)
+            } else {
+                (BackendId::BackendA, *backend_a_root)
+            }
+        }
+        NodeState::BackendA {
+            backend_a_inode, ..
+        } => (BackendId::BackendA, *backend_a_inode),
+        NodeState::BackendB {
+            backend_b_inode, ..
+        } => (BackendId::BackendB, *backend_b_inode),
+        NodeState::MergedDir {
+            backend_a_inode,
+            backend_b_inode,
+        } => {
+            if metadata == BackendId::BackendB {
+                (BackendId::BackendB, *backend_b_inode)
+            } else {
+                (BackendId::BackendA, *backend_a_inode)
+            }
+        }
+        NodeState::Init => unreachable!("INIT_INODE handled by caller"),
+    }
+}
+
+/// Get the backend reference from DualFs by BackendId.
+pub(crate) fn backend(fs: &DualFs, id: BackendId) -> &dyn DynFileSystem {
+    match id {
+        BackendId::BackendA => fs.backend_a.as_ref(),
+        BackendId::BackendB => fs.backend_b.as_ref(),
+    }
+}
+
+/// Check if a name is whited out for a specific backend.
+pub(crate) fn is_whited_out(state: &DualState, parent: u64, name: &[u8], hidden_backend: BackendId) -> bool {
+    state.is_whited_out(parent, name, hidden_backend)
+}
+
+/// Check if a directory is opaque against a specific backend.
+pub(crate) fn is_opaque_against(state: &DualState, dir_inode: u64, hidden_backend: BackendId) -> bool {
+    state.is_opaque(dir_inode, hidden_backend)
+}
+
+/// Ensure a directory has presence on the target backend (promote if needed).
+pub(crate) fn ensure_backend_presence(
+    fs: &DualFs,
+    ctx: Context,
+    dir_guest_inode: u64,
+    target: BackendId,
+) -> io::Result<()> {
+    if dir_guest_inode == ROOT_INODE {
+        return Ok(()); // Root always has both.
+    }
+
+    let node = get_node(&fs.state, dir_guest_inode)?;
+    let state = node.state.read().unwrap();
+
+    match &*state {
+        NodeState::Root { .. } | NodeState::MergedDir { .. } => Ok(()),
+        NodeState::BackendA { .. } if target == BackendId::BackendA => Ok(()),
+        NodeState::BackendB { .. } if target == BackendId::BackendB => Ok(()),
+        NodeState::BackendA { .. } | NodeState::BackendB { .. } => {
+            drop(state);
+            super::materialize::promote_directory_to_merged(fs, ctx, dir_guest_inode, target)
+        }
+        NodeState::Init => Err(platform::enotdir()),
+    }
+}
+
+/// Ensure a node's deferred alias linkage is consistent before target-side mutation.
+///
+/// Readdir auto-registration creates dentry/alias entries lazily. Before performing
+/// a target-side unlink or rename, confirm that the alias index includes the
+/// (parent, name) link so anchor repair and eviction logic have accurate data.
+pub(crate) fn ensure_alias_linked(
+    state: &DualState,
+    guest_inode: u64,
+    parent: u64,
+    name: &[u8],
+) -> io::Result<()> {
+    // Verify the dentry exists.
+    let exists = state
+        .dentries
+        .read()
+        .unwrap()
+        .contains_key(&(parent, name.to_vec()));
+    if !exists {
+        return Err(io::Error::from_raw_os_error(libc::ENOENT));
+    }
+
+    // Ensure alias_index includes this link (may have been deferred).
+    state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(guest_inode)
+        .or_default()
+        .insert((parent, name.to_vec()));
+
+    Ok(())
+}
+
+/// Mark metadata authority on a node.
+pub(crate) fn mark_metadata_authority(state: &DualState, guest_inode: u64, target: BackendId) {
+    if let Some(node) = state.nodes.read().unwrap().get(&guest_inode) {
+        node.metadata_backend.store(target, Ordering::Relaxed);
+    }
+}
+
+/// Dentry lookup — returns an Entry if the name is already registered.
+fn dentry_lookup(fs: &DualFs, parent: u64, name: &[u8]) -> io::Result<Option<Entry>> {
+    let child_ino = {
+        let dentries = fs.state.dentries.read().unwrap();
+        match dentries.get(&(parent, name.to_vec())) {
+            Some(&ino) => ino,
+            None => return Ok(None),
+        }
+    };
+
+    let node = get_node(&fs.state, child_ino)?;
+    node.lookup_refs.fetch_add(1, Ordering::Relaxed);
+
+    // Get attrs from active backend.
+    let st = get_child_attrs(fs, &node, child_ino)?;
+
+    Ok(Some(Entry {
+        inode: child_ino,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    }))
+}
+
+/// Get attributes of a child node from its active backend.
+fn get_child_attrs(fs: &DualFs, node: &GuestNode, guest_inode: u64) -> io::Result<crate::stat64> {
+    if guest_inode == init_binary::INIT_INODE {
+        return Ok(init_binary::init_stat());
+    }
+
+    let state = node.state.read().unwrap();
+    match &*state {
+        NodeState::Init => Ok(init_binary::init_stat()),
+        _ => {
+            let (backend_id, child_inode) = match &*state {
+                NodeState::Root {
+                    backend_a_root, ..
+                } => (BackendId::BackendA, *backend_a_root),
+                NodeState::BackendA {
+                    backend_a_inode, ..
+                } => (BackendId::BackendA, *backend_a_inode),
+                NodeState::BackendB {
+                    backend_b_inode, ..
+                } => (BackendId::BackendB, *backend_b_inode),
+                NodeState::MergedDir {
+                    backend_a_inode, ..
+                } => {
+                    let md = node.metadata_backend.load(Ordering::Relaxed);
+                    if md == BackendId::BackendB {
+                        (BackendId::BackendB, state.backend_inode(BackendId::BackendB).unwrap())
+                    } else {
+                        (BackendId::BackendA, *backend_a_inode)
+                    }
+                }
+                NodeState::Init => unreachable!(),
+            };
+            drop(state);
+
+            let ctx = Context { uid: 0, gid: 0, pid: 0 };
+            let (mut st, _) = backend(fs, backend_id).getattr(ctx, child_inode, None)?;
+            st.st_ino = guest_inode;
+            Ok(st)
+        }
+    }
+}
+
+/// Execute merge lookup with precedence order.
+fn execute_merge_lookup(
+    fs: &DualFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    precedence: BackendChoice,
+    hook_ctx: &mut HookCtx,
+) -> io::Result<Entry> {
+    let name_bytes = name.to_bytes();
+
+    let (first_id, second_id) = match precedence {
+        BackendChoice::BackendBFirst => (BackendId::BackendB, BackendId::BackendA),
+        BackendChoice::BackendAFirst => (BackendId::BackendA, BackendId::BackendB),
+    };
+
+    // Try preferred backend.
+    if !is_whited_out(&fs.state, parent, name_bytes, first_id)
+        && !is_opaque_against(&fs.state, parent, first_id)
+    {
+        if let Some(first_parent) = resolve_backend_inode(&fs.state, parent, first_id) {
+            let step = DispatchStep {
+                backend: first_id,
+                op: OpKind::Lookup,
+                inode: first_parent,
+                handle: None,
+            };
+
+            if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+                run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
+                    h.before_dispatch(ctx, &step)
+                }),
+                decode_entry,
+            ) {
+                return r;
+            }
+
+            match backend(fs, first_id).lookup(ctx, first_parent, name) {
+                Ok(entry) => {
+                    notify_observers(&fs.hooks, |h| {
+                        h.after_dispatch(hook_ctx, &step, &StepResult::Entry(super::hooks::copy_entry(&entry)));
+                    });
+                    return register(fs, ctx, entry, parent, name_bytes, first_id);
+                }
+                Err(e) if e.raw_os_error() == Some(libc::ENOENT) => {
+                    notify_observers(&fs.hooks, |h| {
+                        h.after_dispatch(
+                            hook_ctx,
+                            &step,
+                            &StepResult::Err(io::Error::from_raw_os_error(libc::ENOENT)),
+                        );
+                    });
+                    // Fall through to second backend.
+                }
+                Err(e) => {
+                    notify_observers(&fs.hooks, |h| {
+                        h.after_dispatch(
+                            hook_ctx,
+                            &step,
+                            &StepResult::Err(io::Error::from_raw_os_error(
+                                e.raw_os_error().unwrap_or(libc::EIO),
+                            )),
+                        );
+                    });
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    // Try other backend.
+    if is_whited_out(&fs.state, parent, name_bytes, second_id)
+        || is_opaque_against(&fs.state, parent, second_id)
+    {
+        return Err(platform::enoent());
+    }
+
+    if let Some(second_parent) = resolve_backend_inode(&fs.state, parent, second_id) {
+        let step = DispatchStep {
+            backend: second_id,
+            op: OpKind::Lookup,
+            inode: second_parent,
+            handle: None,
+        };
+
+        if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+            run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
+                h.before_dispatch(ctx, &step)
+            }),
+            decode_entry,
+        ) {
+            return r;
+        }
+
+        match backend(fs, second_id).lookup(ctx, second_parent, name) {
+            Ok(entry) => {
+                notify_observers(&fs.hooks, |h| {
+                    h.after_dispatch(hook_ctx, &step, &StepResult::Entry(super::hooks::copy_entry(&entry)));
+                });
+                return register(fs, ctx, entry, parent, name_bytes, second_id);
+            }
+            Err(e) => {
+                notify_observers(&fs.hooks, |h| {
+                    h.after_dispatch(
+                        hook_ctx,
+                        &step,
+                        &StepResult::Err(io::Error::from_raw_os_error(
+                            e.raw_os_error().unwrap_or(libc::EIO),
+                        )),
+                    );
+                });
+                return Err(e);
+            }
+        }
+    }
+
+    Err(platform::enoent())
+}
+
+/// Execute single-backend lookup (for BackendAOnly-style policies).
+fn execute_single_backend_lookup(
+    fs: &DualFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    backend_id: BackendId,
+    hook_ctx: &mut HookCtx,
+) -> io::Result<Entry> {
+    let name_bytes = name.to_bytes();
+
+    let parent_inode = resolve_backend_inode(&fs.state, parent, backend_id)
+        .ok_or_else(platform::enoent)?;
+
+    let step = DispatchStep {
+        backend: backend_id,
+        op: OpKind::Lookup,
+        inode: parent_inode,
+        handle: None,
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_entry,
+    ) {
+        return r;
+    }
+
+    match backend(fs, backend_id).lookup(ctx, parent_inode, name) {
+        Ok(entry) => {
+            notify_observers(&fs.hooks, |h| {
+                h.after_dispatch(hook_ctx, &step, &StepResult::Entry(super::hooks::copy_entry(&entry)));
+            });
+            register(fs, ctx, entry, parent, name_bytes, backend_id)
+        }
+        Err(e) => {
+            notify_observers(&fs.hooks, |h| {
+                h.after_dispatch(
+                    hook_ctx,
+                    &step,
+                    &StepResult::Err(io::Error::from_raw_os_error(
+                        e.raw_os_error().unwrap_or(libc::EIO),
+                    )),
+                );
+            });
+            Err(e)
+        }
+    }
+}
+
+/// REGISTER: assign a guest inode for a discovered child backend entry.
+pub(crate) fn register(
+    fs: &DualFs,
+    _ctx: Context,
+    child_entry: Entry,
+    parent: u64,
+    name: &[u8],
+    source: BackendId,
+) -> io::Result<Entry> {
+    let inode_map = fs.state.inode_map(source);
+
+    // Check hardlink dedup.
+    {
+        let map = inode_map.read().unwrap();
+        if let Some(&guest_inode) = map.get(&child_entry.inode) {
+            let nodes = fs.state.nodes.read().unwrap();
+            if let Some(existing_node) = nodes.get(&guest_inode) {
+                existing_node.lookup_refs.fetch_add(1, Ordering::Relaxed);
+
+                // Record dentry and alias.
+                drop(nodes);
+                fs.state
+                    .dentries
+                    .write()
+                    .unwrap()
+                    .insert((parent, name.to_vec()), guest_inode);
+                fs.state
+                    .alias_index
+                    .write()
+                    .unwrap()
+                    .entry(guest_inode)
+                    .or_default()
+                    .insert((parent, name.to_vec()));
+
+                // Immediately forget the transient lookup ref.
+                backend(fs, source).forget(
+                    Context { uid: 0, gid: 0, pid: 0 },
+                    child_entry.inode,
+                    1,
+                );
+
+                let mut st = child_entry.attr;
+                st.st_ino = guest_inode;
+
+                return Ok(Entry {
+                    inode: guest_inode,
+                    generation: 0,
+                    attr: st,
+                    attr_flags: 0,
+                    attr_timeout: fs.cfg.attr_timeout,
+                    entry_timeout: fs.cfg.entry_timeout,
+                });
+            }
+        }
+    }
+
+    // New entry — assign a guest inode.
+    let guest_inode = fs
+        .state
+        .next_inode
+        .fetch_add(1, Ordering::Relaxed);
+    let kind = FileKind::from_mode(child_entry.attr.st_mode as u32);
+
+    let node_state = match source {
+        BackendId::BackendA => NodeState::BackendA {
+            backend_a_inode: child_entry.inode,
+            former_backend_b_inode: None,
+        },
+        BackendId::BackendB => NodeState::BackendB {
+            backend_b_inode: child_entry.inode,
+            former_backend_a_inode: None,
+        },
+    };
+
+    let node = Arc::new(GuestNode {
+        guest_inode,
+        kind,
+        lookup_refs: std::sync::atomic::AtomicU64::new(1),
+        anchor_parent: std::sync::atomic::AtomicU64::new(parent),
+        anchor_name: std::sync::RwLock::new(name.to_vec()),
+        metadata_backend: AtomicBackendId::new(source),
+        state: std::sync::RwLock::new(node_state),
+        copy_up_lock: Mutex::new(()),
+    });
+
+    fs.state
+        .nodes
+        .write()
+        .unwrap()
+        .insert(guest_inode, node);
+    inode_map
+        .write()
+        .unwrap()
+        .insert(child_entry.inode, guest_inode);
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .insert((parent, name.to_vec()), guest_inode);
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(guest_inode)
+        .or_default()
+        .insert((parent, name.to_vec()));
+
+    // hooks.after_commit
+    notify_observers(&fs.hooks, |h| {
+        h.after_commit(&CommitEvent {
+            op: OpKind::Lookup,
+            guest_inode,
+            transition: None,
+            dentry_changes: vec![DentryChange::Added {
+                parent,
+                name: name.to_vec(),
+                child: guest_inode,
+            }],
+        });
+    });
+
+    let mut st = child_entry.attr;
+    st.st_ino = guest_inode;
+
+    Ok(Entry {
+        inode: guest_inode,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    })
+}
+
+/// Auto-register a backend entry discovered via readdir.
+pub(crate) fn auto_register_readdir(
+    fs: &DualFs,
+    ctx: Context,
+    backend_inode: u64,
+    name: &[u8],
+    dtype: u32,
+    guest_parent: u64,
+    anchor_parent_inode: u64,
+    source: BackendId,
+) -> Option<u64> {
+    // Skip internal staging directory.
+    if guest_parent == ROOT_INODE && name == STAGING_DIR_NAME {
+        return None;
+    }
+
+    let inode_map = fs.state.inode_map(source);
+
+    // Already known?
+    {
+        let map = inode_map.read().unwrap();
+        if let Some(&guest_ino) = map.get(&backend_inode) {
+            return Some(guest_ino);
+        }
+    }
+
+    // Acquire retained child pin via explicit lookup.
+    let cname = match std::ffi::CString::new(name) {
+        Ok(c) => c,
+        Err(_) => return None,
+    };
+    let _pin_entry = match backend(fs, source).lookup(ctx, anchor_parent_inode, &cname) {
+        Ok(e) => e,
+        Err(_) => return None,
+    };
+
+    let guest_ino = fs
+        .state
+        .next_inode
+        .fetch_add(1, Ordering::Relaxed);
+    let kind = FileKind::from_dtype(dtype);
+
+    let node_state = match source {
+        BackendId::BackendA => NodeState::BackendA {
+            backend_a_inode: backend_inode,
+            former_backend_b_inode: None,
+        },
+        BackendId::BackendB => NodeState::BackendB {
+            backend_b_inode: backend_inode,
+            former_backend_a_inode: None,
+        },
+    };
+
+    let node = Arc::new(GuestNode {
+        guest_inode: guest_ino,
+        kind,
+        lookup_refs: std::sync::atomic::AtomicU64::new(0),
+        anchor_parent: std::sync::atomic::AtomicU64::new(guest_parent),
+        anchor_name: std::sync::RwLock::new(name.to_vec()),
+        metadata_backend: AtomicBackendId::new(source),
+        state: std::sync::RwLock::new(node_state),
+        copy_up_lock: Mutex::new(()),
+    });
+
+    fs.state
+        .nodes
+        .write()
+        .unwrap()
+        .insert(guest_ino, node);
+    inode_map
+        .write()
+        .unwrap()
+        .insert(backend_inode, guest_ino);
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .insert((guest_parent, name.to_vec()), guest_ino);
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(guest_ino)
+        .or_default()
+        .insert((guest_parent, name.to_vec()));
+
+    Some(guest_ino)
+}
+
+/// Forget one guest inode ref-count, evicting if appropriate.
+fn forget_one(fs: &DualFs, ino: u64, count: u64) {
+    let node = match fs.state.nodes.read().unwrap().get(&ino).cloned() {
+        Some(n) => n,
+        None => return,
+    };
+
+    // CAS loop to prevent wrapping underflow.
+    let new = loop {
+        let old = node.lookup_refs.load(Ordering::Relaxed);
+        let new = old.saturating_sub(count);
+        match node
+            .lookup_refs
+            .compare_exchange(old, new, Ordering::Release, Ordering::Relaxed)
+        {
+            Ok(_) => break new,
+            Err(_) => continue,
+        }
+    };
+
+    if new == 0 {
+        // Check if no aliases remain.
+        let aliases_empty = fs
+            .state
+            .alias_index
+            .read()
+            .unwrap()
+            .get(&ino)
+            .map_or(true, |s| s.is_empty());
+
+        if aliases_empty {
+            // Evict: release retained child pins.
+            let state = node.state.read().unwrap();
+            match &*state {
+                NodeState::BackendA {
+                    backend_a_inode,
+                    former_backend_b_inode,
+                } => {
+                    let ba_ino = *backend_a_inode;
+                    let former = *former_backend_b_inode;
+                    drop(state);
+
+                    fs.backend_a
+                        .forget(Context { uid: 0, gid: 0, pid: 0 }, ba_ino, 1);
+                    fs.state
+                        .backend_a_inode_map
+                        .write()
+                        .unwrap()
+                        .remove(&ba_ino);
+                    if let Some(sec_ino) = former {
+                        fs.state
+                            .backend_b_inode_map
+                            .write()
+                            .unwrap()
+                            .remove(&sec_ino);
+                    }
+                }
+                NodeState::BackendB {
+                    backend_b_inode,
+                    former_backend_a_inode,
+                } => {
+                    let bb_ino = *backend_b_inode;
+                    let former = *former_backend_a_inode;
+                    drop(state);
+
+                    fs.backend_b
+                        .forget(Context { uid: 0, gid: 0, pid: 0 }, bb_ino, 1);
+                    fs.state
+                        .backend_b_inode_map
+                        .write()
+                        .unwrap()
+                        .remove(&bb_ino);
+                    if let Some(pri_ino) = former {
+                        fs.state
+                            .backend_a_inode_map
+                            .write()
+                            .unwrap()
+                            .remove(&pri_ino);
+                    }
+                }
+                NodeState::MergedDir {
+                    backend_a_inode,
+                    backend_b_inode,
+                } => {
+                    let ba_ino = *backend_a_inode;
+                    let bb_ino = *backend_b_inode;
+                    drop(state);
+
+                    fs.backend_a
+                        .forget(Context { uid: 0, gid: 0, pid: 0 }, ba_ino, 1);
+                    fs.state
+                        .backend_a_inode_map
+                        .write()
+                        .unwrap()
+                        .remove(&ba_ino);
+                    fs.backend_b
+                        .forget(Context { uid: 0, gid: 0, pid: 0 }, bb_ino, 1);
+                    fs.state
+                        .backend_b_inode_map
+                        .write()
+                        .unwrap()
+                        .remove(&bb_ino);
+                }
+                NodeState::Root { .. } | NodeState::Init => {
+                    drop(state);
+                    // Root and Init are never evicted.
+                    return;
+                }
+            }
+
+            fs.state.nodes.write().unwrap().remove(&ino);
+            fs.state.alias_index.write().unwrap().remove(&ino);
+        }
+    }
+}
+
+use crate::DynFileSystem;

--- a/crates/filesystem/lib/backends/dualfs/materialize.rs
+++ b/crates/filesystem/lib/backends/dualfs/materialize.rs
@@ -1,0 +1,613 @@
+//! Materialization orchestration: chunked streaming, directory promotion,
+//! ancestor materialization.
+
+use std::ffi::CString;
+use std::io;
+use std::sync::atomic::Ordering;
+use super::lookup::{backend, get_node, resolve_backend_inode};
+use super::types::{BackendId, FileKind, NodeState, ROOT_INODE};
+use super::DualFs;
+use crate::{Context, Extensions, SetattrValid};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Materialize a guest inode from source backend to target backend.
+///
+/// After completion, the node is single-backed on the target backend.
+pub(crate) fn do_materialize(
+    fs: &DualFs,
+    ctx: Context,
+    guest_inode: u64,
+    source: BackendId,
+    target: BackendId,
+) -> io::Result<()> {
+    let node = get_node(&fs.state, guest_inode)?;
+
+    // Fast check: already on target?
+    {
+        let state = node.state.read().unwrap();
+        if state.backend_inode(target).is_some() && state.current_backend() == Some(target) {
+            return Ok(());
+        }
+    }
+
+    // Acquire copy_up_lock.
+    let _lock = node.copy_up_lock.lock().unwrap();
+
+    // Double-check under lock.
+    {
+        let state = node.state.read().unwrap();
+        if state.current_backend() == Some(target) {
+            return Ok(());
+        }
+    }
+
+    // Get source inode.
+    let source_inode = {
+        let state = node.state.read().unwrap();
+        state
+            .backend_inode(source)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?
+    };
+
+    // Ensure ancestors are present on target.
+    ensure_ancestors(fs, ctx, guest_inode, target)?;
+
+    // Resolve parent's inode on target.
+    let (parent_ino, name) = {
+        let alias = fs
+            .state
+            .alias_index
+            .read()
+            .unwrap()
+            .get(&guest_inode)
+            .and_then(|s| s.iter().next().cloned())
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+        alias
+    };
+
+    let parent_target_inode = resolve_backend_inode(&fs.state, parent_ino, target)
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+    let cname = CString::new(name.clone())
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // Copy based on file type.
+    let target_inode = match node.kind {
+        FileKind::RegularFile => {
+            materialize_regular_file(fs, ctx, source, target, source_inode, parent_target_inode, &cname, guest_inode)?
+        }
+        FileKind::Symlink => {
+            materialize_symlink(fs, ctx, source, target, source_inode, parent_target_inode, &cname)?
+        }
+        FileKind::Special => {
+            materialize_special(fs, ctx, source, target, source_inode, parent_target_inode, &cname)?
+        }
+        FileKind::Directory => {
+            // Directories are handled by promote_directory_to_merged, not materialize.
+            return Err(io::Error::from_raw_os_error(libc::EISDIR));
+        }
+    };
+
+    // Transition state.
+    let state_before = node.state.read().unwrap().clone();
+    let new_state = match target {
+        BackendId::BackendA => NodeState::BackendA {
+            backend_a_inode: target_inode,
+            former_backend_b_inode: Some(source_inode),
+        },
+        BackendId::BackendB => NodeState::BackendB {
+            backend_b_inode: target_inode,
+            former_backend_a_inode: Some(source_inode),
+        },
+    };
+    *node.state.write().unwrap() = new_state;
+    node.metadata_backend.store(target, Ordering::Relaxed);
+
+    // Register target inode in dedup map.
+    fs.state
+        .inode_map(target)
+        .write()
+        .unwrap()
+        .insert(target_inode, guest_inode);
+
+    // Release retained source pin.
+    backend(fs, source).forget(Context { uid: 0, gid: 0, pid: 0 }, source_inode, 1);
+
+    // hooks.after_commit
+    super::hooks::notify_observers(&fs.hooks, |h| {
+        h.after_commit(&super::hooks::CommitEvent {
+            op: super::policy::OpKind::Open,
+            guest_inode,
+            transition: Some((state_before.clone(), node.state.read().unwrap().clone())),
+            dentry_changes: vec![],
+        });
+    });
+
+    Ok(())
+}
+
+/// Promote a single-backed directory to MergedDir.
+pub(crate) fn promote_directory_to_merged(
+    fs: &DualFs,
+    ctx: Context,
+    guest_inode: u64,
+    target: BackendId,
+) -> io::Result<()> {
+    let node = get_node(&fs.state, guest_inode)?;
+
+    let (src_backend, src_inode) = {
+        let state = node.state.read().unwrap();
+        match &*state {
+            NodeState::MergedDir { .. } | NodeState::Root { .. } => return Ok(()),
+            NodeState::BackendA { backend_a_inode, .. } if target == BackendId::BackendA => {
+                return Ok(());
+            }
+            NodeState::BackendB { backend_b_inode, .. } if target == BackendId::BackendB => {
+                return Ok(());
+            }
+            NodeState::BackendA { backend_a_inode, .. } => {
+                (BackendId::BackendA, *backend_a_inode)
+            }
+            NodeState::BackendB { backend_b_inode, .. } => {
+                (BackendId::BackendB, *backend_b_inode)
+            }
+            NodeState::Init => return Err(io::Error::from_raw_os_error(libc::ENOTDIR)),
+        }
+    };
+
+    // Get source metadata.
+    let (src_stat, _) = backend(fs, src_backend).getattr(ctx, src_inode, None)?;
+
+    // Resolve parent on target.
+    let (parent_ino, name) = fs
+        .state
+        .alias_index
+        .read()
+        .unwrap()
+        .get(&guest_inode)
+        .and_then(|s| s.iter().next().cloned())
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+    // Ensure parent has target presence (recursive, root-to-leaf).
+    ensure_backend_presence_recursive(fs, ctx, parent_ino, target)?;
+
+    let parent_target_inode = resolve_backend_inode(&fs.state, parent_ino, target)
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+    let cname = CString::new(name)
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // Create directory in target backend.
+    let mode = (src_stat.st_mode as u32) & 0o7777;
+    let entry = backend(fs, target).mkdir(ctx, parent_target_inode, &cname, mode, 0, Extensions::default())?;
+
+    // Copy xattrs.
+    copy_xattrs(fs, ctx, src_backend, src_inode, target, entry.inode)?;
+
+    // Copy timestamps and ownership.
+    copy_metadata(fs, ctx, target, entry.inode, &src_stat)?;
+
+    // Transition to MergedDir.
+    let new_state = match (target, src_backend) {
+        (BackendId::BackendA, BackendId::BackendB) => NodeState::MergedDir {
+            backend_a_inode: entry.inode,
+            backend_b_inode: src_inode,
+        },
+        (BackendId::BackendB, BackendId::BackendA) => NodeState::MergedDir {
+            backend_a_inode: src_inode,
+            backend_b_inode: entry.inode,
+        },
+        _ => unreachable!("promotion requires opposite backends"),
+    };
+
+    *node.state.write().unwrap() = new_state;
+    node.metadata_backend.store(target, Ordering::Relaxed);
+
+    // Register target inode.
+    fs.state
+        .inode_map(target)
+        .write()
+        .unwrap()
+        .insert(entry.inode, guest_inode);
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Ensure all ancestors of a guest inode have presence on the target backend.
+fn ensure_ancestors(
+    fs: &DualFs,
+    ctx: Context,
+    guest_inode: u64,
+    target: BackendId,
+) -> io::Result<()> {
+    // Walk from inode up to root, collecting ancestors.
+    let mut ancestors = Vec::new();
+    let mut current = guest_inode;
+
+    while current != ROOT_INODE {
+        let alias = fs
+            .state
+            .alias_index
+            .read()
+            .unwrap()
+            .get(&current)
+            .and_then(|s| s.iter().next().cloned());
+
+        match alias {
+            Some((parent, _)) => {
+                ancestors.push(parent);
+                current = parent;
+            }
+            None => break,
+        }
+    }
+
+    // Process root-to-leaf (skip root itself — always has both).
+    ancestors.reverse();
+    for &ancestor in &ancestors {
+        if ancestor == ROOT_INODE {
+            continue;
+        }
+        let node = match fs.state.nodes.read().unwrap().get(&ancestor).cloned() {
+            Some(n) => n,
+            None => continue,
+        };
+        let needs_promotion = {
+            let state = node.state.read().unwrap();
+            match &*state {
+                NodeState::MergedDir { .. } | NodeState::Root { .. } => false,
+                NodeState::BackendA { .. } if target == BackendId::BackendA => false,
+                NodeState::BackendB { .. } if target == BackendId::BackendB => false,
+                _ => node.kind == FileKind::Directory,
+            }
+        };
+        if needs_promotion {
+            promote_directory_to_merged(fs, ctx, ancestor, target)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Recursively ensure backend presence (used by promotion itself).
+fn ensure_backend_presence_recursive(
+    fs: &DualFs,
+    ctx: Context,
+    guest_inode: u64,
+    target: BackendId,
+) -> io::Result<()> {
+    if guest_inode == ROOT_INODE {
+        return Ok(());
+    }
+
+    let node = match fs.state.nodes.read().unwrap().get(&guest_inode).cloned() {
+        Some(n) => n,
+        None => return Err(io::Error::from_raw_os_error(libc::ENOENT)),
+    };
+
+    let needs_promotion = {
+        let state = node.state.read().unwrap();
+        match &*state {
+            NodeState::MergedDir { .. } | NodeState::Root { .. } => false,
+            NodeState::BackendA { .. } if target == BackendId::BackendA => false,
+            NodeState::BackendB { .. } if target == BackendId::BackendB => false,
+            _ => node.kind == FileKind::Directory,
+        }
+    };
+
+    if needs_promotion {
+        // Ensure parent first.
+        let parent_ino = fs
+            .state
+            .alias_index
+            .read()
+            .unwrap()
+            .get(&guest_inode)
+            .and_then(|s| s.iter().next().map(|(p, _)| *p))
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+        ensure_backend_presence_recursive(fs, ctx, parent_ino, target)?;
+        promote_directory_to_merged(fs, ctx, guest_inode, target)?;
+    }
+
+    Ok(())
+}
+
+/// Materialize a regular file.
+fn materialize_regular_file(
+    fs: &DualFs,
+    ctx: Context,
+    source: BackendId,
+    target: BackendId,
+    source_inode: u64,
+    parent_target_inode: u64,
+    name: &std::ffi::CStr,
+    guest_inode: u64,
+) -> io::Result<u64> {
+    // Read source metadata.
+    let (src_stat, _) = backend(fs, source).getattr(ctx, source_inode, None)?;
+    let file_size = src_stat.st_size as u64;
+
+    // Create temp file in staging directory.
+    let staging_inode = *fs
+        .state
+        .staging_dirs
+        .read()
+        .unwrap()
+        .get(&target)
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EIO))?;
+
+    let temp_name_str = format!("tmp_{}", guest_inode);
+    let temp_name = CString::new(temp_name_str)
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    let mode = (src_stat.st_mode as u32) & 0o7777;
+    let (temp_entry, temp_handle, _) = backend(fs, target).create(
+        ctx,
+        staging_inode,
+        &temp_name,
+        mode,
+        false,
+        libc::O_WRONLY as u32,
+        0,
+        Extensions::default(),
+    )?;
+
+    // Stream data from source to target in chunks.
+    if file_size > 0 {
+        let (src_handle, _) = backend(fs, source).open(ctx, source_inode, false, libc::O_RDONLY as u32)?;
+        let src_handle = src_handle.unwrap_or(0);
+
+        let mut offset = 0u64;
+        while offset < file_size {
+            let chunk_size = std::cmp::min(fs.cfg.copy_chunk_size as u64, file_size - offset) as u32;
+
+            // Use a pipe/staging approach: read from source, write to target.
+            // We use the init_file as a staging buffer for the transfer.
+            let staging = &fs.init_file;
+            let _read_bytes = backend(fs, source).read(
+                ctx,
+                source_inode,
+                src_handle,
+                &mut StagingWriter { file: staging },
+                chunk_size,
+                offset,
+                None,
+                0,
+            )?;
+
+            let write_handle = temp_handle.unwrap_or(0);
+            let _write_bytes = backend(fs, target).write(
+                ctx,
+                temp_entry.inode,
+                write_handle,
+                &mut StagingReader {
+                    file: staging,
+                    size: _read_bytes,
+                },
+                _read_bytes as u32,
+                offset,
+                None,
+                false,
+                false,
+                0,
+            )?;
+
+            offset += chunk_size as u64;
+        }
+
+        backend(fs, source).release(ctx, source_inode, 0, src_handle, false, false, None)?;
+    }
+
+    let temp_handle_val = temp_handle.unwrap_or(0);
+    backend(fs, target).release(ctx, temp_entry.inode, 0, temp_handle_val, false, false, None)?;
+
+    // Copy xattrs.
+    copy_xattrs(fs, ctx, source, source_inode, target, temp_entry.inode)?;
+
+    // Copy timestamps and ownership.
+    copy_metadata(fs, ctx, target, temp_entry.inode, &src_stat)?;
+
+    // Install: rename from staging to final location.
+    backend(fs, target).rename(ctx, staging_inode, &temp_name, parent_target_inode, name, 0)?;
+
+    Ok(temp_entry.inode)
+}
+
+/// Materialize a symlink.
+fn materialize_symlink(
+    fs: &DualFs,
+    ctx: Context,
+    source: BackendId,
+    target: BackendId,
+    source_inode: u64,
+    parent_target_inode: u64,
+    name: &std::ffi::CStr,
+) -> io::Result<u64> {
+    let link_target = backend(fs, source).readlink(ctx, source_inode)?;
+    let (src_stat, _) = backend(fs, source).getattr(ctx, source_inode, None)?;
+
+    let link_cstr = CString::new(link_target)
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    let entry = backend(fs, target).symlink(
+        ctx,
+        &link_cstr,
+        parent_target_inode,
+        name,
+        Extensions::default(),
+    )?;
+
+    copy_xattrs(fs, ctx, source, source_inode, target, entry.inode)?;
+    copy_metadata(fs, ctx, target, entry.inode, &src_stat)?;
+
+    Ok(entry.inode)
+}
+
+/// Materialize a special file (FIFO, socket, block/char device).
+fn materialize_special(
+    fs: &DualFs,
+    ctx: Context,
+    source: BackendId,
+    target: BackendId,
+    source_inode: u64,
+    parent_target_inode: u64,
+    name: &std::ffi::CStr,
+) -> io::Result<u64> {
+    let (src_stat, _) = backend(fs, source).getattr(ctx, source_inode, None)?;
+
+    let entry = backend(fs, target).mknod(
+        ctx,
+        parent_target_inode,
+        name,
+        src_stat.st_mode as u32,
+        src_stat.st_rdev as u32,
+        0,
+        Extensions::default(),
+    )?;
+
+    copy_xattrs(fs, ctx, source, source_inode, target, entry.inode)?;
+    copy_metadata(fs, ctx, target, entry.inode, &src_stat)?;
+
+    Ok(entry.inode)
+}
+
+/// Copy xattrs from source to target.
+fn copy_xattrs(
+    fs: &DualFs,
+    ctx: Context,
+    source: BackendId,
+    source_inode: u64,
+    target: BackendId,
+    target_inode: u64,
+) -> io::Result<()> {
+    let list = match backend(fs, source).listxattr(ctx, source_inode, 0) {
+        Ok(crate::ListxattrReply::Names(names)) => names,
+        Ok(crate::ListxattrReply::Count(_)) => return Ok(()),
+        Err(_) => return Ok(()), // Some backends don't support xattrs.
+    };
+
+    // Parse null-separated xattr name list.
+    for xattr_name in list.split(|&b| b == 0) {
+        if xattr_name.is_empty() {
+            continue;
+        }
+        let cname = match CString::new(xattr_name) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        match backend(fs, source).getxattr(ctx, source_inode, &cname, 0) {
+            Ok(crate::GetxattrReply::Value(value)) => {
+                let _ = backend(fs, target).setxattr(ctx, target_inode, &cname, &value, 0);
+            }
+            _ => continue,
+        }
+    }
+
+    Ok(())
+}
+
+/// Copy timestamps and ownership from stat to target inode.
+fn copy_metadata(
+    fs: &DualFs,
+    ctx: Context,
+    target: BackendId,
+    target_inode: u64,
+    src_stat: &crate::stat64,
+) -> io::Result<()> {
+    let valid = SetattrValid::UID
+        | SetattrValid::GID
+        | SetattrValid::ATIME
+        | SetattrValid::MTIME;
+
+    backend(fs, target).setattr(ctx, target_inode, *src_stat, None, valid)?;
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Staging Adapters
+//--------------------------------------------------------------------------------------------------
+
+/// Adapter: writes data from a backend read into the staging file.
+struct StagingWriter<'a> {
+    file: &'a std::fs::File,
+}
+
+impl crate::ZeroCopyWriter for StagingWriter<'_> {
+    fn write_from(
+        &mut self,
+        f: &std::fs::File,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        // Read from f at off, write to our staging file at 0.
+        use std::os::fd::AsRawFd;
+
+        let mut buf = vec![0u8; count];
+        let fd = f.as_raw_fd();
+        let n = unsafe {
+            libc::pread(fd, buf.as_mut_ptr() as *mut libc::c_void, count, off as libc::off_t)
+        };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let n = n as usize;
+
+        let staging_fd = self.file.as_raw_fd();
+        let w = unsafe {
+            libc::pwrite(staging_fd, buf.as_ptr() as *const libc::c_void, n, 0)
+        };
+        if w < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(w as usize)
+    }
+}
+
+/// Adapter: reads data from the staging file for a backend write.
+struct StagingReader<'a> {
+    file: &'a std::fs::File,
+    size: usize,
+}
+
+impl crate::ZeroCopyReader for StagingReader<'_> {
+    fn read_to(
+        &mut self,
+        f: &std::fs::File,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        use std::os::fd::AsRawFd;
+
+        let to_read = std::cmp::min(count, self.size);
+        let mut buf = vec![0u8; to_read];
+
+        let staging_fd = self.file.as_raw_fd();
+        let n = unsafe {
+            libc::pread(staging_fd, buf.as_mut_ptr() as *mut libc::c_void, to_read, 0)
+        };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let n = n as usize;
+
+        let fd = f.as_raw_fd();
+        let w = unsafe {
+            libc::pwrite(fd, buf.as_ptr() as *const libc::c_void, n, off as libc::off_t)
+        };
+        if w < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(w as usize)
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/metadata.rs
+++ b/crates/filesystem/lib/backends/dualfs/metadata.rs
@@ -1,0 +1,263 @@
+//! Getattr, setattr, access dispatch.
+
+use std::io;
+use std::time::Duration;
+
+use super::hooks::{
+    DispatchStep, HookCtx, StepResult, decode_attr, decode_ok, handle_hook_decision,
+    notify_observers, run_decision_hooks,
+};
+use super::lookup::{backend, get_node, mark_metadata_authority, resolve_active_backend_inode};
+use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
+use super::types::BackendId;
+use super::DualFs;
+use crate::backends::shared::{init_binary, platform};
+use crate::{Context, SetattrValid, stat64};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle getattr. Direct dispatch from node state, not policy-routed.
+pub(crate) fn do_getattr(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    _handle: Option<u64>,
+) -> io::Result<(stat64, Duration)> {
+    if ino == init_binary::INIT_INODE {
+        return Ok((init_binary::init_stat(), fs.cfg.attr_timeout));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+    let (backend_id, child_inode) = resolve_active_backend_inode(&node);
+
+    // hooks.before_dispatch
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Getattr,
+            guest_inode: ino,
+            node_state: node.state.read().unwrap().clone(),
+            file_kind: node.kind,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: backend_id,
+        op: OpKind::Getattr,
+        inode: child_inode,
+        handle: None,
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_attr,
+    ) {
+        return r;
+    }
+
+    let (mut st, _) = backend(fs, backend_id).getattr(ctx, child_inode, None)?;
+    st.st_ino = ino;
+
+    let result: io::Result<(stat64, Duration)> = Ok((st, fs.cfg.attr_timeout));
+
+    // hooks.after_dispatch
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok((st, ttl)) => StepResult::Attr(*st, *ttl),
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle setattr. Full pipeline with policy routing.
+pub(crate) fn do_setattr(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    attr: stat64,
+    _handle: Option<u64>,
+    valid: SetattrValid,
+) -> io::Result<(stat64, Duration)> {
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::EACCES));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+
+    let node_state = node.state.read().unwrap().clone();
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Setattr,
+            guest_inode: ino,
+            node_state: node_state.clone(),
+            file_kind: node.kind,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    // hooks.before_resolve
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_resolve(ctx)),
+        decode_attr,
+    ) {
+        return r;
+    }
+
+    let view = DualNamespaceView {
+        state: &fs.state,
+    };
+
+    // hooks.after_resolve
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.after_resolve(ctx, &view)
+        }),
+        decode_attr,
+    ) {
+        return r;
+    }
+
+    // hooks.before_plan
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.before_plan(ctx)),
+        decode_attr,
+    ) {
+        return r;
+    }
+
+    let plan = fs.policy.plan(&hook_ctx.req, &view, &hook_ctx.hints)?;
+
+    // hooks.after_plan
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.after_plan(ctx, &plan)
+        }),
+        decode_attr,
+    ) {
+        return r;
+    }
+
+    // Determine target backend.
+    let target = plan
+        .target_backend()
+        .unwrap_or(BackendId::BackendA);
+
+    // Materialize if needed.
+    if let Some(current) = node.state.read().unwrap().current_backend() {
+        if current != target {
+            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
+        }
+    }
+
+    // Dispatch setattr.
+    let target_inode = super::lookup::resolve_backend_inode(&fs.state, ino, target)
+        .ok_or_else(platform::einval)?;
+
+    let step = DispatchStep {
+        backend: target,
+        op: OpKind::Setattr,
+        inode: target_inode,
+        handle: None,
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_attr,
+    ) {
+        return r;
+    }
+
+    let (mut st, ttl) = backend(fs, target).setattr(ctx, target_inode, attr, None, valid)?;
+    st.st_ino = ino;
+
+    mark_metadata_authority(&fs.state, ino, target);
+
+    // hooks.after_dispatch
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(&hook_ctx, &step, &StepResult::Attr(st, ttl));
+    });
+
+    Ok((st, ttl))
+}
+
+/// Handle access. Direct dispatch from node state.
+pub(crate) fn do_access(fs: &DualFs, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        if mask & libc::W_OK as u32 != 0 {
+            return Err(io::Error::from_raw_os_error(libc::EACCES));
+        }
+        return Ok(());
+    }
+
+    let node = get_node(&fs.state, ino)?;
+    let (backend_id, child_inode) = resolve_active_backend_inode(&node);
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Access,
+            guest_inode: ino,
+            node_state: node.state.read().unwrap().clone(),
+            file_kind: node.kind,
+            flags: mask,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: backend_id,
+        op: OpKind::Access,
+        inode: child_inode,
+        handle: None,
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_ok,
+    ) {
+        return r;
+    }
+
+    let result = backend(fs, backend_id).access(ctx, child_inode, mask);
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(()) => StepResult::Ok,
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}

--- a/crates/filesystem/lib/backends/dualfs/mod.rs
+++ b/crates/filesystem/lib/backends/dualfs/mod.rs
@@ -1,0 +1,519 @@
+//! Two-backend compositional filesystem with programmable dispatch policies.
+//!
+//! `DualFs` presents a single merged filesystem to the guest through exactly
+//! two child `DynFileSystem` backends — a **backend_a** and a **backend_b** —
+//! with a programmable dispatch policy and lifecycle hooks.
+
+pub(crate) mod builder;
+mod create_ops;
+mod dir_ops;
+mod file_ops;
+/// Lifecycle hooks for observing and influencing dispatch.
+pub mod hooks;
+mod lookup;
+mod materialize;
+mod metadata;
+/// Built-in dispatch policies.
+pub mod policies;
+/// Dispatch policy traits and plan types.
+pub mod policy;
+mod remove_ops;
+mod special;
+/// Core type definitions.
+pub mod types;
+mod xattr_ops;
+
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use hooks::DualDispatchHook;
+use policy::DualDispatchPolicy;
+use types::{
+    AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE,
+};
+
+use crate::backends::shared::init_binary;
+use crate::{
+    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Name of the hidden staging directory.
+const STAGING_DIR_NAME: &str = ".dualfs_staging";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Two-backend compositional filesystem with programmable dispatch policies
+/// and lifecycle hooks.
+pub struct DualFs {
+    /// The backend_a backend.
+    backend_a: Box<dyn DynFileSystem>,
+
+    /// The backend_b backend.
+    backend_b: Box<dyn DynFileSystem>,
+
+    /// Dispatch policy.
+    policy: Arc<dyn DualDispatchPolicy>,
+
+    /// Lifecycle hooks.
+    hooks: Vec<Arc<dyn DualDispatchHook>>,
+
+    /// All mutable namespace state.
+    state: DualState,
+
+    /// File containing the init binary bytes.
+    init_file: File,
+
+    /// Configuration.
+    cfg: DualFsConfig,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DualFs {
+    /// Create a builder for constructing a DualFs.
+    pub fn builder() -> builder::DualFsBuilder {
+        builder::DualFsBuilder::new()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DynFileSystem for DualFs {
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        // Initialize both child backends.
+        let ba_supported = self.backend_a.init(capable)?;
+        let bb_supported = self.backend_b.init(capable)?;
+        let child_support = ba_supported & bb_supported;
+
+        let mut opts = FsOptions::empty();
+
+        let wanted = FsOptions::DONT_MASK
+            | FsOptions::BIG_WRITES
+            | FsOptions::ASYNC_READ
+            | FsOptions::PARALLEL_DIROPS
+            | FsOptions::MAX_PAGES
+            | FsOptions::HANDLE_KILLPRIV_V2;
+        opts |= capable & child_support & wanted;
+
+        if capable.contains(FsOptions::DO_READDIRPLUS)
+            && child_support.contains(FsOptions::DO_READDIRPLUS)
+        {
+            opts |= FsOptions::DO_READDIRPLUS | FsOptions::READDIRPLUS_AUTO;
+        }
+
+        if self.cfg.writeback
+            && capable.contains(FsOptions::WRITEBACK_CACHE)
+            && child_support.contains(FsOptions::WRITEBACK_CACHE)
+        {
+            opts |= FsOptions::WRITEBACK_CACHE;
+            self.state
+                .writeback
+                .store(true, Ordering::Relaxed);
+        }
+
+        // Create staging directories in both backends.
+        let staging_name =
+            std::ffi::CString::new(STAGING_DIR_NAME).unwrap();
+
+        // Get root inodes from both backends.
+        let ba_root_entry = self
+            .backend_a
+            .lookup(Context { uid: 0, gid: 0, pid: 0 }, 1, &staging_name)
+            .or_else(|_| {
+                self.backend_a.mkdir(
+                    Context { uid: 0, gid: 0, pid: 0 },
+                    1,
+                    &staging_name,
+                    0o700,
+                    0,
+                    Extensions::default(),
+                )
+            })?;
+
+        let bb_root_entry = self
+            .backend_b
+            .lookup(Context { uid: 0, gid: 0, pid: 0 }, 1, &staging_name)
+            .or_else(|_| {
+                self.backend_b.mkdir(
+                    Context { uid: 0, gid: 0, pid: 0 },
+                    1,
+                    &staging_name,
+                    0o700,
+                    0,
+                    Extensions::default(),
+                )
+            })?;
+
+        // Store staging dir inodes.
+        {
+            let mut staging_dirs = self.state.staging_dirs.write().unwrap();
+            staging_dirs.insert(BackendId::BackendA, ba_root_entry.inode);
+            staging_dirs.insert(BackendId::BackendB, bb_root_entry.inode);
+        }
+
+        // Register root node: root always has both backends.
+        // Backend_a root = 1, backend_b root = 1 (FUSE convention).
+        let root_node = Arc::new(GuestNode {
+            guest_inode: ROOT_INODE,
+            kind: FileKind::Directory,
+            lookup_refs: AtomicU64::new(u64::MAX / 2),
+            anchor_parent: AtomicU64::new(ROOT_INODE),
+            anchor_name: std::sync::RwLock::new(Vec::new()),
+            metadata_backend: AtomicBackendId::new(BackendId::BackendA),
+            state: std::sync::RwLock::new(NodeState::Root {
+                backend_a_root: 1,
+                backend_b_root: 1,
+            }),
+            copy_up_lock: Mutex::new(()),
+        });
+        self.state
+            .nodes
+            .write()
+            .unwrap()
+            .insert(ROOT_INODE, root_node);
+
+        // Register init node.
+        let init_node = Arc::new(GuestNode {
+            guest_inode: init_binary::INIT_INODE,
+            kind: FileKind::RegularFile,
+            lookup_refs: AtomicU64::new(u64::MAX / 2),
+            anchor_parent: AtomicU64::new(ROOT_INODE),
+            anchor_name: std::sync::RwLock::new(init_binary::INIT_FILENAME.to_vec()),
+            metadata_backend: AtomicBackendId::new(BackendId::BackendA),
+            state: std::sync::RwLock::new(NodeState::Init),
+            copy_up_lock: Mutex::new(()),
+        });
+        self.state
+            .nodes
+            .write()
+            .unwrap()
+            .insert(init_binary::INIT_INODE, init_node);
+
+        Ok(opts)
+    }
+
+    fn destroy(&self) {
+        self.state.file_handles.write().unwrap().clear();
+        self.state.dir_handles.write().unwrap().clear();
+        self.backend_a.destroy();
+        self.backend_b.destroy();
+    }
+
+    fn lookup(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        lookup::do_lookup(self, ctx, parent, name)
+    }
+
+    fn forget(&self, ctx: Context, ino: u64, count: u64) {
+        lookup::do_forget(self, ctx, ino, count);
+    }
+
+    fn batch_forget(&self, ctx: Context, requests: Vec<(u64, u64)>) {
+        lookup::do_batch_forget(self, ctx, requests);
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: Option<u64>,
+    ) -> io::Result<(stat64, Duration)> {
+        metadata::do_getattr(self, ctx, ino, handle)
+    }
+
+    fn setattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        attr: stat64,
+        handle: Option<u64>,
+        valid: SetattrValid,
+    ) -> io::Result<(stat64, Duration)> {
+        metadata::do_setattr(self, ctx, ino, attr, handle, valid)
+    }
+
+    fn readlink(&self, ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
+        file_ops::do_readlink(self, ctx, ino)
+    }
+
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: u64,
+        name: &CStr,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_symlink(self, ctx, linkname, parent, name, extensions)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_mknod(self, ctx, parent, name, mode, rdev, umask, extensions)
+    }
+
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_mkdir(self, ctx, parent, name, mode, umask, extensions)
+    }
+
+    fn unlink(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        remove_ops::do_unlink(self, ctx, parent, name)
+    }
+
+    fn rmdir(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        remove_ops::do_rmdir(self, ctx, parent, name)
+    }
+
+    fn rename(
+        &self,
+        ctx: Context,
+        olddir: u64,
+        oldname: &CStr,
+        newdir: u64,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        remove_ops::do_rename(self, ctx, olddir, oldname, newdir, newname, flags)
+    }
+
+    fn link(
+        &self,
+        ctx: Context,
+        ino: u64,
+        newparent: u64,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        create_ops::do_link(self, ctx, ino, newparent, newname)
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        ino: u64,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        file_ops::do_open(self, ctx, ino, kill_priv, flags)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        kill_priv: bool,
+        flags: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+        create_ops::do_create(self, ctx, parent, name, mode, kill_priv, flags, umask, extensions)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        file_ops::do_read(self, ctx, ino, handle, w, size, offset, lock_owner, flags)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<usize> {
+        file_ops::do_write(
+            self,
+            ctx,
+            ino,
+            handle,
+            r,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            kill_priv,
+            flags,
+        )
+    }
+
+    fn flush(&self, ctx: Context, ino: u64, handle: u64, lock_owner: u64) -> io::Result<()> {
+        file_ops::do_flush(self, ctx, ino, handle, lock_owner)
+    }
+
+    fn fsync(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        special::do_fsync(self, ctx, ino, datasync, handle)
+    }
+
+    fn fallocate(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        special::do_fallocate(self, ctx, ino, handle, mode, offset, length)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn release(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+        handle: u64,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        file_ops::do_release(self, ctx, ino, flags, handle, flush, flock_release, lock_owner)
+    }
+
+    fn statfs(&self, ctx: Context, ino: u64) -> io::Result<statvfs64> {
+        special::do_statfs(self, ctx, ino)
+    }
+
+    fn setxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        xattr_ops::do_setxattr(self, ctx, ino, name, value, flags)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        xattr_ops::do_getxattr(self, ctx, ino, name, size)
+    }
+
+    fn listxattr(&self, ctx: Context, ino: u64, size: u32) -> io::Result<ListxattrReply> {
+        xattr_ops::do_listxattr(self, ctx, ino, size)
+    }
+
+    fn removexattr(&self, ctx: Context, ino: u64, name: &CStr) -> io::Result<()> {
+        xattr_ops::do_removexattr(self, ctx, ino, name)
+    }
+
+    fn opendir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        dir_ops::do_opendir(self, ctx, ino, flags)
+    }
+
+    fn readdir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<DirEntry<'static>>> {
+        dir_ops::do_readdir(self, ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+        dir_ops::do_readdirplus(self, ctx, ino, handle, size, offset)
+    }
+
+    fn fsyncdir(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        special::do_fsyncdir(self, ctx, ino, datasync, handle)
+    }
+
+    fn releasedir(&self, ctx: Context, ino: u64, flags: u32, handle: u64) -> io::Result<()> {
+        dir_ops::do_releasedir(self, ctx, ino, flags, handle)
+    }
+
+    fn access(&self, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
+        metadata::do_access(self, ctx, ino, mask)
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        special::do_lseek(self, ctx, ino, handle, offset, whence)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use policies::{
+    BackendAFallbackToBackendBRead, BackendAOnly, MergeReadsBackendAPrecedence,
+    ReadBackendBWriteBackendA,
+};
+pub use types::{CachePolicy, DualFsConfig};

--- a/crates/filesystem/lib/backends/dualfs/policies/backend_a_fallback_to_backend_b.rs
+++ b/crates/filesystem/lib/backends/dualfs/policies/backend_a_fallback_to_backend_b.rs
@@ -1,0 +1,40 @@
+//! Reads try backend_a first, fall back to backend_b on ENOENT. Writes go to backend_a.
+
+use std::io;
+
+use crate::backends::dualfs::policy::{
+    BackendChoice, BackendOp, DualDispatchPlan, DualDispatchPolicy, DualNamespaceView, HintBag,
+    OpKind, RequestCtx,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Reads try backend_a first, fall back to backend_b on ENOENT.
+/// Writes go to backend_a.
+pub struct BackendAFallbackToBackendBRead;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DualDispatchPolicy for BackendAFallbackToBackendBRead {
+    fn plan(
+        &self,
+        req: &RequestCtx,
+        _view: &DualNamespaceView<'_>,
+        _hints: &HintBag,
+    ) -> io::Result<DualDispatchPlan> {
+        match req.op {
+            OpKind::Lookup => Ok(DualDispatchPlan::MergeLookup {
+                precedence: BackendChoice::BackendAFirst,
+            }),
+
+            // All mutations go to backend_a.
+            _ => Ok(DualDispatchPlan::UseBackendA {
+                op: BackendOp::passthrough(),
+            }),
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/policies/backend_a_only.rs
+++ b/crates/filesystem/lib/backends/dualfs/policies/backend_a_only.rs
@@ -1,0 +1,35 @@
+//! All policy-routed operations go to backend_a; backend_b is never consulted.
+
+use std::io;
+
+use crate::backends::dualfs::policy::{
+    BackendOp, DualDispatchPlan, DualDispatchPolicy, DualNamespaceView, HintBag, RequestCtx,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// All operations go to backend_a. Backend_b is never consulted for lookups,
+/// creates, or mutations.
+///
+/// Note: `statfs` is core-dispatched (not policy-routed) and always merges
+/// both backends regardless of policy.
+pub struct BackendAOnly;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DualDispatchPolicy for BackendAOnly {
+    fn plan(
+        &self,
+        _req: &RequestCtx,
+        _view: &DualNamespaceView<'_>,
+        _hints: &HintBag,
+    ) -> io::Result<DualDispatchPlan> {
+        Ok(DualDispatchPlan::UseBackendA {
+            op: BackendOp::passthrough(),
+        })
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/policies/merge_reads.rs
+++ b/crates/filesystem/lib/backends/dualfs/policies/merge_reads.rs
@@ -1,0 +1,45 @@
+//! Lookups and readdir merge with backend_a winning ties. Mutations go to backend_a.
+
+use std::io;
+
+use crate::backends::dualfs::policy::{
+    BackendChoice, BackendOp, DualDispatchPlan, DualDispatchPolicy, DualNamespaceView, HintBag,
+    OpKind, RequestCtx,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Lookups and readdir merge with backend_a winning ties.
+/// Mutations go to backend_a.
+pub struct MergeReadsBackendAPrecedence;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DualDispatchPolicy for MergeReadsBackendAPrecedence {
+    fn plan(
+        &self,
+        req: &RequestCtx,
+        _view: &DualNamespaceView<'_>,
+        _hints: &HintBag,
+    ) -> io::Result<DualDispatchPlan> {
+        match req.op {
+            OpKind::Lookup => Ok(DualDispatchPlan::MergeLookup {
+                precedence: BackendChoice::BackendAFirst,
+            }),
+
+            OpKind::Readdir | OpKind::Readdirplus | OpKind::Opendir => {
+                Ok(DualDispatchPlan::MergeReaddir {
+                    precedence: BackendChoice::BackendAFirst,
+                })
+            }
+
+            _ => Ok(DualDispatchPlan::UseBackendA {
+                op: BackendOp::passthrough(),
+            }),
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/policies/mod.rs
+++ b/crates/filesystem/lib/backends/dualfs/policies/mod.rs
@@ -1,0 +1,15 @@
+//! Built-in dispatch policies for DualFs.
+
+mod backend_a_fallback_to_backend_b;
+mod backend_a_only;
+mod merge_reads;
+mod read_backend_b_write_backend_a;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use backend_a_fallback_to_backend_b::BackendAFallbackToBackendBRead;
+pub use backend_a_only::BackendAOnly;
+pub use merge_reads::MergeReadsBackendAPrecedence;
+pub use read_backend_b_write_backend_a::ReadBackendBWriteBackendA;

--- a/crates/filesystem/lib/backends/dualfs/policies/read_backend_b_write_backend_a.rs
+++ b/crates/filesystem/lib/backends/dualfs/policies/read_backend_b_write_backend_a.rs
@@ -1,0 +1,117 @@
+//! Default policy: reads fall through to backend_b, writes go to backend_a.
+
+use std::io;
+
+use crate::backends::dualfs::policy::{
+    BackendChoice, BackendOp, DualDispatchPlan, DualDispatchPolicy, DualNamespaceView, HintBag,
+    OpKind, RequestCtx,
+};
+use crate::backends::dualfs::types::{BackendId, NodeState};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Default dispatch policy: read from backend_b, write to backend_a.
+///
+/// Lookups merge with backend_b precedence. Writes go to backend_a,
+/// triggering materialization when the target is backed by backend_b.
+pub struct ReadBackendBWriteBackendA;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DualDispatchPolicy for ReadBackendBWriteBackendA {
+    fn plan(
+        &self,
+        req: &RequestCtx,
+        _view: &DualNamespaceView<'_>,
+        _hints: &HintBag,
+    ) -> io::Result<DualDispatchPlan> {
+        match req.op {
+            OpKind::Lookup => Ok(DualDispatchPlan::MergeLookup {
+                precedence: BackendChoice::BackendBFirst,
+            }),
+
+            OpKind::Open => {
+                let write_flags = libc::O_WRONLY | libc::O_RDWR | libc::O_TRUNC;
+                let is_write = (req.flags as i32) & write_flags != 0;
+
+                if is_write {
+                    match &req.node_state {
+                        NodeState::BackendB { .. } => {
+                            Ok(DualDispatchPlan::MaterializeToBackendThen {
+                                source: BackendId::BackendB,
+                                target: BackendId::BackendA,
+                                then: BackendOp::passthrough(),
+                            })
+                        }
+                        NodeState::BackendA { .. }
+                        | NodeState::MergedDir { .. }
+                        | NodeState::Root { .. } => Ok(DualDispatchPlan::UseBackendA {
+                            op: BackendOp::passthrough(),
+                        }),
+                        NodeState::Init => Ok(DualDispatchPlan::Deny {
+                            errno: libc::EACCES,
+                        }),
+                    }
+                } else {
+                    match &req.node_state {
+                        NodeState::BackendA { .. }
+                        | NodeState::MergedDir { .. }
+                        | NodeState::Root { .. } => Ok(DualDispatchPlan::UseBackendA {
+                            op: BackendOp::passthrough(),
+                        }),
+                        NodeState::BackendB { .. } => Ok(DualDispatchPlan::UseBackendB {
+                            op: BackendOp::passthrough(),
+                        }),
+                        NodeState::Init => Ok(DualDispatchPlan::Deny {
+                            errno: libc::EACCES,
+                        }),
+                    }
+                }
+            }
+
+            OpKind::Create
+            | OpKind::Mkdir
+            | OpKind::Mknod
+            | OpKind::Symlink
+            | OpKind::Link
+            | OpKind::Unlink
+            | OpKind::Rmdir
+            | OpKind::Rename => Ok(DualDispatchPlan::UseBackendA {
+                op: BackendOp::passthrough(),
+            }),
+
+            OpKind::Setattr | OpKind::Setxattr | OpKind::Removexattr => {
+                match &req.node_state {
+                    NodeState::BackendB { .. } => {
+                        Ok(DualDispatchPlan::MaterializeToBackendThen {
+                            source: BackendId::BackendB,
+                            target: BackendId::BackendA,
+                            then: BackendOp::passthrough(),
+                        })
+                    }
+                    _ => Ok(DualDispatchPlan::UseBackendA {
+                        op: BackendOp::passthrough(),
+                    }),
+                }
+            }
+
+            OpKind::Readdir | OpKind::Readdirplus => Ok(DualDispatchPlan::MergeReaddir {
+                precedence: BackendChoice::BackendBFirst,
+            }),
+
+            OpKind::Opendir => Ok(DualDispatchPlan::MergeReaddir {
+                precedence: BackendChoice::BackendBFirst,
+            }),
+
+            // Handle-bound and direct-dispatch ops are not policy-routed.
+            // Return UseBackendA as fallback — the core handles routing.
+            _ => Ok(DualDispatchPlan::UseBackendA {
+                op: BackendOp::passthrough(),
+            }),
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/policy.rs
+++ b/crates/filesystem/lib/backends/dualfs/policy.rs
@@ -1,0 +1,238 @@
+//! Dispatch policy traits and plan types.
+//!
+//! The policy decides how each FUSE operation uses the two child backends.
+//! The core calls `policy.plan()` to get a `DualDispatchPlan` and executes
+//! it safely.
+
+use std::io;
+
+use super::types::{BackendId, DualState, NodeState};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Decides how each FUSE operation should be dispatched to the two backends.
+///
+/// Called once per plan-eligible operation, before dispatch. Must be fast (no I/O).
+pub trait DualDispatchPolicy: Send + Sync {
+    /// Plan the dispatch strategy for the given request.
+    fn plan(
+        &self,
+        req: &RequestCtx,
+        view: &DualNamespaceView<'_>,
+        hints: &HintBag,
+    ) -> io::Result<DualDispatchPlan>;
+}
+
+/// Describes the incoming FUSE operation for the policy to inspect.
+pub struct RequestCtx {
+    /// The FUSE operation kind.
+    pub op: OpKind,
+    /// Guest inode the operation targets.
+    pub guest_inode: u64,
+    /// Current backing state of the target node.
+    pub node_state: NodeState,
+    /// File kind.
+    pub file_kind: super::types::FileKind,
+    /// Operation-specific flags.
+    pub flags: u32,
+    /// Name argument (for name-based ops).
+    pub name: Vec<u8>,
+    /// Parent guest inode (for name-based ops). 0 for inode-only ops.
+    pub parent_inode: u64,
+}
+
+/// FUSE operation kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum OpKind {
+    Lookup,
+    Getattr,
+    Setattr,
+    Readlink,
+    Open,
+    Read,
+    Write,
+    Create,
+    Mkdir,
+    Mknod,
+    Symlink,
+    Link,
+    Unlink,
+    Rmdir,
+    Rename,
+    Opendir,
+    Readdir,
+    Readdirplus,
+    Setxattr,
+    Getxattr,
+    Listxattr,
+    Removexattr,
+    Flush,
+    Release,
+    Releasedir,
+    Fsync,
+    Fsyncdir,
+    Access,
+    Lseek,
+    Fallocate,
+    Statfs,
+}
+
+/// Read-only view of the namespace state for policy decisions.
+pub struct DualNamespaceView<'a> {
+    pub(crate) state: &'a DualState,
+}
+
+/// Hints accumulated from hooks during the before_plan phase.
+pub struct HintBag {
+    /// Accumulated hints.
+    pub hints: Vec<Hint>,
+}
+
+/// A typed hint from a hook to the policy.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum Hint {
+    /// Prefer a specific backend for this operation.
+    PreferBackend(BackendId),
+    /// Subtree affinity.
+    SubtreeAffinity {
+        root_inode: u64,
+        backend: BackendId,
+    },
+    /// Custom string hint for policy-specific use.
+    Custom(String),
+}
+
+/// The dispatch plan returned by policy.plan().
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum DualDispatchPlan {
+    /// Route the operation to backend_a.
+    UseBackendA { op: BackendOp },
+    /// Route the operation to backend_b.
+    UseBackendB { op: BackendOp },
+    /// Try backend_a first; on specified errno(s), fall back to backend_b.
+    TryBackendAThenBackendB {
+        op: BackendOp,
+        fallback_on: Vec<i32>,
+    },
+    /// Try backend_b first; on specified errno(s), fall back to backend_a.
+    TryBackendBThenBackendA {
+        op: BackendOp,
+        fallback_on: Vec<i32>,
+    },
+    /// Merge lookup: try both backends with precedence order.
+    MergeLookup { precedence: BackendChoice },
+    /// Merge readdir results from both backends.
+    MergeReaddir { precedence: BackendChoice },
+    /// Materialize then execute the operation.
+    MaterializeToBackendThen {
+        source: BackendId,
+        target: BackendId,
+        then: BackendOp,
+    },
+    /// Return a synthetic response without calling any backend.
+    Synthetic {
+        response: super::hooks::SyntheticResponse,
+    },
+    /// Deny the operation with an errno.
+    Deny { errno: i32 },
+}
+
+/// Precedence for merge operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendChoice {
+    /// Try backend_a first.
+    BackendAFirst,
+    /// Try backend_b first.
+    BackendBFirst,
+}
+
+/// Opaque operation descriptor.
+#[derive(Debug, Clone)]
+pub struct BackendOp {
+    /// Additional flags or overrides for the backend call.
+    pub flags: u32,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DualNamespaceView<'_> {
+    /// Check if a dentry exists.
+    pub fn has_dentry(&self, parent: u64, name: &[u8]) -> bool {
+        self.state
+            .dentries
+            .read()
+            .unwrap()
+            .contains_key(&(parent, name.to_vec()))
+    }
+
+    /// Check if a name is hidden for a specific backend.
+    pub fn is_whiteout(&self, parent: u64, name: &[u8], hidden_backend: BackendId) -> bool {
+        self.state.is_whited_out(parent, name, hidden_backend)
+    }
+
+    /// Check if a directory is opaque against a specific backend.
+    pub fn is_opaque(&self, dir_inode: u64, hidden_backend: BackendId) -> bool {
+        self.state.is_opaque(dir_inode, hidden_backend)
+    }
+
+    /// Get node state for a guest inode.
+    pub fn node_state(&self, inode: u64) -> Option<NodeState> {
+        self.state
+            .nodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(|n| n.state.read().unwrap().clone())
+    }
+
+    /// Check if a backend_b inode has been seen before.
+    pub fn backend_b_inode_known(&self, backend_b_inode: u64) -> bool {
+        self.state
+            .backend_b_inode_map
+            .read()
+            .unwrap()
+            .contains_key(&backend_b_inode)
+    }
+}
+
+impl HintBag {
+    pub(crate) fn new() -> Self {
+        HintBag { hints: Vec::new() }
+    }
+
+    /// Add a hint.
+    pub fn push(&mut self, hint: Hint) {
+        self.hints.push(hint);
+    }
+
+    /// Add multiple hints.
+    pub fn extend(&mut self, hints: Vec<Hint>) {
+        self.hints.extend(hints);
+    }
+}
+
+impl BackendOp {
+    /// Create a passthrough operation with no flag overrides.
+    pub fn passthrough() -> Self {
+        BackendOp { flags: 0 }
+    }
+}
+
+impl DualDispatchPlan {
+    /// Return the target backend for plans that select a single backend.
+    pub(crate) fn target_backend(&self) -> Option<BackendId> {
+        match self {
+            DualDispatchPlan::UseBackendA { .. } => Some(BackendId::BackendA),
+            DualDispatchPlan::UseBackendB { .. } => Some(BackendId::BackendB),
+            DualDispatchPlan::MaterializeToBackendThen { target, .. } => Some(*target),
+            _ => None,
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/remove_ops.rs
@@ -1,0 +1,444 @@
+//! Unlink, rmdir, rename, and whiteout management.
+
+use std::ffi::CStr;
+use std::io;
+use std::sync::atomic::Ordering;
+
+use super::hooks::{CommitEvent, DentryChange, notify_observers};
+use super::lookup::{
+    backend, ensure_alias_linked, ensure_backend_presence, get_node, mark_metadata_authority,
+    resolve_backend_inode,
+};
+use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
+use super::types::{BackendId, FileKind, GuestNode, ROOT_INODE};
+use super::DualFs;
+use crate::backends::shared::{init_binary, name_validation, platform};
+use crate::Context;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle unlink.
+pub(crate) fn do_unlink(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+    let name_bytes = name.to_bytes();
+    name_validation::validate_name(name)?;
+
+    // Protect init.krun.
+    if parent == ROOT_INODE && init_binary::is_init_name(name_bytes) {
+        return Err(io::Error::from_raw_os_error(libc::EPERM));
+    }
+
+    let parent_node = get_node(&fs.state, parent)?;
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Unlink,
+        guest_inode: parent,
+        node_state: parent_node.state.read().unwrap().clone(),
+        file_kind: parent_node.kind,
+        flags: 0,
+        name: name_bytes.to_vec(),
+        parent_inode: parent,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    ensure_backend_presence(fs, ctx, parent, target)?;
+
+    // Resolve the child.
+    let child_ino = fs
+        .state
+        .dentries
+        .read()
+        .unwrap()
+        .get(&(parent, name_bytes.to_vec()))
+        .copied()
+        .ok_or_else(platform::enoent)?;
+
+    let child_node = get_node(&fs.state, child_ino)?;
+
+    // Ensure deferred alias linkage before target-side mutation.
+    ensure_alias_linked(&fs.state, child_ino, parent, name_bytes)?;
+
+    // If child has presence on target, unlink it there.
+    if let Some(_target_child_inode) = child_node.state.read().unwrap().backend_inode(target) {
+        if let Some(parent_target_inode) = resolve_backend_inode(&fs.state, parent, target) {
+            backend(fs, target).unlink(ctx, parent_target_inode, name)?;
+        }
+    }
+
+    // If child still has visible presence on the other backend, create whiteout.
+    let other = target.other();
+    if child_node.state.read().unwrap().backend_inode(other).is_some()
+        && !super::lookup::is_opaque_against(&fs.state, parent, other)
+    {
+        fs.state
+            .whiteouts
+            .write()
+            .unwrap()
+            .insert((parent, name_bytes.to_vec(), other));
+    }
+
+    mark_metadata_authority(&fs.state, parent, target);
+
+    // Remove dentry.
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .remove(&(parent, name_bytes.to_vec()));
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(child_ino)
+        .and_modify(|s| {
+            s.remove(&(parent, name_bytes.to_vec()));
+        });
+
+    // Anchor repair.
+    let anchor_parent = child_node.anchor_parent.load(Ordering::Relaxed);
+    let anchor_name = child_node.anchor_name.read().unwrap().clone();
+    if anchor_parent == parent && anchor_name == name_bytes {
+        if let Some(aliases) = fs.state.alias_index.read().unwrap().get(&child_ino) {
+            if let Some((new_p, new_n)) = aliases.iter().next() {
+                child_node.anchor_parent.store(*new_p, Ordering::Relaxed);
+                *child_node.anchor_name.write().unwrap() = new_n.clone();
+            }
+        }
+    }
+
+    // hooks.after_commit
+    notify_observers(&fs.hooks, |h| {
+        h.after_commit(&CommitEvent {
+            op: OpKind::Unlink,
+            guest_inode: child_ino,
+            transition: None,
+            dentry_changes: vec![DentryChange::Removed {
+                parent,
+                name: name_bytes.to_vec(),
+                child: child_ino,
+            }],
+        });
+    });
+
+    Ok(())
+}
+
+/// Handle rmdir.
+pub(crate) fn do_rmdir(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+    let name_bytes = name.to_bytes();
+    name_validation::validate_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name_bytes) {
+        return Err(io::Error::from_raw_os_error(libc::EPERM));
+    }
+
+    let parent_node = get_node(&fs.state, parent)?;
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Rmdir,
+        guest_inode: parent,
+        node_state: parent_node.state.read().unwrap().clone(),
+        file_kind: parent_node.kind,
+        flags: 0,
+        name: name_bytes.to_vec(),
+        parent_inode: parent,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    ensure_backend_presence(fs, ctx, parent, target)?;
+
+    let child_ino = fs
+        .state
+        .dentries
+        .read()
+        .unwrap()
+        .get(&(parent, name_bytes.to_vec()))
+        .copied()
+        .ok_or_else(platform::enoent)?;
+
+    let child_node = get_node(&fs.state, child_ino)?;
+    if child_node.kind != FileKind::Directory {
+        return Err(platform::enotdir());
+    }
+
+    // Check merged emptiness: target-side children (from dentries) +
+    // non-target-side children (minus whiteouts) must all be empty.
+    check_merged_dir_empty(fs, ctx, child_ino, &child_node, target)?;
+
+    // If child has target presence, rmdir it there.
+    if child_node.state.read().unwrap().backend_inode(target).is_some() {
+        if let Some(parent_target_inode) = resolve_backend_inode(&fs.state, parent, target) {
+            backend(fs, target).rmdir(ctx, parent_target_inode, name)?;
+        }
+    }
+
+    // Whiteout if other side still has the dir.
+    let other = target.other();
+    if child_node.state.read().unwrap().backend_inode(other).is_some()
+        && !super::lookup::is_opaque_against(&fs.state, parent, other)
+    {
+        fs.state
+            .whiteouts
+            .write()
+            .unwrap()
+            .insert((parent, name_bytes.to_vec(), other));
+    }
+
+    mark_metadata_authority(&fs.state, parent, target);
+
+    // Remove dentry.
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .remove(&(parent, name_bytes.to_vec()));
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(child_ino)
+        .and_modify(|s| {
+            s.remove(&(parent, name_bytes.to_vec()));
+        });
+
+    Ok(())
+}
+
+/// Handle rename.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_rename(
+    fs: &DualFs,
+    ctx: Context,
+    olddir: u64,
+    oldname: &CStr,
+    newdir: u64,
+    newname: &CStr,
+    flags: u32,
+) -> io::Result<()> {
+    let oldname_bytes = oldname.to_bytes();
+    let newname_bytes = newname.to_bytes();
+    name_validation::validate_name(oldname)?;
+    name_validation::validate_name(newname)?;
+
+    // Protect init.krun.
+    if (olddir == ROOT_INODE && init_binary::is_init_name(oldname_bytes))
+        || (newdir == ROOT_INODE && init_binary::is_init_name(newname_bytes))
+    {
+        return Err(io::Error::from_raw_os_error(libc::EPERM));
+    }
+
+    // Resolve source.
+    let source_ino = fs
+        .state
+        .dentries
+        .read()
+        .unwrap()
+        .get(&(olddir, oldname_bytes.to_vec()))
+        .copied()
+        .ok_or_else(platform::enoent)?;
+
+    let source_node = get_node(&fs.state, source_ino)?;
+
+    let _parent_node = get_node(&fs.state, olddir)?;
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Rename,
+        guest_inode: source_ino,
+        node_state: source_node.state.read().unwrap().clone(),
+        file_kind: source_node.kind,
+        flags,
+        name: oldname_bytes.to_vec(),
+        parent_inode: olddir,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    // Directory rename: check if cross-layer EXDEV.
+    if source_node.kind == FileKind::Directory {
+        let state = source_node.state.read().unwrap();
+        if !state.is_pure_on(target) {
+            return Err(io::Error::from_raw_os_error(libc::EXDEV));
+        }
+    }
+
+    // Materialize source if needed.
+    if let Some(current) = source_node.state.read().unwrap().current_backend() {
+        if current != target {
+            super::materialize::do_materialize(fs, ctx, source_ino, current, target)?;
+        }
+    }
+
+    ensure_backend_presence(fs, ctx, olddir, target)?;
+    ensure_backend_presence(fs, ctx, newdir, target)?;
+
+    // Ensure deferred alias linkage on source before target-side mutation.
+    ensure_alias_linked(&fs.state, source_ino, olddir, oldname_bytes)?;
+
+    // Handle destination: if exists, remove it first in namespace.
+    let dest_ino = fs
+        .state
+        .dentries
+        .read()
+        .unwrap()
+        .get(&(newdir, newname_bytes.to_vec()))
+        .copied();
+
+    if let Some(dest_ino) = dest_ino {
+        let dest_node = get_node(&fs.state, dest_ino)?;
+
+        // If dest has target presence, unlink/rmdir it there.
+        if dest_node.state.read().unwrap().backend_inode(target).is_some() {
+            if let Some(newdir_target) = resolve_backend_inode(&fs.state, newdir, target) {
+                if dest_node.kind == FileKind::Directory {
+                    backend(fs, target).rmdir(ctx, newdir_target, newname)?;
+                } else {
+                    backend(fs, target).unlink(ctx, newdir_target, newname)?;
+                }
+            }
+        }
+
+        // Whiteout if dest still has other-backend presence.
+        let other = target.other();
+        if dest_node.state.read().unwrap().backend_inode(other).is_some()
+            && !super::lookup::is_opaque_against(&fs.state, newdir, other)
+        {
+            fs.state
+                .whiteouts
+                .write()
+                .unwrap()
+                .insert((newdir, newname_bytes.to_vec(), other));
+        }
+
+        // Remove dest dentry.
+        fs.state
+            .dentries
+            .write()
+            .unwrap()
+            .remove(&(newdir, newname_bytes.to_vec()));
+        fs.state
+            .alias_index
+            .write()
+            .unwrap()
+            .entry(dest_ino)
+            .and_modify(|s| {
+                s.remove(&(newdir, newname_bytes.to_vec()));
+            });
+    }
+
+    // Delegate rename in target backend.
+    let olddir_target = resolve_backend_inode(&fs.state, olddir, target)
+        .ok_or_else(platform::enoent)?;
+    let newdir_target = resolve_backend_inode(&fs.state, newdir, target)
+        .ok_or_else(platform::enoent)?;
+
+    backend(fs, target).rename(ctx, olddir_target, oldname, newdir_target, newname, flags)?;
+
+    // If old name still has visible presence on other backend, whiteout it.
+    let other = target.other();
+    if resolve_backend_inode(&fs.state, source_ino, other).is_some()
+        && !super::lookup::is_opaque_against(&fs.state, olddir, other)
+    {
+        fs.state
+            .whiteouts
+            .write()
+            .unwrap()
+            .insert((olddir, oldname_bytes.to_vec(), other));
+    }
+
+    mark_metadata_authority(&fs.state, olddir, target);
+    mark_metadata_authority(&fs.state, newdir, target);
+
+    // Update dentries.
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .remove(&(olddir, oldname_bytes.to_vec()));
+    fs.state
+        .dentries
+        .write()
+        .unwrap()
+        .insert((newdir, newname_bytes.to_vec()), source_ino);
+
+    // Update alias_index.
+    fs.state
+        .alias_index
+        .write()
+        .unwrap()
+        .entry(source_ino)
+        .and_modify(|s| {
+            s.remove(&(olddir, oldname_bytes.to_vec()));
+            s.insert((newdir, newname_bytes.to_vec()));
+        });
+
+    // Update anchor.
+    source_node
+        .anchor_parent
+        .store(newdir, Ordering::Relaxed);
+    *source_node.anchor_name.write().unwrap() = newname_bytes.to_vec();
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Name of the hidden staging directory (filtered from emptiness checks).
+const STAGING_DIR_NAME: &[u8] = b".dualfs_staging";
+
+/// Check that a directory is empty in the merged view before rmdir.
+///
+/// Checks both target-side children (from dentries) and non-target-side
+/// children (via readdir on the other backend, minus whiteouts/opaque).
+fn check_merged_dir_empty(
+    fs: &DualFs,
+    ctx: Context,
+    dir_ino: u64,
+    dir_node: &GuestNode,
+    target: BackendId,
+) -> io::Result<()> {
+    // Check target-side: any registered dentries under this dir?
+    {
+        let dentries = fs.state.dentries.read().unwrap();
+        if dentries.keys().any(|(p, _)| *p == dir_ino) {
+            return Err(io::Error::from_raw_os_error(libc::ENOTEMPTY));
+        }
+    }
+
+    // Check non-target-side children (minus whiteouts).
+    let other = target.other();
+    if super::lookup::is_opaque_against(&fs.state, dir_ino, other) {
+        // Directory is opaque against the other backend — no visible children there.
+        return Ok(());
+    }
+
+    if let Some(other_inode) = dir_node.state.read().unwrap().backend_inode(other) {
+        let other_backend = backend(fs, other);
+        if let Ok((dh, _)) = other_backend.opendir(ctx, other_inode, 0) {
+            let dh_val = dh.unwrap_or(0);
+            if let Ok(entries) = other_backend.readdir(ctx, other_inode, dh_val, u32::MAX, 0) {
+                let whiteouts = fs.state.whiteouts.read().unwrap();
+                for entry in &entries {
+                    let name = entry.name.to_vec();
+                    if name == b"." || name == b".." {
+                        continue;
+                    }
+                    if dir_ino == ROOT_INODE && name == STAGING_DIR_NAME {
+                        continue;
+                    }
+                    if !whiteouts.contains(&(dir_ino, name, other)) {
+                        let _ = other_backend.releasedir(ctx, other_inode, 0, dh_val);
+                        return Err(io::Error::from_raw_os_error(libc::ENOTEMPTY));
+                    }
+                }
+            }
+            let _ = other_backend.releasedir(ctx, other_inode, 0, dh_val);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/dualfs/special.rs
+++ b/crates/filesystem/lib/backends/dualfs/special.rs
@@ -1,0 +1,337 @@
+//! Statfs (merge both backends), lseek, fallocate, fsync, fsyncdir.
+
+use std::io;
+use std::sync::Arc;
+
+use super::hooks::{
+    DispatchStep, HookCtx, StepResult, decode_ok, handle_hook_decision, notify_observers,
+    run_decision_hooks,
+};
+use super::lookup::get_node;
+use super::policy::{HintBag, OpKind, RequestCtx};
+use super::types::{DualHandle, FileKind, NodeState, ROOT_INODE};
+use super::DualFs;
+use crate::backends::shared::init_binary;
+use crate::{Context, statvfs64};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle statfs. Core-dispatched: always merges both backends.
+pub(crate) fn do_statfs(fs: &DualFs, ctx: Context, _ino: u64) -> io::Result<statvfs64> {
+    let root_node = get_node(&fs.state, ROOT_INODE)?;
+    let state = root_node.state.read().unwrap();
+
+    let (ba_root, bb_root) = match &*state {
+        NodeState::Root {
+            backend_a_root,
+            backend_b_root,
+        } => (*backend_a_root, *backend_b_root),
+        _ => return Err(io::Error::from_raw_os_error(libc::EIO)),
+    };
+    drop(state);
+
+    let ba_stat = fs.backend_a.statfs(ctx, ba_root)?;
+    let bb_stat = fs.backend_b.statfs(ctx, bb_root)?;
+
+    let unit = std::cmp::min(
+        std::cmp::max(ba_stat.f_frsize, 1),
+        std::cmp::max(bb_stat.f_frsize, 1),
+    );
+
+    let to_units = |blocks: u64, frsize: u64| -> u64 {
+        blocks
+            .saturating_mul(std::cmp::max(frsize, 1))
+            .saturating_div(unit)
+    };
+
+    let mut st: statvfs64 = unsafe { std::mem::zeroed() };
+
+    #[cfg(target_os = "linux")]
+    {
+        st.f_bsize = unit;
+        st.f_frsize = unit;
+        st.f_blocks = to_units(ba_stat.f_blocks, ba_stat.f_frsize)
+            .saturating_add(to_units(bb_stat.f_blocks, bb_stat.f_frsize));
+        st.f_bfree = to_units(ba_stat.f_bfree, ba_stat.f_frsize)
+            .saturating_add(to_units(bb_stat.f_bfree, bb_stat.f_frsize));
+        st.f_bavail = to_units(ba_stat.f_bavail, ba_stat.f_frsize)
+            .saturating_add(to_units(bb_stat.f_bavail, bb_stat.f_frsize));
+        st.f_files = ba_stat.f_files.saturating_add(bb_stat.f_files);
+        st.f_ffree = ba_stat.f_ffree.saturating_add(bb_stat.f_ffree);
+        st.f_favail = ba_stat.f_favail.saturating_add(bb_stat.f_favail);
+        st.f_namemax = std::cmp::min(ba_stat.f_namemax, bb_stat.f_namemax);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        st.f_bsize = unit;
+        st.f_frsize = unit;
+        st.f_blocks = to_units(ba_stat.f_blocks as u64, ba_stat.f_frsize)
+            .saturating_add(to_units(bb_stat.f_blocks as u64, bb_stat.f_frsize)) as u32;
+        st.f_bfree = to_units(ba_stat.f_bfree as u64, ba_stat.f_frsize)
+            .saturating_add(to_units(bb_stat.f_bfree as u64, bb_stat.f_frsize)) as u32;
+        st.f_bavail = to_units(ba_stat.f_bavail as u64, ba_stat.f_frsize)
+            .saturating_add(to_units(bb_stat.f_bavail as u64, bb_stat.f_frsize)) as u32;
+        st.f_files = (ba_stat.f_files as u64)
+            .saturating_add(bb_stat.f_files as u64) as u32;
+        st.f_ffree = (ba_stat.f_ffree as u64)
+            .saturating_add(bb_stat.f_ffree as u64) as u32;
+        st.f_favail = (ba_stat.f_favail as u64)
+            .saturating_add(bb_stat.f_favail as u64) as u32;
+        st.f_namemax = std::cmp::min(ba_stat.f_namemax, bb_stat.f_namemax);
+    }
+
+    Ok(st)
+}
+
+/// Handle fsync. Handle-bound dispatch with hooks.
+pub(crate) fn do_fsync(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    datasync: bool,
+    handle: u64,
+) -> io::Result<()> {
+    let fh = get_file_handle(fs, handle)?;
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Fsync,
+            guest_inode: ino,
+            node_state: NodeState::Init, // Placeholder, handle-bound.
+            file_kind: FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Fsync,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_ok,
+    ) {
+        return r;
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => fs.backend_a.fsync(ctx, *backend_a_inode, datasync, *backend_a_handle),
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => fs.backend_b.fsync(ctx, *backend_b_inode, datasync, *backend_b_handle),
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(()) => StepResult::Ok,
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle fsyncdir. No-op.
+pub(crate) fn do_fsyncdir(
+    _fs: &DualFs,
+    _ctx: Context,
+    _ino: u64,
+    _datasync: bool,
+    _handle: u64,
+) -> io::Result<()> {
+    Ok(())
+}
+
+/// Handle lseek. Handle-bound dispatch with hooks.
+pub(crate) fn do_lseek(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    handle: u64,
+    offset: u64,
+    whence: u32,
+) -> io::Result<u64> {
+    if ino == init_binary::INIT_INODE {
+        // Simple seek for init binary.
+        let size = crate::agentd::AGENTD_BYTES.len() as u64;
+        return match whence {
+            w if w == libc::SEEK_SET as u32 => Ok(offset),
+            w if w == libc::SEEK_END as u32 => Ok(size),
+            _ => Ok(offset),
+        };
+    }
+
+    let fh = get_file_handle(fs, handle)?;
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Lseek,
+            guest_inode: ino,
+            node_state: NodeState::Init,
+            file_kind: FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Lseek,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        super::hooks::decode_usize,
+    ) {
+        return r.map(|n| n as u64);
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => fs.backend_a.lseek(ctx, *backend_a_inode, *backend_a_handle, offset, whence),
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => fs.backend_b.lseek(ctx, *backend_b_inode, *backend_b_handle, offset, whence),
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(n) => StepResult::Data(*n as usize),
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+/// Handle fallocate. Handle-bound dispatch with hooks.
+pub(crate) fn do_fallocate(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    handle: u64,
+    mode: u32,
+    offset: u64,
+    length: u64,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::EACCES));
+    }
+
+    let fh = get_file_handle(fs, handle)?;
+
+    let mut hook_ctx = HookCtx {
+        req: RequestCtx {
+            op: OpKind::Fallocate,
+            guest_inode: ino,
+            node_state: NodeState::Init,
+            file_kind: FileKind::RegularFile,
+            flags: 0,
+            name: Vec::new(),
+            parent_inode: 0,
+        },
+        hints: HintBag::new(),
+        metadata: Default::default(),
+    };
+
+    let step = DispatchStep {
+        backend: fh.backend_id(),
+        op: OpKind::Fallocate,
+        inode: fh.child_inode(),
+        handle: Some(fh.child_handle()),
+    };
+
+    if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
+            h.before_dispatch(ctx, &step)
+        }),
+        decode_ok,
+    ) {
+        return r;
+    }
+
+    let result = match fh.as_ref() {
+        DualHandle::BackendA {
+            backend_a_inode,
+            backend_a_handle,
+            ..
+        } => fs.backend_a.fallocate(ctx, *backend_a_inode, *backend_a_handle, mode, offset, length),
+        DualHandle::BackendB {
+            backend_b_inode,
+            backend_b_handle,
+            ..
+        } => fs.backend_b.fallocate(ctx, *backend_b_inode, *backend_b_handle, mode, offset, length),
+    };
+
+    notify_observers(&fs.hooks, |h| {
+        h.after_dispatch(
+            &hook_ctx,
+            &step,
+            &match &result {
+                Ok(()) => StepResult::Ok,
+                Err(e) => StepResult::Err(io::Error::from_raw_os_error(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                )),
+            },
+        );
+    });
+
+    result
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Get a file handle by guest handle ID.
+fn get_file_handle(fs: &DualFs, handle: u64) -> io::Result<Arc<DualHandle>> {
+    fs.state
+        .file_handles
+        .read()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))
+}

--- a/crates/filesystem/lib/backends/dualfs/types.rs
+++ b/crates/filesystem/lib/backends/dualfs/types.rs
@@ -1,0 +1,461 @@
+//! Core type definitions for the DualFs backend.
+//!
+//! Defines guest-visible inode state, handle types, namespace tables,
+//! and configuration. DualFs owns no storage — all data lives in child backends.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+use super::policy::DualDispatchPlan;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Root inode number (FUSE convention).
+pub(crate) const ROOT_INODE: u64 = 1;
+
+/// Default materialization chunk size (1 MiB).
+const DEFAULT_COPY_CHUNK_SIZE: usize = 1024 * 1024;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Identifies one of the two child backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BackendId {
+    /// The first backend slot.
+    BackendA,
+    /// The second backend slot.
+    BackendB,
+}
+
+/// Atomic storage for a `BackendId` value.
+pub(crate) struct AtomicBackendId(AtomicU8);
+
+/// File type cached from child stat on first discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum FileKind {
+    RegularFile,
+    Directory,
+    Symlink,
+    /// FIFO, socket, block device, char device.
+    Special,
+}
+
+/// A guest-visible filesystem object tracked by DualFs.
+///
+/// The core owns the guest identity; child backends own the storage.
+#[allow(dead_code)]
+pub(crate) struct GuestNode {
+    /// Synthetic FUSE inode number.
+    pub guest_inode: u64,
+
+    /// File type (cached from child stat on first discovery).
+    pub kind: FileKind,
+
+    /// FUSE lookup reference count.
+    pub lookup_refs: AtomicU64,
+
+    /// Stable guest alias for reverse lookup (used by materialization).
+    pub anchor_parent: AtomicU64,
+    /// Stable name for the anchor alias.
+    pub anchor_name: RwLock<Vec<u8>>,
+
+    /// Which backend currently supplies authoritative metadata.
+    pub metadata_backend: AtomicBackendId,
+
+    /// Which child backend(s) currently back this object.
+    pub state: RwLock<NodeState>,
+
+    /// Serializes materialization of this node.
+    pub copy_up_lock: Mutex<()>,
+}
+
+/// Tracks which child backend(s) back a guest-visible object.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum NodeState {
+    /// The synthetic DualFs root directory.
+    Root {
+        backend_a_root: u64,
+        backend_b_root: u64,
+    },
+
+    /// Entry lives exclusively in backend_a.
+    BackendA {
+        backend_a_inode: u64,
+        /// If materialized from backend_b, the original backend_b inode.
+        former_backend_b_inode: Option<u64>,
+    },
+
+    /// Entry lives exclusively in backend_b.
+    BackendB {
+        backend_b_inode: u64,
+        /// If materialized from backend_a, the original backend_a inode.
+        former_backend_a_inode: Option<u64>,
+    },
+
+    /// Directory exists in both backends (for readdir merging).
+    MergedDir {
+        backend_a_inode: u64,
+        backend_b_inode: u64,
+    },
+
+    /// The virtual init.krun binary.
+    Init,
+}
+
+/// File handle for regular files.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) enum DualHandle {
+    /// Handle to a backend_a file.
+    BackendA {
+        guest_inode: u64,
+        backend_a_inode: u64,
+        backend_a_handle: u64,
+    },
+    /// Handle to a backend_b file.
+    BackendB {
+        guest_inode: u64,
+        backend_b_inode: u64,
+        backend_b_handle: u64,
+    },
+}
+
+/// Directory handle.
+pub(crate) struct DualDirHandle {
+    /// Guest inode this handle refers to.
+    pub guest_inode: u64,
+    /// Backend_a inode (if dir has backend_a presence).
+    pub backend_a_inode: Option<u64>,
+    /// Backend_b inode (if dir has backend_b presence).
+    pub backend_b_inode: Option<u64>,
+    /// Readdir plan chosen at opendir time.
+    pub readdir_plan: DualDispatchPlan,
+    /// Merged snapshot, built on first readdir.
+    pub snapshot: Mutex<Option<DirSnapshot>>,
+}
+
+/// Point-in-time snapshot of a directory's merged entries.
+pub(crate) struct DirSnapshot {
+    pub entries: Vec<MergedDirEntry>,
+}
+
+/// A single entry in a merged directory snapshot.
+pub(crate) struct MergedDirEntry {
+    pub name: Vec<u8>,
+    /// Stable guest inode.
+    pub inode: u64,
+    /// 1-based monotonically increasing offset.
+    pub offset: u64,
+    /// d_type value.
+    pub file_type: u32,
+}
+
+/// All mutable namespace state for DualFs.
+pub(crate) struct DualState {
+    /// Node table: guest inode -> GuestNode.
+    pub nodes: RwLock<BTreeMap<u64, Arc<GuestNode>>>,
+
+    /// Dentry table: (parent_inode, name) -> guest inode.
+    pub dentries: RwLock<BTreeMap<(u64, Vec<u8>), u64>>,
+
+    /// Reverse dentry index: guest_inode -> { (parent, name), ... }
+    pub alias_index: RwLock<BTreeMap<u64, BTreeSet<(u64, Vec<u8>)>>>,
+
+    /// Backend_a inode -> guest inode dedup map.
+    pub backend_a_inode_map: RwLock<BTreeMap<u64, u64>>,
+
+    /// Backend_b inode -> guest inode dedup map.
+    pub backend_b_inode_map: RwLock<BTreeMap<u64, u64>>,
+
+    /// In-memory whiteouts: (parent_guest_inode, name, hidden_backend).
+    pub whiteouts: RwLock<HashSet<(u64, Vec<u8>, BackendId)>>,
+
+    /// Directories marked opaque against a specific backend.
+    pub opaque_dirs: RwLock<HashSet<(u64, BackendId)>>,
+
+    /// Next guest inode number.
+    pub next_inode: AtomicU64,
+
+    /// File handle table.
+    pub file_handles: RwLock<BTreeMap<u64, Arc<DualHandle>>>,
+
+    /// Directory handle table.
+    pub dir_handles: RwLock<BTreeMap<u64, Arc<DualDirHandle>>>,
+
+    /// Hidden per-backend staging directories for materialization.
+    pub staging_dirs: RwLock<BTreeMap<BackendId, u64>>,
+
+    /// Next handle number.
+    pub next_handle: AtomicU64,
+
+    /// Whether writeback caching is negotiated.
+    pub writeback: AtomicBool,
+}
+
+/// Cache policy for FUSE caching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachePolicy {
+    /// Never cache.
+    Never,
+    /// Cache based on FUSE defaults.
+    Auto,
+    /// Always cache.
+    Always,
+}
+
+/// Configuration for DualFs.
+pub struct DualFsConfig {
+    /// FUSE entry cache timeout.
+    pub entry_timeout: Duration,
+    /// FUSE attribute cache timeout.
+    pub attr_timeout: Duration,
+    /// Cache policy.
+    pub cache_policy: CachePolicy,
+    /// Enable writeback caching.
+    pub writeback: bool,
+    /// Chunk size for materialization data streaming.
+    pub copy_chunk_size: usize,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl AtomicBackendId {
+    pub(crate) fn new(id: BackendId) -> Self {
+        AtomicBackendId(AtomicU8::new(id.to_u8()))
+    }
+
+    pub(crate) fn load(&self, ordering: Ordering) -> BackendId {
+        BackendId::from_u8(self.0.load(ordering))
+    }
+
+    pub(crate) fn store(&self, id: BackendId, ordering: Ordering) {
+        self.0.store(id.to_u8(), ordering);
+    }
+}
+
+impl BackendId {
+    fn to_u8(self) -> u8 {
+        match self {
+            BackendId::BackendA => 0,
+            BackendId::BackendB => 1,
+        }
+    }
+
+    fn from_u8(v: u8) -> Self {
+        match v {
+            0 => BackendId::BackendA,
+            _ => BackendId::BackendB,
+        }
+    }
+
+    /// Return the other backend.
+    pub(crate) fn other(self) -> Self {
+        match self {
+            BackendId::BackendA => BackendId::BackendB,
+            BackendId::BackendB => BackendId::BackendA,
+        }
+    }
+}
+
+impl DualHandle {
+    /// Return which backend this handle is bound to.
+    pub(crate) fn backend_id(&self) -> BackendId {
+        match self {
+            DualHandle::BackendA { .. } => BackendId::BackendA,
+            DualHandle::BackendB { .. } => BackendId::BackendB,
+        }
+    }
+
+    /// Return the guest inode for this handle.
+    #[allow(dead_code)]
+    pub(crate) fn guest_inode(&self) -> u64 {
+        match self {
+            DualHandle::BackendA { guest_inode, .. }
+            | DualHandle::BackendB { guest_inode, .. } => *guest_inode,
+        }
+    }
+
+    /// Return the child backend inode for this handle.
+    pub(crate) fn child_inode(&self) -> u64 {
+        match self {
+            DualHandle::BackendA {
+                backend_a_inode, ..
+            } => *backend_a_inode,
+            DualHandle::BackendB {
+                backend_b_inode, ..
+            } => *backend_b_inode,
+        }
+    }
+
+    /// Return the child backend handle for this handle.
+    pub(crate) fn child_handle(&self) -> u64 {
+        match self {
+            DualHandle::BackendA {
+                backend_a_handle, ..
+            } => *backend_a_handle,
+            DualHandle::BackendB {
+                backend_b_handle, ..
+            } => *backend_b_handle,
+        }
+    }
+}
+
+impl DualState {
+    /// Create a new empty DualState.
+    pub(crate) fn new() -> Self {
+        DualState {
+            nodes: RwLock::new(BTreeMap::new()),
+            dentries: RwLock::new(BTreeMap::new()),
+            alias_index: RwLock::new(BTreeMap::new()),
+            backend_a_inode_map: RwLock::new(BTreeMap::new()),
+            backend_b_inode_map: RwLock::new(BTreeMap::new()),
+            whiteouts: RwLock::new(HashSet::new()),
+            opaque_dirs: RwLock::new(HashSet::new()),
+            next_inode: AtomicU64::new(3), // 1=root, 2=init
+            file_handles: RwLock::new(BTreeMap::new()),
+            dir_handles: RwLock::new(BTreeMap::new()),
+            staging_dirs: RwLock::new(BTreeMap::new()),
+            next_handle: AtomicU64::new(1), // 0=init handle
+            writeback: AtomicBool::new(false),
+        }
+    }
+
+    /// Get the inode map for a given backend.
+    pub(crate) fn inode_map(
+        &self,
+        backend: BackendId,
+    ) -> &RwLock<BTreeMap<u64, u64>> {
+        match backend {
+            BackendId::BackendA => &self.backend_a_inode_map,
+            BackendId::BackendB => &self.backend_b_inode_map,
+        }
+    }
+
+    /// Check if a name is hidden for a specific backend.
+    pub(crate) fn is_whited_out(&self, parent: u64, name: &[u8], hidden_backend: BackendId) -> bool {
+        self.whiteouts
+            .read()
+            .unwrap()
+            .contains(&(parent, name.to_vec(), hidden_backend))
+    }
+
+    /// Check if a directory is opaque against a specific backend.
+    pub(crate) fn is_opaque(&self, dir_inode: u64, hidden_backend: BackendId) -> bool {
+        self.opaque_dirs
+            .read()
+            .unwrap()
+            .contains(&(dir_inode, hidden_backend))
+    }
+}
+
+impl FileKind {
+    /// Convert from stat st_mode to FileKind.
+    pub(crate) fn from_mode(mode: u32) -> Self {
+        let fmt = mode & libc::S_IFMT as u32;
+        if fmt == libc::S_IFREG as u32 {
+            FileKind::RegularFile
+        } else if fmt == libc::S_IFDIR as u32 {
+            FileKind::Directory
+        } else if fmt == libc::S_IFLNK as u32 {
+            FileKind::Symlink
+        } else {
+            FileKind::Special
+        }
+    }
+
+    /// Convert to d_type value.
+    pub(crate) fn to_dtype(self) -> u32 {
+        match self {
+            FileKind::RegularFile => libc::DT_REG as u32,
+            FileKind::Directory => libc::DT_DIR as u32,
+            FileKind::Symlink => libc::DT_LNK as u32,
+            FileKind::Special => libc::DT_UNKNOWN as u32,
+        }
+    }
+
+    /// Convert from d_type to FileKind.
+    pub(crate) fn from_dtype(dtype: u32) -> Self {
+        if dtype == libc::DT_REG as u32 {
+            FileKind::RegularFile
+        } else if dtype == libc::DT_DIR as u32 {
+            FileKind::Directory
+        } else if dtype == libc::DT_LNK as u32 {
+            FileKind::Symlink
+        } else {
+            FileKind::Special
+        }
+    }
+}
+
+impl NodeState {
+    /// Resolve the child backend inode for a given backend, if present.
+    pub(crate) fn backend_inode(&self, backend: BackendId) -> Option<u64> {
+        match (self, backend) {
+            (NodeState::Root { backend_a_root, .. }, BackendId::BackendA) => Some(*backend_a_root),
+            (NodeState::Root { backend_b_root, .. }, BackendId::BackendB) => Some(*backend_b_root),
+            (NodeState::BackendA { backend_a_inode, .. }, BackendId::BackendA) => {
+                Some(*backend_a_inode)
+            }
+            (NodeState::BackendB { backend_b_inode, .. }, BackendId::BackendB) => {
+                Some(*backend_b_inode)
+            }
+            (NodeState::MergedDir { backend_a_inode, .. }, BackendId::BackendA) => {
+                Some(*backend_a_inode)
+            }
+            (NodeState::MergedDir { backend_b_inode, .. }, BackendId::BackendB) => {
+                Some(*backend_b_inode)
+            }
+            _ => None,
+        }
+    }
+
+    /// Return the single active backend for a single-backed node.
+    pub(crate) fn current_backend(&self) -> Option<BackendId> {
+        match self {
+            NodeState::BackendA { .. } => Some(BackendId::BackendA),
+            NodeState::BackendB { .. } => Some(BackendId::BackendB),
+            _ => None,
+        }
+    }
+
+    /// Check if this is a pure single-backed directory on the given backend.
+    pub(crate) fn is_pure_on(&self, backend: BackendId) -> bool {
+        match (self, backend) {
+            (NodeState::BackendA { .. }, BackendId::BackendA) => true,
+            (NodeState::BackendB { .. }, BackendId::BackendB) => true,
+            _ => false,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for CachePolicy {
+    fn default() -> Self {
+        CachePolicy::Auto
+    }
+}
+
+impl Default for DualFsConfig {
+    fn default() -> Self {
+        DualFsConfig {
+            entry_timeout: Duration::from_secs(5),
+            attr_timeout: Duration::from_secs(5),
+            cache_policy: CachePolicy::default(),
+            writeback: false,
+            copy_chunk_size: DEFAULT_COPY_CHUNK_SIZE,
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/dualfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/xattr_ops.rs
@@ -1,0 +1,139 @@
+//! Extended attribute operations: getxattr, listxattr, setxattr, removexattr.
+
+use std::ffi::CStr;
+use std::io;
+
+use super::lookup::{backend, get_node, mark_metadata_authority, resolve_active_backend_inode};
+use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
+use super::types::BackendId;
+use super::DualFs;
+use crate::backends::shared::init_binary;
+use crate::{Context, GetxattrReply, ListxattrReply};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Handle getxattr. Direct dispatch from node state.
+pub(crate) fn do_getxattr(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    name: &CStr,
+    size: u32,
+) -> io::Result<GetxattrReply> {
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::ENODATA));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+    let (backend_id, child_inode) = resolve_active_backend_inode(&node);
+
+    backend(fs, backend_id).getxattr(ctx, child_inode, name, size)
+}
+
+/// Handle listxattr. Direct dispatch from node state.
+pub(crate) fn do_listxattr(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    size: u32,
+) -> io::Result<ListxattrReply> {
+    if ino == init_binary::INIT_INODE {
+        if size == 0 {
+            return Ok(ListxattrReply::Count(0));
+        }
+        return Ok(ListxattrReply::Names(Vec::new()));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+    let (backend_id, child_inode) = resolve_active_backend_inode(&node);
+
+    backend(fs, backend_id).listxattr(ctx, child_inode, size)
+}
+
+/// Handle setxattr. Full pipeline with policy routing.
+pub(crate) fn do_setxattr(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    name: &CStr,
+    value: &[u8],
+    flags: u32,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::EACCES));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Setxattr,
+        guest_inode: ino,
+        node_state: node.state.read().unwrap().clone(),
+        file_kind: node.kind,
+        flags,
+        name: Vec::new(),
+        parent_inode: 0,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    // Materialize if needed.
+    if let Some(current) = node.state.read().unwrap().current_backend() {
+        if current != target {
+            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
+        }
+    }
+
+    let target_inode = super::lookup::resolve_backend_inode(&fs.state, ino, target)
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    backend(fs, target).setxattr(ctx, target_inode, name, value, flags)?;
+    mark_metadata_authority(&fs.state, ino, target);
+
+    Ok(())
+}
+
+/// Handle removexattr. Full pipeline with policy routing.
+pub(crate) fn do_removexattr(
+    fs: &DualFs,
+    ctx: Context,
+    ino: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(io::Error::from_raw_os_error(libc::EACCES));
+    }
+
+    let node = get_node(&fs.state, ino)?;
+
+    let view = DualNamespaceView { state: &fs.state };
+    let req = RequestCtx {
+        op: OpKind::Removexattr,
+        guest_inode: ino,
+        node_state: node.state.read().unwrap().clone(),
+        file_kind: node.kind,
+        flags: 0,
+        name: Vec::new(),
+        parent_inode: 0,
+    };
+    let plan = fs.policy.plan(&req, &view, &HintBag::new())?;
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
+
+    // Materialize if needed.
+    if let Some(current) = node.state.read().unwrap().current_backend() {
+        if current != target {
+            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
+        }
+    }
+
+    let target_inode = super::lookup::resolve_backend_inode(&fs.state, ino, target)
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    backend(fs, target).removexattr(ctx, target_inode, name)?;
+    mark_metadata_authority(&fs.state, ino, target);
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/memfs/builder.rs
+++ b/crates/filesystem/lib/backends/memfs/builder.rs
@@ -1,0 +1,170 @@
+//! Builder API for constructing a MemFs instance.
+//!
+//! ```ignore
+//! MemFs::builder()
+//!     .capacity(1024 * 1024 * 64)
+//!     .max_inodes(10_000)
+//!     .build()?
+//! ```
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+use super::MemFs;
+use super::inode;
+use super::types::{
+    CachePolicy, InodeContent, InodeMeta, MemFsConfig, MemNode, ROOT_INODE,
+};
+use crate::backends::shared::init_binary;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Builder for constructing a [`MemFs`] instance.
+pub struct MemFsBuilder {
+    capacity: Option<u64>,
+    max_inodes: Option<u64>,
+    entry_timeout: Duration,
+    attr_timeout: Duration,
+    cache_policy: CachePolicy,
+    writeback: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MemFsBuilder {
+    /// Create a new builder with default settings.
+    pub(crate) fn new() -> Self {
+        Self {
+            capacity: None,
+            max_inodes: None,
+            entry_timeout: Duration::from_secs(5),
+            attr_timeout: Duration::from_secs(5),
+            cache_policy: CachePolicy::Always,
+            writeback: true,
+        }
+    }
+
+    /// Set the maximum capacity in bytes for file data.
+    pub fn capacity(mut self, bytes: u64) -> Self {
+        self.capacity = Some(bytes);
+        self
+    }
+
+    /// Set the maximum number of inodes.
+    pub fn max_inodes(mut self, count: u64) -> Self {
+        self.max_inodes = Some(count);
+        self
+    }
+
+    /// Set the FUSE entry cache timeout.
+    pub fn entry_timeout(mut self, timeout: Duration) -> Self {
+        self.entry_timeout = timeout;
+        self
+    }
+
+    /// Set the FUSE attribute cache timeout.
+    pub fn attr_timeout(mut self, timeout: Duration) -> Self {
+        self.attr_timeout = timeout;
+        self
+    }
+
+    /// Set the cache policy.
+    pub fn cache_policy(mut self, policy: CachePolicy) -> Self {
+        self.cache_policy = policy;
+        self
+    }
+
+    /// Enable or disable writeback caching.
+    pub fn writeback(mut self, enabled: bool) -> Self {
+        self.writeback = enabled;
+        self
+    }
+
+    /// Build the MemFs instance.
+    pub fn build(self) -> io::Result<MemFs> {
+        let now = inode::current_time();
+
+        let root = Arc::new(MemNode {
+            inode: ROOT_INODE,
+            kind: libc::S_IFDIR as u32,
+            lookup_refs: AtomicU64::new(u64::MAX / 2),
+            meta: RwLock::new(InodeMeta {
+                uid: 0,
+                gid: 0,
+                mode: libc::S_IFDIR as u32 | 0o755,
+                rdev: 0,
+                nlink: 2,
+                size: 0,
+                atime: now,
+                mtime: now,
+                ctime: now,
+            }),
+            content: InodeContent::Directory {
+                children: RwLock::new(BTreeMap::new()),
+                parent: AtomicU64::new(ROOT_INODE),
+            },
+            xattrs: RwLock::new(BTreeMap::new()),
+        });
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(ROOT_INODE, root);
+
+        let init_file = init_binary::create_init_file()?;
+        let staging_file = create_staging_file()?;
+
+        let cfg = MemFsConfig {
+            capacity: self.capacity,
+            max_inodes: self.max_inodes,
+            entry_timeout: self.entry_timeout,
+            attr_timeout: self.attr_timeout,
+            cache_policy: self.cache_policy,
+            writeback: self.writeback,
+        };
+
+        Ok(MemFs {
+            nodes: RwLock::new(nodes),
+            file_handles: RwLock::new(BTreeMap::new()),
+            dir_handles: RwLock::new(BTreeMap::new()),
+            next_inode: AtomicU64::new(3), // 1=root, 2=init
+            next_handle: AtomicU64::new(1), // 0=init handle
+            used_bytes: AtomicU64::new(0),
+            inode_count: AtomicU64::new(1), // root
+            writeback: AtomicBool::new(false),
+            staging_file: Mutex::new(staging_file),
+            init_file,
+            cfg,
+        })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create a staging file for ZeroCopy I/O data transfer.
+fn create_staging_file() -> io::Result<File> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::FromRawFd;
+
+        let name = std::ffi::CString::new("memfs-staging").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        tempfile::tempfile()
+    }
+}

--- a/crates/filesystem/lib/backends/memfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/create_ops.rs
@@ -1,0 +1,407 @@
+//! Creation operations: create, mkdir, mknod, symlink, link.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::{ffi::CStr, io};
+
+use super::MemFs;
+use super::inode;
+use super::types::{FileHandle, InodeContent, InodeMeta, MemNode, ROOT_INODE};
+use crate::backends::shared::init_binary;
+use crate::backends::shared::name_validation;
+use crate::backends::shared::platform;
+use crate::{Context, Entry, Extensions, OpenOptions};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create a regular file and open it atomically.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_create(
+    fs: &MemFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    _kill_priv: bool,
+    flags: u32,
+    umask: u32,
+    _extensions: Extensions,
+) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+    name_validation::validate_memfs_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eexist());
+    }
+
+    let parent_node = inode::get_node(fs, parent)?;
+    let ino = inode::alloc_inode(fs)?;
+    let now = inode::current_time();
+    let effective_mode = libc::S_IFREG as u32 | (mode & !umask & 0o7777);
+
+    let node = Arc::new(MemNode {
+        inode: ino,
+        kind: libc::S_IFREG as u32,
+        lookup_refs: AtomicU64::new(1),
+        meta: RwLock::new(InodeMeta {
+            uid: ctx.uid,
+            gid: ctx.gid,
+            mode: effective_mode,
+            rdev: 0,
+            nlink: 1,
+            size: 0,
+            atime: now,
+            mtime: now,
+            ctime: now,
+        }),
+        content: InodeContent::RegularFile {
+            data: RwLock::new(Vec::new()),
+        },
+        xattrs: RwLock::new(BTreeMap::new()),
+    });
+
+    // Insert into parent's children.
+    let name_bytes = name.to_bytes().to_vec();
+    match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let mut ch = children.write().unwrap();
+            if ch.contains_key(&name_bytes) {
+                // Undo inode allocation.
+                fs.inode_count
+                    .fetch_sub(1, Ordering::Relaxed);
+                return Err(platform::eexist());
+            }
+            ch.insert(name_bytes, ino);
+        }
+        _ => {
+            fs.inode_count
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(platform::enotdir());
+        }
+    }
+
+    // Update parent timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    // Register node.
+    fs.nodes.write().unwrap().insert(ino, node.clone());
+
+    // Create file handle.
+    let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let fh = Arc::new(FileHandle {
+        inode: ino,
+        node: node.clone(),
+        flags,
+    });
+    fs.file_handles.write().unwrap().insert(handle, fh);
+
+    let entry = inode::build_entry(fs, &node);
+    Ok((entry, Some(handle), fs.cache_open_options()))
+}
+
+/// Create a directory.
+pub(crate) fn do_mkdir(
+    fs: &MemFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    umask: u32,
+    _extensions: Extensions,
+) -> io::Result<Entry> {
+    name_validation::validate_memfs_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eexist());
+    }
+
+    let parent_node = inode::get_node(fs, parent)?;
+    let ino = inode::alloc_inode(fs)?;
+    let now = inode::current_time();
+    let effective_mode = libc::S_IFDIR as u32 | (mode & !umask & 0o7777);
+
+    let node = Arc::new(MemNode {
+        inode: ino,
+        kind: libc::S_IFDIR as u32,
+        lookup_refs: AtomicU64::new(1),
+        meta: RwLock::new(InodeMeta {
+            uid: ctx.uid,
+            gid: ctx.gid,
+            mode: effective_mode,
+            rdev: 0,
+            nlink: 2, // . and parent's link
+            size: 4096,
+            atime: now,
+            mtime: now,
+            ctime: now,
+        }),
+        content: InodeContent::Directory {
+            children: RwLock::new(BTreeMap::new()),
+            parent: AtomicU64::new(parent),
+        },
+        xattrs: RwLock::new(BTreeMap::new()),
+    });
+
+    // Insert into parent's children.
+    let name_bytes = name.to_bytes().to_vec();
+    match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let mut ch = children.write().unwrap();
+            if ch.contains_key(&name_bytes) {
+                fs.inode_count
+                    .fetch_sub(1, Ordering::Relaxed);
+                return Err(platform::eexist());
+            }
+            ch.insert(name_bytes, ino);
+        }
+        _ => {
+            fs.inode_count
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(platform::enotdir());
+        }
+    }
+
+    // Update parent: increment nlink (subdirectory adds a "..") and timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.nlink += 1;
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    // Register node.
+    fs.nodes.write().unwrap().insert(ino, node.clone());
+
+    let entry = inode::build_entry(fs, &node);
+    Ok(entry)
+}
+
+/// Create a file node (regular file, special file, etc).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_mknod(
+    fs: &MemFs,
+    ctx: Context,
+    parent: u64,
+    name: &CStr,
+    mode: u32,
+    rdev: u32,
+    umask: u32,
+    _extensions: Extensions,
+) -> io::Result<Entry> {
+    name_validation::validate_memfs_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eexist());
+    }
+
+    let parent_node = inode::get_node(fs, parent)?;
+    let ino = inode::alloc_inode(fs)?;
+    let now = inode::current_time();
+
+    let file_type = mode & libc::S_IFMT as u32;
+    let effective_mode = file_type | (mode & !umask & 0o7777);
+
+    let (kind, content) = match file_type {
+        m if m == libc::S_IFREG as u32 => (
+            libc::S_IFREG as u32,
+            InodeContent::RegularFile {
+                data: RwLock::new(Vec::new()),
+            },
+        ),
+        m if m == libc::S_IFBLK as u32
+            || m == libc::S_IFCHR as u32
+            || m == libc::S_IFIFO as u32
+            || m == libc::S_IFSOCK as u32 =>
+        {
+            (file_type, InodeContent::Special)
+        }
+        _ => {
+            fs.inode_count
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(platform::einval());
+        }
+    };
+
+    let node = Arc::new(MemNode {
+        inode: ino,
+        kind,
+        lookup_refs: AtomicU64::new(1),
+        meta: RwLock::new(InodeMeta {
+            uid: ctx.uid,
+            gid: ctx.gid,
+            mode: effective_mode,
+            rdev,
+            nlink: 1,
+            size: 0,
+            atime: now,
+            mtime: now,
+            ctime: now,
+        }),
+        content,
+        xattrs: RwLock::new(BTreeMap::new()),
+    });
+
+    // Insert into parent's children.
+    let name_bytes = name.to_bytes().to_vec();
+    match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let mut ch = children.write().unwrap();
+            if ch.contains_key(&name_bytes) {
+                fs.inode_count
+                    .fetch_sub(1, Ordering::Relaxed);
+                return Err(platform::eexist());
+            }
+            ch.insert(name_bytes, ino);
+        }
+        _ => {
+            fs.inode_count
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(platform::enotdir());
+        }
+    }
+
+    // Update parent timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    fs.nodes.write().unwrap().insert(ino, node.clone());
+
+    let entry = inode::build_entry(fs, &node);
+    Ok(entry)
+}
+
+/// Create a symbolic link.
+pub(crate) fn do_symlink(
+    fs: &MemFs,
+    ctx: Context,
+    linkname: &CStr,
+    parent: u64,
+    name: &CStr,
+    _extensions: Extensions,
+) -> io::Result<Entry> {
+    name_validation::validate_memfs_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eexist());
+    }
+
+    let parent_node = inode::get_node(fs, parent)?;
+    let ino = inode::alloc_inode(fs)?;
+    let now = inode::current_time();
+    let target = linkname.to_bytes().to_vec();
+
+    let node = Arc::new(MemNode {
+        inode: ino,
+        kind: libc::S_IFLNK as u32,
+        lookup_refs: AtomicU64::new(1),
+        meta: RwLock::new(InodeMeta {
+            uid: ctx.uid,
+            gid: ctx.gid,
+            mode: libc::S_IFLNK as u32 | 0o777,
+            rdev: 0,
+            nlink: 1,
+            size: target.len() as u64,
+            atime: now,
+            mtime: now,
+            ctime: now,
+        }),
+        content: InodeContent::Symlink { target },
+        xattrs: RwLock::new(BTreeMap::new()),
+    });
+
+    // Insert into parent's children.
+    let name_bytes = name.to_bytes().to_vec();
+    match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let mut ch = children.write().unwrap();
+            if ch.contains_key(&name_bytes) {
+                fs.inode_count
+                    .fetch_sub(1, Ordering::Relaxed);
+                return Err(platform::eexist());
+            }
+            ch.insert(name_bytes, ino);
+        }
+        _ => {
+            fs.inode_count
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(platform::enotdir());
+        }
+    }
+
+    // Update parent timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    fs.nodes.write().unwrap().insert(ino, node.clone());
+
+    let entry = inode::build_entry(fs, &node);
+    Ok(entry)
+}
+
+/// Create a hard link.
+pub(crate) fn do_link(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    newparent: u64,
+    newname: &CStr,
+) -> io::Result<Entry> {
+    name_validation::validate_memfs_name(newname)?;
+
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+
+    // Cannot hardlink directories.
+    if node.kind == libc::S_IFDIR as u32 {
+        return Err(platform::eperm());
+    }
+
+    let parent_node = inode::get_node(fs, newparent)?;
+    let name_bytes = newname.to_bytes().to_vec();
+    let now = inode::current_time();
+
+    // Insert into parent's children.
+    match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let mut ch = children.write().unwrap();
+            if ch.contains_key(&name_bytes) {
+                return Err(platform::eexist());
+            }
+            ch.insert(name_bytes, ino);
+        }
+        _ => return Err(platform::enotdir()),
+    }
+
+    // Increment nlink and lookup_refs.
+    {
+        let mut meta = node.meta.write().unwrap();
+        meta.nlink += 1;
+        meta.ctime = now;
+    }
+    inode::inc_lookup(&node);
+
+    // Update parent timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    let entry = inode::build_entry(fs, &node);
+    Ok(entry)
+}

--- a/crates/filesystem/lib/backends/memfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/dir_ops.rs
@@ -1,0 +1,250 @@
+//! Directory operations: opendir, readdir, readdirplus, releasedir.
+//!
+//! Readdir builds a point-in-time snapshot on first call. The snapshot is
+//! immutable for the handle's lifetime. Names use the bounded-leak technique
+//! for `DirEntry<'static>` lifetime requirements.
+
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use std::io;
+
+use super::MemFs;
+use super::inode;
+use super::types::{DirHandle, DirSnapshot, InodeContent, MemDirEntry, ROOT_INODE};
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, DirEntry, Entry, OpenOptions};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Open a directory and return a handle.
+pub(crate) fn do_opendir(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    _flags: u32,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    let node = inode::get_node(fs, ino)?;
+
+    if node.kind != libc::S_IFDIR as u32 {
+        return Err(platform::enotdir());
+    }
+
+    let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let dh = Arc::new(DirHandle {
+        inode: ino,
+        node: Arc::clone(&node),
+        snapshot: Mutex::new(None),
+    });
+
+    fs.dir_handles.write().unwrap().insert(handle, dh);
+    Ok((Some(handle), fs.cache_dir_options()))
+}
+
+/// Read directory entries from a snapshot.
+pub(crate) fn do_readdir(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+) -> io::Result<Vec<DirEntry<'static>>> {
+    serve_snapshot_entries(fs, ino, handle, offset)
+}
+
+/// Read directory entries with attributes (readdirplus).
+pub(crate) fn do_readdirplus(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    _size: u32,
+    offset: u64,
+) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+    let dir_entries = serve_snapshot_entries(fs, ino, handle, offset)?;
+    let mut result = Vec::with_capacity(dir_entries.len());
+
+    for de in dir_entries {
+        let name_bytes = de.name;
+
+        // Skip . and ..
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+
+        // For init.krun, return synthetic entry.
+        if name_bytes == init_binary::INIT_FILENAME {
+            let entry = init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+            result.push((de, entry));
+            continue;
+        }
+
+        // Look up the entry to get full attributes.
+        let child_ino = de.ino;
+        if let Ok(node) = inode::get_node(fs, child_ino) {
+            inode::inc_lookup(&node);
+            let entry = inode::build_entry(fs, &node);
+            result.push((de, entry));
+        }
+    }
+
+    Ok(result)
+}
+
+/// Release an open directory handle.
+pub(crate) fn do_releasedir(
+    fs: &MemFs,
+    _ctx: Context,
+    _ino: u64,
+    _flags: u32,
+    handle: u64,
+) -> io::Result<()> {
+    fs.dir_handles.write().unwrap().remove(&handle);
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Build or retrieve the snapshot and serve entries from the given offset.
+fn serve_snapshot_entries(
+    fs: &MemFs,
+    ino: u64,
+    handle: u64,
+    offset: u64,
+) -> io::Result<Vec<DirEntry<'static>>> {
+    let handles = fs.dir_handles.read().unwrap();
+    let dh = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    // Build snapshot on first call.
+    let mut snapshot_lock = dh.snapshot.lock().unwrap();
+    if snapshot_lock.is_none() {
+        *snapshot_lock = Some(build_snapshot(fs, ino, &dh.node)?);
+    }
+    let snapshot = snapshot_lock.as_ref().unwrap();
+
+    // Serve entries from offset.
+    let start = if offset == 0 {
+        0
+    } else {
+        snapshot
+            .entries
+            .iter()
+            .position(|e| e.offset > offset)
+            .unwrap_or(snapshot.entries.len())
+    };
+
+    if start >= snapshot.entries.len() {
+        return Ok(Vec::new());
+    }
+
+    let slice = &snapshot.entries[start..];
+
+    // Collect names into a contiguous buffer for bounded leak.
+    let mut names_buf: Vec<u8> = Vec::new();
+    let mut raw_entries: Vec<(u64, u64, u32, usize, usize)> = Vec::new();
+
+    for entry in slice {
+        let name_offset = names_buf.len();
+        names_buf.extend_from_slice(&entry.name);
+        raw_entries.push((
+            entry.inode,
+            entry.offset,
+            entry.file_type,
+            name_offset,
+            entry.name.len(),
+        ));
+    }
+
+    if raw_entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Leak one contiguous buffer (bounded: one per readdir call).
+    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
+
+    let entries = raw_entries
+        .into_iter()
+        .map(|(ino, off, typ, start, len)| DirEntry {
+            ino,
+            offset: off,
+            type_: typ,
+            name: &leaked[start..start + len],
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+/// Build a point-in-time snapshot of a directory's entries.
+fn build_snapshot(
+    fs: &MemFs,
+    ino: u64,
+    node: &super::types::MemNode,
+) -> io::Result<DirSnapshot> {
+    let children = match &node.content {
+        InodeContent::Directory { children, .. } => children.read().unwrap(),
+        _ => return Err(platform::enotdir()),
+    };
+
+    let mut entries = Vec::with_capacity(children.len() + 3);
+
+    // "." entry.
+    entries.push(MemDirEntry {
+        name: b".".to_vec(),
+        inode: ino,
+        offset: 0,
+        file_type: libc::DT_DIR as u32,
+    });
+
+    // ".." entry.
+    let parent_ino = match &node.content {
+        InodeContent::Directory { parent, .. } => parent.load(Ordering::Relaxed),
+        _ => ino,
+    };
+    entries.push(MemDirEntry {
+        name: b"..".to_vec(),
+        inode: parent_ino,
+        offset: 0,
+        file_type: libc::DT_DIR as u32,
+    });
+
+    // Inject init.krun for root directory.
+    if ino == ROOT_INODE {
+        entries.push(MemDirEntry {
+            name: init_binary::INIT_FILENAME.to_vec(),
+            inode: init_binary::INIT_INODE,
+            offset: 0,
+            file_type: libc::DT_REG as u32,
+        });
+    }
+
+    // Child entries.
+    for (name, &child_ino) in children.iter() {
+        let child_type = {
+            let nodes = fs.nodes.read().unwrap();
+            match nodes.get(&child_ino) {
+                Some(child) => inode::mode_to_dtype(child.kind),
+                None => libc::DT_UNKNOWN as u32,
+            }
+        };
+
+        entries.push(MemDirEntry {
+            name: name.clone(),
+            inode: child_ino,
+            offset: 0,
+            file_type: child_type,
+        });
+    }
+
+    // Assign 1-based monotonic offsets.
+    for (i, entry) in entries.iter_mut().enumerate() {
+        entry.offset = (i + 1) as u64;
+    }
+
+    Ok(DirSnapshot { entries })
+}

--- a/crates/filesystem/lib/backends/memfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/file_ops.rs
@@ -1,0 +1,288 @@
+//! File operations: open, read, write, readlink, flush, release.
+//!
+//! File data lives in `Vec<u8>` buffers in memory. Read and write use a
+//! staging file (memfd/tmpfile) to bridge the ZeroCopy traits, which
+//! operate on file descriptors rather than byte slices.
+
+use std::os::fd::AsRawFd;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::{cmp, io};
+
+use super::MemFs;
+use super::inode;
+use super::types::{FileHandle, InodeContent};
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Open a file and return a handle.
+pub(crate) fn do_open(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    kill_priv: bool,
+    flags: u32,
+) -> io::Result<(Option<u64>, OpenOptions)> {
+    if ino == init_binary::INIT_INODE {
+        return Ok((Some(init_binary::INIT_HANDLE), OpenOptions::KEEP_CACHE));
+    }
+
+    let node = inode::get_node(fs, ino)?;
+
+    if node.kind == libc::S_IFDIR as u32 {
+        return Err(platform::eisdir());
+    }
+
+    let mut open_flags = flags as i32;
+
+    // Writeback cache adjustments.
+    if fs.writeback.load(Ordering::Relaxed) {
+        if open_flags & libc::O_WRONLY != 0 {
+            open_flags = (open_flags & !libc::O_WRONLY) | libc::O_RDWR;
+        }
+        open_flags &= !libc::O_APPEND;
+    }
+
+    // Handle O_TRUNC: truncate file data.
+    if open_flags & libc::O_TRUNC != 0 {
+        if let InodeContent::RegularFile { ref data } = node.content {
+            let mut data = data.write().unwrap();
+            let old_len = data.len() as u64;
+            data.clear();
+            if old_len > 0 {
+                inode::release_bytes(fs, old_len);
+            }
+            let mut meta = node.meta.write().unwrap();
+            meta.size = 0;
+            let now = inode::current_time();
+            meta.mtime = now;
+            meta.ctime = now;
+        }
+    }
+
+    // Handle kill_priv: clear SUID/SGID on truncate.
+    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
+        let mut meta = node.meta.write().unwrap();
+        if meta.mode & (libc::S_ISUID as u32 | libc::S_ISGID as u32) != 0 {
+            meta.mode &= !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+            meta.ctime = inode::current_time();
+        }
+    }
+
+    let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let fh = Arc::new(FileHandle {
+        inode: ino,
+        node: Arc::clone(&node),
+        flags: open_flags as u32,
+    });
+
+    fs.file_handles.write().unwrap().insert(handle, fh);
+    Ok((Some(handle), fs.cache_open_options()))
+}
+
+/// Read data from a file.
+///
+/// Uses the staging file to bridge in-memory data to the ZeroCopyWriter.
+pub(crate) fn do_read(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    w: &mut dyn ZeroCopyWriter,
+    size: u32,
+    offset: u64,
+) -> io::Result<usize> {
+    if ino == init_binary::INIT_INODE {
+        return init_binary::read_init(w, &fs.init_file, size, offset);
+    }
+
+    let handles = fs.file_handles.read().unwrap();
+    let fh = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    let data = match &fh.node.content {
+        InodeContent::RegularFile { data } => data.read().unwrap(),
+        _ => return Err(platform::eisdir()),
+    };
+
+    if offset >= data.len() as u64 {
+        return Ok(0);
+    }
+
+    let end = cmp::min(offset as usize + size as usize, data.len());
+    let slice = &data[offset as usize..end];
+    let count = slice.len();
+
+    if count == 0 {
+        return Ok(0);
+    }
+
+    // Write data to staging file, then use write_from for FUSE transfer.
+    let staging = fs.staging_file.lock().unwrap();
+    let written = unsafe {
+        libc::pwrite(
+            staging.as_raw_fd(),
+            slice.as_ptr() as *const libc::c_void,
+            count,
+            0,
+        )
+    };
+    if written < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    w.write_from(&*staging, count, 0)
+}
+
+/// Write data to a file.
+///
+/// Uses the staging file to bridge ZeroCopyReader data to the in-memory buffer.
+pub(crate) fn do_write(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    r: &mut dyn ZeroCopyReader,
+    size: u32,
+    offset: u64,
+    kill_priv: bool,
+) -> io::Result<usize> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let handles = fs.file_handles.read().unwrap();
+    let fh = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    let data_lock = match &fh.node.content {
+        InodeContent::RegularFile { data } => data,
+        _ => return Err(platform::eisdir()),
+    };
+
+    // Validate that the write won't exceed stat64 representable size.
+    let requested_end = (offset as u64)
+        .checked_add(size as u64)
+        .ok_or_else(platform::einval)?;
+    if requested_end > i64::MAX as u64 {
+        return Err(platform::efbig());
+    }
+
+    // Read from guest into staging file.
+    let staging = fs.staging_file.lock().unwrap();
+    let count = r.read_to(&*staging, size as usize, 0)?;
+
+    if count == 0 {
+        return Ok(0);
+    }
+
+    // Read data back from staging file.
+    let mut buf = vec![0u8; count];
+    let read_back = unsafe {
+        libc::pread(
+            staging.as_raw_fd(),
+            buf.as_mut_ptr() as *mut libc::c_void,
+            count,
+            0,
+        )
+    };
+    if read_back < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    drop(staging);
+
+    let count = read_back as usize;
+    let start = offset as usize;
+    let new_end = start
+        .checked_add(count)
+        .ok_or_else(platform::efbig)?;
+
+    // Reserve capacity for growth.
+    {
+        let current_len = data_lock.read().unwrap().len();
+        if new_end > current_len {
+            let delta = (new_end - current_len) as u64;
+            inode::reserve_bytes(fs, delta)?;
+        }
+    }
+
+    // Write to in-memory data.
+    {
+        let mut data = data_lock.write().unwrap();
+        if new_end > data.len() {
+            data.resize(new_end, 0);
+        }
+        data[start..new_end].copy_from_slice(&buf[..count]);
+
+        // Update metadata.
+        let mut meta = fh.node.meta.write().unwrap();
+        meta.size = data.len() as u64;
+        let now = inode::current_time();
+        meta.mtime = now;
+        meta.ctime = now;
+
+        // kill_priv: clear SUID/SGID on data write.
+        if kill_priv {
+            meta.mode &= !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+        }
+    }
+
+    Ok(count)
+}
+
+/// Read the target of a symbolic link.
+pub(crate) fn do_readlink(fs: &MemFs, _ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::einval());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    match &node.content {
+        InodeContent::Symlink { target } => Ok(target.clone()),
+        _ => Err(platform::einval()),
+    }
+}
+
+/// Flush pending data for a file handle.
+pub(crate) fn do_flush(
+    _fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    _handle: u64,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Ok(());
+    }
+    // No-op for MemFs — data is already in memory.
+    Ok(())
+}
+
+/// Release an open file handle.
+pub(crate) fn do_release(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Ok(());
+    }
+
+    if let Some(fh) = fs.file_handles.write().unwrap().remove(&handle) {
+        // If this was the last reference to a regular file already evicted
+        // from the nodes table, release the capacity.
+        if fh.node.kind == libc::S_IFREG as u32 && Arc::strong_count(&fh.node) == 1 {
+            if let InodeContent::RegularFile { ref data } = fh.node.content {
+                let size = data.read().unwrap().len() as u64;
+                if size > 0 {
+                    inode::release_bytes(fs, size);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/memfs/inode.rs
+++ b/crates/filesystem/lib/backends/memfs/inode.rs
@@ -1,0 +1,216 @@
+//! Inode management: allocation, lookup, forget, stat building, capacity tracking.
+
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::MemFs;
+use super::types::{InodeContent, InodeMeta, MemNode, Timespec};
+use crate::backends::shared::platform;
+use crate::{Entry, stat64};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Get the current time as a `Timespec`.
+pub(crate) fn current_time() -> Timespec {
+    let mut tp = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut tp) };
+    Timespec {
+        sec: tp.tv_sec as i64,
+        nsec: tp.tv_nsec as i64,
+    }
+}
+
+/// Allocate a new inode number, checking the max_inodes limit.
+pub(crate) fn alloc_inode(fs: &MemFs) -> io::Result<u64> {
+    if let Some(max) = fs.cfg.max_inodes {
+        let current = fs.inode_count.load(Ordering::Relaxed);
+        if current >= max {
+            return Err(platform::enospc());
+        }
+    }
+
+    let ino = fs.next_inode.fetch_add(1, Ordering::Relaxed);
+    fs.inode_count.fetch_add(1, Ordering::Relaxed);
+    Ok(ino)
+}
+
+/// Get a node by inode number.
+pub(crate) fn get_node(fs: &MemFs, ino: u64) -> io::Result<Arc<MemNode>> {
+    let nodes = fs.nodes.read().unwrap();
+    nodes.get(&ino).cloned().ok_or_else(platform::enoent)
+}
+
+/// Build a `stat64` from a `MemNode`.
+pub(crate) fn build_stat(node: &MemNode) -> stat64 {
+    let meta = node.meta.read().unwrap();
+    build_stat_from_meta(node.inode, &meta)
+}
+
+/// Build a `stat64` from inode number and metadata.
+pub(crate) fn build_stat_from_meta(ino: u64, meta: &InodeMeta) -> stat64 {
+    let mut st: stat64 = unsafe { std::mem::zeroed() };
+
+    st.st_ino = ino;
+
+    #[cfg(target_os = "linux")]
+    {
+        st.st_mode = meta.mode;
+        st.st_nlink = meta.nlink;
+        st.st_rdev = meta.rdev as u64;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        st.st_mode = meta.mode as u16;
+        st.st_nlink = meta.nlink as u16;
+        st.st_rdev = meta.rdev as i32;
+    }
+
+    st.st_uid = meta.uid;
+    st.st_gid = meta.gid;
+    st.st_size = meta.size as i64;
+    st.st_blksize = 4096;
+    st.st_blocks = (meta.size as i64 + 511) / 512;
+    st.st_atime = meta.atime.sec;
+    st.st_atime_nsec = meta.atime.nsec;
+    st.st_mtime = meta.mtime.sec;
+    st.st_mtime_nsec = meta.mtime.nsec;
+    st.st_ctime = meta.ctime.sec;
+    st.st_ctime_nsec = meta.ctime.nsec;
+
+    st
+}
+
+/// Build a FUSE `Entry` from a `MemNode`.
+pub(crate) fn build_entry(fs: &MemFs, node: &MemNode) -> Entry {
+    let st = build_stat(node);
+    Entry {
+        inode: node.inode,
+        generation: 0,
+        attr: st,
+        attr_flags: 0,
+        attr_timeout: fs.cfg.attr_timeout,
+        entry_timeout: fs.cfg.entry_timeout,
+    }
+}
+
+/// Increment lookup reference count for a node.
+pub(crate) fn inc_lookup(node: &MemNode) {
+    node.lookup_refs.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Forget an inode: decrement lookup refs and evict if unreferenced.
+pub(crate) fn forget_one(fs: &MemFs, ino: u64, count: u64) {
+    let should_evict = {
+        let nodes = fs.nodes.read().unwrap();
+        match nodes.get(&ino) {
+            Some(node) => {
+                let prev = node.lookup_refs.fetch_sub(count, Ordering::Relaxed);
+                if prev < count {
+                    node.lookup_refs.store(0, Ordering::Relaxed);
+                }
+                let refs = node.lookup_refs.load(Ordering::Relaxed);
+                let nlink = node.meta.read().unwrap().nlink;
+                refs == 0 && nlink == 0
+            }
+            None => false,
+        }
+    };
+
+    if should_evict {
+        evict_inode(fs, ino);
+    }
+}
+
+/// Try to evict a node if it's unreferenced (nlink == 0 && lookup_refs == 0).
+pub(crate) fn try_evict(fs: &MemFs, ino: u64) {
+    let should_evict = {
+        let nodes = fs.nodes.read().unwrap();
+        match nodes.get(&ino) {
+            Some(node) => {
+                let refs = node.lookup_refs.load(Ordering::Relaxed);
+                let nlink = node.meta.read().unwrap().nlink;
+                refs == 0 && nlink == 0
+            }
+            None => false,
+        }
+    };
+
+    if should_evict {
+        evict_inode(fs, ino);
+    }
+}
+
+/// Remove an inode from the nodes table and release its resources.
+///
+/// Capacity for regular file data is released only when no open handles
+/// still pin the node alive. If handles exist, the bytes remain charged
+/// until the last handle is released (see `do_release`).
+fn evict_inode(fs: &MemFs, ino: u64) {
+    let removed = fs.nodes.write().unwrap().remove(&ino);
+    if let Some(node) = removed {
+        // Only release bytes if this is the last Arc holder (no open handles).
+        if Arc::strong_count(&node) == 1 {
+            if let InodeContent::RegularFile { ref data } = node.content {
+                let size = data.read().unwrap().len() as u64;
+                if size > 0 {
+                    release_bytes(fs, size);
+                }
+            }
+        }
+        fs.inode_count.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Reserve bytes against the capacity limit using a CAS loop.
+pub(crate) fn reserve_bytes(fs: &MemFs, amount: u64) -> io::Result<()> {
+    if amount == 0 {
+        return Ok(());
+    }
+
+    let cap = match fs.cfg.capacity {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    loop {
+        let current = fs.used_bytes.load(Ordering::Relaxed);
+        let new = current.checked_add(amount).ok_or_else(platform::enospc)?;
+        if new > cap {
+            return Err(platform::enospc());
+        }
+        if fs
+            .used_bytes
+            .compare_exchange_weak(current, new, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+}
+
+/// Release bytes from the capacity tracker.
+pub(crate) fn release_bytes(fs: &MemFs, amount: u64) {
+    if amount > 0 {
+        fs.used_bytes.fetch_sub(amount, Ordering::Relaxed);
+    }
+}
+
+/// Convert a file mode type to a directory entry type.
+pub(crate) fn mode_to_dtype(mode_type: u32) -> u32 {
+    match mode_type & libc::S_IFMT as u32 {
+        m if m == libc::S_IFLNK as u32 => libc::DT_LNK as u32,
+        m if m == libc::S_IFDIR as u32 => libc::DT_DIR as u32,
+        m if m == libc::S_IFCHR as u32 => libc::DT_CHR as u32,
+        m if m == libc::S_IFBLK as u32 => libc::DT_BLK as u32,
+        m if m == libc::S_IFIFO as u32 => libc::DT_FIFO as u32,
+        m if m == libc::S_IFSOCK as u32 => libc::DT_SOCK as u32,
+        _ => libc::DT_REG as u32,
+    }
+}

--- a/crates/filesystem/lib/backends/memfs/metadata.rs
+++ b/crates/filesystem/lib/backends/memfs/metadata.rs
@@ -1,0 +1,181 @@
+//! Attribute operations: getattr, setattr, access.
+//!
+//! All stat results are built directly from in-memory metadata.
+//! No xattr-based stat virtualization is needed — MemFs owns all metadata.
+
+use std::io;
+use std::time::Duration;
+
+use super::MemFs;
+use super::inode;
+use super::types::InodeContent;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, SetattrValid, stat64};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Get attributes for an inode.
+pub(crate) fn do_getattr(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    _handle: Option<u64>,
+) -> io::Result<(stat64, Duration)> {
+    if ino == init_binary::INIT_INODE {
+        return Ok((init_binary::init_stat(), fs.cfg.attr_timeout));
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let st = inode::build_stat(&node);
+    Ok((st, fs.cfg.attr_timeout))
+}
+
+/// Set attributes on an inode.
+pub(crate) fn do_setattr(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    attr: stat64,
+    _handle: Option<u64>,
+    valid: SetattrValid,
+) -> io::Result<(stat64, Duration)> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let mut meta = node.meta.write().unwrap();
+
+    // Handle size changes (truncate/extend).
+    if valid.contains(SetattrValid::SIZE) {
+        if let InodeContent::RegularFile { ref data } = node.content {
+            let old_len = {
+                let d = data.read().unwrap();
+                d.len() as u64
+            };
+            if attr.st_size < 0 {
+                return Err(platform::einval());
+            }
+            let new_len = attr.st_size as u64;
+            if new_len > i64::MAX as u64 {
+                return Err(platform::efbig());
+            }
+            let new_len_usize = usize::try_from(new_len).map_err(|_| platform::efbig())?;
+
+            if new_len < old_len {
+                let mut d = data.write().unwrap();
+                d.truncate(new_len_usize);
+                inode::release_bytes(fs, old_len - new_len);
+            } else if new_len > old_len {
+                let growth = new_len - old_len;
+                inode::reserve_bytes(fs, growth)?;
+                let mut d = data.write().unwrap();
+                d.resize(new_len_usize, 0);
+            }
+            meta.size = new_len;
+        } else {
+            return Err(platform::einval());
+        }
+    }
+
+    // Handle mode changes (preserve file type bits).
+    if valid.contains(SetattrValid::MODE) {
+        #[cfg(target_os = "linux")]
+        let attr_mode = attr.st_mode;
+        #[cfg(target_os = "macos")]
+        let attr_mode = attr.st_mode as u32;
+        meta.mode = (meta.mode & libc::S_IFMT as u32) | (attr_mode & !libc::S_IFMT as u32);
+    }
+
+    if valid.contains(SetattrValid::UID) {
+        meta.uid = attr.st_uid;
+    }
+
+    if valid.contains(SetattrValid::GID) {
+        meta.gid = attr.st_gid;
+    }
+
+    // Handle timestamp changes.
+    if valid.contains(SetattrValid::ATIME) {
+        if valid.contains(SetattrValid::ATIME_NOW) {
+            meta.atime = inode::current_time();
+        } else {
+            meta.atime = super::types::Timespec {
+                sec: attr.st_atime,
+                nsec: attr.st_atime_nsec,
+            };
+        }
+    }
+
+    if valid.contains(SetattrValid::MTIME) {
+        if valid.contains(SetattrValid::MTIME_NOW) {
+            meta.mtime = inode::current_time();
+        } else {
+            meta.mtime = super::types::Timespec {
+                sec: attr.st_mtime,
+                nsec: attr.st_mtime_nsec,
+            };
+        }
+    }
+
+    // Handle kill SUID/SGID.
+    if valid.contains(SetattrValid::KILL_SUIDGID) {
+        meta.mode &= !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+    }
+
+    meta.ctime = inode::current_time();
+
+    let st = inode::build_stat_from_meta(ino, &meta);
+    Ok((st, fs.cfg.attr_timeout))
+}
+
+/// Check file access permissions using in-memory metadata.
+pub(crate) fn do_access(fs: &MemFs, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        if mask & libc::W_OK as u32 != 0 {
+            return Err(platform::eacces());
+        }
+        return Ok(());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let meta = node.meta.read().unwrap();
+
+    // F_OK: just check existence.
+    if mask == libc::F_OK as u32 {
+        return Ok(());
+    }
+
+    let st_mode = meta.mode;
+
+    // Root bypasses read/write checks.
+    if ctx.uid == 0 {
+        if mask & libc::X_OK as u32 != 0 && st_mode & 0o111 == 0 {
+            return Err(platform::eacces());
+        }
+        return Ok(());
+    }
+
+    let bits = if meta.uid == ctx.uid {
+        (st_mode >> 6) & 0o7
+    } else if meta.gid == ctx.gid {
+        (st_mode >> 3) & 0o7
+    } else {
+        st_mode & 0o7
+    };
+
+    if mask & libc::R_OK as u32 != 0 && bits & 0o4 == 0 {
+        return Err(platform::eacces());
+    }
+    if mask & libc::W_OK as u32 != 0 && bits & 0o2 == 0 {
+        return Err(platform::eacces());
+    }
+    if mask & libc::X_OK as u32 != 0 && bits & 0o1 == 0 {
+        return Err(platform::eacces());
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/memfs/mod.rs
+++ b/crates/filesystem/lib/backends/memfs/mod.rs
@@ -1,0 +1,457 @@
+//! In-memory filesystem backend.
+//!
+//! Provides a pure in-memory filesystem implementing [`DynFileSystem`].
+//! All inodes, directory entries, file data, metadata, and xattrs live
+//! entirely in process memory. The filesystem is ephemeral — all data
+//! is lost when the backend is dropped.
+
+pub(crate) mod builder;
+mod create_ops;
+mod dir_ops;
+mod file_ops;
+mod inode;
+mod metadata;
+mod remove_ops;
+mod special;
+/// Type definitions for the in-memory filesystem.
+pub mod types;
+mod xattr_ops;
+
+use std::collections::BTreeMap;
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, RwLock};
+use std::time::Duration;
+
+use types::{DirHandle, FileHandle, MemNode, ROOT_INODE};
+
+use crate::backends::shared::init_binary;
+use crate::{
+    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// In-memory filesystem backend.
+///
+/// Implements [`DynFileSystem`] with all data stored in process memory.
+/// No host filesystem interaction occurs (except for the embedded init binary).
+pub struct MemFs {
+    /// Inode table: FUSE inode → MemNode.
+    pub(crate) nodes: RwLock<BTreeMap<u64, std::sync::Arc<MemNode>>>,
+
+    /// Open file handle table.
+    pub(crate) file_handles: RwLock<BTreeMap<u64, std::sync::Arc<FileHandle>>>,
+
+    /// Open directory handle table.
+    pub(crate) dir_handles: RwLock<BTreeMap<u64, std::sync::Arc<DirHandle>>>,
+
+    /// Next FUSE inode number to allocate (starts at 3: 1=root, 2=init).
+    pub(crate) next_inode: AtomicU64,
+
+    /// Next handle number to allocate (starts at 1: 0=init handle).
+    pub(crate) next_handle: AtomicU64,
+
+    /// Total bytes used by regular file data.
+    pub(crate) used_bytes: AtomicU64,
+
+    /// Total number of inodes in the nodes table.
+    pub(crate) inode_count: AtomicU64,
+
+    /// Whether writeback caching is negotiated.
+    pub(crate) writeback: AtomicBool,
+
+    /// Staging file for ZeroCopy I/O (memfd on Linux, tmpfile on macOS).
+    pub(crate) staging_file: Mutex<File>,
+
+    /// File containing the init binary bytes.
+    pub(crate) init_file: File,
+
+    /// Configuration.
+    pub(crate) cfg: MemFsConfig,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MemFs {
+    /// Create a builder for constructing a MemFs.
+    pub fn builder() -> builder::MemFsBuilder {
+        builder::MemFsBuilder::new()
+    }
+
+    /// Get the `OpenOptions` for file opens based on cache policy.
+    pub(crate) fn cache_open_options(&self) -> OpenOptions {
+        match self.cfg.cache_policy {
+            types::CachePolicy::Never => OpenOptions::DIRECT_IO,
+            types::CachePolicy::Auto => OpenOptions::empty(),
+            types::CachePolicy::Always => OpenOptions::KEEP_CACHE,
+        }
+    }
+
+    /// Get the `OpenOptions` for directory opens based on cache policy.
+    pub(crate) fn cache_dir_options(&self) -> OpenOptions {
+        match self.cfg.cache_policy {
+            types::CachePolicy::Never => OpenOptions::DIRECT_IO,
+            types::CachePolicy::Auto => OpenOptions::empty(),
+            types::CachePolicy::Always => OpenOptions::CACHE_DIR,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DynFileSystem for MemFs {
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        let mut opts = FsOptions::empty();
+
+        let wanted = FsOptions::DONT_MASK
+            | FsOptions::BIG_WRITES
+            | FsOptions::ASYNC_READ
+            | FsOptions::PARALLEL_DIROPS
+            | FsOptions::MAX_PAGES
+            | FsOptions::HANDLE_KILLPRIV_V2;
+        opts |= capable & wanted;
+
+        if capable.contains(FsOptions::DO_READDIRPLUS) {
+            opts |= FsOptions::DO_READDIRPLUS | FsOptions::READDIRPLUS_AUTO;
+        }
+
+        if self.cfg.writeback && capable.contains(FsOptions::WRITEBACK_CACHE) {
+            opts |= FsOptions::WRITEBACK_CACHE;
+            self.writeback.store(true, Ordering::Relaxed);
+        }
+
+        Ok(opts)
+    }
+
+    fn destroy(&self) {
+        self.file_handles.write().unwrap().clear();
+        self.dir_handles.write().unwrap().clear();
+        self.nodes.write().unwrap().clear();
+    }
+
+    fn lookup(&self, _ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+            return Ok(init_binary::init_entry(
+                self.cfg.entry_timeout,
+                self.cfg.attr_timeout,
+            ));
+        }
+
+        let parent_node = inode::get_node(self, parent)?;
+        let name_bytes = name.to_bytes();
+
+        let child_ino = match &parent_node.content {
+            types::InodeContent::Directory { children, .. } => {
+                let ch = children.read().unwrap();
+                *ch.get(name_bytes).ok_or_else(crate::backends::shared::platform::enoent)?
+            }
+            _ => return Err(crate::backends::shared::platform::enotdir()),
+        };
+
+        let child = inode::get_node(self, child_ino)?;
+        inode::inc_lookup(&child);
+        let entry = inode::build_entry(self, &child);
+        Ok(entry)
+    }
+
+    fn forget(&self, _ctx: Context, ino: u64, count: u64) {
+        if ino == init_binary::INIT_INODE {
+            return;
+        }
+        inode::forget_one(self, ino, count);
+    }
+
+    fn batch_forget(&self, _ctx: Context, requests: Vec<(u64, u64)>) {
+        for (ino, count) in requests {
+            if ino == init_binary::INIT_INODE {
+                continue;
+            }
+            inode::forget_one(self, ino, count);
+        }
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: Option<u64>,
+    ) -> io::Result<(stat64, Duration)> {
+        metadata::do_getattr(self, ctx, ino, handle)
+    }
+
+    fn setattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        attr: stat64,
+        handle: Option<u64>,
+        valid: SetattrValid,
+    ) -> io::Result<(stat64, Duration)> {
+        metadata::do_setattr(self, ctx, ino, attr, handle, valid)
+    }
+
+    fn readlink(&self, ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
+        file_ops::do_readlink(self, ctx, ino)
+    }
+
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: u64,
+        name: &CStr,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_symlink(self, ctx, linkname, parent, name, extensions)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_mknod(self, ctx, parent, name, mode, rdev, umask, extensions)
+    }
+
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        create_ops::do_mkdir(self, ctx, parent, name, mode, umask, extensions)
+    }
+
+    fn unlink(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        remove_ops::do_unlink(self, ctx, parent, name)
+    }
+
+    fn rmdir(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        remove_ops::do_rmdir(self, ctx, parent, name)
+    }
+
+    fn rename(
+        &self,
+        ctx: Context,
+        olddir: u64,
+        oldname: &CStr,
+        newdir: u64,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        remove_ops::do_rename(self, ctx, olddir, oldname, newdir, newname, flags)
+    }
+
+    fn link(
+        &self,
+        ctx: Context,
+        ino: u64,
+        newparent: u64,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        create_ops::do_link(self, ctx, ino, newparent, newname)
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        ino: u64,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        file_ops::do_open(self, ctx, ino, kill_priv, flags)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        kill_priv: bool,
+        flags: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+        create_ops::do_create(self, ctx, parent, name, mode, kill_priv, flags, umask, extensions)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        file_ops::do_read(self, ctx, ino, handle, w, size, offset)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _delayed_write: bool,
+        kill_priv: bool,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        file_ops::do_write(self, ctx, ino, handle, r, size, offset, kill_priv)
+    }
+
+    fn flush(&self, ctx: Context, ino: u64, handle: u64, _lock_owner: u64) -> io::Result<()> {
+        file_ops::do_flush(self, ctx, ino, handle)
+    }
+
+    fn fsync(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        special::do_fsync(self, ctx, ino, datasync, handle)
+    }
+
+    fn fallocate(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        special::do_fallocate(self, ctx, ino, handle, mode, offset, length)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn release(
+        &self,
+        ctx: Context,
+        ino: u64,
+        _flags: u32,
+        handle: u64,
+        _flush: bool,
+        _flock_release: bool,
+        _lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        file_ops::do_release(self, ctx, ino, handle)
+    }
+
+    fn statfs(&self, ctx: Context, ino: u64) -> io::Result<statvfs64> {
+        special::do_statfs(self, ctx, ino)
+    }
+
+    fn setxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        xattr_ops::do_setxattr(self, ctx, ino, name, value, flags)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        xattr_ops::do_getxattr(self, ctx, ino, name, size)
+    }
+
+    fn listxattr(&self, ctx: Context, ino: u64, size: u32) -> io::Result<ListxattrReply> {
+        xattr_ops::do_listxattr(self, ctx, ino, size)
+    }
+
+    fn removexattr(&self, ctx: Context, ino: u64, name: &CStr) -> io::Result<()> {
+        xattr_ops::do_removexattr(self, ctx, ino, name)
+    }
+
+    fn opendir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        dir_ops::do_opendir(self, ctx, ino, flags)
+    }
+
+    fn readdir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<DirEntry<'static>>> {
+        dir_ops::do_readdir(self, ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+        dir_ops::do_readdirplus(self, ctx, ino, handle, size, offset)
+    }
+
+    fn fsyncdir(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        special::do_fsyncdir(self, ctx, ino, datasync, handle)
+    }
+
+    fn releasedir(&self, ctx: Context, ino: u64, flags: u32, handle: u64) -> io::Result<()> {
+        dir_ops::do_releasedir(self, ctx, ino, flags, handle)
+    }
+
+    fn access(&self, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
+        metadata::do_access(self, ctx, ino, mask)
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        special::do_lseek(self, ctx, ino, handle, offset, whence)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use types::{CachePolicy, MemFsConfig};

--- a/crates/filesystem/lib/backends/memfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/remove_ops.rs
@@ -1,0 +1,302 @@
+//! Deletion operations: unlink, rmdir, rename.
+
+use std::ffi::CStr;
+use std::io;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::MemFs;
+use super::inode;
+use super::types::{InodeContent, ROOT_INODE};
+use crate::backends::shared::init_binary;
+use crate::backends::shared::name_validation;
+use crate::backends::shared::platform;
+use crate::Context;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Unlink a file (remove directory entry).
+pub(crate) fn do_unlink(
+    fs: &MemFs,
+    _ctx: Context,
+    parent: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    name_validation::validate_memfs_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_node = inode::get_node(fs, parent)?;
+    let name_bytes = name.to_bytes().to_vec();
+    let now = inode::current_time();
+
+    // Remove from parent and get child inode.
+    let child_ino = match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let mut ch = children.write().unwrap();
+            ch.remove(&name_bytes).ok_or_else(platform::enoent)?
+        }
+        _ => return Err(platform::enotdir()),
+    };
+
+    // Verify it's not a directory.
+    let child_node = inode::get_node(fs, child_ino)?;
+    if child_node.kind == libc::S_IFDIR as u32 {
+        // Re-insert the entry since we shouldn't have removed it.
+        if let InodeContent::Directory { children, .. } = &parent_node.content {
+            children.write().unwrap().insert(name_bytes, child_ino);
+        }
+        return Err(platform::eisdir());
+    }
+
+    // Decrement nlink.
+    {
+        let mut meta = child_node.meta.write().unwrap();
+        meta.nlink = meta.nlink.saturating_sub(1);
+        meta.ctime = now;
+    }
+
+    // Update parent timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    // Try to evict if unreferenced.
+    inode::try_evict(fs, child_ino);
+
+    Ok(())
+}
+
+/// Remove an empty directory.
+pub(crate) fn do_rmdir(
+    fs: &MemFs,
+    _ctx: Context,
+    parent: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    name_validation::validate_memfs_name(name)?;
+
+    if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
+        return Err(platform::eacces());
+    }
+
+    let parent_node = inode::get_node(fs, parent)?;
+    let name_bytes = name.to_bytes().to_vec();
+    let now = inode::current_time();
+
+    // Look up child inode first (don't remove yet).
+    let child_ino = match &parent_node.content {
+        InodeContent::Directory { children, .. } => {
+            let ch = children.read().unwrap();
+            *ch.get(&name_bytes).ok_or_else(platform::enoent)?
+        }
+        _ => return Err(platform::enotdir()),
+    };
+
+    let child_node = inode::get_node(fs, child_ino)?;
+
+    // Verify it's a directory.
+    if child_node.kind != libc::S_IFDIR as u32 {
+        return Err(platform::enotdir());
+    }
+
+    // Verify it's empty.
+    if let InodeContent::Directory { children, .. } = &child_node.content {
+        if !children.read().unwrap().is_empty() {
+            return Err(platform::enotempty());
+        }
+    }
+
+    // Now remove from parent.
+    if let InodeContent::Directory { children, .. } = &parent_node.content {
+        children.write().unwrap().remove(&name_bytes);
+    }
+
+    // Set child nlink to 0.
+    {
+        let mut meta = child_node.meta.write().unwrap();
+        meta.nlink = 0;
+        meta.ctime = now;
+    }
+
+    // Decrement parent nlink (lost a subdirectory) and update timestamps.
+    {
+        let mut meta = parent_node.meta.write().unwrap();
+        meta.nlink = meta.nlink.saturating_sub(1);
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    // Try to evict if unreferenced.
+    inode::try_evict(fs, child_ino);
+
+    Ok(())
+}
+
+/// Rename a file or directory.
+pub(crate) fn do_rename(
+    fs: &MemFs,
+    _ctx: Context,
+    olddir: u64,
+    oldname: &CStr,
+    newdir: u64,
+    newname: &CStr,
+    _flags: u32,
+) -> io::Result<()> {
+    name_validation::validate_memfs_name(oldname)?;
+    name_validation::validate_memfs_name(newname)?;
+
+    let old_bytes = oldname.to_bytes().to_vec();
+    let new_bytes = newname.to_bytes().to_vec();
+
+    // Protect init.krun.
+    if olddir == ROOT_INODE && init_binary::is_init_name(&old_bytes) {
+        return Err(platform::eacces());
+    }
+    if newdir == ROOT_INODE && init_binary::is_init_name(&new_bytes) {
+        return Err(platform::eacces());
+    }
+
+    // No-op if same parent and same name.
+    if olddir == newdir && old_bytes == new_bytes {
+        return Ok(());
+    }
+
+    let old_parent = inode::get_node(fs, olddir)?;
+    let new_parent = if newdir == olddir {
+        Arc::clone(&old_parent)
+    } else {
+        inode::get_node(fs, newdir)?
+    };
+
+    let now = inode::current_time();
+
+    // Get source inode.
+    let source_ino = match &old_parent.content {
+        InodeContent::Directory { children, .. } => {
+            let ch = children.read().unwrap();
+            *ch.get(&old_bytes).ok_or_else(platform::enoent)?
+        }
+        _ => return Err(platform::enotdir()),
+    };
+
+    let source_node = inode::get_node(fs, source_ino)?;
+    let source_is_dir = source_node.kind == libc::S_IFDIR as u32;
+
+    // Check destination.
+    let dest_ino = match &new_parent.content {
+        InodeContent::Directory { children, .. } => {
+            let ch = children.read().unwrap();
+            ch.get(&new_bytes).copied()
+        }
+        _ => return Err(platform::enotdir()),
+    };
+
+    // Handle existing destination.
+    let mut evict_dest = None;
+    if let Some(dest) = dest_ino {
+        let dest_node = inode::get_node(fs, dest)?;
+        let dest_is_dir = dest_node.kind == libc::S_IFDIR as u32;
+
+        // Type compatibility checks.
+        if source_is_dir && !dest_is_dir {
+            return Err(platform::enotdir());
+        }
+        if !source_is_dir && dest_is_dir {
+            return Err(platform::eisdir());
+        }
+
+        // If destination is a directory, it must be empty.
+        if dest_is_dir {
+            if let InodeContent::Directory { children, .. } = &dest_node.content {
+                if !children.read().unwrap().is_empty() {
+                    return Err(platform::enotempty());
+                }
+            }
+        }
+
+        // Decrement destination nlink.
+        {
+            let mut meta = dest_node.meta.write().unwrap();
+            if dest_is_dir {
+                meta.nlink = 0;
+            } else {
+                meta.nlink = meta.nlink.saturating_sub(1);
+            }
+            meta.ctime = now;
+        }
+
+        // If destination is a directory, decrement new_parent nlink.
+        if dest_is_dir {
+            let mut meta = new_parent.meta.write().unwrap();
+            meta.nlink = meta.nlink.saturating_sub(1);
+        }
+
+        evict_dest = Some(dest);
+    }
+
+    // Perform the rename: remove from old, insert into new.
+    if olddir == newdir {
+        // Same parent — single children lock.
+        if let InodeContent::Directory { children, .. } = &old_parent.content {
+            let mut ch = children.write().unwrap();
+            ch.remove(&old_bytes);
+            ch.insert(new_bytes, source_ino);
+        }
+    } else {
+        // Different parents — lock old first, then new.
+        if let InodeContent::Directory { children, .. } = &old_parent.content {
+            children.write().unwrap().remove(&old_bytes);
+        }
+        if let InodeContent::Directory { children, .. } = &new_parent.content {
+            children.write().unwrap().insert(new_bytes, source_ino);
+        }
+    }
+
+    // Update nlinks and parent pointer for directory moves.
+    if source_is_dir && olddir != newdir {
+        // Old parent lost a subdirectory.
+        {
+            let mut meta = old_parent.meta.write().unwrap();
+            meta.nlink = meta.nlink.saturating_sub(1);
+        }
+        // New parent gained a subdirectory.
+        {
+            let mut meta = new_parent.meta.write().unwrap();
+            meta.nlink += 1;
+        }
+        // Update source's parent pointer.
+        if let InodeContent::Directory { parent, .. } = &source_node.content {
+            parent.store(newdir, Ordering::Relaxed);
+        }
+    }
+
+    // Update timestamps.
+    {
+        let mut meta = source_node.meta.write().unwrap();
+        meta.ctime = now;
+    }
+    {
+        let mut meta = old_parent.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+    if olddir != newdir {
+        let mut meta = new_parent.meta.write().unwrap();
+        meta.mtime = now;
+        meta.ctime = now;
+    }
+
+    // Evict replaced destination if unreferenced.
+    if let Some(dest) = evict_dest {
+        inode::try_evict(fs, dest);
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/memfs/special.rs
+++ b/crates/filesystem/lib/backends/memfs/special.rs
@@ -1,0 +1,246 @@
+//! Special operations: statfs, lseek, fallocate, fsync, fsyncdir.
+
+use std::io;
+use std::sync::atomic::Ordering;
+
+use super::MemFs;
+use super::inode;
+use super::types::InodeContent;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, statvfs64};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// `SEEK_DATA` — seek to next data region.
+const SEEK_DATA: u32 = 3;
+
+/// `SEEK_HOLE` — seek to next hole region.
+const SEEK_HOLE: u32 = 4;
+
+/// `FALLOC_FL_PUNCH_HOLE` — punch a hole (zero-fill) in the file.
+const FALLOC_FL_PUNCH_HOLE: u32 = 0x02;
+
+/// `FALLOC_FL_KEEP_SIZE` — don't change file size.
+const FALLOC_FL_KEEP_SIZE: u32 = 0x01;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Return filesystem statistics.
+pub(crate) fn do_statfs(fs: &MemFs, _ctx: Context, _ino: u64) -> io::Result<statvfs64> {
+    let bsize = 4096u64;
+
+    let total_bytes = fs.cfg.capacity.unwrap_or(1u64 << 50); // 1 PiB
+    let total_inodes = fs.cfg.max_inodes.unwrap_or(1u64 << 30); // ~1 billion
+
+    let used = fs.used_bytes.load(Ordering::Relaxed);
+    let used_ino = fs.inode_count.load(Ordering::Relaxed);
+
+    let mut st: statvfs64 = unsafe { std::mem::zeroed() };
+
+    #[cfg(target_os = "linux")]
+    {
+        st.f_bsize = bsize;
+        st.f_frsize = bsize;
+        st.f_blocks = total_bytes / bsize;
+        st.f_bfree = total_bytes.saturating_sub(used) / bsize;
+        st.f_bavail = total_bytes.saturating_sub(used) / bsize;
+        st.f_files = total_inodes;
+        st.f_ffree = total_inodes.saturating_sub(used_ino);
+        st.f_favail = total_inodes.saturating_sub(used_ino);
+        st.f_namemax = 255;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        st.f_bsize = bsize;
+        st.f_frsize = bsize;
+        st.f_blocks = (total_bytes / bsize) as u32;
+        st.f_bfree = (total_bytes.saturating_sub(used) / bsize) as u32;
+        st.f_bavail = (total_bytes.saturating_sub(used) / bsize) as u32;
+        st.f_files = total_inodes as u32;
+        st.f_ffree = total_inodes.saturating_sub(used_ino) as u32;
+        st.f_favail = total_inodes.saturating_sub(used_ino) as u32;
+        st.f_namemax = 255;
+    }
+
+    Ok(st)
+}
+
+/// Seek to a position in a file.
+pub(crate) fn do_lseek(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    offset: u64,
+    whence: u32,
+) -> io::Result<u64> {
+    if ino == init_binary::INIT_INODE {
+        return lseek_init(offset, whence);
+    }
+
+    let handles = fs.file_handles.read().unwrap();
+    let fh = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    let data = match &fh.node.content {
+        InodeContent::RegularFile { data } => data.read().unwrap(),
+        _ => return Err(platform::einval()),
+    };
+
+    let file_size = data.len() as u64;
+
+    match whence {
+        w if w == libc::SEEK_SET as u32 => Ok(offset),
+        w if w == libc::SEEK_END as u32 => {
+            let signed_offset = offset as i64;
+            let pos = (file_size as i64)
+                .checked_add(signed_offset)
+                .ok_or_else(platform::einval)?;
+            if pos < 0 {
+                return Err(platform::einval());
+            }
+            Ok(pos as u64)
+        }
+        SEEK_DATA => {
+            // All data is non-sparse in memory.
+            if offset >= file_size {
+                Err(platform::enxio())
+            } else {
+                Ok(offset)
+            }
+        }
+        SEEK_HOLE => {
+            // Hole starts at EOF.
+            if offset >= file_size {
+                Err(platform::enxio())
+            } else {
+                Ok(file_size)
+            }
+        }
+        _ => Err(platform::einval()),
+    }
+}
+
+/// Allocate or punch a hole in a file.
+pub(crate) fn do_fallocate(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    handle: u64,
+    mode: u32,
+    offset: u64,
+    length: u64,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let handles = fs.file_handles.read().unwrap();
+    let fh = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    if fh.node.kind != libc::S_IFREG as u32 {
+        return Err(platform::enodev());
+    }
+
+    if mode == 0 {
+        // Allocate space: extend file if needed.
+        let new_end = offset
+            .checked_add(length)
+            .ok_or_else(platform::einval)?;
+        if new_end > i64::MAX as u64 {
+            return Err(platform::efbig());
+        }
+        let new_end_usize = usize::try_from(new_end).map_err(|_| platform::efbig())?;
+
+        if let InodeContent::RegularFile { ref data } = fh.node.content {
+            let mut d = data.write().unwrap();
+            if new_end_usize > d.len() {
+                let growth = new_end - d.len() as u64;
+                inode::reserve_bytes(fs, growth)?;
+                d.resize(new_end_usize, 0);
+                fh.node.meta.write().unwrap().size = new_end;
+            }
+        }
+        Ok(())
+    } else if mode & FALLOC_FL_PUNCH_HOLE != 0 && mode & FALLOC_FL_KEEP_SIZE != 0 {
+        // Punch hole: zero out range without changing file size.
+        if let InodeContent::RegularFile { ref data } = fh.node.content {
+            let mut d = data.write().unwrap();
+            let start = std::cmp::min(offset as usize, d.len());
+            let end_offset = offset.checked_add(length).unwrap_or(u64::MAX);
+            let end = std::cmp::min(end_offset as usize, d.len());
+            if start < end {
+                d[start..end].fill(0);
+            }
+        }
+        Ok(())
+    } else {
+        Err(platform::eopnotsupp())
+    }
+}
+
+/// Sync a file to disk (no-op for MemFs).
+pub(crate) fn do_fsync(
+    _fs: &MemFs,
+    _ctx: Context,
+    _ino: u64,
+    _datasync: bool,
+    _handle: u64,
+) -> io::Result<()> {
+    Ok(())
+}
+
+/// Sync a directory to disk (no-op for MemFs).
+pub(crate) fn do_fsyncdir(
+    _fs: &MemFs,
+    _ctx: Context,
+    _ino: u64,
+    _datasync: bool,
+    _handle: u64,
+) -> io::Result<()> {
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// lseek on the virtual init binary.
+fn lseek_init(offset: u64, whence: u32) -> io::Result<u64> {
+    use crate::agentd::AGENTD_BYTES;
+    let file_size = AGENTD_BYTES.len() as u64;
+
+    match whence {
+        w if w == libc::SEEK_SET as u32 => Ok(offset),
+        w if w == libc::SEEK_END as u32 => {
+            let signed_offset = offset as i64;
+            let pos = (file_size as i64)
+                .checked_add(signed_offset)
+                .ok_or_else(platform::einval)?;
+            if pos < 0 {
+                return Err(platform::einval());
+            }
+            Ok(pos as u64)
+        }
+        SEEK_DATA => {
+            if offset >= file_size {
+                Err(platform::enxio())
+            } else {
+                Ok(offset)
+            }
+        }
+        SEEK_HOLE => {
+            if offset >= file_size {
+                Err(platform::enxio())
+            } else {
+                Ok(file_size)
+            }
+        }
+        _ => Err(platform::einval()),
+    }
+}

--- a/crates/filesystem/lib/backends/memfs/types.rs
+++ b/crates/filesystem/lib/backends/memfs/types.rs
@@ -1,0 +1,182 @@
+//! Type definitions for the in-memory filesystem backend.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Root inode number (FUSE convention).
+pub(crate) const ROOT_INODE: u64 = 1;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Configuration for the in-memory filesystem.
+pub struct MemFsConfig {
+    /// Maximum total bytes for file data (None = unlimited).
+    pub capacity: Option<u64>,
+
+    /// Maximum number of inodes (None = unlimited).
+    pub max_inodes: Option<u64>,
+
+    /// FUSE entry cache timeout (default: 5s).
+    pub entry_timeout: Duration,
+
+    /// FUSE attribute cache timeout (default: 5s).
+    pub attr_timeout: Duration,
+
+    /// Cache policy (default: Auto).
+    pub cache_policy: CachePolicy,
+
+    /// Enable writeback caching (default: false).
+    pub writeback: bool,
+}
+
+/// Cache policy for FUSE open options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachePolicy {
+    /// No caching — sets DIRECT_IO.
+    Never,
+    /// Let the kernel decide.
+    Auto,
+    /// Aggressive caching — sets KEEP_CACHE.
+    Always,
+}
+
+/// A filesystem node in the in-memory filesystem.
+pub(crate) struct MemNode {
+    /// FUSE inode number.
+    pub inode: u64,
+
+    /// File type (S_IFREG, S_IFDIR, S_IFLNK, etc).
+    pub kind: u32,
+
+    /// FUSE lookup reference count.
+    pub lookup_refs: AtomicU64,
+
+    /// Metadata (uid, gid, mode, timestamps, etc).
+    pub meta: RwLock<InodeMeta>,
+
+    /// Content data.
+    pub content: InodeContent,
+
+    /// Extended attributes.
+    pub xattrs: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,
+}
+
+/// Metadata for an in-memory inode.
+pub(crate) struct InodeMeta {
+    /// Owner user ID.
+    pub uid: u32,
+
+    /// Owner group ID.
+    pub gid: u32,
+
+    /// File mode (includes type bits).
+    pub mode: u32,
+
+    /// Device number (for special files).
+    pub rdev: u32,
+
+    /// Number of hard links.
+    pub nlink: u64,
+
+    /// File size in bytes.
+    pub size: u64,
+
+    /// Last access time.
+    pub atime: Timespec,
+
+    /// Last modification time.
+    pub mtime: Timespec,
+
+    /// Last status change time.
+    pub ctime: Timespec,
+}
+
+/// Content stored in an inode.
+pub(crate) enum InodeContent {
+    /// Regular file with in-memory data.
+    RegularFile {
+        /// File data bytes.
+        data: RwLock<Vec<u8>>,
+    },
+
+    /// Directory with child entries.
+    Directory {
+        /// Map from child name to child inode number.
+        children: RwLock<BTreeMap<Vec<u8>, u64>>,
+
+        /// Parent inode number.
+        parent: AtomicU64,
+    },
+
+    /// Symbolic link.
+    Symlink {
+        /// Link target path.
+        target: Vec<u8>,
+    },
+
+    /// Special file (socket, char device, block device, fifo).
+    Special,
+}
+
+/// Open file handle.
+pub(crate) struct FileHandle {
+    /// Inode this handle refers to.
+    pub inode: u64,
+
+    /// Reference to the node (keeps it alive after unlink).
+    pub node: Arc<MemNode>,
+
+    /// Open flags.
+    pub flags: u32,
+}
+
+/// Open directory handle.
+pub(crate) struct DirHandle {
+    /// Inode this handle refers to.
+    pub inode: u64,
+
+    /// Reference to the node (keeps it alive after rmdir).
+    pub node: Arc<MemNode>,
+
+    /// Merged entry snapshot, built on first readdir call.
+    pub snapshot: Mutex<Option<DirSnapshot>>,
+}
+
+/// A point-in-time snapshot of a directory's entries.
+pub(crate) struct DirSnapshot {
+    /// Directory entries.
+    pub entries: Vec<MemDirEntry>,
+}
+
+/// A single entry in a directory snapshot.
+pub(crate) struct MemDirEntry {
+    /// Entry name.
+    pub name: Vec<u8>,
+
+    /// Inode number.
+    pub inode: u64,
+
+    /// Stable offset cookie (1-based).
+    pub offset: u64,
+
+    /// File type (d_type).
+    pub file_type: u32,
+}
+
+/// Timestamp with second and nanosecond precision.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Timespec {
+    /// Seconds since epoch.
+    pub sec: i64,
+
+    /// Nanoseconds.
+    pub nsec: i64,
+}

--- a/crates/filesystem/lib/backends/memfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/xattr_ops.rs
@@ -1,0 +1,140 @@
+//! Extended attribute operations: setxattr, getxattr, listxattr, removexattr.
+//!
+//! Xattrs are stored entirely in memory as raw byte key-value pairs.
+//! No internal xattrs are used — MemFs stores metadata directly.
+
+use std::ffi::CStr;
+use std::io;
+
+use super::MemFs;
+use super::inode;
+use crate::backends::shared::init_binary;
+use crate::backends::shared::platform;
+use crate::{Context, GetxattrReply, ListxattrReply};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// XATTR_CREATE flag (Linux value).
+const XATTR_CREATE: u32 = 1;
+
+/// XATTR_REPLACE flag (Linux value).
+const XATTR_REPLACE: u32 = 2;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Set an extended attribute.
+pub(crate) fn do_setxattr(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    name: &CStr,
+    value: &[u8],
+    flags: u32,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let mut xattrs = node.xattrs.write().unwrap();
+    let key = name.to_bytes().to_vec();
+
+    if flags & XATTR_CREATE != 0 && xattrs.contains_key(&key) {
+        return Err(platform::eexist());
+    }
+    if flags & XATTR_REPLACE != 0 && !xattrs.contains_key(&key) {
+        return Err(platform::enodata());
+    }
+
+    xattrs.insert(key, value.to_vec());
+    Ok(())
+}
+
+/// Get an extended attribute.
+pub(crate) fn do_getxattr(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    name: &CStr,
+    size: u32,
+) -> io::Result<GetxattrReply> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::enodata());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let xattrs = node.xattrs.read().unwrap();
+    let key = name.to_bytes();
+
+    match xattrs.get(key) {
+        Some(value) => {
+            if size == 0 {
+                Ok(GetxattrReply::Count(value.len() as u32))
+            } else if value.len() > size as usize {
+                Err(platform::erange())
+            } else {
+                Ok(GetxattrReply::Value(value.clone()))
+            }
+        }
+        None => Err(platform::enodata()),
+    }
+}
+
+/// List extended attribute names.
+pub(crate) fn do_listxattr(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    size: u32,
+) -> io::Result<ListxattrReply> {
+    if ino == init_binary::INIT_INODE {
+        if size == 0 {
+            return Ok(ListxattrReply::Count(0));
+        }
+        return Ok(ListxattrReply::Names(Vec::new()));
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let xattrs = node.xattrs.read().unwrap();
+
+    // Build NUL-separated list of xattr names.
+    let mut buf = Vec::new();
+    for key in xattrs.keys() {
+        buf.extend_from_slice(key);
+        buf.push(0);
+    }
+
+    if size == 0 {
+        Ok(ListxattrReply::Count(buf.len() as u32))
+    } else if buf.len() > size as usize {
+        Err(platform::erange())
+    } else {
+        Ok(ListxattrReply::Names(buf))
+    }
+}
+
+/// Remove an extended attribute.
+pub(crate) fn do_removexattr(
+    fs: &MemFs,
+    _ctx: Context,
+    ino: u64,
+    name: &CStr,
+) -> io::Result<()> {
+    if ino == init_binary::INIT_INODE {
+        return Err(platform::eacces());
+    }
+
+    let node = inode::get_node(fs, ino)?;
+    let mut xattrs = node.xattrs.write().unwrap();
+    let key = name.to_bytes();
+
+    if xattrs.remove(key).is_none() {
+        return Err(platform::enodata());
+    }
+
+    Ok(())
+}

--- a/crates/filesystem/lib/backends/mod.rs
+++ b/crates/filesystem/lib/backends/mod.rs
@@ -3,6 +3,9 @@
 //! Currently provides [`PassthroughFs`](passthrough::PassthroughFs) which exposes
 //! a single host directory to the guest VM via virtio-fs with stat virtualization.
 
+pub mod dualfs;
+pub mod memfs;
 pub mod overlayfs;
 pub mod passthroughfs;
+pub mod proxy;
 pub(crate) mod shared;

--- a/crates/filesystem/lib/backends/passthroughfs/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/builder.rs
@@ -1,0 +1,179 @@
+//! Builder API for constructing a PassthroughFs instance.
+//!
+//! ```ignore
+//! PassthroughFs::builder()
+//!     .root_dir("./rootfs")
+//!     .xattr(true)
+//!     .strict(true)
+//!     .build()?
+//! ```
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::RwLock;
+use std::time::Duration;
+
+use super::{CachePolicy, PassthroughFs};
+use crate::backends::shared::inode_table::MultikeyBTreeMap;
+use crate::backends::shared::{init_binary, platform, stat_override};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Builder for constructing a [`PassthroughFs`] instance.
+pub struct PassthroughFsBuilder {
+    root_dir: Option<PathBuf>,
+    xattr: bool,
+    strict: bool,
+    entry_timeout: Duration,
+    attr_timeout: Duration,
+    cache_policy: CachePolicy,
+    writeback: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PassthroughFsBuilder {
+    /// Create a new builder with default settings.
+    pub(crate) fn new() -> Self {
+        Self {
+            root_dir: None,
+            xattr: true,
+            strict: true,
+            entry_timeout: Duration::from_secs(5),
+            attr_timeout: Duration::from_secs(5),
+            cache_policy: CachePolicy::Auto,
+            writeback: false,
+        }
+    }
+
+    /// Set the host directory to expose.
+    pub fn root_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.root_dir = Some(path.into());
+        self
+    }
+
+    /// Enable or disable xattr-based stat virtualization.
+    pub fn xattr(mut self, enabled: bool) -> Self {
+        self.xattr = enabled;
+        self
+    }
+
+    /// Enable or disable strict mode.
+    pub fn strict(mut self, enabled: bool) -> Self {
+        self.strict = enabled;
+        self
+    }
+
+    /// Set the FUSE entry cache timeout.
+    pub fn entry_timeout(mut self, timeout: Duration) -> Self {
+        self.entry_timeout = timeout;
+        self
+    }
+
+    /// Set the FUSE attribute cache timeout.
+    pub fn attr_timeout(mut self, timeout: Duration) -> Self {
+        self.attr_timeout = timeout;
+        self
+    }
+
+    /// Set the cache policy.
+    pub fn cache_policy(mut self, policy: CachePolicy) -> Self {
+        self.cache_policy = policy;
+        self
+    }
+
+    /// Enable or disable writeback caching.
+    pub fn writeback(mut self, enabled: bool) -> Self {
+        self.writeback = enabled;
+        self
+    }
+
+    /// Build the PassthroughFs instance.
+    pub fn build(self) -> io::Result<PassthroughFs> {
+        let root_dir = self.root_dir.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "root_dir not set")
+        })?;
+
+        // Open the root directory.
+        let root_path = std::ffi::CString::new(
+            root_dir
+                .to_str()
+                .ok_or_else(platform::einval)?
+                .as_bytes(),
+        )
+        .map_err(|_| platform::einval())?;
+
+        let root_fd_raw = unsafe {
+            libc::open(
+                root_path.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY,
+            )
+        };
+        if root_fd_raw < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        let root_fd = unsafe { File::from_raw_fd(root_fd_raw) };
+
+        // Probe xattr support if strict mode is enabled.
+        if self.strict && self.xattr {
+            let supported = stat_override::probe_xattr_support(root_fd.as_raw_fd())?;
+            if !supported {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "xattr not supported on root filesystem and strict mode is enabled",
+                ));
+            }
+        }
+
+        // Create the init binary file.
+        let init_file = init_binary::create_init_file()?;
+
+        // Probe openat2 / RESOLVE_BENEATH availability (Linux 5.6+).
+        #[cfg(target_os = "linux")]
+        let has_openat2 = AtomicBool::new(platform::probe_openat2());
+
+        // Open /proc/self/fd on Linux for efficient path resolution.
+        #[cfg(target_os = "linux")]
+        let proc_self_fd = {
+            let path = std::ffi::CString::new("/proc/self/fd").unwrap();
+            let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+            if fd < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+            unsafe { File::from_raw_fd(fd) }
+        };
+
+        let cfg = super::PassthroughConfig {
+            root_dir,
+            xattr: self.xattr,
+            strict: self.strict,
+            entry_timeout: self.entry_timeout,
+            attr_timeout: self.attr_timeout,
+            cache_policy: self.cache_policy,
+            writeback: self.writeback,
+        };
+
+        Ok(PassthroughFs {
+            cfg,
+            root_fd,
+            inodes: RwLock::new(MultikeyBTreeMap::new()),
+            next_inode: AtomicU64::new(3), // 1=root, 2=init
+            handles: RwLock::new(BTreeMap::new()),
+            next_handle: AtomicU64::new(1), // 0=init handle
+            writeback: AtomicBool::new(false),
+            init_file,
+            #[cfg(target_os = "linux")]
+            has_openat2,
+            #[cfg(target_os = "linux")]
+            proc_self_fd,
+        })
+    }
+}

--- a/crates/filesystem/lib/backends/passthroughfs/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/mod.rs
@@ -4,6 +4,7 @@
 //! stat virtualization (uid/gid/mode via xattr), init.krun injection,
 //! and name validation.
 
+pub(crate) mod builder;
 mod create_ops;
 mod dir_ops;
 mod file_ops;
@@ -119,6 +120,11 @@ pub struct PassthroughFs {
 //--------------------------------------------------------------------------------------------------
 
 impl PassthroughFs {
+    /// Create a builder for constructing a `PassthroughFs` instance.
+    pub fn builder() -> builder::PassthroughFsBuilder {
+        builder::PassthroughFsBuilder::new()
+    }
+
     /// Create a new passthrough filesystem backend.
     ///
     /// Opens the root directory and optionally probes for xattr support.
@@ -654,6 +660,12 @@ impl DynFileSystem for PassthroughFs {
         )
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use builder::PassthroughFsBuilder;
 
 //--------------------------------------------------------------------------------------------------
 // Tests

--- a/crates/filesystem/lib/backends/proxy/adapters.rs
+++ b/crates/filesystem/lib/backends/proxy/adapters.rs
@@ -1,0 +1,98 @@
+//! ZeroCopy adapters for buffered hook interception.
+//!
+//! `VecWriter` collects data into a `Vec<u8>` via `ZeroCopyWriter`,
+//! used to capture inner backend read output for the `on_read` hook.
+//!
+//! `SliceReader` presents a `&[u8]` slice as a `ZeroCopyReader`,
+//! used to feed transformed data from the `on_write` hook to the inner backend.
+
+use std::fs::File;
+use std::io;
+use std::os::fd::AsRawFd;
+
+use crate::{ZeroCopyReader, ZeroCopyWriter};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Writer that collects data into a `Vec<u8>` buffer.
+///
+/// Implements `ZeroCopyWriter` by reading from the provided file descriptor
+/// into an internal buffer via `pread`.
+pub(crate) struct VecWriter {
+    pub(crate) buf: Vec<u8>,
+}
+
+/// Reader that presents an in-memory slice as a `ZeroCopyReader`.
+///
+/// Implements `ZeroCopyReader` by writing from the internal buffer
+/// to the provided file descriptor via `pwrite`.
+pub(crate) struct SliceReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl VecWriter {
+    pub(crate) fn new() -> Self {
+        VecWriter { buf: Vec::new() }
+    }
+}
+
+impl<'a> SliceReader<'a> {
+    pub(crate) fn new(data: &'a [u8]) -> Self {
+        SliceReader { data, pos: 0 }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ZeroCopyWriter for VecWriter {
+    fn write_from(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
+        let mut tmp = vec![0u8; count];
+        let n = unsafe {
+            libc::pread(
+                f.as_raw_fd(),
+                tmp.as_mut_ptr() as *mut libc::c_void,
+                count,
+                off as i64,
+            )
+        };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let n = n as usize;
+        self.buf.extend_from_slice(&tmp[..n]);
+        Ok(n)
+    }
+}
+
+impl ZeroCopyReader for SliceReader<'_> {
+    fn read_to(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
+        let remaining = &self.data[self.pos..];
+        let to_write = std::cmp::min(count, remaining.len());
+        if to_write == 0 {
+            return Ok(0);
+        }
+        let n = unsafe {
+            libc::pwrite(
+                f.as_raw_fd(),
+                remaining.as_ptr() as *const libc::c_void,
+                to_write,
+                off as i64,
+            )
+        };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let n = n as usize;
+        self.pos += n;
+        Ok(n)
+    }
+}

--- a/crates/filesystem/lib/backends/proxy/builder.rs
+++ b/crates/filesystem/lib/backends/proxy/builder.rs
@@ -1,0 +1,131 @@
+//! ProxyFs builder.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::{Mutex, RwLock};
+
+use super::{AccessMode, ProxyFs};
+use crate::DynFileSystem;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Builder for constructing a [`ProxyFs`].
+pub struct ProxyFsBuilder {
+    inner: Box<dyn DynFileSystem>,
+    on_access: Option<Box<dyn Fn(&str, AccessMode) -> Result<(), io::Error> + Send + Sync>>,
+    on_read: Option<Box<dyn Fn(&str, &[u8]) -> Vec<u8> + Send + Sync>>,
+    on_write: Option<Box<dyn Fn(&str, &[u8]) -> Vec<u8> + Send + Sync>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ProxyFsBuilder {
+    pub(crate) fn new(inner: Box<dyn DynFileSystem>) -> Self {
+        ProxyFsBuilder {
+            inner,
+            on_access: None,
+            on_read: None,
+            on_write: None,
+        }
+    }
+
+    /// Set the access control hook.
+    ///
+    /// Called before `open`, `create`, and `opendir`. Receives the file path
+    /// (relative to mount root) and the access mode. Return `Ok(())` to allow,
+    /// `Err(e)` to deny with that error.
+    pub fn on_access(
+        mut self,
+        hook: impl Fn(&str, AccessMode) -> Result<(), io::Error> + Send + Sync + 'static,
+    ) -> Self {
+        self.on_access = Some(Box::new(hook));
+        self
+    }
+
+    /// Set the read interception hook.
+    ///
+    /// Called after data is read from the inner backend, before returning to
+    /// the guest. Receives the path and raw data, returns (possibly transformed)
+    /// data. When set, the zero-copy read path is broken — data flows through memory.
+    pub fn on_read(
+        mut self,
+        hook: impl Fn(&str, &[u8]) -> Vec<u8> + Send + Sync + 'static,
+    ) -> Self {
+        self.on_read = Some(Box::new(hook));
+        self
+    }
+
+    /// Set the write interception hook.
+    ///
+    /// Called after receiving data from the guest, before passing to the inner
+    /// backend. Receives the path and raw data, returns (possibly transformed)
+    /// data. When set, the zero-copy write path is broken — data flows through memory.
+    pub fn on_write(
+        mut self,
+        hook: impl Fn(&str, &[u8]) -> Vec<u8> + Send + Sync + 'static,
+    ) -> Self {
+        self.on_write = Some(Box::new(hook));
+        self
+    }
+
+    /// Build the `ProxyFs`.
+    pub fn build(self) -> io::Result<ProxyFs> {
+        // Only create staging file if read or write hooks need buffering.
+        let staging_file = if self.on_read.is_some() || self.on_write.is_some() {
+            Some(Mutex::new(create_staging_file()?))
+        } else {
+            None
+        };
+
+        // Pre-seed root inode path.
+        let mut paths = HashMap::new();
+        paths.insert(1u64, String::new());
+
+        Ok(ProxyFs {
+            inner: self.inner,
+            on_access: self.on_access,
+            on_read: self.on_read,
+            on_write: self.on_write,
+            paths: RwLock::new(paths),
+            handle_paths: RwLock::new(HashMap::new()),
+            staging_file,
+        })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Create a staging file for buffered hook interception.
+fn create_staging_file() -> io::Result<std::fs::File> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::FromRawFd;
+
+        let name = std::ffi::CString::new("proxyfs-staging").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // Pre-allocate a 128KB buffer for typical FUSE read/write chunks.
+        let buf = vec![0u8; 128 * 1024];
+        let written =
+            unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
+        if written < 0 {
+            let err = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(err);
+        }
+        Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        tempfile::tempfile()
+    }
+}

--- a/crates/filesystem/lib/backends/proxy/hooks.rs
+++ b/crates/filesystem/lib/backends/proxy/hooks.rs
@@ -1,0 +1,199 @@
+//! Hook dispatch: access check, read interception, write interception.
+//!
+//! Hooks are called at specific FUSE operation points:
+//! - `on_access`: Before open/create/opendir to enforce access control.
+//! - `on_read`: After inner.read() to transform data before returning to guest.
+//! - `on_write`: After reading from guest, before inner.write() to transform data.
+
+use std::io;
+use std::os::fd::AsRawFd;
+
+use super::adapters::{SliceReader, VecWriter};
+use super::{AccessMode, ProxyFs};
+use crate::{ZeroCopyReader, ZeroCopyWriter};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Check access via the on_access hook.
+///
+/// Maps FUSE open flags to `AccessMode` and calls the hook. For `O_RDWR`,
+/// both Read and Write checks must pass.
+pub(crate) fn check_access(fs: &ProxyFs, inode: u64, flags: u32) -> io::Result<()> {
+    let on_access = match &fs.on_access {
+        Some(hook) => hook,
+        None => return Ok(()),
+    };
+
+    let path = fs
+        .paths
+        .read()
+        .unwrap()
+        .get(&inode)
+        .cloned()
+        .unwrap_or_default();
+
+    let accmode = (flags as i32) & libc::O_ACCMODE;
+
+    if accmode == libc::O_RDONLY {
+        on_access(&path, AccessMode::Read)?;
+    } else if accmode == libc::O_WRONLY {
+        on_access(&path, AccessMode::Write)?;
+    } else {
+        // O_RDWR — both must succeed.
+        on_access(&path, AccessMode::Read)?;
+        on_access(&path, AccessMode::Write)?;
+    }
+
+    Ok(())
+}
+
+/// Check access for a path (used by create where the file doesn't exist yet).
+pub(crate) fn check_access_by_path(
+    fs: &ProxyFs,
+    path: &str,
+    mode: AccessMode,
+) -> io::Result<()> {
+    if let Some(ref on_access) = fs.on_access {
+        on_access(path, mode)?;
+    }
+    Ok(())
+}
+
+/// Intercepted read: capture inner output, transform via hook, write to guest.
+///
+/// Uses the staging file to bridge between ZeroCopy traits and in-memory buffers.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_intercepted_read(
+    fs: &ProxyFs,
+    ctx: crate::Context,
+    ino: u64,
+    handle: u64,
+    w: &mut dyn ZeroCopyWriter,
+    size: u32,
+    offset: u64,
+    lock_owner: Option<u64>,
+    flags: u32,
+) -> io::Result<usize> {
+    let on_read = fs.on_read.as_ref().unwrap();
+    let path = fs
+        .handle_paths
+        .read()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .unwrap_or_default();
+
+    // Step 1: Read from inner into VecWriter.
+    let mut vec_writer = VecWriter::new();
+    let n = fs.inner.read(
+        ctx,
+        ino,
+        handle,
+        &mut vec_writer,
+        size,
+        offset,
+        lock_owner,
+        flags,
+    )?;
+
+    if n == 0 {
+        return Ok(0);
+    }
+
+    // Step 2: Transform through hook.
+    let transformed = on_read(&path, &vec_writer.buf[..n]);
+
+    if transformed.is_empty() {
+        return Ok(0);
+    }
+
+    // Step 3: Write transformed data to real FUSE buffer via staging file.
+    let staging = fs.staging_file.as_ref().unwrap().lock().unwrap();
+    let written = unsafe {
+        libc::pwrite(
+            staging.as_raw_fd(),
+            transformed.as_ptr() as *const libc::c_void,
+            transformed.len(),
+            0,
+        )
+    };
+    if written < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    w.write_from(&*staging, transformed.len(), 0)
+}
+
+/// Intercepted write: capture guest input, transform via hook, write to inner.
+///
+/// Uses the staging file to bridge between ZeroCopy traits and in-memory buffers.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn do_intercepted_write(
+    fs: &ProxyFs,
+    ctx: crate::Context,
+    ino: u64,
+    handle: u64,
+    r: &mut dyn ZeroCopyReader,
+    size: u32,
+    offset: u64,
+    lock_owner: Option<u64>,
+    delayed_write: bool,
+    kill_priv: bool,
+    flags: u32,
+) -> io::Result<usize> {
+    let on_write = fs.on_write.as_ref().unwrap();
+    let path = fs
+        .handle_paths
+        .read()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .unwrap_or_default();
+
+    // Step 1: Read guest data via staging file.
+    let staging = fs.staging_file.as_ref().unwrap().lock().unwrap();
+    let count = r.read_to(&*staging, size as usize, 0)?;
+
+    if count == 0 {
+        return Ok(0);
+    }
+
+    let mut buf = vec![0u8; count];
+    let read_back = unsafe {
+        libc::pread(
+            staging.as_raw_fd(),
+            buf.as_mut_ptr() as *mut libc::c_void,
+            count,
+            0,
+        )
+    };
+    drop(staging);
+
+    if read_back < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let n = read_back as usize;
+
+    // Step 2: Transform through hook.
+    let transformed = on_write(&path, &buf[..n]);
+
+    // Step 3: Write transformed data to inner via SliceReader.
+    let mut slice_reader = SliceReader::new(&transformed);
+    fs.inner.write(
+        ctx,
+        ino,
+        handle,
+        &mut slice_reader,
+        transformed.len() as u32,
+        offset,
+        lock_owner,
+        delayed_write,
+        kill_priv,
+        flags,
+    )?;
+
+    // Return number of bytes consumed from guest's perspective.
+    Ok(n)
+}

--- a/crates/filesystem/lib/backends/proxy/mod.rs
+++ b/crates/filesystem/lib/backends/proxy/mod.rs
@@ -1,0 +1,475 @@
+//! Proxy filesystem backend.
+//!
+//! Decorator wrapping any [`DynFileSystem`] with hooks for access control,
+//! read/write interception, and path tracking. Non-intercepted operations
+//! are delegated transparently to the inner backend.
+//!
+//! When no hooks are set, ProxyFs adds zero overhead beyond cheap path tracking.
+//! When hooks are set, the zero-copy FUSE path is broken and data flows through
+//! memory for transformation.
+
+pub(crate) mod adapters;
+pub(crate) mod builder;
+mod hooks;
+mod path_tracking;
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::sync::{Mutex, RwLock};
+
+use crate::{
+    Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Proxy filesystem backend.
+///
+/// Wraps any [`DynFileSystem`] and intercepts specific FUSE operations for
+/// user-supplied hooks. All non-intercepted operations are delegated
+/// transparently to the inner backend.
+pub struct ProxyFs {
+    /// The wrapped filesystem backend.
+    inner: Box<dyn DynFileSystem>,
+
+    /// Access control hook, called before open/create/opendir.
+    on_access: Option<Box<dyn Fn(&str, AccessMode) -> Result<(), io::Error> + Send + Sync>>,
+
+    /// Read interception hook, called after inner.read() succeeds.
+    on_read: Option<Box<dyn Fn(&str, &[u8]) -> Vec<u8> + Send + Sync>>,
+
+    /// Write interception hook, called before inner.write().
+    on_write: Option<Box<dyn Fn(&str, &[u8]) -> Vec<u8> + Send + Sync>>,
+
+    /// Inode-to-path table (relative to mount root).
+    paths: RwLock<HashMap<u64, String>>,
+
+    /// Handle-to-path table for O(1) lookup during read/write.
+    handle_paths: RwLock<HashMap<u64, String>>,
+
+    /// Staging file for buffered hook interception (created only when hooks need it).
+    staging_file: Option<Mutex<File>>,
+}
+
+/// Access modes passed to the on_access hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMode {
+    /// Read access (e.g. O_RDONLY open, opendir).
+    Read,
+    /// Write access (e.g. O_WRONLY open, create).
+    Write,
+    /// Execute access.
+    Execute,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ProxyFs {
+    /// Create a builder for constructing a ProxyFs wrapping the given backend.
+    pub fn builder(inner: Box<dyn DynFileSystem>) -> builder::ProxyFsBuilder {
+        builder::ProxyFsBuilder::new(inner)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DynFileSystem for ProxyFs {
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        self.inner.init(capable)
+    }
+
+    fn destroy(&self) {
+        self.inner.destroy()
+    }
+
+    fn lookup(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        let entry = self.inner.lookup(ctx, parent, name)?;
+        let path = path_tracking::build_path(self, parent, name);
+        path_tracking::register_path(self, entry.inode, path);
+        Ok(entry)
+    }
+
+    fn forget(&self, ctx: Context, ino: u64, count: u64) {
+        self.inner.forget(ctx, ino, count);
+        self.paths.write().unwrap().remove(&ino);
+    }
+
+    fn batch_forget(&self, ctx: Context, requests: Vec<(u64, u64)>) {
+        let inodes: Vec<u64> = requests.iter().map(|&(ino, _)| ino).collect();
+        self.inner.batch_forget(ctx, requests);
+        let mut paths = self.paths.write().unwrap();
+        for ino in inodes {
+            paths.remove(&ino);
+        }
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: Option<u64>,
+    ) -> io::Result<(stat64, std::time::Duration)> {
+        self.inner.getattr(ctx, ino, handle)
+    }
+
+    fn setattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        attr: stat64,
+        handle: Option<u64>,
+        valid: SetattrValid,
+    ) -> io::Result<(stat64, std::time::Duration)> {
+        self.inner.setattr(ctx, ino, attr, handle, valid)
+    }
+
+    fn readlink(&self, ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
+        self.inner.readlink(ctx, ino)
+    }
+
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: u64,
+        name: &CStr,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        let entry = self.inner.symlink(ctx, linkname, parent, name, extensions)?;
+        let path = path_tracking::build_path(self, parent, name);
+        path_tracking::register_path(self, entry.inode, path);
+        Ok(entry)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        let entry = self.inner.mknod(ctx, parent, name, mode, rdev, umask, extensions)?;
+        let path = path_tracking::build_path(self, parent, name);
+        path_tracking::register_path(self, entry.inode, path);
+        Ok(entry)
+    }
+
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        let entry = self.inner.mkdir(ctx, parent, name, mode, umask, extensions)?;
+        let path = path_tracking::build_path(self, parent, name);
+        path_tracking::register_path(self, entry.inode, path);
+        Ok(entry)
+    }
+
+    fn unlink(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        self.inner.unlink(ctx, parent, name)
+    }
+
+    fn rmdir(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+        self.inner.rmdir(ctx, parent, name)
+    }
+
+    fn rename(
+        &self,
+        ctx: Context,
+        olddir: u64,
+        oldname: &CStr,
+        newdir: u64,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        let renamed_inode = path_tracking::resolve_inode(self, olddir, oldname);
+        self.inner.rename(ctx, olddir, oldname, newdir, newname, flags)?;
+        if let Some(ino) = renamed_inode {
+            path_tracking::update_paths_after_rename(self, olddir, oldname, newdir, newname, ino);
+        }
+        Ok(())
+    }
+
+    fn link(
+        &self,
+        ctx: Context,
+        ino: u64,
+        newparent: u64,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        let entry = self.inner.link(ctx, ino, newparent, newname)?;
+        let path = path_tracking::build_path(self, newparent, newname);
+        path_tracking::register_path(self, entry.inode, path);
+        Ok(entry)
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        ino: u64,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        hooks::check_access(self, ino, flags)?;
+        let (handle, opts) = self.inner.open(ctx, ino, kill_priv, flags)?;
+        if let Some(h) = handle {
+            path_tracking::register_handle_path(self, ino, h);
+        }
+        Ok((handle, opts))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create(
+        &self,
+        ctx: Context,
+        parent: u64,
+        name: &CStr,
+        mode: u32,
+        kill_priv: bool,
+        flags: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+        let path = path_tracking::build_path(self, parent, name);
+        hooks::check_access_by_path(self, &path, AccessMode::Write)?;
+
+        let (entry, handle, opts) =
+            self.inner
+                .create(ctx, parent, name, mode, kill_priv, flags, umask, extensions)?;
+
+        path_tracking::register_path(self, entry.inode, path.clone());
+        if let Some(h) = handle {
+            self.handle_paths.write().unwrap().insert(h, path);
+        }
+
+        Ok((entry, handle, opts))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        if self.on_read.is_none() {
+            return self
+                .inner
+                .read(ctx, ino, handle, w, size, offset, lock_owner, flags);
+        }
+        hooks::do_intercepted_read(self, ctx, ino, handle, w, size, offset, lock_owner, flags)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<usize> {
+        if self.on_write.is_none() {
+            return self.inner.write(
+                ctx,
+                ino,
+                handle,
+                r,
+                size,
+                offset,
+                lock_owner,
+                delayed_write,
+                kill_priv,
+                flags,
+            );
+        }
+        hooks::do_intercepted_write(
+            self,
+            ctx,
+            ino,
+            handle,
+            r,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            kill_priv,
+            flags,
+        )
+    }
+
+    fn flush(&self, ctx: Context, ino: u64, handle: u64, lock_owner: u64) -> io::Result<()> {
+        self.inner.flush(ctx, ino, handle, lock_owner)
+    }
+
+    fn fsync(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        self.inner.fsync(ctx, ino, datasync, handle)
+    }
+
+    fn fallocate(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        self.inner
+            .fallocate(ctx, ino, handle, mode, offset, length)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn release(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+        handle: u64,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        self.inner
+            .release(ctx, ino, flags, handle, flush, flock_release, lock_owner)?;
+        path_tracking::remove_handle_path(self, handle);
+        Ok(())
+    }
+
+    fn statfs(&self, ctx: Context, ino: u64) -> io::Result<statvfs64> {
+        self.inner.statfs(ctx, ino)
+    }
+
+    fn setxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        self.inner.setxattr(ctx, ino, name, value, flags)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        ino: u64,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        self.inner.getxattr(ctx, ino, name, size)
+    }
+
+    fn listxattr(&self, ctx: Context, ino: u64, size: u32) -> io::Result<ListxattrReply> {
+        self.inner.listxattr(ctx, ino, size)
+    }
+
+    fn removexattr(&self, ctx: Context, ino: u64, name: &CStr) -> io::Result<()> {
+        self.inner.removexattr(ctx, ino, name)
+    }
+
+    fn opendir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        if let Some(ref on_access) = self.on_access {
+            let path = self
+                .paths
+                .read()
+                .unwrap()
+                .get(&ino)
+                .cloned()
+                .unwrap_or_default();
+            on_access(&path, AccessMode::Read)?;
+        }
+
+        let (handle, opts) = self.inner.opendir(ctx, ino, flags)?;
+        if let Some(h) = handle {
+            path_tracking::register_handle_path(self, ino, h);
+        }
+        Ok((handle, opts))
+    }
+
+    fn readdir(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<DirEntry<'static>>> {
+        self.inner.readdir(ctx, ino, handle, size, offset)
+    }
+
+    fn readdirplus(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+        self.inner.readdirplus(ctx, ino, handle, size, offset)
+    }
+
+    fn fsyncdir(&self, ctx: Context, ino: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        self.inner.fsyncdir(ctx, ino, datasync, handle)
+    }
+
+    fn releasedir(&self, ctx: Context, ino: u64, flags: u32, handle: u64) -> io::Result<()> {
+        self.inner.releasedir(ctx, ino, flags, handle)?;
+        path_tracking::remove_handle_path(self, handle);
+        Ok(())
+    }
+
+    fn access(&self, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
+        self.inner.access(ctx, ino, mask)
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        ino: u64,
+        handle: u64,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        self.inner.lseek(ctx, ino, handle, offset, whence)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use builder::ProxyFsBuilder;

--- a/crates/filesystem/lib/backends/proxy/path_tracking.rs
+++ b/crates/filesystem/lib/backends/proxy/path_tracking.rs
@@ -1,0 +1,111 @@
+//! Path tracking for inode-to-path and handle-to-path mappings.
+//!
+//! ProxyFs maintains best-effort path maps so hooks receive human-readable
+//! paths instead of opaque inode numbers. Paths are relative to the mount
+//! root with no leading `/`.
+
+use std::ffi::CStr;
+
+use super::ProxyFs;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Root inode number (FUSE convention).
+const ROOT_INODE: u64 = 1;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build a path for a child entry from its parent inode and name.
+///
+/// Returns a path relative to mount root (e.g. `"etc/passwd"`, `"config.toml"`).
+/// Root-level entries are returned as just the name (no leading `/`).
+pub(crate) fn build_path(fs: &ProxyFs, parent_inode: u64, name: &CStr) -> String {
+    let name_str = name.to_string_lossy();
+    let paths = fs.paths.read().unwrap();
+
+    if parent_inode == ROOT_INODE {
+        name_str.into_owned()
+    } else if let Some(parent_path) = paths.get(&parent_inode) {
+        if parent_path.is_empty() {
+            name_str.into_owned()
+        } else {
+            format!("{}/{}", parent_path, name_str)
+        }
+    } else {
+        // Parent path unknown — use inode number as fallback.
+        format!("<{}>/{}", parent_inode, name_str)
+    }
+}
+
+/// Update path tracking after a rename operation.
+///
+/// Updates the renamed inode's path and all descendant paths that share
+/// the old prefix. This is O(n) where n is the number of tracked paths.
+pub(crate) fn update_paths_after_rename(
+    fs: &ProxyFs,
+    old_parent: u64,
+    old_name: &CStr,
+    new_parent: u64,
+    new_name: &CStr,
+    renamed_inode: u64,
+) {
+    let old_path = build_path(fs, old_parent, old_name);
+    let new_path = build_path(fs, new_parent, new_name);
+
+    let mut paths = fs.paths.write().unwrap();
+
+    // Update the renamed entry itself.
+    paths.insert(renamed_inode, new_path.clone());
+
+    // Update all descendant paths (prefix replacement).
+    let old_prefix = format!("{}/", old_path);
+    let new_prefix = format!("{}/", new_path);
+
+    let updates: Vec<(u64, String)> = paths
+        .iter()
+        .filter(|(_, path)| path.starts_with(&old_prefix))
+        .map(|(&ino, path)| {
+            let suffix = &path[old_prefix.len()..];
+            (ino, format!("{}{}", new_prefix, suffix))
+        })
+        .collect();
+
+    for (ino, updated_path) in updates {
+        paths.insert(ino, updated_path);
+    }
+}
+
+/// Resolve the inode for a child within a parent directory.
+///
+/// Searches the path table for an inode whose path matches
+/// `build_path(parent, name)`. Returns `None` if not found.
+pub(crate) fn resolve_inode(fs: &ProxyFs, parent: u64, name: &CStr) -> Option<u64> {
+    let expected_path = build_path(fs, parent, name);
+    let paths = fs.paths.read().unwrap();
+    paths
+        .iter()
+        .find(|(_, path)| **path == expected_path)
+        .map(|(&ino, _)| ino)
+}
+
+/// Register a path for an inode in the paths table.
+pub(crate) fn register_path(fs: &ProxyFs, inode: u64, path: String) {
+    fs.paths.write().unwrap().insert(inode, path);
+}
+
+/// Copy an inode's path to the handle_paths table.
+pub(crate) fn register_handle_path(fs: &ProxyFs, inode: u64, handle: u64) {
+    let path = fs.paths.read().unwrap().get(&inode).cloned();
+    if let Some(path) = path {
+        fs.handle_paths.write().unwrap().insert(handle, path);
+    }
+}
+
+/// Remove a handle from the handle_paths table.
+pub(crate) fn remove_handle_path(fs: &ProxyFs, handle: u64) {
+    fs.handle_paths.write().unwrap().remove(&handle);
+}

--- a/crates/filesystem/lib/backends/shared/name_validation.rs
+++ b/crates/filesystem/lib/backends/shared/name_validation.rs
@@ -38,6 +38,26 @@ pub(crate) fn validate_name(name: &CStr) -> io::Result<()> {
 /// Maximum allowed component length (NAME_MAX on Linux).
 const NAME_MAX: usize = 255;
 
+/// Validate a directory entry name for in-memory filesystem operations.
+///
+/// Extends [`validate_name`] with rejection of:
+/// - `.` (would alias the directory itself)
+/// - Names longer than `NAME_MAX` (255 bytes)
+pub(crate) fn validate_memfs_name(name: &CStr) -> io::Result<()> {
+    validate_name(name)?;
+
+    let bytes = name.to_bytes();
+
+    if bytes == b"." {
+        return Err(platform::eperm());
+    }
+    if bytes.len() > NAME_MAX {
+        return Err(platform::enametoolong());
+    }
+
+    Ok(())
+}
+
 /// Validate a directory entry name for overlay operations.
 ///
 /// Extends [`validate_name`] with overlay-specific rejection of:

--- a/crates/filesystem/lib/backends/shared/platform.rs
+++ b/crates/filesystem/lib/backends/shared/platform.rs
@@ -295,6 +295,41 @@ pub(crate) fn eexist() -> io::Error {
     io::Error::from_raw_os_error(LINUX_EEXIST)
 }
 
+/// Create an `io::Error` with Linux `ENOSPC`.
+pub(crate) fn enospc() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENOSPC)
+}
+
+/// Create an `io::Error` with Linux `EFBIG`.
+pub(crate) fn efbig() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EFBIG)
+}
+
+/// Create an `io::Error` with Linux `EOPNOTSUPP`.
+pub(crate) fn eopnotsupp() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EOPNOTSUPP)
+}
+
+/// Create an `io::Error` with Linux `ENODEV`.
+pub(crate) fn enodev() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENODEV)
+}
+
+/// Create an `io::Error` with Linux `ENXIO`.
+pub(crate) fn enxio() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_ENXIO)
+}
+
+/// Create an `io::Error` with Linux `ERANGE`.
+pub(crate) fn erange() -> io::Error {
+    io::Error::from_raw_os_error(34) // LINUX_ERANGE
+}
+
+/// Create an `io::Error` with Linux `EXDEV`.
+pub(crate) fn exdev() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EXDEV)
+}
+
 /// Check if an error is ENOENT.
 ///
 /// ENOENT is 2 on both Linux and macOS, so a single check suffices

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -14,8 +14,14 @@ pub mod backends;
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use backends::dualfs::{
+    BackendAFallbackToBackendBRead, BackendAOnly, CachePolicy as DualCachePolicy, DualFs,
+    DualFsConfig, MergeReadsBackendAPrecedence, ReadBackendBWriteBackendA,
+};
+pub use backends::memfs::{CachePolicy as MemCachePolicy, MemFs, MemFsConfig};
 pub use backends::overlayfs::{CachePolicy as OverlayCachePolicy, OverlayConfig, OverlayFs};
-pub use backends::passthroughfs::{CachePolicy, PassthroughConfig, PassthroughFs};
+pub use backends::passthroughfs::{CachePolicy, PassthroughConfig, PassthroughFs, PassthroughFsBuilder};
+pub use backends::proxy::{AccessMode, ProxyFs, ProxyFsBuilder};
 pub use msb_krun::backends::fs::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
     OpenOptions, RemovemappingOne, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,


### PR DESCRIPTION
## Summary

- Add three new filesystem backends (MemFs, ProxyFs, DualFs) to the microsandbox VM filesystem crate, expanding from the existing PassthroughFs and OverlayFs
- MemFs provides a pure in-memory filesystem for ephemeral scratch space and as a writable layer for composition
- ProxyFs is a decorator backend enabling access control, read/write interception, and path tracking over any DynFileSystem
- DualFs composes two backends with programmable dispatch policies and lifecycle hooks for flexible layered filesystems
- Also adds a PassthroughFsBuilder for ergonomic construction and shared error helpers used across backends

## Changes

### New backend: MemFs (11 files, ~2,800 lines)
- In-memory filesystem with capacity limits, inode tracking, and xattr support
- Uses staging-file-based ZeroCopy I/O (memfd on Linux, tmpfile on macOS)
- Builder pattern with configurable capacity, max inodes, cache policy, and writeback mode
- Full DynFileSystem implementation: create, mkdir, mknod, symlink, link, unlink, rmdir, rename, open, read, write, readdir, getattr, setattr, statfs, xattr ops

### New backend: ProxyFs (5 files, ~1,000 lines)
- Decorator wrapping any `Box<dyn DynFileSystem>` with optional hook callbacks
- Three hook types: `on_access` (access control), `on_read` (read interception), `on_write` (write interception)
- Automatic path tracking across lookup/create/rename/forget operations
- ZeroCopy adapters (VecWriter, SliceReader) for buffered hook interception via staging file
- Zero overhead when hooks are None -- direct delegation to inner backend

### New backend: DualFs (19 files, ~5,500 lines)
- Two-backend compositional filesystem with full hook pipeline (before/after dispatch, commit, response)
- Four pluggable dispatch policies: ReadBackendBWriteBackendA, BackendAOnly, BackendAFallbackToBackendBRead, MergeReadsBackendAPrecedence
- Materialization engine with chunked data streaming, ancestor chain promotion, and copy-up locking
- In-memory whiteout and opaque directory tracking for merged views (no .wh. files on disk)
- Merged readdir with auto-registration, rmdir emptiness checks across both backends, and cross-backend rename handling
- Staging directories for atomic materialization operations

### PassthroughFs enhancements (2 files)
- Added `PassthroughFsBuilder` with fluent builder pattern for ergonomic construction
- Added `PassthroughFs::builder()` static method and re-export

### Shared infrastructure (2 files modified)
- Added `validate_memfs_name()` to name_validation.rs for in-memory filesystem entry validation
- Added platform error helpers: `enospc()`, `efbig()`, `eopnotsupp()`, `enodev()`, `enxio()`, `erange()`, `exdev()`

### Module registration (2 files modified)
- Registered `dualfs`, `memfs`, `proxy` modules in `backends/mod.rs`
- Added public re-exports in `lib.rs` for all new backend types, configs, and policies

## Test Plan

- [x] Run `cargo build` to verify all three backends compile successfully
- [x] Run `cargo clippy` to verify no warnings on new code
- [ ] Run `cargo test` to verify no regressions in existing tests
- [ ] Integration testing with actual VM boot using DualFs composition (PassthroughFs + MemFs)
- [ ] Verify MemFs capacity enforcement and inode limits
- [ ] Verify ProxyFs hook interception for read/write operations
- [ ] Verify DualFs materialization and whiteout behavior