### PR TITLE
feat(sandbox): add type-safe byte-size units for SDK APIs

### DIFF
--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod db;
 pub mod runtime;
 pub mod sandbox;
 pub mod setup;
+pub mod size;
 pub mod volume;
 
 pub use error::*;

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -5,6 +5,7 @@ use microsandbox_runtime::policy::ShutdownMode;
 use super::config::SandboxConfig;
 use super::types::{MountBuilder, RootfsSource};
 use crate::MicrosandboxResult;
+use crate::size::Mebibytes;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -44,9 +45,16 @@ impl SandboxBuilder {
         self
     }
 
-    /// Set guest memory in MiB.
-    pub fn memory(mut self, mib: u32) -> Self {
-        self.config.memory_mib = mib;
+    /// Set guest memory size.
+    ///
+    /// Accepts bare `u32` (interpreted as MiB) or a [`SizeExt`](crate::size::SizeExt) helper:
+    /// ```ignore
+    /// .memory(512)         // 512 MiB
+    /// .memory(512.mib())   // 512 MiB (explicit)
+    /// .memory(1.gib())     // 1 GiB = 1024 MiB
+    /// ```
+    pub fn memory(mut self, size: impl Into<Mebibytes>) -> Self {
+        self.config.memory_mib = size.into().as_u32();
         self
     }
 
@@ -132,7 +140,7 @@ impl SandboxBuilder {
     /// .volume("/data", |m| m.bind("/host/data"))
     /// .volume("/config", |m| m.bind("/host/config").readonly())
     /// .volume("/cache", |m| m.named("my-cache"))
-    /// .volume("/tmp", |m| m.tmpfs().size_mib(100))
+    /// .volume("/tmp", |m| m.tmpfs().size(100))
     /// .volume("/watched", |m| m.bind("/host/data").on_read(|_path, data| data.to_vec()))
     /// ```
     pub fn volume(

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -187,15 +187,6 @@ pub trait IntoExecOptions {
     fn into_exec_options(self) -> ExecOptions;
 }
 
-/// Helper trait for readable byte sizes.
-pub trait SizeExt {
-    /// Convert to kibibytes.
-    fn kib(self) -> u64;
-    /// Convert to mebibytes.
-    fn mib(self) -> u64;
-    /// Convert to gibibytes.
-    fn gib(self) -> u64;
-}
 
 //--------------------------------------------------------------------------------------------------
 // Methods
@@ -502,14 +493,3 @@ impl TryFrom<&str> for RlimitResource {
     }
 }
 
-impl SizeExt for u64 {
-    fn kib(self) -> u64 {
-        self * 1024
-    }
-    fn mib(self) -> u64 {
-        self * 1024 * 1024
-    }
-    fn gib(self) -> u64 {
-        self * 1024 * 1024 * 1024
-    }
-}

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -41,7 +41,7 @@ use self::exec::{ExecEvent, ExecHandle, ExecOutput, ExecSink, IntoExecOptions, S
 pub use attach::{AttachOptions, AttachOptionsBuilder, IntoAttachCmd, IntoAttachOptions, SessionInfo};
 pub use builder::SandboxBuilder;
 pub use config::SandboxConfig;
-pub use exec::{ExecOptionsBuilder, ExitStatus as ExecExitStatus, Rlimit, RlimitResource, SizeExt};
+pub use exec::{ExecOptionsBuilder, ExitStatus as ExecExitStatus, Rlimit, RlimitResource};
 pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, SandboxFs};
 pub use microsandbox_filesystem::AccessMode;
 pub use types::{

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use microsandbox_filesystem::{AccessMode, DynFileSystem, PassthroughConfig, PassthroughFs, ProxyFs};
 use serde::{Deserialize, Serialize};
 
+use crate::size::Mebibytes;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -159,9 +161,16 @@ impl MountBuilder {
         self
     }
 
-    /// Set size limit in MiB (for tmpfs).
-    pub fn size_mib(mut self, size: u32) -> Self {
-        self.size_mib = Some(size);
+    /// Set size limit (for tmpfs).
+    ///
+    /// Accepts bare `u32` (interpreted as MiB) or a [`SizeExt`](crate::size::SizeExt) helper:
+    /// ```ignore
+    /// .tmpfs().size(100)         // 100 MiB
+    /// .tmpfs().size(100.mib())   // 100 MiB (explicit)
+    /// .tmpfs().size(1.gib())     // 1 GiB = 1024 MiB
+    /// ```
+    pub fn size(mut self, size: impl Into<Mebibytes>) -> Self {
+        self.size_mib = Some(size.into().as_u32());
         self
     }
 

--- a/crates/microsandbox/lib/size.rs
+++ b/crates/microsandbox/lib/size.rs
@@ -1,0 +1,202 @@
+//! Byte-size types and conversion helpers.
+//!
+//! Provides [`ByteSize`], [`Bytes`], and [`Mebibytes`] for type-safe size
+//! specification across the SDK.  The [`SizeExt`] trait adds `.bytes()`,
+//! `.kib()`, `.mib()`, and `.gib()` helpers to integer literals.
+//!
+//! ```ignore
+//! use microsandbox::size::{SizeExt, Mebibytes};
+//!
+//! // All equivalent — 512 MiB:
+//! let a: Mebibytes = 512.into();    // bare integer
+//! let b: Mebibytes = 512.mib().into(); // explicit unit
+//!
+//! // Cross-unit conversion:
+//! let c: Mebibytes = 1.gib().into();  // 1 GiB → 1024 MiB
+//! ```
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A byte-size value returned by [`SizeExt`] helpers.
+///
+/// Acts as the universal intermediate type that converts [`Into`] both
+/// [`Bytes`] and [`Mebibytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ByteSize(u64);
+
+/// A size measured in bytes.
+///
+/// Accepted by APIs that operate at byte-level precision (e.g. filesystem
+/// capacity, rlimit values).
+///
+/// **Bare integer path:** `u64` converts directly via [`From`].
+/// **Helper path:** any [`ByteSize`] (from `.kib()`, `.mib()`, `.gib()`)
+/// converts via [`From`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bytes(u64);
+
+/// A size measured in mebibytes (MiB).
+///
+/// Accepted by APIs that operate at MiB-level precision (e.g. sandbox
+/// memory, volume quota, tmpfs size).
+///
+/// **Bare integer path:** `u32` converts directly via [`From`].
+/// **Helper path:** any [`ByteSize`] (from `.kib()`, `.mib()`, `.gib()`)
+/// converts via [`From`] (truncates to whole MiB).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Mebibytes(u32);
+
+/// Helper trait for readable byte sizes.
+///
+/// Implemented for common integer types so that literals like `512.mib()`
+/// or `1.gib()` return a [`ByteSize`] that converts into either [`Bytes`]
+/// or [`Mebibytes`].
+pub trait SizeExt {
+    /// Create a [`ByteSize`] representing this many bytes.
+    fn bytes(self) -> ByteSize;
+    /// Create a [`ByteSize`] representing this many kibibytes (×1024).
+    fn kib(self) -> ByteSize;
+    /// Create a [`ByteSize`] representing this many mebibytes (×1024²).
+    fn mib(self) -> ByteSize;
+    /// Create a [`ByteSize`] representing this many gibibytes (×1024³).
+    fn gib(self) -> ByteSize;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ByteSize {
+    /// Get the raw byte count.
+    pub fn as_bytes(self) -> u64 {
+        self.0
+    }
+
+    /// Get the value in whole mebibytes (truncates sub-MiB remainder).
+    pub fn as_mib(self) -> u32 {
+        (self.0 / (1024 * 1024)) as u32
+    }
+}
+
+impl Bytes {
+    /// Get the raw byte count.
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl Mebibytes {
+    /// Get the MiB count.
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+// ByteSize → destination types.
+
+impl From<ByteSize> for Bytes {
+    fn from(bs: ByteSize) -> Self {
+        Self(bs.0)
+    }
+}
+
+impl From<ByteSize> for Mebibytes {
+    fn from(bs: ByteSize) -> Self {
+        Self((bs.0 / (1024 * 1024)) as u32)
+    }
+}
+
+// Bare integers → destination types.
+
+impl From<u64> for Bytes {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<u32> for Mebibytes {
+    fn from(v: u32) -> Self {
+        Self(v)
+    }
+}
+
+// SizeExt implementations for common integer types.
+
+macro_rules! impl_size_ext {
+    ($($t:ty),*) => {
+        $(
+            impl SizeExt for $t {
+                fn bytes(self) -> ByteSize { ByteSize(self as u64) }
+                fn kib(self) -> ByteSize { ByteSize(self as u64 * 1024) }
+                fn mib(self) -> ByteSize { ByteSize(self as u64 * 1024 * 1024) }
+                fn gib(self) -> ByteSize { ByteSize(self as u64 * 1024 * 1024 * 1024) }
+            }
+        )*
+    };
+}
+
+impl_size_ext!(u8, u16, u32, u64, usize, i32);
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_size_ext_helpers() {
+        assert_eq!(1u64.kib().as_bytes(), 1024);
+        assert_eq!(1u64.mib().as_bytes(), 1024 * 1024);
+        assert_eq!(1u64.gib().as_bytes(), 1024 * 1024 * 1024);
+        assert_eq!(512u64.mib().as_bytes(), 512 * 1024 * 1024);
+        assert_eq!(64i32.mib().as_bytes(), 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_bytesize_to_mebibytes() {
+        let mib: Mebibytes = 512.mib().into();
+        assert_eq!(mib.as_u32(), 512);
+
+        let mib: Mebibytes = 1.gib().into();
+        assert_eq!(mib.as_u32(), 1024);
+    }
+
+    #[test]
+    fn test_bytesize_to_bytes() {
+        let b: Bytes = 64.mib().into();
+        assert_eq!(b.as_u64(), 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_bare_u32_to_mebibytes() {
+        let mib: Mebibytes = 512u32.into();
+        assert_eq!(mib.as_u32(), 512);
+    }
+
+    #[test]
+    fn test_bare_u64_to_bytes() {
+        let b: Bytes = 4096u64.into();
+        assert_eq!(b.as_u64(), 4096);
+    }
+
+    #[test]
+    fn test_truncation() {
+        // 1.5 MiB → truncates to 1 MiB
+        let bs = ByteSize(1024 * 1024 + 512 * 1024);
+        let mib: Mebibytes = bs.into();
+        assert_eq!(mib.as_u32(), 1);
+    }
+
+    #[test]
+    fn test_bytes_helper() {
+        assert_eq!(4096.bytes().as_bytes(), 4096);
+    }
+}

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -15,6 +15,7 @@ use sea_orm::{
 use crate::MicrosandboxError;
 use crate::MicrosandboxResult;
 use crate::db::entity::volume as volume_entity;
+use crate::size::Mebibytes;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -209,9 +210,16 @@ impl VolumeBuilder {
         }
     }
 
-    /// Set the size quota in MiB.
-    pub fn quota(mut self, mib: u32) -> Self {
-        self.config.quota_mib = Some(mib);
+    /// Set the size quota.
+    ///
+    /// Accepts bare `u32` (interpreted as MiB) or a [`SizeExt`](crate::size::SizeExt) helper:
+    /// ```ignore
+    /// .quota(1024)         // 1024 MiB
+    /// .quota(1024.mib())   // 1024 MiB (explicit)
+    /// .quota(1.gib())      // 1 GiB = 1024 MiB
+    /// ```
+    pub fn quota(mut self, size: impl Into<Mebibytes>) -> Self {
+        self.config.quota_mib = Some(size.into().as_u32());
         self
     }
 


### PR DESCRIPTION
## Summary

- Replace raw integer size parameters with type-safe `ByteSize`, `Bytes`, and `Mebibytes` types across the SDK API
- Previously, some APIs expected MiB as `u32` while others expected bytes as `u64`, making the `SizeExt` helpers (`.mib()`, `.gib()`) usable only with byte-accepting APIs
- Now all size-accepting methods use `impl Into<Mebibytes>` or `impl Into<Bytes>`, so both bare integers and cross-unit helpers work uniformly everywhere
- Bare integers still work unchanged (e.g. `.memory(512)` is still 512 MiB), maintaining backward compatibility

## Changes

- Add new `size` module (`crates/microsandbox/lib/size.rs`) with:
  - `ByteSize` - universal intermediate type returned by `SizeExt` helpers
  - `Bytes` - destination type for byte-precision APIs, accepts bare `u64`
  - `Mebibytes` - destination type for MiB-precision APIs, accepts bare `u32`
  - `SizeExt` trait with `.bytes()`, `.kib()`, `.mib()`, `.gib()` helpers implemented for `u8`, `u16`, `u32`, `u64`, `usize`, `i32`
  - `From` conversions: `ByteSize` into both `Bytes` and `Mebibytes`, bare `u64` into `Bytes`, bare `u32` into `Mebibytes`
  - 7 unit tests covering helpers, conversions, bare integers, and truncation
- Update `SandboxBuilder::memory()` from `mib: u32` to `size: impl Into<Mebibytes>`
- Update `VolumeBuilder::quota()` from `mib: u32` to `size: impl Into<Mebibytes>`
- Rename `MountBuilder::size_mib()` to `size()` with `impl Into<Mebibytes>` parameter
- Remove old `SizeExt` trait and `impl SizeExt for u64` from `exec.rs`
- Remove `SizeExt` re-export from `sandbox/mod.rs`

## Test Plan

- Run `cargo test -p microsandbox size` to verify the 7 new unit tests pass
- Run `cargo check --workspace` to verify all crates compile (including the `basic` example which uses `.memory(512)`)
- Run `cargo test --workspace` to verify no regressions across the full test suite (844 tests)