### PR TITLE
feat(sandbox): add ImageSource for smart rootfs detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     rev: v4.3.0
     hooks:
       - id: no-commit-to-branch
-        args: ["-b", "main"]
+        args: ["-b", "main", "-b", "microsandbox"]
       - id: check-merge-conflict
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 resolver = "3"
-exclude = ["sdk/rust", "crates/agentd"]
+exclude = ["crates/agentd", "sdk/rust"]
 members = [
-    "crates/microsandbox",
     "crates/cli",
     "crates/db",
     "crates/filesystem",
     "crates/image",
+    "crates/microsandbox",
     "crates/migration",
     "crates/network",
     "crates/protocol",
@@ -71,8 +71,8 @@ psutil = "3.3.0"
 rand = "0.9"
 regex = "1.10"
 reqwest = { version = "0.13", features = ["json", "stream"] }
-reqwest-middleware = "0.3"                                                  # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
-reqwest-retry = "0.8"                                                       # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
+reqwest-middleware = "0.3" # Cannot upgrade to 0.4 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
+reqwest-retry = "0.8" # Cannot upgrade to 0.7 due to https://github.com/TrueLayer/reqwest-middleware/issues/204
 scopeguard = "1.2"
 semver = { version = "1.0.24", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -101,6 +101,13 @@ walkdir = "2.4"
 which = "8"
 xattr = "1.3"
 rstest = "0.26"
-sea-orm = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
-sea-orm-migration = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls"] }
+sea-orm = { version = "1.1", features = [
+    "macros",
+    "runtime-tokio-rustls",
+    "sqlx-sqlite",
+] }
+sea-orm-migration = { version = "1.1", features = [
+    "runtime-tokio-rustls",
+    "sqlx-sqlite",
+] }
 ureq = "3"

--- a/Dockerfile.agentd
+++ b/Dockerfile.agentd
@@ -28,7 +28,6 @@ ciborium = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 thiserror = "2.0"
-tokio = { version = "1.42", features = ["full"] }
 EOF
 
 RUN cd crates/agentd && cargo build --release

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -184,15 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,29 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,25 +285,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -407,12 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +409,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -18,7 +18,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0"
 thiserror = "2.0"
-tokio = { version = "1.42", features = ["full"] }
+tokio = { version = "1.42", default-features = false }
+
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true
+panic = "abort"
 
 [package]
 name = "microsandbox-agentd"
@@ -36,12 +42,28 @@ path = "bin/main.rs"
 path = "lib/lib.rs"
 
 [dependencies]
-microsandbox-protocol = { path = "../protocol" }
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-nix = { workspace = true, features = ["fs", "mount", "process", "signal", "term"] }
+microsandbox-protocol = { path = "../protocol" }
+nix = { workspace = true, features = [
+    "fs",
+    "mount",
+    "process",
+    "signal",
+    "term",
+] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt", "io-util", "process", "time", "fs", "signal", "net"] }
+tokio = { workspace = true, features = [
+    "fs",
+    "io-util",
+    "macros",
+    "net",
+    "process",
+    "rt",
+    "signal",
+    "sync",
+    "time",
+] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,8 +16,8 @@ name = "microsandbox_cli"
 path = "lib/lib.rs"
 
 [dependencies]
-microsandbox-runtime = { path = "../runtime" }
 clap.workspace = true
+microsandbox-runtime = { path = "../runtime" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -1,8 +1,11 @@
 //! Entry point for the `msb` CLI binary.
 
 use clap::{Parser, Subcommand};
-use microsandbox_cli::microvm_cmd::{self, MicrovmArgs};
-use microsandbox_cli::supervisor_cmd::{self, SupervisorArgs};
+use microsandbox_cli::{
+    log_args::{self, LogArgs},
+    microvm_cmd::{self, MicrovmArgs},
+    supervisor_cmd::{self, SupervisorArgs},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -12,6 +15,9 @@ use microsandbox_cli::supervisor_cmd::{self, SupervisorArgs};
 #[derive(Parser)]
 #[command(name = "msb", version, about = "Microsandbox CLI", styles = microsandbox_cli::styles::styles())]
 struct Cli {
+    #[command(flatten)]
+    logs: LogArgs,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -35,20 +41,18 @@ async fn main() {
     // Auto-set MSB_PATH so the library can find the msb binary
     // when spawning supervisor processes.
     // Safety: called before any threads are spawned (single-threaded at this point).
-    if std::env::var("MSB_PATH").is_err() {
-        if let Ok(exe) = std::env::current_exe() {
-            unsafe { std::env::set_var("MSB_PATH", &exe) };
-        }
+    if std::env::var("MSB_PATH").is_err()
+        && let Ok(exe) = std::env::current_exe()
+    {
+        unsafe { std::env::set_var("MSB_PATH", &exe) };
     }
 
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .init();
-
     let cli = Cli::parse();
+    let log_level = cli.logs.selected_level();
+    log_args::init_tracing(log_level);
 
     let result = match cli.command {
-        Commands::Supervisor(args) => supervisor_cmd::run(args).await,
+        Commands::Supervisor(args) => supervisor_cmd::run(args, log_level).await,
         Commands::Microvm(args) => microvm_cmd::run(args),
     };
 

--- a/crates/cli/lib/lib.rs
+++ b/crates/cli/lib/lib.rs
@@ -8,6 +8,7 @@
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub mod log_args;
 pub mod microvm_cmd;
 pub mod styles;
 pub mod supervisor_cmd;

--- a/crates/cli/lib/log_args.rs
+++ b/crates/cli/lib/log_args.rs
@@ -1,0 +1,116 @@
+//! Shared CLI verbosity flags for `msb` and its hidden runtime subcommands.
+
+use clap::Args;
+use microsandbox_runtime::logging::LogLevel;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Mutually-exclusive tracing verbosity flags.
+#[derive(Debug, Clone, Default, Args)]
+pub struct LogArgs {
+    /// Show logs with error level.
+    #[arg(long, global = true, conflicts_with_all = ["warn", "info", "debug", "trace"])]
+    pub error: bool,
+
+    /// Show logs with warn level.
+    #[arg(long, global = true, conflicts_with_all = ["error", "info", "debug", "trace"])]
+    pub warn: bool,
+
+    /// Show logs with info level.
+    #[arg(long, global = true, conflicts_with_all = ["error", "warn", "debug", "trace"])]
+    pub info: bool,
+
+    /// Show logs with debug level.
+    #[arg(long, global = true, conflicts_with_all = ["error", "warn", "info", "trace"])]
+    pub debug: bool,
+
+    /// Show logs with trace level.
+    #[arg(long, global = true, conflicts_with_all = ["error", "warn", "info", "debug"])]
+    pub trace: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Install a tracing subscriber for the selected level.
+///
+/// If no level is selected, logging stays disabled.
+pub fn init_tracing(log_level: Option<LogLevel>) {
+    if let Some(level) = log_level {
+        tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_max_level(level.as_tracing_level())
+            .init();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl LogArgs {
+    /// Return the selected log level, if any.
+    pub const fn selected_level(&self) -> Option<LogLevel> {
+        if self.error {
+            Some(LogLevel::Error)
+        } else if self.warn {
+            Some(LogLevel::Warn)
+        } else if self.info {
+            Some(LogLevel::Info)
+        } else if self.debug {
+            Some(LogLevel::Debug)
+        } else if self.trace {
+            Some(LogLevel::Trace)
+        } else {
+            None
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Parser, Subcommand};
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        logs: LogArgs,
+
+        #[command(subcommand)]
+        command: TestCommand,
+    }
+
+    #[derive(Debug, Subcommand)]
+    enum TestCommand {
+        Supervisor,
+        Microvm,
+    }
+
+    #[test]
+    fn test_global_log_flag_after_subcommand() {
+        let cli = TestCli::parse_from(["msb", "supervisor", "--debug"]);
+        assert_eq!(cli.logs.selected_level(), Some(LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_no_log_flag_means_silent() {
+        let cli = TestCli::parse_from(["msb", "microvm"]);
+        assert_eq!(cli.logs.selected_level(), None);
+    }
+
+    #[test]
+    fn test_log_flags_conflict() {
+        let err = TestCli::try_parse_from(["msb", "--info", "--debug", "supervisor"]).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains("--debug"));
+        assert!(rendered.contains("--info"));
+    }
+}

--- a/crates/cli/lib/microvm_cmd.rs
+++ b/crates/cli/lib/microvm_cmd.rs
@@ -3,12 +3,10 @@
 //! Parses CLI arguments, builds a `VmConfig`, and delegates to
 //! `microsandbox_runtime::vm::enter()`. This function never returns.
 
-use std::os::fd::RawFd;
-use std::path::PathBuf;
+use std::{os::fd::RawFd, path::PathBuf};
 
 use clap::Args;
-use microsandbox_runtime::RuntimeResult;
-use microsandbox_runtime::vm::VmConfig;
+use microsandbox_runtime::{RuntimeResult, vm::VmConfig};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/cli/lib/supervisor_cmd.rs
+++ b/crates/cli/lib/supervisor_cmd.rs
@@ -3,16 +3,16 @@
 //! Parses CLI arguments, builds a `SupervisorConfig`, and delegates to
 //! `microsandbox_runtime::supervisor::run()`.
 
-use std::os::fd::RawFd;
-use std::path::PathBuf;
+use std::{os::fd::RawFd, path::PathBuf};
 
 use clap::Args;
-use microsandbox_runtime::RuntimeResult;
-use microsandbox_runtime::policy::{
-    ChildPolicies, ChildPolicy, ExitAction, ShutdownMode, SupervisorPolicy,
+use microsandbox_runtime::{
+    RuntimeResult,
+    logging::LogLevel,
+    policy::{ChildPolicies, ChildPolicy, ExitAction, ShutdownMode, SupervisorPolicy},
+    supervisor::SupervisorConfig,
+    vm::VmConfig,
 };
-use microsandbox_runtime::supervisor::SupervisorConfig;
-use microsandbox_runtime::vm::VmConfig;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -24,6 +24,10 @@ pub struct SupervisorArgs {
     /// Name of the sandbox.
     #[arg(long = "name")]
     pub sandbox_name: String,
+
+    /// Database ID of the sandbox.
+    #[arg(long = "sandbox-id")]
+    pub sandbox_id: i32,
 
     /// Path to the sandbox database file.
     #[arg(long = "db-path")]
@@ -130,7 +134,7 @@ pub struct SupervisorArgs {
 //--------------------------------------------------------------------------------------------------
 
 /// Run the supervisor with the given CLI arguments.
-pub async fn run(args: SupervisorArgs) -> RuntimeResult<()> {
+pub async fn run(args: SupervisorArgs, log_level: Option<LogLevel>) -> RuntimeResult<()> {
     let child_policies = ChildPolicies {
         vm: ChildPolicy {
             on_exit: args.vm_on_exit,
@@ -167,6 +171,8 @@ pub async fn run(args: SupervisorArgs) -> RuntimeResult<()> {
 
     let config = SupervisorConfig {
         sandbox_name: args.sandbox_name,
+        sandbox_id: args.sandbox_id,
+        log_level,
         sandbox_db_path: args.sandbox_db_path,
         log_dir: args.log_dir,
         runtime_dir: args.runtime_dir,

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -10,12 +10,12 @@ edition.workspace = true
 path = "lib/lib.rs"
 
 [dependencies]
-msb_krun = "0.1.2"
-microsandbox-utils = { path = "../utils" }
 libc.workspace = true
-tracing.workspace = true
+microsandbox-utils = { path = "../utils" }
+msb_krun = "0.1.2"
 scopeguard.workspace = true
 tempfile.workspace = true
+tracing.workspace = true
 
 [features]
 prebuilt = ["dep:ureq"]

--- a/crates/filesystem/build.rs
+++ b/crates/filesystem/build.rs
@@ -1,5 +1,7 @@
-use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::{
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
 
 use microsandbox_utils::AGENTD_BINARY;
 #[cfg(feature = "prebuilt")]
@@ -54,17 +56,16 @@ fn build_agentd(workspace_root: &Path, out_dir: &Path) {
         // when msb embeds an older guest payload than the source implies.
         let agentd_src = workspace_root.join("crates/agentd");
         let protocol_src = workspace_root.join("crates/protocol");
-        if let Ok(bin_time) = std::fs::metadata(&source).and_then(|m| m.modified()) {
-            if newest_tree_mtime(&agentd_src)
+        if let Ok(bin_time) = std::fs::metadata(&source).and_then(|m| m.modified())
+            && newest_tree_mtime(&agentd_src)
                 .into_iter()
                 .chain(newest_tree_mtime(&protocol_src))
                 .any(|src_time| src_time > bin_time)
-            {
-                panic!(
-                    "build/{AGENTD_BINARY} is older than crates/agentd or crates/protocol source.\n\
-                     Run `just build-agentd` to rebuild the guest agent binary."
-                );
-            }
+        {
+            panic!(
+                "build/{AGENTD_BINARY} is older than crates/agentd or crates/protocol source.\n\
+                 Run `just build-agentd` to rebuild the guest agent binary."
+            );
         }
 
         let dest = out_dir.join(AGENTD_BINARY);

--- a/crates/filesystem/lib/backends/dualfs/builder.rs
+++ b/crates/filesystem/lib/backends/dualfs/builder.rs
@@ -2,15 +2,15 @@
 
 use std::sync::Arc;
 
-use super::hooks::DualDispatchHook;
-use super::policies::ReadBackendBWriteBackendA;
-use super::policy::DualDispatchPolicy;
-use super::types::{CachePolicy, DualFsConfig, DualState};
-use crate::backends::shared::init_binary;
-use crate::DynFileSystem;
+use super::{
+    hooks::DualDispatchHook,
+    policies::ReadBackendBWriteBackendA,
+    policy::DualDispatchPolicy,
+    types::{CachePolicy, DualFsConfig, DualState},
+};
+use crate::{DynFileSystem, backends::shared::init_binary};
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -106,12 +106,12 @@ impl DualFsBuilder {
 
     /// Build the `DualFs` backend.
     pub fn build(self) -> io::Result<super::DualFs> {
-        let backend_a = self.backend_a.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "backend_a is required")
-        })?;
-        let backend_b = self.backend_b.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "backend_b is required")
-        })?;
+        let backend_a = self
+            .backend_a
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "backend_a is required"))?;
+        let backend_b = self
+            .backend_b
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "backend_b is required"))?;
 
         let policy: Arc<dyn DualDispatchPolicy> = self
             .policy

--- a/crates/filesystem/lib/backends/dualfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/create_ops.rs
@@ -1,22 +1,27 @@
 //! Create, mkdir, mknod, symlink, link operations.
 
-use std::ffi::CStr;
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::{
+    ffi::CStr,
+    io,
+    sync::{Arc, Mutex, atomic::Ordering},
+};
 
-use super::hooks::{
-    CommitEvent, DentryChange, HookCtx, decode_entry, handle_hook_decision, notify_observers,
-    run_decision_hooks,
+use super::{
+    DualFs,
+    hooks::{
+        CommitEvent, DentryChange, HookCtx, decode_entry, handle_hook_decision, notify_observers,
+        run_decision_hooks,
+    },
+    lookup::{
+        backend, ensure_backend_presence, get_node, mark_metadata_authority, resolve_backend_inode,
+    },
+    policy::{DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::{AtomicBackendId, BackendId, FileKind, GuestNode, NodeState},
 };
-use super::lookup::{
-    backend, ensure_backend_presence, get_node, mark_metadata_authority, resolve_backend_inode,
+use crate::{
+    Context, Entry, Extensions, OpenOptions,
+    backends::shared::{init_binary, name_validation, platform},
 };
-use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
-use super::types::{AtomicBackendId, BackendId, FileKind, GuestNode, NodeState};
-use super::DualFs;
-use crate::backends::shared::{init_binary, name_validation, platform};
-use crate::{Context, Entry, Extensions, OpenOptions};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -64,9 +69,7 @@ pub(crate) fn do_create(
         return Ok((entry, None, OpenOptions::empty()));
     }
 
-    let view = DualNamespaceView {
-        state: &fs.state,
-    };
+    let view = DualNamespaceView { state: &fs.state };
     let plan = fs.policy.plan(&hook_ctx.req, &view, &hook_ctx.hints)?;
     let target = plan.target_backend().unwrap_or(BackendId::BackendA);
 
@@ -77,8 +80,8 @@ pub(crate) fn do_create(
     check_name_available(fs, parent, name_bytes, target)?;
 
     // Resolve parent on target.
-    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
-        .ok_or_else(platform::enoent)?;
+    let parent_target_inode =
+        resolve_backend_inode(&fs.state, parent, target).ok_or_else(platform::enoent)?;
 
     // Delegate.
     let (child_entry, child_handle, opts) = backend(fs, target).create(
@@ -98,7 +101,14 @@ pub(crate) fn do_create(
     mark_metadata_authority(&fs.state, parent, target);
 
     // Register new node.
-    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, FileKind::RegularFile);
+    let guest_inode = register_new_node(
+        fs,
+        child_entry.inode,
+        name_bytes,
+        parent,
+        target,
+        FileKind::RegularFile,
+    );
 
     // Create file handle.
     let child_handle_val = child_handle.unwrap_or(0);
@@ -203,15 +213,23 @@ pub(crate) fn do_mkdir(
         check_name_available(fs, parent, name_bytes, target)?;
     }
 
-    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
-        .ok_or_else(platform::enoent)?;
+    let parent_target_inode =
+        resolve_backend_inode(&fs.state, parent, target).ok_or_else(platform::enoent)?;
 
-    let child_entry = backend(fs, target).mkdir(ctx, parent_target_inode, name, mode, umask, extensions)?;
+    let child_entry =
+        backend(fs, target).mkdir(ctx, parent_target_inode, name, mode, umask, extensions)?;
 
     clear_whiteout(fs, parent, name_bytes, target);
     mark_metadata_authority(&fs.state, parent, target);
 
-    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, FileKind::Directory);
+    let guest_inode = register_new_node(
+        fs,
+        child_entry.inode,
+        name_bytes,
+        parent,
+        target,
+        FileKind::Directory,
+    );
 
     // If recreating over a deleted dir, make opaque against the other backend.
     if had_whiteout {
@@ -267,10 +285,18 @@ pub(crate) fn do_mknod(
     ensure_backend_presence(fs, ctx, parent, target)?;
     check_name_available(fs, parent, name_bytes, target)?;
 
-    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
-        .ok_or_else(platform::enoent)?;
+    let parent_target_inode =
+        resolve_backend_inode(&fs.state, parent, target).ok_or_else(platform::enoent)?;
 
-    let child_entry = backend(fs, target).mknod(ctx, parent_target_inode, name, mode, rdev, umask, extensions)?;
+    let child_entry = backend(fs, target).mknod(
+        ctx,
+        parent_target_inode,
+        name,
+        mode,
+        rdev,
+        umask,
+        extensions,
+    )?;
 
     clear_whiteout(fs, parent, name_bytes, target);
     mark_metadata_authority(&fs.state, parent, target);
@@ -320,15 +346,23 @@ pub(crate) fn do_symlink(
     ensure_backend_presence(fs, ctx, parent, target)?;
     check_name_available(fs, parent, name_bytes, target)?;
 
-    let parent_target_inode = resolve_backend_inode(&fs.state, parent, target)
-        .ok_or_else(platform::enoent)?;
+    let parent_target_inode =
+        resolve_backend_inode(&fs.state, parent, target).ok_or_else(platform::enoent)?;
 
-    let child_entry = backend(fs, target).symlink(ctx, linkname, parent_target_inode, name, extensions)?;
+    let child_entry =
+        backend(fs, target).symlink(ctx, linkname, parent_target_inode, name, extensions)?;
 
     clear_whiteout(fs, parent, name_bytes, target);
     mark_metadata_authority(&fs.state, parent, target);
 
-    let guest_inode = register_new_node(fs, child_entry.inode, name_bytes, parent, target, FileKind::Symlink);
+    let guest_inode = register_new_node(
+        fs,
+        child_entry.inode,
+        name_bytes,
+        parent,
+        target,
+        FileKind::Symlink,
+    );
 
     let mut st = child_entry.attr;
     st.st_ino = guest_inode;
@@ -373,21 +407,22 @@ pub(crate) fn do_link(
     let target = plan.target_backend().unwrap_or(BackendId::BackendA);
 
     // Materialize source if not on target.
-    if let Some(current) = source_node.state.read().unwrap().current_backend() {
-        if current != target {
-            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
-        }
+    if let Some(current) = source_node.state.read().unwrap().current_backend()
+        && current != target
+    {
+        super::materialize::do_materialize(fs, ctx, ino, current, target)?;
     }
 
     ensure_backend_presence(fs, ctx, newparent, target)?;
     check_name_available(fs, newparent, newname_bytes, target)?;
 
-    let source_target_inode = resolve_backend_inode(&fs.state, ino, target)
-        .ok_or_else(platform::einval)?;
-    let newparent_target_inode = resolve_backend_inode(&fs.state, newparent, target)
-        .ok_or_else(platform::enoent)?;
+    let source_target_inode =
+        resolve_backend_inode(&fs.state, ino, target).ok_or_else(platform::einval)?;
+    let newparent_target_inode =
+        resolve_backend_inode(&fs.state, newparent, target).ok_or_else(platform::enoent)?;
 
-    let child_entry = backend(fs, target).link(ctx, source_target_inode, newparent_target_inode, newname)?;
+    let child_entry =
+        backend(fs, target).link(ctx, source_target_inode, newparent_target_inode, newname)?;
 
     mark_metadata_authority(&fs.state, newparent, target);
 
@@ -487,12 +522,12 @@ fn check_name_available(
     target: BackendId,
 ) -> io::Result<()> {
     // If whited out against other backend, the name is "deleted" — available.
-    let whited_out = fs
-        .state
-        .whiteouts
-        .read()
-        .unwrap()
-        .contains(&(parent, name.to_vec(), target.other()));
+    let whited_out =
+        fs.state
+            .whiteouts
+            .read()
+            .unwrap()
+            .contains(&(parent, name.to_vec(), target.other()));
     if whited_out {
         return Ok(());
     }

--- a/crates/filesystem/lib/backends/dualfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/dir_ops.rs
@@ -1,18 +1,20 @@
 //! Opendir, readdir, readdirplus, releasedir, and snapshot building.
 
-use std::collections::HashSet;
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
-use super::lookup::{auto_register_readdir, backend, get_node};
-use super::policy::{BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx};
-use super::types::{
-    BackendId, DirSnapshot, DualDirHandle, FileKind, MergedDirEntry, NodeState, ROOT_INODE,
+use std::{
+    collections::HashSet,
+    io,
+    sync::{Arc, atomic::Ordering},
 };
-use super::DualFs;
-use crate::backends::shared::init_binary;
-use crate::{Context, DirEntry, Entry, OpenOptions};
+
+use super::{
+    DualFs,
+    lookup::{auto_register_readdir, backend, get_node},
+    policy::{BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::{
+        BackendId, DirSnapshot, DualDirHandle, FileKind, MergedDirEntry, NodeState, ROOT_INODE,
+    },
+};
+use crate::{Context, DirEntry, Entry, OpenOptions, backends::shared::init_binary};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -48,9 +50,7 @@ pub(crate) fn do_opendir(
         name: Vec::new(),
         parent_inode: 0,
     };
-    let view = DualNamespaceView {
-        state: &fs.state,
-    };
+    let view = DualNamespaceView { state: &fs.state };
     let hints = HintBag::new();
 
     let readdir_plan = fs.policy.plan(&req_ctx, &view, &hints)?;
@@ -85,10 +85,7 @@ pub(crate) fn do_opendir(
         }
     };
 
-    let handle = fs
-        .state
-        .next_handle
-        .fetch_add(1, Ordering::Relaxed);
+    let handle = fs.state.next_handle.fetch_add(1, Ordering::Relaxed);
 
     fs.state.dir_handles.write().unwrap().insert(
         handle,
@@ -271,21 +268,19 @@ fn build_readdir_snapshot(
             precedence: BackendChoice::BackendBFirst,
         } => {
             // Pass 1: backend_b via readdir.
-            if !opaque_b {
-                if let Some(bb_inode) = dh.backend_b_inode {
-                    collect_backend_entries(
-                        fs,
-                        ctx,
-                        BackendId::BackendB,
-                        bb_inode,
-                        guest_inode,
-                        &mut seen,
-                        &mut entries,
-                        &mut off,
-                        &whiteouts,
-                        BackendId::BackendB,
-                    )?;
-                }
+            if !opaque_b && let Some(bb_inode) = dh.backend_b_inode {
+                collect_backend_entries(
+                    fs,
+                    ctx,
+                    BackendId::BackendB,
+                    bb_inode,
+                    guest_inode,
+                    &mut seen,
+                    &mut entries,
+                    &mut off,
+                    &whiteouts,
+                    BackendId::BackendB,
+                )?;
             }
 
             // Pass 2: backend_a children from dentries.
@@ -306,77 +301,69 @@ fn build_readdir_snapshot(
             precedence: BackendChoice::BackendAFirst,
         } => {
             // Pass 1: backend_a via readdir.
-            if !opaque_a {
-                if let Some(ba_inode) = dh.backend_a_inode {
-                    collect_backend_entries(
-                        fs,
-                        ctx,
-                        BackendId::BackendA,
-                        ba_inode,
-                        guest_inode,
-                        &mut seen,
-                        &mut entries,
-                        &mut off,
-                        &whiteouts,
-                        BackendId::BackendA,
-                    )?;
-                }
+            if !opaque_a && let Some(ba_inode) = dh.backend_a_inode {
+                collect_backend_entries(
+                    fs,
+                    ctx,
+                    BackendId::BackendA,
+                    ba_inode,
+                    guest_inode,
+                    &mut seen,
+                    &mut entries,
+                    &mut off,
+                    &whiteouts,
+                    BackendId::BackendA,
+                )?;
             }
 
             // Pass 2: backend_b via readdir.
-            if !opaque_b {
-                if let Some(bb_inode) = dh.backend_b_inode {
-                    collect_backend_entries(
-                        fs,
-                        ctx,
-                        BackendId::BackendB,
-                        bb_inode,
-                        guest_inode,
-                        &mut seen,
-                        &mut entries,
-                        &mut off,
-                        &whiteouts,
-                        BackendId::BackendB,
-                    )?;
-                }
+            if !opaque_b && let Some(bb_inode) = dh.backend_b_inode {
+                collect_backend_entries(
+                    fs,
+                    ctx,
+                    BackendId::BackendB,
+                    bb_inode,
+                    guest_inode,
+                    &mut seen,
+                    &mut entries,
+                    &mut off,
+                    &whiteouts,
+                    BackendId::BackendB,
+                )?;
             }
         }
 
         DualDispatchPlan::UseBackendA { .. } => {
-            if !opaque_a {
-                if let Some(ba_inode) = dh.backend_a_inode {
-                    collect_backend_entries(
-                        fs,
-                        ctx,
-                        BackendId::BackendA,
-                        ba_inode,
-                        guest_inode,
-                        &mut seen,
-                        &mut entries,
-                        &mut off,
-                        &whiteouts,
-                        BackendId::BackendA,
-                    )?;
-                }
+            if !opaque_a && let Some(ba_inode) = dh.backend_a_inode {
+                collect_backend_entries(
+                    fs,
+                    ctx,
+                    BackendId::BackendA,
+                    ba_inode,
+                    guest_inode,
+                    &mut seen,
+                    &mut entries,
+                    &mut off,
+                    &whiteouts,
+                    BackendId::BackendA,
+                )?;
             }
         }
 
         DualDispatchPlan::UseBackendB { .. } => {
-            if !opaque_b {
-                if let Some(bb_inode) = dh.backend_b_inode {
-                    collect_backend_entries(
-                        fs,
-                        ctx,
-                        BackendId::BackendB,
-                        bb_inode,
-                        guest_inode,
-                        &mut seen,
-                        &mut entries,
-                        &mut off,
-                        &whiteouts,
-                        BackendId::BackendB,
-                    )?;
-                }
+            if !opaque_b && let Some(bb_inode) = dh.backend_b_inode {
+                collect_backend_entries(
+                    fs,
+                    ctx,
+                    BackendId::BackendB,
+                    bb_inode,
+                    guest_inode,
+                    &mut seen,
+                    &mut entries,
+                    &mut off,
+                    &whiteouts,
+                    BackendId::BackendB,
+                )?;
             }
         }
 
@@ -403,7 +390,8 @@ fn collect_backend_entries(
     let (dir_handle, _) = backend(fs, backend_id).opendir(ctx, backend_inode, 0)?;
     let dir_handle_val = dir_handle.unwrap_or(0);
 
-    let child_entries = backend(fs, backend_id).readdir(ctx, backend_inode, dir_handle_val, u32::MAX, 0)?;
+    let child_entries =
+        backend(fs, backend_id).readdir(ctx, backend_inode, dir_handle_val, u32::MAX, 0)?;
     let _ = backend(fs, backend_id).releasedir(ctx, backend_inode, 0, dir_handle_val);
 
     for entry in child_entries {
@@ -486,12 +474,12 @@ fn collect_dentry_entries(
 
         // Only include nodes that are on the filter backend or merged.
         let state = child_node.state.read().unwrap();
-        let include = match (&*state, backend_filter) {
-            (NodeState::BackendA { .. }, BackendId::BackendA) => true,
-            (NodeState::BackendB { .. }, BackendId::BackendB) => true,
-            (NodeState::MergedDir { .. }, _) => true,
-            _ => false,
-        };
+        let include = matches!(
+            (&*state, backend_filter),
+            (NodeState::BackendA { .. }, BackendId::BackendA)
+                | (NodeState::BackendB { .. }, BackendId::BackendB)
+                | (NodeState::MergedDir { .. }, _)
+        );
 
         if include {
             seen.insert(name.clone());
@@ -507,10 +495,7 @@ fn collect_dentry_entries(
 }
 
 /// Serve readdir results from a snapshot starting at the given offset.
-fn serve_readdir(
-    snapshot: &DirSnapshot,
-    offset: u64,
-) -> io::Result<Vec<DirEntry<'static>>> {
+fn serve_readdir(snapshot: &DirSnapshot, offset: u64) -> io::Result<Vec<DirEntry<'static>>> {
     let start = snapshot
         .entries
         .iter()
@@ -529,7 +514,13 @@ fn serve_readdir(
     for entry in result_entries {
         let name_start = names_buf.len();
         names_buf.extend_from_slice(&entry.name);
-        offsets_vec.push((name_start, entry.name.len(), entry.inode, entry.offset, entry.file_type));
+        offsets_vec.push((
+            name_start,
+            entry.name.len(),
+            entry.inode,
+            entry.offset,
+            entry.file_type,
+        ));
     }
 
     let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());

--- a/crates/filesystem/lib/backends/dualfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/file_ops.rs
@@ -1,19 +1,24 @@
 //! Open, read, write, flush, release for regular files.
 
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
-use super::hooks::{
-    DispatchStep, HookCtx, StepResult, decode_ok, decode_open, handle_hook_decision,
-    notify_observers, run_decision_hooks,
+use std::{
+    io,
+    sync::{Arc, atomic::Ordering},
 };
-use super::lookup::{backend, get_node, resolve_backend_inode};
-use super::policy::{DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx};
-use super::types::{BackendId, DualHandle, NodeState};
-use super::DualFs;
-use crate::backends::shared::{init_binary, platform};
-use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+
+use super::{
+    DualFs,
+    hooks::{
+        DispatchStep, HookCtx, StepResult, decode_ok, decode_open, handle_hook_decision,
+        notify_observers, run_decision_hooks,
+    },
+    lookup::{backend, get_node, resolve_backend_inode},
+    policy::{DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::{BackendId, DualHandle, NodeState},
+};
+use crate::{
+    Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::{init_binary, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -65,9 +70,7 @@ pub(crate) fn do_open(
         return r;
     }
 
-    let view = DualNamespaceView {
-        state: &fs.state,
-    };
+    let view = DualNamespaceView { state: &fs.state };
 
     // hooks.after_resolve
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
@@ -91,9 +94,7 @@ pub(crate) fn do_open(
 
     // hooks.after_plan
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
-            h.after_plan(ctx, &plan)
-        }),
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.after_plan(ctx, &plan)),
         decode_open,
     ) {
         return r;
@@ -101,20 +102,28 @@ pub(crate) fn do_open(
 
     // Dispatch.
     match plan {
-        DualDispatchPlan::MaterializeToBackendThen {
-            source,
-            target,
-            ..
-        } => {
+        DualDispatchPlan::MaterializeToBackendThen { source, target, .. } => {
             super::materialize::do_materialize(fs, ctx, ino, source, target)?;
             open_on_backend(fs, ctx, ino, kill_priv, flags, target, &mut hook_ctx)
         }
-        DualDispatchPlan::UseBackendA { .. } => {
-            open_on_backend(fs, ctx, ino, kill_priv, flags, BackendId::BackendA, &mut hook_ctx)
-        }
-        DualDispatchPlan::UseBackendB { .. } => {
-            open_on_backend(fs, ctx, ino, kill_priv, flags, BackendId::BackendB, &mut hook_ctx)
-        }
+        DualDispatchPlan::UseBackendA { .. } => open_on_backend(
+            fs,
+            ctx,
+            ino,
+            kill_priv,
+            flags,
+            BackendId::BackendA,
+            &mut hook_ctx,
+        ),
+        DualDispatchPlan::UseBackendB { .. } => open_on_backend(
+            fs,
+            ctx,
+            ino,
+            kill_priv,
+            flags,
+            BackendId::BackendB,
+            &mut hook_ctx,
+        ),
         DualDispatchPlan::Deny { errno } => Err(io::Error::from_raw_os_error(errno)),
         _ => Err(platform::einval()),
     }
@@ -363,12 +372,16 @@ pub(crate) fn do_flush(
             backend_a_inode,
             backend_a_handle,
             ..
-        } => fs.backend_a.flush(ctx, *backend_a_inode, *backend_a_handle, lock_owner),
+        } => fs
+            .backend_a
+            .flush(ctx, *backend_a_inode, *backend_a_handle, lock_owner),
         DualHandle::BackendB {
             backend_b_inode,
             backend_b_handle,
             ..
-        } => fs.backend_b.flush(ctx, *backend_b_inode, *backend_b_handle, lock_owner),
+        } => fs
+            .backend_b
+            .flush(ctx, *backend_b_inode, *backend_b_handle, lock_owner),
     };
 
     notify_observers(&fs.hooks, |h| {
@@ -439,32 +452,28 @@ pub(crate) fn do_release(
             backend_a_inode,
             backend_a_handle,
             ..
-        } => {
-            fs.backend_a.release(
-                ctx,
-                *backend_a_inode,
-                flags,
-                *backend_a_handle,
-                flush,
-                flock_release,
-                lock_owner,
-            )
-        }
+        } => fs.backend_a.release(
+            ctx,
+            *backend_a_inode,
+            flags,
+            *backend_a_handle,
+            flush,
+            flock_release,
+            lock_owner,
+        ),
         DualHandle::BackendB {
             backend_b_inode,
             backend_b_handle,
             ..
-        } => {
-            fs.backend_b.release(
-                ctx,
-                *backend_b_inode,
-                flags,
-                *backend_b_handle,
-                flush,
-                flock_release,
-                lock_owner,
-            )
-        }
+        } => fs.backend_b.release(
+            ctx,
+            *backend_b_inode,
+            flags,
+            *backend_b_handle,
+            flush,
+            flock_release,
+            lock_owner,
+        ),
     };
 
     notify_observers(&fs.hooks, |h| {
@@ -517,8 +526,8 @@ fn open_on_backend(
     target: BackendId,
     hook_ctx: &mut HookCtx,
 ) -> io::Result<(Option<u64>, OpenOptions)> {
-    let target_inode = resolve_backend_inode(&fs.state, ino, target)
-        .ok_or_else(platform::einval)?;
+    let target_inode =
+        resolve_backend_inode(&fs.state, ino, target).ok_or_else(platform::einval)?;
 
     let step = DispatchStep {
         backend: target,
@@ -528,9 +537,7 @@ fn open_on_backend(
     };
 
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-        run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
-            h.before_dispatch(ctx, &step)
-        }),
+        run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| h.before_dispatch(ctx, &step)),
         decode_open,
     ) {
         return r;
@@ -539,10 +546,7 @@ fn open_on_backend(
     let (child_handle, opts) = backend(fs, target).open(ctx, target_inode, kill_priv, flags)?;
     let child_handle_val = child_handle.unwrap_or(0);
 
-    let guest_handle = fs
-        .state
-        .next_handle
-        .fetch_add(1, Ordering::Relaxed);
+    let guest_handle = fs.state.next_handle.fetch_add(1, Ordering::Relaxed);
 
     let dual_handle = match target {
         BackendId::BackendA => DualHandle::BackendA {
@@ -564,11 +568,7 @@ fn open_on_backend(
         .insert(guest_handle, Arc::new(dual_handle));
 
     notify_observers(&fs.hooks, |h| {
-        h.after_dispatch(
-            hook_ctx,
-            &step,
-            &StepResult::Handle(guest_handle, opts),
-        );
+        h.after_dispatch(hook_ctx, &step, &StepResult::Handle(guest_handle, opts));
     });
 
     Ok((Some(guest_handle), opts))

--- a/crates/filesystem/lib/backends/dualfs/hooks.rs
+++ b/crates/filesystem/lib/backends/dualfs/hooks.rs
@@ -4,12 +4,12 @@
 //! They run at defined pipeline points and can add hints, deny operations,
 //! or short-circuit responses.
 
-use std::collections::HashMap;
-use std::io;
-use std::time::Duration;
+use std::{collections::HashMap, io, time::Duration};
 
-use super::policy::{DualDispatchPlan, DualNamespaceView, HintBag, Hint, OpKind, RequestCtx};
-use super::types::{BackendId, NodeState};
+use super::{
+    policy::{DualDispatchPlan, DualNamespaceView, Hint, HintBag, OpKind, RequestCtx},
+    types::{BackendId, NodeState},
+};
 use crate::{Entry, OpenOptions, stat64};
 
 //--------------------------------------------------------------------------------------------------
@@ -239,10 +239,8 @@ where
 }
 
 /// Notify observer hooks (fire-and-forget).
-pub(crate) fn notify_observers<F>(
-    hooks: &[std::sync::Arc<dyn DualDispatchHook>],
-    invoke: F,
-) where
+pub(crate) fn notify_observers<F>(hooks: &[std::sync::Arc<dyn DualDispatchHook>], invoke: F)
+where
     F: Fn(&dyn DualDispatchHook),
 {
     for hook in hooks {

--- a/crates/filesystem/lib/backends/dualfs/lookup.rs
+++ b/crates/filesystem/lib/backends/dualfs/lookup.rs
@@ -1,23 +1,24 @@
 //! Lookup pipeline, REGISTER, whiteout/opaque checking, and backend pin management.
 
-use std::ffi::CStr;
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::{
+    ffi::CStr,
+    io,
+    sync::{Arc, Mutex, atomic::Ordering},
+};
 
-use super::hooks::{
-    CommitEvent, DentryChange, DispatchStep, HookCtx, StepResult,
-    decode_entry, handle_hook_decision, notify_observers, run_decision_hooks,
+use super::{
+    DualFs,
+    hooks::{
+        CommitEvent, DentryChange, DispatchStep, HookCtx, StepResult, decode_entry,
+        handle_hook_decision, notify_observers, run_decision_hooks,
+    },
+    policy::{BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::{AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE},
 };
-use super::policy::{
-    BackendChoice, DualDispatchPlan, DualNamespaceView, HintBag, OpKind, RequestCtx,
+use crate::{
+    Context, Entry,
+    backends::shared::{init_binary, name_validation, platform},
 };
-use super::types::{
-    AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE,
-};
-use super::DualFs;
-use crate::backends::shared::{init_binary, name_validation, platform};
-use crate::{Context, Entry};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -86,9 +87,7 @@ pub(crate) fn do_lookup(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> 
     }
 
     // hooks.after_resolve
-    let view = DualNamespaceView {
-        state: &fs.state,
-    };
+    let view = DualNamespaceView { state: &fs.state };
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
         run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
             h.after_resolve(ctx, &view)
@@ -111,9 +110,7 @@ pub(crate) fn do_lookup(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> 
 
     // hooks.after_plan
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
-            h.after_plan(ctx, &plan)
-        }),
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.after_plan(ctx, &plan)),
         decode_entry,
     ) {
         return r;
@@ -126,24 +123,10 @@ pub(crate) fn do_lookup(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> 
         }
         DualDispatchPlan::UseBackendA { .. } => {
             // Single-backend lookup (e.g., BackendAOnly policy).
-            execute_single_backend_lookup(
-                fs,
-                ctx,
-                parent,
-                name,
-                BackendId::BackendA,
-                &mut hook_ctx,
-            )
+            execute_single_backend_lookup(fs, ctx, parent, name, BackendId::BackendA, &mut hook_ctx)
         }
         DualDispatchPlan::UseBackendB { .. } => {
-            execute_single_backend_lookup(
-                fs,
-                ctx,
-                parent,
-                name,
-                BackendId::BackendB,
-                &mut hook_ctx,
-            )
+            execute_single_backend_lookup(fs, ctx, parent, name, BackendId::BackendB, &mut hook_ctx)
         }
         DualDispatchPlan::Deny { errno } => Err(io::Error::from_raw_os_error(errno)),
         _ => Err(platform::einval()),
@@ -154,9 +137,10 @@ pub(crate) fn do_lookup(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> 
         h.after_response(&super::hooks::ResponseEvent {
             op: OpKind::Lookup,
             guest_inode: parent,
-            result: result.as_ref().map(|_| ()).map_err(|e| {
-                e.raw_os_error().unwrap_or(libc::EIO)
-            }),
+            result: result
+                .as_ref()
+                .map(|_| ())
+                .map_err(|e| e.raw_os_error().unwrap_or(libc::EIO)),
             latency: std::time::Duration::ZERO,
         });
     });
@@ -198,7 +182,11 @@ pub(crate) fn get_node(state: &DualState, ino: u64) -> io::Result<Arc<GuestNode>
 }
 
 /// Resolve a child backend inode for a given backend.
-pub(crate) fn resolve_backend_inode(state: &DualState, guest_inode: u64, backend: BackendId) -> Option<u64> {
+pub(crate) fn resolve_backend_inode(
+    state: &DualState,
+    guest_inode: u64,
+    backend: BackendId,
+) -> Option<u64> {
     let nodes = state.nodes.read().unwrap();
     let node = nodes.get(&guest_inode)?;
     node.state.read().unwrap().backend_inode(backend)
@@ -248,12 +236,21 @@ pub(crate) fn backend(fs: &DualFs, id: BackendId) -> &dyn DynFileSystem {
 }
 
 /// Check if a name is whited out for a specific backend.
-pub(crate) fn is_whited_out(state: &DualState, parent: u64, name: &[u8], hidden_backend: BackendId) -> bool {
+pub(crate) fn is_whited_out(
+    state: &DualState,
+    parent: u64,
+    name: &[u8],
+    hidden_backend: BackendId,
+) -> bool {
     state.is_whited_out(parent, name, hidden_backend)
 }
 
 /// Check if a directory is opaque against a specific backend.
-pub(crate) fn is_opaque_against(state: &DualState, dir_inode: u64, hidden_backend: BackendId) -> bool {
+pub(crate) fn is_opaque_against(
+    state: &DualState,
+    dir_inode: u64,
+    hidden_backend: BackendId,
+) -> bool {
     state.is_opaque(dir_inode, hidden_backend)
 }
 
@@ -360,9 +357,7 @@ fn get_child_attrs(fs: &DualFs, node: &GuestNode, guest_inode: u64) -> io::Resul
         NodeState::Init => Ok(init_binary::init_stat()),
         _ => {
             let (backend_id, child_inode) = match &*state {
-                NodeState::Root {
-                    backend_a_root, ..
-                } => (BackendId::BackendA, *backend_a_root),
+                NodeState::Root { backend_a_root, .. } => (BackendId::BackendA, *backend_a_root),
                 NodeState::BackendA {
                     backend_a_inode, ..
                 } => (BackendId::BackendA, *backend_a_inode),
@@ -374,7 +369,10 @@ fn get_child_attrs(fs: &DualFs, node: &GuestNode, guest_inode: u64) -> io::Resul
                 } => {
                     let md = node.metadata_backend.load(Ordering::Relaxed);
                     if md == BackendId::BackendB {
-                        (BackendId::BackendB, state.backend_inode(BackendId::BackendB).unwrap())
+                        (
+                            BackendId::BackendB,
+                            state.backend_inode(BackendId::BackendB).unwrap(),
+                        )
                     } else {
                         (BackendId::BackendA, *backend_a_inode)
                     }
@@ -383,7 +381,11 @@ fn get_child_attrs(fs: &DualFs, node: &GuestNode, guest_inode: u64) -> io::Resul
             };
             drop(state);
 
-            let ctx = Context { uid: 0, gid: 0, pid: 0 };
+            let ctx = Context {
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            };
             let (mut st, _) = backend(fs, backend_id).getattr(ctx, child_inode, None)?;
             st.st_ino = guest_inode;
             Ok(st)
@@ -410,53 +412,54 @@ fn execute_merge_lookup(
     // Try preferred backend.
     if !is_whited_out(&fs.state, parent, name_bytes, first_id)
         && !is_opaque_against(&fs.state, parent, first_id)
+        && let Some(first_parent) = resolve_backend_inode(&fs.state, parent, first_id)
     {
-        if let Some(first_parent) = resolve_backend_inode(&fs.state, parent, first_id) {
-            let step = DispatchStep {
-                backend: first_id,
-                op: OpKind::Lookup,
-                inode: first_parent,
-                handle: None,
-            };
+        let step = DispatchStep {
+            backend: first_id,
+            op: OpKind::Lookup,
+            inode: first_parent,
+            handle: None,
+        };
 
-            if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-                run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
-                    h.before_dispatch(ctx, &step)
-                }),
-                decode_entry,
-            ) {
-                return r;
+        if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
+            run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| h.before_dispatch(ctx, &step)),
+            decode_entry,
+        ) {
+            return r;
+        }
+
+        match backend(fs, first_id).lookup(ctx, first_parent, name) {
+            Ok(entry) => {
+                notify_observers(&fs.hooks, |h| {
+                    h.after_dispatch(
+                        hook_ctx,
+                        &step,
+                        &StepResult::Entry(super::hooks::copy_entry(&entry)),
+                    );
+                });
+                return register(fs, ctx, entry, parent, name_bytes, first_id);
             }
-
-            match backend(fs, first_id).lookup(ctx, first_parent, name) {
-                Ok(entry) => {
-                    notify_observers(&fs.hooks, |h| {
-                        h.after_dispatch(hook_ctx, &step, &StepResult::Entry(super::hooks::copy_entry(&entry)));
-                    });
-                    return register(fs, ctx, entry, parent, name_bytes, first_id);
-                }
-                Err(e) if e.raw_os_error() == Some(libc::ENOENT) => {
-                    notify_observers(&fs.hooks, |h| {
-                        h.after_dispatch(
-                            hook_ctx,
-                            &step,
-                            &StepResult::Err(io::Error::from_raw_os_error(libc::ENOENT)),
-                        );
-                    });
-                    // Fall through to second backend.
-                }
-                Err(e) => {
-                    notify_observers(&fs.hooks, |h| {
-                        h.after_dispatch(
-                            hook_ctx,
-                            &step,
-                            &StepResult::Err(io::Error::from_raw_os_error(
-                                e.raw_os_error().unwrap_or(libc::EIO),
-                            )),
-                        );
-                    });
-                    return Err(e);
-                }
+            Err(e) if e.raw_os_error() == Some(libc::ENOENT) => {
+                notify_observers(&fs.hooks, |h| {
+                    h.after_dispatch(
+                        hook_ctx,
+                        &step,
+                        &StepResult::Err(io::Error::from_raw_os_error(libc::ENOENT)),
+                    );
+                });
+                // Fall through to second backend.
+            }
+            Err(e) => {
+                notify_observers(&fs.hooks, |h| {
+                    h.after_dispatch(
+                        hook_ctx,
+                        &step,
+                        &StepResult::Err(io::Error::from_raw_os_error(
+                            e.raw_os_error().unwrap_or(libc::EIO),
+                        )),
+                    );
+                });
+                return Err(e);
             }
         }
     }
@@ -477,9 +480,7 @@ fn execute_merge_lookup(
         };
 
         if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-            run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
-                h.before_dispatch(ctx, &step)
-            }),
+            run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| h.before_dispatch(ctx, &step)),
             decode_entry,
         ) {
             return r;
@@ -488,7 +489,11 @@ fn execute_merge_lookup(
         match backend(fs, second_id).lookup(ctx, second_parent, name) {
             Ok(entry) => {
                 notify_observers(&fs.hooks, |h| {
-                    h.after_dispatch(hook_ctx, &step, &StepResult::Entry(super::hooks::copy_entry(&entry)));
+                    h.after_dispatch(
+                        hook_ctx,
+                        &step,
+                        &StepResult::Entry(super::hooks::copy_entry(&entry)),
+                    );
                 });
                 return register(fs, ctx, entry, parent, name_bytes, second_id);
             }
@@ -521,8 +526,8 @@ fn execute_single_backend_lookup(
 ) -> io::Result<Entry> {
     let name_bytes = name.to_bytes();
 
-    let parent_inode = resolve_backend_inode(&fs.state, parent, backend_id)
-        .ok_or_else(platform::enoent)?;
+    let parent_inode =
+        resolve_backend_inode(&fs.state, parent, backend_id).ok_or_else(platform::enoent)?;
 
     let step = DispatchStep {
         backend: backend_id,
@@ -532,9 +537,7 @@ fn execute_single_backend_lookup(
     };
 
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-        run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| {
-            h.before_dispatch(ctx, &step)
-        }),
+        run_decision_hooks(&fs.hooks, hook_ctx, |h, ctx| h.before_dispatch(ctx, &step)),
         decode_entry,
     ) {
         return r;
@@ -543,7 +546,11 @@ fn execute_single_backend_lookup(
     match backend(fs, backend_id).lookup(ctx, parent_inode, name) {
         Ok(entry) => {
             notify_observers(&fs.hooks, |h| {
-                h.after_dispatch(hook_ctx, &step, &StepResult::Entry(super::hooks::copy_entry(&entry)));
+                h.after_dispatch(
+                    hook_ctx,
+                    &step,
+                    &StepResult::Entry(super::hooks::copy_entry(&entry)),
+                );
             });
             register(fs, ctx, entry, parent, name_bytes, backend_id)
         }
@@ -598,7 +605,11 @@ pub(crate) fn register(
 
                 // Immediately forget the transient lookup ref.
                 backend(fs, source).forget(
-                    Context { uid: 0, gid: 0, pid: 0 },
+                    Context {
+                        uid: 0,
+                        gid: 0,
+                        pid: 0,
+                    },
                     child_entry.inode,
                     1,
                 );
@@ -619,10 +630,7 @@ pub(crate) fn register(
     }
 
     // New entry — assign a guest inode.
-    let guest_inode = fs
-        .state
-        .next_inode
-        .fetch_add(1, Ordering::Relaxed);
+    let guest_inode = fs.state.next_inode.fetch_add(1, Ordering::Relaxed);
     let kind = FileKind::from_mode(child_entry.attr.st_mode as u32);
 
     let node_state = match source {
@@ -647,11 +655,7 @@ pub(crate) fn register(
         copy_up_lock: Mutex::new(()),
     });
 
-    fs.state
-        .nodes
-        .write()
-        .unwrap()
-        .insert(guest_inode, node);
+    fs.state.nodes.write().unwrap().insert(guest_inode, node);
     inode_map
         .write()
         .unwrap()
@@ -697,6 +701,7 @@ pub(crate) fn register(
 }
 
 /// Auto-register a backend entry discovered via readdir.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn auto_register_readdir(
     fs: &DualFs,
     ctx: Context,
@@ -732,10 +737,7 @@ pub(crate) fn auto_register_readdir(
         Err(_) => return None,
     };
 
-    let guest_ino = fs
-        .state
-        .next_inode
-        .fetch_add(1, Ordering::Relaxed);
+    let guest_ino = fs.state.next_inode.fetch_add(1, Ordering::Relaxed);
     let kind = FileKind::from_dtype(dtype);
 
     let node_state = match source {
@@ -760,15 +762,8 @@ pub(crate) fn auto_register_readdir(
         copy_up_lock: Mutex::new(()),
     });
 
-    fs.state
-        .nodes
-        .write()
-        .unwrap()
-        .insert(guest_ino, node);
-    inode_map
-        .write()
-        .unwrap()
-        .insert(backend_inode, guest_ino);
+    fs.state.nodes.write().unwrap().insert(guest_ino, node);
+    inode_map.write().unwrap().insert(backend_inode, guest_ino);
     fs.state
         .dentries
         .write()
@@ -813,7 +808,7 @@ fn forget_one(fs: &DualFs, ino: u64, count: u64) {
             .read()
             .unwrap()
             .get(&ino)
-            .map_or(true, |s| s.is_empty());
+            .is_none_or(|s| s.is_empty());
 
         if aliases_empty {
             // Evict: release retained child pins.
@@ -827,8 +822,15 @@ fn forget_one(fs: &DualFs, ino: u64, count: u64) {
                     let former = *former_backend_b_inode;
                     drop(state);
 
-                    fs.backend_a
-                        .forget(Context { uid: 0, gid: 0, pid: 0 }, ba_ino, 1);
+                    fs.backend_a.forget(
+                        Context {
+                            uid: 0,
+                            gid: 0,
+                            pid: 0,
+                        },
+                        ba_ino,
+                        1,
+                    );
                     fs.state
                         .backend_a_inode_map
                         .write()
@@ -850,8 +852,15 @@ fn forget_one(fs: &DualFs, ino: u64, count: u64) {
                     let former = *former_backend_a_inode;
                     drop(state);
 
-                    fs.backend_b
-                        .forget(Context { uid: 0, gid: 0, pid: 0 }, bb_ino, 1);
+                    fs.backend_b.forget(
+                        Context {
+                            uid: 0,
+                            gid: 0,
+                            pid: 0,
+                        },
+                        bb_ino,
+                        1,
+                    );
                     fs.state
                         .backend_b_inode_map
                         .write()
@@ -873,15 +882,29 @@ fn forget_one(fs: &DualFs, ino: u64, count: u64) {
                     let bb_ino = *backend_b_inode;
                     drop(state);
 
-                    fs.backend_a
-                        .forget(Context { uid: 0, gid: 0, pid: 0 }, ba_ino, 1);
+                    fs.backend_a.forget(
+                        Context {
+                            uid: 0,
+                            gid: 0,
+                            pid: 0,
+                        },
+                        ba_ino,
+                        1,
+                    );
                     fs.state
                         .backend_a_inode_map
                         .write()
                         .unwrap()
                         .remove(&ba_ino);
-                    fs.backend_b
-                        .forget(Context { uid: 0, gid: 0, pid: 0 }, bb_ino, 1);
+                    fs.backend_b.forget(
+                        Context {
+                            uid: 0,
+                            gid: 0,
+                            pid: 0,
+                        },
+                        bb_ino,
+                        1,
+                    );
                     fs.state
                         .backend_b_inode_map
                         .write()

--- a/crates/filesystem/lib/backends/dualfs/materialize.rs
+++ b/crates/filesystem/lib/backends/dualfs/materialize.rs
@@ -1,13 +1,13 @@
 //! Materialization orchestration: chunked streaming, directory promotion,
 //! ancestor materialization.
 
-use std::ffi::CString;
-use std::io;
-use std::sync::atomic::Ordering;
-use super::lookup::{backend, get_node, resolve_backend_inode};
-use super::types::{BackendId, FileKind, NodeState, ROOT_INODE};
-use super::DualFs;
+use super::{
+    DualFs,
+    lookup::{backend, get_node, resolve_backend_inode},
+    types::{BackendId, FileKind, NodeState, ROOT_INODE},
+};
 use crate::{Context, Extensions, SetattrValid};
+use std::{ffi::CString, io, sync::atomic::Ordering};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -57,34 +57,51 @@ pub(crate) fn do_materialize(
 
     // Resolve parent's inode on target.
     let (parent_ino, name) = {
-        let alias = fs
-            .state
+        fs.state
             .alias_index
             .read()
             .unwrap()
             .get(&guest_inode)
             .and_then(|s| s.iter().next().cloned())
-            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
-        alias
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?
     };
 
     let parent_target_inode = resolve_backend_inode(&fs.state, parent_ino, target)
         .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
 
-    let cname = CString::new(name.clone())
-        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let cname =
+        CString::new(name.clone()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
     // Copy based on file type.
     let target_inode = match node.kind {
-        FileKind::RegularFile => {
-            materialize_regular_file(fs, ctx, source, target, source_inode, parent_target_inode, &cname, guest_inode)?
-        }
-        FileKind::Symlink => {
-            materialize_symlink(fs, ctx, source, target, source_inode, parent_target_inode, &cname)?
-        }
-        FileKind::Special => {
-            materialize_special(fs, ctx, source, target, source_inode, parent_target_inode, &cname)?
-        }
+        FileKind::RegularFile => materialize_regular_file(
+            fs,
+            ctx,
+            source,
+            target,
+            source_inode,
+            parent_target_inode,
+            &cname,
+            guest_inode,
+        )?,
+        FileKind::Symlink => materialize_symlink(
+            fs,
+            ctx,
+            source,
+            target,
+            source_inode,
+            parent_target_inode,
+            &cname,
+        )?,
+        FileKind::Special => materialize_special(
+            fs,
+            ctx,
+            source,
+            target,
+            source_inode,
+            parent_target_inode,
+            &cname,
+        )?,
         FileKind::Directory => {
             // Directories are handled by promote_directory_to_merged, not materialize.
             return Err(io::Error::from_raw_os_error(libc::EISDIR));
@@ -114,7 +131,15 @@ pub(crate) fn do_materialize(
         .insert(target_inode, guest_inode);
 
     // Release retained source pin.
-    backend(fs, source).forget(Context { uid: 0, gid: 0, pid: 0 }, source_inode, 1);
+    backend(fs, source).forget(
+        Context {
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        },
+        source_inode,
+        1,
+    );
 
     // hooks.after_commit
     super::hooks::notify_observers(&fs.hooks, |h| {
@@ -142,18 +167,22 @@ pub(crate) fn promote_directory_to_merged(
         let state = node.state.read().unwrap();
         match &*state {
             NodeState::MergedDir { .. } | NodeState::Root { .. } => return Ok(()),
-            NodeState::BackendA { backend_a_inode, .. } if target == BackendId::BackendA => {
+            NodeState::BackendA {
+                backend_a_inode, ..
+            } if target == BackendId::BackendA => {
                 return Ok(());
             }
-            NodeState::BackendB { backend_b_inode, .. } if target == BackendId::BackendB => {
+            NodeState::BackendB {
+                backend_b_inode, ..
+            } if target == BackendId::BackendB => {
                 return Ok(());
             }
-            NodeState::BackendA { backend_a_inode, .. } => {
-                (BackendId::BackendA, *backend_a_inode)
-            }
-            NodeState::BackendB { backend_b_inode, .. } => {
-                (BackendId::BackendB, *backend_b_inode)
-            }
+            NodeState::BackendA {
+                backend_a_inode, ..
+            } => (BackendId::BackendA, *backend_a_inode),
+            NodeState::BackendB {
+                backend_b_inode, ..
+            } => (BackendId::BackendB, *backend_b_inode),
             NodeState::Init => return Err(io::Error::from_raw_os_error(libc::ENOTDIR)),
         }
     };
@@ -177,12 +206,18 @@ pub(crate) fn promote_directory_to_merged(
     let parent_target_inode = resolve_backend_inode(&fs.state, parent_ino, target)
         .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
 
-    let cname = CString::new(name)
-        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let cname = CString::new(name).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
     // Create directory in target backend.
     let mode = (src_stat.st_mode as u32) & 0o7777;
-    let entry = backend(fs, target).mkdir(ctx, parent_target_inode, &cname, mode, 0, Extensions::default())?;
+    let entry = backend(fs, target).mkdir(
+        ctx,
+        parent_target_inode,
+        &cname,
+        mode,
+        0,
+        Extensions::default(),
+    )?;
 
     // Copy xattrs.
     copy_xattrs(fs, ctx, src_backend, src_inode, target, entry.inode)?;
@@ -321,6 +356,7 @@ fn ensure_backend_presence_recursive(
 }
 
 /// Materialize a regular file.
+#[allow(clippy::too_many_arguments)]
 fn materialize_regular_file(
     fs: &DualFs,
     ctx: Context,
@@ -345,8 +381,8 @@ fn materialize_regular_file(
         .ok_or_else(|| io::Error::from_raw_os_error(libc::EIO))?;
 
     let temp_name_str = format!("tmp_{}", guest_inode);
-    let temp_name = CString::new(temp_name_str)
-        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let temp_name =
+        CString::new(temp_name_str).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
     let mode = (src_stat.st_mode as u32) & 0o7777;
     let (temp_entry, temp_handle, _) = backend(fs, target).create(
@@ -362,12 +398,14 @@ fn materialize_regular_file(
 
     // Stream data from source to target in chunks.
     if file_size > 0 {
-        let (src_handle, _) = backend(fs, source).open(ctx, source_inode, false, libc::O_RDONLY as u32)?;
+        let (src_handle, _) =
+            backend(fs, source).open(ctx, source_inode, false, libc::O_RDONLY as u32)?;
         let src_handle = src_handle.unwrap_or(0);
 
         let mut offset = 0u64;
         while offset < file_size {
-            let chunk_size = std::cmp::min(fs.cfg.copy_chunk_size as u64, file_size - offset) as u32;
+            let chunk_size =
+                std::cmp::min(fs.cfg.copy_chunk_size as u64, file_size - offset) as u32;
 
             // Use a pipe/staging approach: read from source, write to target.
             // We use the init_file as a staging buffer for the transfer.
@@ -407,7 +445,15 @@ fn materialize_regular_file(
     }
 
     let temp_handle_val = temp_handle.unwrap_or(0);
-    backend(fs, target).release(ctx, temp_entry.inode, 0, temp_handle_val, false, false, None)?;
+    backend(fs, target).release(
+        ctx,
+        temp_entry.inode,
+        0,
+        temp_handle_val,
+        false,
+        false,
+        None,
+    )?;
 
     // Copy xattrs.
     copy_xattrs(fs, ctx, source, source_inode, target, temp_entry.inode)?;
@@ -434,8 +480,8 @@ fn materialize_symlink(
     let link_target = backend(fs, source).readlink(ctx, source_inode)?;
     let (src_stat, _) = backend(fs, source).getattr(ctx, source_inode, None)?;
 
-    let link_cstr = CString::new(link_target)
-        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let link_cstr =
+        CString::new(link_target).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
     let entry = backend(fs, target).symlink(
         ctx,
@@ -522,10 +568,7 @@ fn copy_metadata(
     target_inode: u64,
     src_stat: &crate::stat64,
 ) -> io::Result<()> {
-    let valid = SetattrValid::UID
-        | SetattrValid::GID
-        | SetattrValid::ATIME
-        | SetattrValid::MTIME;
+    let valid = SetattrValid::UID | SetattrValid::GID | SetattrValid::ATIME | SetattrValid::MTIME;
 
     backend(fs, target).setattr(ctx, target_inode, *src_stat, None, valid)?;
 
@@ -542,19 +585,19 @@ struct StagingWriter<'a> {
 }
 
 impl crate::ZeroCopyWriter for StagingWriter<'_> {
-    fn write_from(
-        &mut self,
-        f: &std::fs::File,
-        count: usize,
-        off: u64,
-    ) -> io::Result<usize> {
+    fn write_from(&mut self, f: &std::fs::File, count: usize, off: u64) -> io::Result<usize> {
         // Read from f at off, write to our staging file at 0.
         use std::os::fd::AsRawFd;
 
         let mut buf = vec![0u8; count];
         let fd = f.as_raw_fd();
         let n = unsafe {
-            libc::pread(fd, buf.as_mut_ptr() as *mut libc::c_void, count, off as libc::off_t)
+            libc::pread(
+                fd,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                count,
+                off as libc::off_t,
+            )
         };
         if n < 0 {
             return Err(io::Error::last_os_error());
@@ -562,9 +605,7 @@ impl crate::ZeroCopyWriter for StagingWriter<'_> {
         let n = n as usize;
 
         let staging_fd = self.file.as_raw_fd();
-        let w = unsafe {
-            libc::pwrite(staging_fd, buf.as_ptr() as *const libc::c_void, n, 0)
-        };
+        let w = unsafe { libc::pwrite(staging_fd, buf.as_ptr() as *const libc::c_void, n, 0) };
         if w < 0 {
             return Err(io::Error::last_os_error());
         }
@@ -580,12 +621,7 @@ struct StagingReader<'a> {
 }
 
 impl crate::ZeroCopyReader for StagingReader<'_> {
-    fn read_to(
-        &mut self,
-        f: &std::fs::File,
-        count: usize,
-        off: u64,
-    ) -> io::Result<usize> {
+    fn read_to(&mut self, f: &std::fs::File, count: usize, off: u64) -> io::Result<usize> {
         use std::os::fd::AsRawFd;
 
         let to_read = std::cmp::min(count, self.size);
@@ -593,7 +629,12 @@ impl crate::ZeroCopyReader for StagingReader<'_> {
 
         let staging_fd = self.file.as_raw_fd();
         let n = unsafe {
-            libc::pread(staging_fd, buf.as_mut_ptr() as *mut libc::c_void, to_read, 0)
+            libc::pread(
+                staging_fd,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                to_read,
+                0,
+            )
         };
         if n < 0 {
             return Err(io::Error::last_os_error());
@@ -602,7 +643,12 @@ impl crate::ZeroCopyReader for StagingReader<'_> {
 
         let fd = f.as_raw_fd();
         let w = unsafe {
-            libc::pwrite(fd, buf.as_ptr() as *const libc::c_void, n, off as libc::off_t)
+            libc::pwrite(
+                fd,
+                buf.as_ptr() as *const libc::c_void,
+                n,
+                off as libc::off_t,
+            )
         };
         if w < 0 {
             return Err(io::Error::last_os_error());

--- a/crates/filesystem/lib/backends/dualfs/metadata.rs
+++ b/crates/filesystem/lib/backends/dualfs/metadata.rs
@@ -1,18 +1,22 @@
 //! Getattr, setattr, access dispatch.
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
-use super::hooks::{
-    DispatchStep, HookCtx, StepResult, decode_attr, decode_ok, handle_hook_decision,
-    notify_observers, run_decision_hooks,
+use super::{
+    DualFs,
+    hooks::{
+        DispatchStep, HookCtx, StepResult, decode_attr, decode_ok, handle_hook_decision,
+        notify_observers, run_decision_hooks,
+    },
+    lookup::{backend, get_node, mark_metadata_authority, resolve_active_backend_inode},
+    policy::{DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::BackendId,
 };
-use super::lookup::{backend, get_node, mark_metadata_authority, resolve_active_backend_inode};
-use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
-use super::types::BackendId;
-use super::DualFs;
-use crate::backends::shared::{init_binary, platform};
-use crate::{Context, SetattrValid, stat64};
+use crate::{
+    Context, SetattrValid,
+    backends::shared::{init_binary, platform},
+    stat64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -123,9 +127,7 @@ pub(crate) fn do_setattr(
         return r;
     }
 
-    let view = DualNamespaceView {
-        state: &fs.state,
-    };
+    let view = DualNamespaceView { state: &fs.state };
 
     // hooks.after_resolve
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
@@ -149,25 +151,21 @@ pub(crate) fn do_setattr(
 
     // hooks.after_plan
     if let std::ops::ControlFlow::Break(r) = handle_hook_decision(
-        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| {
-            h.after_plan(ctx, &plan)
-        }),
+        run_decision_hooks(&fs.hooks, &mut hook_ctx, |h, ctx| h.after_plan(ctx, &plan)),
         decode_attr,
     ) {
         return r;
     }
 
     // Determine target backend.
-    let target = plan
-        .target_backend()
-        .unwrap_or(BackendId::BackendA);
+    let target = plan.target_backend().unwrap_or(BackendId::BackendA);
 
     // Materialize if needed.
     let current_backend = node.state.read().unwrap().current_backend();
-    if let Some(current) = current_backend {
-        if current != target {
-            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
-        }
+    if let Some(current) = current_backend
+        && current != target
+    {
+        super::materialize::do_materialize(fs, ctx, ino, current, target)?;
     }
 
     // Dispatch setattr.

--- a/crates/filesystem/lib/backends/dualfs/mod.rs
+++ b/crates/filesystem/lib/backends/dualfs/mod.rs
@@ -23,23 +23,25 @@ mod special;
 pub mod types;
 mod xattr_ops;
 
-use std::ffi::CStr;
-use std::fs::File;
-use std::io;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    ffi::CStr,
+    fs::File,
+    io,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use hooks::DualDispatchHook;
 use policy::DualDispatchPolicy;
-use types::{
-    AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE,
-};
+use types::{AtomicBackendId, BackendId, DualState, FileKind, GuestNode, NodeState, ROOT_INODE};
 
-use crate::backends::shared::init_binary;
 use crate::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, backends::shared::init_binary,
+    stat64, statvfs64,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -121,22 +123,31 @@ impl DynFileSystem for DualFs {
             && child_support.contains(FsOptions::WRITEBACK_CACHE)
         {
             opts |= FsOptions::WRITEBACK_CACHE;
-            self.state
-                .writeback
-                .store(true, Ordering::Relaxed);
+            self.state.writeback.store(true, Ordering::Relaxed);
         }
 
         // Create staging directories in both backends.
-        let staging_name =
-            std::ffi::CString::new(STAGING_DIR_NAME).unwrap();
+        let staging_name = std::ffi::CString::new(STAGING_DIR_NAME).unwrap();
 
         // Get root inodes from both backends.
         let ba_root_entry = self
             .backend_a
-            .lookup(Context { uid: 0, gid: 0, pid: 0 }, 1, &staging_name)
+            .lookup(
+                Context {
+                    uid: 0,
+                    gid: 0,
+                    pid: 0,
+                },
+                1,
+                &staging_name,
+            )
             .or_else(|_| {
                 self.backend_a.mkdir(
-                    Context { uid: 0, gid: 0, pid: 0 },
+                    Context {
+                        uid: 0,
+                        gid: 0,
+                        pid: 0,
+                    },
                     1,
                     &staging_name,
                     0o700,
@@ -147,10 +158,22 @@ impl DynFileSystem for DualFs {
 
         let bb_root_entry = self
             .backend_b
-            .lookup(Context { uid: 0, gid: 0, pid: 0 }, 1, &staging_name)
+            .lookup(
+                Context {
+                    uid: 0,
+                    gid: 0,
+                    pid: 0,
+                },
+                1,
+                &staging_name,
+            )
             .or_else(|_| {
                 self.backend_b.mkdir(
-                    Context { uid: 0, gid: 0, pid: 0 },
+                    Context {
+                        uid: 0,
+                        gid: 0,
+                        pid: 0,
+                    },
                     1,
                     &staging_name,
                     0o700,
@@ -307,13 +330,7 @@ impl DynFileSystem for DualFs {
         remove_ops::do_rename(self, ctx, olddir, oldname, newdir, newname, flags)
     }
 
-    fn link(
-        &self,
-        ctx: Context,
-        ino: u64,
-        newparent: u64,
-        newname: &CStr,
-    ) -> io::Result<Entry> {
+    fn link(&self, ctx: Context, ino: u64, newparent: u64, newname: &CStr) -> io::Result<Entry> {
         create_ops::do_link(self, ctx, ino, newparent, newname)
     }
 
@@ -339,7 +356,9 @@ impl DynFileSystem for DualFs {
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
-        create_ops::do_create(self, ctx, parent, name, mode, kill_priv, flags, umask, extensions)
+        create_ops::do_create(
+            self, ctx, parent, name, mode, kill_priv, flags, umask, extensions,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -417,7 +436,16 @@ impl DynFileSystem for DualFs {
         flock_release: bool,
         lock_owner: Option<u64>,
     ) -> io::Result<()> {
-        file_ops::do_release(self, ctx, ino, flags, handle, flush, flock_release, lock_owner)
+        file_ops::do_release(
+            self,
+            ctx,
+            ino,
+            flags,
+            handle,
+            flush,
+            flock_release,
+            lock_owner,
+        )
     }
 
     fn statfs(&self, ctx: Context, ino: u64) -> io::Result<statvfs64> {

--- a/crates/filesystem/lib/backends/dualfs/policies/read_backend_b_write_backend_a.rs
+++ b/crates/filesystem/lib/backends/dualfs/policies/read_backend_b_write_backend_a.rs
@@ -2,11 +2,13 @@
 
 use std::io;
 
-use crate::backends::dualfs::policy::{
-    BackendChoice, BackendOp, DualDispatchPlan, DualDispatchPolicy, DualNamespaceView, HintBag,
-    OpKind, RequestCtx,
+use crate::backends::dualfs::{
+    policy::{
+        BackendChoice, BackendOp, DualDispatchPlan, DualDispatchPolicy, DualNamespaceView, HintBag,
+        OpKind, RequestCtx,
+    },
+    types::{BackendId, NodeState},
 };
-use crate::backends::dualfs::types::{BackendId, NodeState};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -84,20 +86,16 @@ impl DualDispatchPolicy for ReadBackendBWriteBackendA {
                 op: BackendOp::passthrough(),
             }),
 
-            OpKind::Setattr | OpKind::Setxattr | OpKind::Removexattr => {
-                match &req.node_state {
-                    NodeState::BackendB { .. } => {
-                        Ok(DualDispatchPlan::MaterializeToBackendThen {
-                            source: BackendId::BackendB,
-                            target: BackendId::BackendA,
-                            then: BackendOp::passthrough(),
-                        })
-                    }
-                    _ => Ok(DualDispatchPlan::UseBackendA {
-                        op: BackendOp::passthrough(),
-                    }),
-                }
-            }
+            OpKind::Setattr | OpKind::Setxattr | OpKind::Removexattr => match &req.node_state {
+                NodeState::BackendB { .. } => Ok(DualDispatchPlan::MaterializeToBackendThen {
+                    source: BackendId::BackendB,
+                    target: BackendId::BackendA,
+                    then: BackendOp::passthrough(),
+                }),
+                _ => Ok(DualDispatchPlan::UseBackendA {
+                    op: BackendOp::passthrough(),
+                }),
+            },
 
             OpKind::Readdir | OpKind::Readdirplus => Ok(DualDispatchPlan::MergeReaddir {
                 precedence: BackendChoice::BackendBFirst,

--- a/crates/filesystem/lib/backends/dualfs/policy.rs
+++ b/crates/filesystem/lib/backends/dualfs/policy.rs
@@ -98,10 +98,7 @@ pub enum Hint {
     /// Prefer a specific backend for this operation.
     PreferBackend(BackendId),
     /// Subtree affinity.
-    SubtreeAffinity {
-        root_inode: u64,
-        backend: BackendId,
-    },
+    SubtreeAffinity { root_inode: u64, backend: BackendId },
     /// Custom string hint for policy-specific use.
     Custom(String),
 }

--- a/crates/filesystem/lib/backends/dualfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/remove_ops.rs
@@ -1,19 +1,21 @@
 //! Unlink, rmdir, rename, and whiteout management.
 
-use std::ffi::CStr;
-use std::io;
-use std::sync::atomic::Ordering;
+use std::{ffi::CStr, io, sync::atomic::Ordering};
 
-use super::hooks::{CommitEvent, DentryChange, notify_observers};
-use super::lookup::{
-    backend, ensure_alias_linked, ensure_backend_presence, get_node, mark_metadata_authority,
-    resolve_backend_inode,
+use super::{
+    DualFs,
+    hooks::{CommitEvent, DentryChange, notify_observers},
+    lookup::{
+        backend, ensure_alias_linked, ensure_backend_presence, get_node, mark_metadata_authority,
+        resolve_backend_inode,
+    },
+    policy::{DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::{BackendId, FileKind, GuestNode, ROOT_INODE},
 };
-use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
-use super::types::{BackendId, FileKind, GuestNode, ROOT_INODE};
-use super::DualFs;
-use crate::backends::shared::{init_binary, name_validation, platform};
-use crate::Context;
+use crate::{
+    Context,
+    backends::shared::{init_binary, name_validation, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -61,15 +63,20 @@ pub(crate) fn do_unlink(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> 
     ensure_alias_linked(&fs.state, child_ino, parent, name_bytes)?;
 
     // If child has presence on target, unlink it there.
-    if let Some(_target_child_inode) = child_node.state.read().unwrap().backend_inode(target) {
-        if let Some(parent_target_inode) = resolve_backend_inode(&fs.state, parent, target) {
-            backend(fs, target).unlink(ctx, parent_target_inode, name)?;
-        }
+    if let Some(_target_child_inode) = child_node.state.read().unwrap().backend_inode(target)
+        && let Some(parent_target_inode) = resolve_backend_inode(&fs.state, parent, target)
+    {
+        backend(fs, target).unlink(ctx, parent_target_inode, name)?;
     }
 
     // If child still has visible presence on the other backend, create whiteout.
     let other = target.other();
-    if child_node.state.read().unwrap().backend_inode(other).is_some()
+    if child_node
+        .state
+        .read()
+        .unwrap()
+        .backend_inode(other)
+        .is_some()
         && !super::lookup::is_opaque_against(&fs.state, parent, other)
     {
         fs.state
@@ -99,13 +106,13 @@ pub(crate) fn do_unlink(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> 
     // Anchor repair.
     let anchor_parent = child_node.anchor_parent.load(Ordering::Relaxed);
     let anchor_name = child_node.anchor_name.read().unwrap().clone();
-    if anchor_parent == parent && anchor_name == name_bytes {
-        if let Some(aliases) = fs.state.alias_index.read().unwrap().get(&child_ino) {
-            if let Some((new_p, new_n)) = aliases.iter().next() {
-                child_node.anchor_parent.store(*new_p, Ordering::Relaxed);
-                *child_node.anchor_name.write().unwrap() = new_n.clone();
-            }
-        }
+    if anchor_parent == parent
+        && anchor_name == name_bytes
+        && let Some(aliases) = fs.state.alias_index.read().unwrap().get(&child_ino)
+        && let Some((new_p, new_n)) = aliases.iter().next()
+    {
+        child_node.anchor_parent.store(*new_p, Ordering::Relaxed);
+        *child_node.anchor_name.write().unwrap() = new_n.clone();
     }
 
     // hooks.after_commit
@@ -169,15 +176,25 @@ pub(crate) fn do_rmdir(fs: &DualFs, ctx: Context, parent: u64, name: &CStr) -> i
     check_merged_dir_empty(fs, ctx, child_ino, &child_node, target)?;
 
     // If child has target presence, rmdir it there.
-    if child_node.state.read().unwrap().backend_inode(target).is_some() {
-        if let Some(parent_target_inode) = resolve_backend_inode(&fs.state, parent, target) {
-            backend(fs, target).rmdir(ctx, parent_target_inode, name)?;
-        }
+    if child_node
+        .state
+        .read()
+        .unwrap()
+        .backend_inode(target)
+        .is_some()
+        && let Some(parent_target_inode) = resolve_backend_inode(&fs.state, parent, target)
+    {
+        backend(fs, target).rmdir(ctx, parent_target_inode, name)?;
     }
 
     // Whiteout if other side still has the dir.
     let other = target.other();
-    if child_node.state.read().unwrap().backend_inode(other).is_some()
+    if child_node
+        .state
+        .read()
+        .unwrap()
+        .backend_inode(other)
+        .is_some()
         && !super::lookup::is_opaque_against(&fs.state, parent, other)
     {
         fs.state
@@ -280,10 +297,10 @@ pub(crate) fn do_rename(
 
     // Materialize source if needed.
     let current_backend = source_node.state.read().unwrap().current_backend();
-    if let Some(current) = current_backend {
-        if current != target {
-            super::materialize::do_materialize(fs, ctx, source_ino, current, target)?;
-        }
+    if let Some(current) = current_backend
+        && current != target
+    {
+        super::materialize::do_materialize(fs, ctx, source_ino, current, target)?;
     }
 
     ensure_backend_presence(fs, ctx, olddir, target)?;
@@ -313,32 +330,19 @@ pub(crate) fn do_rename(
 
         // Materialize destination if needed.
         let dest_current = dest_node.state.read().unwrap().current_backend();
-        if let Some(current) = dest_current {
-            if current != target {
-                super::materialize::do_materialize(
-                    fs,
-                    ctx,
-                    dest_guest_ino,
-                    current,
-                    target,
-                )?;
-            }
+        if let Some(current) = dest_current
+            && current != target
+        {
+            super::materialize::do_materialize(fs, ctx, dest_guest_ino, current, target)?;
         }
         ensure_alias_linked(&fs.state, dest_guest_ino, newdir, newname_bytes)?;
 
         // Delegate exchange to target backend.
-        let olddir_target = resolve_backend_inode(&fs.state, olddir, target)
-            .ok_or_else(platform::enoent)?;
-        let newdir_target = resolve_backend_inode(&fs.state, newdir, target)
-            .ok_or_else(platform::enoent)?;
-        backend(fs, target).rename(
-            ctx,
-            olddir_target,
-            oldname,
-            newdir_target,
-            newname,
-            flags,
-        )?;
+        let olddir_target =
+            resolve_backend_inode(&fs.state, olddir, target).ok_or_else(platform::enoent)?;
+        let newdir_target =
+            resolve_backend_inode(&fs.state, newdir, target).ok_or_else(platform::enoent)?;
+        backend(fs, target).rename(ctx, olddir_target, oldname, newdir_target, newname, flags)?;
 
         // Swap dentries.
         {
@@ -361,13 +365,9 @@ pub(crate) fn do_rename(
         }
 
         // Update anchors.
-        source_node
-            .anchor_parent
-            .store(newdir, Ordering::Relaxed);
+        source_node.anchor_parent.store(newdir, Ordering::Relaxed);
         *source_node.anchor_name.write().unwrap() = newname_bytes.to_vec();
-        dest_node
-            .anchor_parent
-            .store(olddir, Ordering::Relaxed);
+        dest_node.anchor_parent.store(olddir, Ordering::Relaxed);
         *dest_node.anchor_name.write().unwrap() = oldname_bytes.to_vec();
 
         return Ok(());
@@ -378,19 +378,29 @@ pub(crate) fn do_rename(
         let dest_node = get_node(&fs.state, dest_ino)?;
 
         // If dest has target presence, unlink/rmdir it there.
-        if dest_node.state.read().unwrap().backend_inode(target).is_some() {
-            if let Some(newdir_target) = resolve_backend_inode(&fs.state, newdir, target) {
-                if dest_node.kind == FileKind::Directory {
-                    backend(fs, target).rmdir(ctx, newdir_target, newname)?;
-                } else {
-                    backend(fs, target).unlink(ctx, newdir_target, newname)?;
-                }
+        if dest_node
+            .state
+            .read()
+            .unwrap()
+            .backend_inode(target)
+            .is_some()
+            && let Some(newdir_target) = resolve_backend_inode(&fs.state, newdir, target)
+        {
+            if dest_node.kind == FileKind::Directory {
+                backend(fs, target).rmdir(ctx, newdir_target, newname)?;
+            } else {
+                backend(fs, target).unlink(ctx, newdir_target, newname)?;
             }
         }
 
         // Whiteout if dest still has other-backend presence.
         let other = target.other();
-        if dest_node.state.read().unwrap().backend_inode(other).is_some()
+        if dest_node
+            .state
+            .read()
+            .unwrap()
+            .backend_inode(other)
+            .is_some()
             && !super::lookup::is_opaque_against(&fs.state, newdir, other)
         {
             fs.state
@@ -417,10 +427,10 @@ pub(crate) fn do_rename(
     }
 
     // Delegate rename in target backend.
-    let olddir_target = resolve_backend_inode(&fs.state, olddir, target)
-        .ok_or_else(platform::enoent)?;
-    let newdir_target = resolve_backend_inode(&fs.state, newdir, target)
-        .ok_or_else(platform::enoent)?;
+    let olddir_target =
+        resolve_backend_inode(&fs.state, olddir, target).ok_or_else(platform::enoent)?;
+    let newdir_target =
+        resolve_backend_inode(&fs.state, newdir, target).ok_or_else(platform::enoent)?;
 
     backend(fs, target).rename(ctx, olddir_target, oldname, newdir_target, newname, flags)?;
 
@@ -463,9 +473,7 @@ pub(crate) fn do_rename(
         });
 
     // Update anchor.
-    source_node
-        .anchor_parent
-        .store(newdir, Ordering::Relaxed);
+    source_node.anchor_parent.store(newdir, Ordering::Relaxed);
     *source_node.anchor_name.write().unwrap() = newname_bytes.to_vec();
 
     Ok(())

--- a/crates/filesystem/lib/backends/dualfs/special.rs
+++ b/crates/filesystem/lib/backends/dualfs/special.rs
@@ -1,18 +1,18 @@
 //! Statfs (merge both backends), lseek, fallocate, fsync, fsyncdir.
 
-use std::io;
-use std::sync::Arc;
+use std::{io, sync::Arc};
 
-use super::hooks::{
-    DispatchStep, HookCtx, StepResult, decode_ok, handle_hook_decision, notify_observers,
-    run_decision_hooks,
+use super::{
+    DualFs,
+    hooks::{
+        DispatchStep, HookCtx, StepResult, decode_ok, handle_hook_decision, notify_observers,
+        run_decision_hooks,
+    },
+    lookup::get_node,
+    policy::{HintBag, OpKind, RequestCtx},
+    types::{DualHandle, FileKind, NodeState, ROOT_INODE},
 };
-use super::lookup::get_node;
-use super::policy::{HintBag, OpKind, RequestCtx};
-use super::types::{DualHandle, FileKind, NodeState, ROOT_INODE};
-use super::DualFs;
-use crate::backends::shared::init_binary;
-use crate::{Context, statvfs64};
+use crate::{Context, backends::shared::init_binary, statvfs64};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -69,17 +69,17 @@ pub(crate) fn do_statfs(fs: &DualFs, ctx: Context, _ino: u64) -> io::Result<stat
         st.f_bsize = unit;
         st.f_frsize = unit;
         st.f_blocks = to_units(ba_stat.f_blocks as u64, ba_stat.f_frsize)
-            .saturating_add(to_units(bb_stat.f_blocks as u64, bb_stat.f_frsize)) as u32;
+            .saturating_add(to_units(bb_stat.f_blocks as u64, bb_stat.f_frsize))
+            as u32;
         st.f_bfree = to_units(ba_stat.f_bfree as u64, ba_stat.f_frsize)
-            .saturating_add(to_units(bb_stat.f_bfree as u64, bb_stat.f_frsize)) as u32;
+            .saturating_add(to_units(bb_stat.f_bfree as u64, bb_stat.f_frsize))
+            as u32;
         st.f_bavail = to_units(ba_stat.f_bavail as u64, ba_stat.f_frsize)
-            .saturating_add(to_units(bb_stat.f_bavail as u64, bb_stat.f_frsize)) as u32;
-        st.f_files = (ba_stat.f_files as u64)
-            .saturating_add(bb_stat.f_files as u64) as u32;
-        st.f_ffree = (ba_stat.f_ffree as u64)
-            .saturating_add(bb_stat.f_ffree as u64) as u32;
-        st.f_favail = (ba_stat.f_favail as u64)
-            .saturating_add(bb_stat.f_favail as u64) as u32;
+            .saturating_add(to_units(bb_stat.f_bavail as u64, bb_stat.f_frsize))
+            as u32;
+        st.f_files = (ba_stat.f_files as u64).saturating_add(bb_stat.f_files as u64) as u32;
+        st.f_ffree = (ba_stat.f_ffree as u64).saturating_add(bb_stat.f_ffree as u64) as u32;
+        st.f_favail = (ba_stat.f_favail as u64).saturating_add(bb_stat.f_favail as u64) as u32;
         st.f_namemax = std::cmp::min(ba_stat.f_namemax, bb_stat.f_namemax);
     }
 
@@ -131,12 +131,16 @@ pub(crate) fn do_fsync(
             backend_a_inode,
             backend_a_handle,
             ..
-        } => fs.backend_a.fsync(ctx, *backend_a_inode, datasync, *backend_a_handle),
+        } => fs
+            .backend_a
+            .fsync(ctx, *backend_a_inode, datasync, *backend_a_handle),
         DualHandle::BackendB {
             backend_b_inode,
             backend_b_handle,
             ..
-        } => fs.backend_b.fsync(ctx, *backend_b_inode, datasync, *backend_b_handle),
+        } => fs
+            .backend_b
+            .fsync(ctx, *backend_b_inode, datasync, *backend_b_handle),
     };
 
     notify_observers(&fs.hooks, |h| {
@@ -222,12 +226,16 @@ pub(crate) fn do_lseek(
             backend_a_inode,
             backend_a_handle,
             ..
-        } => fs.backend_a.lseek(ctx, *backend_a_inode, *backend_a_handle, offset, whence),
+        } => fs
+            .backend_a
+            .lseek(ctx, *backend_a_inode, *backend_a_handle, offset, whence),
         DualHandle::BackendB {
             backend_b_inode,
             backend_b_handle,
             ..
-        } => fs.backend_b.lseek(ctx, *backend_b_inode, *backend_b_handle, offset, whence),
+        } => fs
+            .backend_b
+            .lseek(ctx, *backend_b_inode, *backend_b_handle, offset, whence),
     };
 
     notify_observers(&fs.hooks, |h| {
@@ -297,12 +305,26 @@ pub(crate) fn do_fallocate(
             backend_a_inode,
             backend_a_handle,
             ..
-        } => fs.backend_a.fallocate(ctx, *backend_a_inode, *backend_a_handle, mode, offset, length),
+        } => fs.backend_a.fallocate(
+            ctx,
+            *backend_a_inode,
+            *backend_a_handle,
+            mode,
+            offset,
+            length,
+        ),
         DualHandle::BackendB {
             backend_b_inode,
             backend_b_handle,
             ..
-        } => fs.backend_b.fallocate(ctx, *backend_b_inode, *backend_b_handle, mode, offset, length),
+        } => fs.backend_b.fallocate(
+            ctx,
+            *backend_b_inode,
+            *backend_b_handle,
+            mode,
+            offset,
+            length,
+        ),
     };
 
     notify_observers(&fs.hooks, |h| {

--- a/crates/filesystem/lib/backends/dualfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/mod.rs
@@ -22,17 +22,12 @@ mod test_special_ops;
 mod test_whiteouts;
 mod test_xattr;
 
-use std::ffi::CString;
-use std::fs::File;
-use std::io;
-use std::os::fd::AsRawFd;
-use std::sync::Arc;
+use std::{ffi::CString, fs::File, io, os::fd::AsRawFd, sync::Arc};
 
 use super::*;
-use crate::backends::memfs::MemFs;
 use crate::{
     Context, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    SetattrValid, ZeroCopyReader, ZeroCopyWriter, backends::memfs::MemFs,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -167,9 +162,7 @@ impl DualFsTestSandbox {
     fn with_hooks(hooks_list: Vec<Arc<dyn hooks::DualDispatchHook>>) -> Self {
         let backend_a = MemFs::builder().build().unwrap();
         let backend_b = MemFs::builder().build().unwrap();
-        let mut builder = DualFs::builder()
-            .backend_a(backend_a)
-            .backend_b(backend_b);
+        let mut builder = DualFs::builder().backend_a(backend_a).backend_b(backend_b);
         for h in hooks_list {
             builder = builder.hook(h);
         }
@@ -299,12 +292,7 @@ impl DualFsTestSandbox {
     }
 
     /// Create a file in the given parent with content, then release the handle.
-    fn create_file_with_content(
-        &self,
-        parent: u64,
-        name: &str,
-        data: &[u8],
-    ) -> io::Result<u64> {
+    fn create_file_with_content(&self, parent: u64, name: &str, data: &[u8]) -> io::Result<u64> {
         let (entry, handle) = self.fuse_create(parent, name, 0o644)?;
         self.fuse_write(entry.inode, handle, data, 0)?;
         self.fs

--- a/crates/filesystem/lib/backends/dualfs/tests/test_bootstrap.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_bootstrap.rs
@@ -80,7 +80,10 @@ fn test_init_writeback_one_child_unsupported() {
 #[test]
 fn test_root_exists_after_init() {
     let sb = DualFsTestSandbox::new();
-    let (st, _) = sb.fs.getattr(DualFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
+    let (st, _) = sb
+        .fs
+        .getattr(DualFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
     let mode = st.st_mode as u32;
     assert_eq!(
         mode & libc::S_IFMT as u32,

--- a/crates/filesystem/lib/backends/dualfs/tests/test_concurrency.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_concurrency.rs
@@ -40,15 +40,21 @@ fn test_concurrent_materialization() {
         let sb = &sb;
         let mut handles = Vec::new();
         for _ in 0..8 {
-            handles.push(s.spawn(move || {
-                sb.fuse_open(inode, libc::O_RDWR as u32)
-            }));
+            handles.push(s.spawn(move || sb.fuse_open(inode, libc::O_RDWR as u32)));
         }
         for h in handles {
             let result = h.join().unwrap();
             if let Ok(handle) = result {
                 sb.fs
-                    .release(DualFsTestSandbox::ctx(), inode, 0, handle, false, false, None)
+                    .release(
+                        DualFsTestSandbox::ctx(),
+                        inode,
+                        0,
+                        handle,
+                        false,
+                        false,
+                        None,
+                    )
                     .unwrap();
             }
         }
@@ -59,7 +65,15 @@ fn test_concurrent_materialization() {
     let data = sb.fuse_read(inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"concurrent data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -81,7 +95,15 @@ fn test_concurrent_creates_different_files() {
             .map(|h| {
                 let (entry, handle) = h.join().unwrap();
                 sb.fs
-                    .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+                    .release(
+                        DualFsTestSandbox::ctx(),
+                        entry.inode,
+                        0,
+                        handle,
+                        false,
+                        false,
+                        None,
+                    )
                     .unwrap();
                 entry.inode
             })
@@ -97,7 +119,10 @@ fn test_concurrent_creates_different_files() {
     for i in 0..8 {
         let name = format!("concurrent_{i}.txt");
         let entry = sb.lookup_root(&name).unwrap();
-        assert!(entry.inode >= 3, "created file {name} should be discoverable");
+        assert!(
+            entry.inode >= 3,
+            "created file {name} should be discoverable"
+        );
     }
 }
 
@@ -163,5 +188,8 @@ fn test_concurrent_policy_plan() {
 
     // No crash or deadlock means success.
     let entry = sb.lookup_root("pre_0.txt").unwrap();
-    assert!(entry.inode >= 3, "filesystem should be functional after concurrent plans");
+    assert!(
+        entry.inode >= 3,
+        "filesystem should be functional after concurrent plans"
+    );
 }

--- a/crates/filesystem/lib/backends/dualfs/tests/test_create_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_create_ops.rs
@@ -6,7 +6,15 @@ fn test_create_routes_to_policy_target() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("new_file.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // File should be discoverable via lookup.
     let e = sb.lookup_root("new_file.txt").unwrap();
@@ -21,7 +29,15 @@ fn test_create_file() {
     let written = sb.fuse_write(entry.inode, handle, b"hello", 0).unwrap();
     assert_eq!(written, 5);
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Lookup succeeds.
     let e = sb.lookup_root("writable.txt").unwrap();
@@ -82,7 +98,10 @@ fn test_symlink() {
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFLNK as u32);
     // readlink should return the target.
-    let link = sb.fs.readlink(DualFsTestSandbox::ctx(), entry.inode).unwrap();
+    let link = sb
+        .fs
+        .readlink(DualFsTestSandbox::ctx(), entry.inode)
+        .unwrap();
     assert_eq!(link, b"/some/target");
 }
 
@@ -91,22 +110,32 @@ fn test_link() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("original.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Hard link.
     let link_name = DualFsTestSandbox::cstr("hardlink.txt");
     let link_entry = sb
         .fs
-        .link(DualFsTestSandbox::ctx(), entry.inode, ROOT_INODE, &link_name)
+        .link(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            ROOT_INODE,
+            &link_name,
+        )
         .unwrap();
     assert_eq!(
         link_entry.inode, entry.inode,
         "hard link should share the same guest inode"
     );
-    assert!(
-        link_entry.attr.st_nlink >= 2,
-        "nlink should be incremented"
-    );
+    assert!(link_entry.attr.st_nlink >= 2, "nlink should be incremented");
 }
 
 #[test]
@@ -138,7 +167,15 @@ fn test_create_registers_dentry() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("registered.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Lookup should succeed (dentry registered).
     let e = sb.lookup_root("registered.txt").unwrap();
@@ -150,7 +187,15 @@ fn test_create_duplicate() {
     let sb = DualFsTestSandbox::new();
     let (_entry, handle) = sb.fuse_create_root("dup.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), _entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            _entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Second create with same name should fail.
     let result = sb.fuse_create_root("dup.txt");
@@ -165,23 +210,42 @@ fn test_create_updates_alias_index() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("aliased.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Verify the file can be looked up (which proves the dentry and alias were registered).
     let e = sb.lookup_root("aliased.txt").unwrap();
-    assert_eq!(e.inode, entry.inode, "dentry should map to the created inode");
+    assert_eq!(
+        e.inode, entry.inode,
+        "dentry should map to the created inode"
+    );
 
     // Verify stability: a second lookup returns the same inode, proving the alias_index
     // dedup path works correctly.
     let e2 = sb.lookup_root("aliased.txt").unwrap();
-    assert_eq!(e2.inode, entry.inode, "repeated lookup should return same guest inode");
+    assert_eq!(
+        e2.inode, entry.inode,
+        "repeated lookup should return same guest inode"
+    );
 
     // Create a hard link to the same file. This adds a second alias entry.
     let link_name = DualFsTestSandbox::cstr("alias_link.txt");
     let link_entry = sb
         .fs
-        .link(DualFsTestSandbox::ctx(), entry.inode, ROOT_INODE, &link_name)
+        .link(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            ROOT_INODE,
+            &link_name,
+        )
         .unwrap();
     assert_eq!(
         link_entry.inode, entry.inode,
@@ -191,5 +255,8 @@ fn test_create_updates_alias_index() {
     // Both names should resolve to the same guest inode.
     let e_orig = sb.lookup_root("aliased.txt").unwrap();
     let e_link = sb.lookup_root("alias_link.txt").unwrap();
-    assert_eq!(e_orig.inode, e_link.inode, "both aliases should resolve to the same inode");
+    assert_eq!(
+        e_orig.inode, e_link.inode,
+        "both aliases should resolve to the same inode"
+    );
 }

--- a/crates/filesystem/lib/backends/dualfs/tests/test_dir_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_dir_ops.rs
@@ -132,7 +132,10 @@ fn test_readdirplus_merged() {
     assert!(names.contains(&"b_plus.txt".to_string()));
     // Each entry should have valid attrs.
     for (_, entry) in &entries {
-        assert!(entry.inode > 0, "readdirplus entries should have valid inodes");
+        assert!(
+            entry.inode > 0,
+            "readdirplus entries should have valid inodes"
+        );
     }
     sb.fs
         .releasedir(DualFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
@@ -174,12 +177,9 @@ fn test_readdir_backend_a_precedence() {
     // With MergeReadsBackendAPrecedence policy, readdir uses MergeReaddir with
     // BackendAFirst precedence. When the same file name exists in both backends,
     // readdir should show it only once (deduplicated).
-    let sb = DualFsTestSandbox::with_policy_and_backend_b(
-        MergeReadsBackendAPrecedence,
-        |b| {
-            memfs_create_file(b, 1, "shared.txt", b"from_b");
-        },
-    );
+    let sb = DualFsTestSandbox::with_policy_and_backend_b(MergeReadsBackendAPrecedence, |b| {
+        memfs_create_file(b, 1, "shared.txt", b"from_b");
+    });
     // Create a file with the same name in backend_a via DualFs.
     sb.create_file_with_content(ROOT_INODE, "shared.txt", b"from_a")
         .unwrap();

--- a/crates/filesystem/lib/backends/dualfs/tests/test_file_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_file_ops.rs
@@ -10,14 +10,24 @@ fn test_read_from_backend_b() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"backend_b_data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
 #[test]
 fn test_read_from_backend_a() {
     let sb = DualFsTestSandbox::new();
-    let ino = sb.create_file_with_content(ROOT_INODE, "a_file.txt", b"backend_a_data").unwrap();
+    let ino = sb
+        .create_file_with_content(ROOT_INODE, "a_file.txt", b"backend_a_data")
+        .unwrap();
     let handle = sb.fuse_open(ino, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(ino, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"backend_a_data");
@@ -30,12 +40,22 @@ fn test_read_from_backend_a() {
 fn test_write_to_backend_a() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("writable.txt").unwrap();
-    let written = sb.fuse_write(entry.inode, handle, b"hello world", 0).unwrap();
+    let written = sb
+        .fuse_write(entry.inode, handle, b"hello world", 0)
+        .unwrap();
     assert_eq!(written, 11);
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"hello world");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -46,20 +66,34 @@ fn test_write_triggers_materialization() {
     });
     let entry = sb.lookup_root("b_file.txt").unwrap();
     // Open for write -> triggers materialization from backend_b to backend_a.
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     let written = sb.fuse_write(entry.inode, handle, b"modified", 0).unwrap();
     assert_eq!(written, 8);
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Read back should show modified data.
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"modified");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -75,7 +109,15 @@ fn test_write_preserves_data() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], original);
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -87,7 +129,15 @@ fn test_handle_dispatch_backend_a() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"data_a");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -101,7 +151,15 @@ fn test_handle_dispatch_backend_b() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"data_b");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -114,7 +172,15 @@ fn test_read_after_write() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"write_then_read");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -125,11 +191,21 @@ fn test_write_large() {
     let large_data = vec![0xABu8; 1024 * 1024]; // 1 MB
     let written = sb.fuse_write(entry.inode, handle, &large_data, 0).unwrap();
     assert_eq!(written, 1024 * 1024);
-    let read_data = sb.fuse_read(entry.inode, handle, 1024 * 1024 + 1, 0).unwrap();
+    let read_data = sb
+        .fuse_read(entry.inode, handle, 1024 * 1024 + 1, 0)
+        .unwrap();
     assert_eq!(read_data.len(), 1024 * 1024);
     assert!(read_data.iter().all(|&b| b == 0xAB));
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -138,7 +214,15 @@ fn test_read_invalid_handle() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("valid.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Use a bogus handle.
     let bad_handle = 999999;
@@ -167,16 +251,16 @@ fn test_try_backend_a_then_b_fallback() {
     // with BackendAFallbackToBackendBRead policy, lookup uses BackendAFirst precedence.
     // A file only in backend_b is found via fallback from backend_a to backend_b.
     // The file is then readable via getattr (which dispatches from node state, not policy).
-    let sb = DualFsTestSandbox::with_policy_and_backend_b(
-        BackendAFallbackToBackendBRead,
-        |b| {
-            memfs_create_file(b, 1, "fallback_b.txt", b"backend_b_content");
-        },
-    );
+    let sb = DualFsTestSandbox::with_policy_and_backend_b(BackendAFallbackToBackendBRead, |b| {
+        memfs_create_file(b, 1, "fallback_b.txt", b"backend_b_content");
+    });
 
     // Lookup should find the file via backend_b fallback.
     let entry = sb.lookup_root("fallback_b.txt").unwrap();
-    assert!(entry.inode >= 3, "file should be found via BackendA->BackendB fallback");
+    assert!(
+        entry.inode >= 3,
+        "file should be found via BackendA->BackendB fallback"
+    );
 
     // getattr dispatches from node state (not policy-routed), so it works for
     // backend_b-only files regardless of policy.
@@ -184,7 +268,10 @@ fn test_try_backend_a_then_b_fallback() {
         .fs
         .getattr(DualFsTestSandbox::ctx(), entry.inode, None)
         .unwrap();
-    assert_eq!(st.st_ino, entry.inode, "getattr should return correct guest inode");
+    assert_eq!(
+        st.st_ino, entry.inode,
+        "getattr should return correct guest inode"
+    );
     let mode = st.st_mode as u32;
     assert_eq!(
         mode & libc::S_IFMT as u32,
@@ -207,13 +294,24 @@ fn test_try_backend_b_then_a_fallback() {
     // Lookup should find the file. With BackendBFirst, backend_b is tried first (ENOENT),
     // then falls back to backend_a where the file exists.
     let entry = sb.lookup_root("fallback_a.txt").unwrap();
-    assert_eq!(entry.inode, ino, "file should be found via backend_a fallback");
+    assert_eq!(
+        entry.inode, ino,
+        "file should be found via backend_a fallback"
+    );
 
     // Open for read and verify content.
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"backend_a_content");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }

--- a/crates/filesystem/lib/backends/dualfs/tests/test_hooks.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_hooks.rs
@@ -186,7 +186,15 @@ fn test_hook_add_hint() {
     assert!(result.is_ok(), "operation should succeed with hint");
     if let Ok((entry, handle)) = result {
         sb.fs
-            .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+            .release(
+                DualFsTestSandbox::ctx(),
+                entry.inode,
+                0,
+                handle,
+                false,
+                false,
+                None,
+            )
             .unwrap();
     }
 }
@@ -230,7 +238,11 @@ fn test_hook_ordering() {
     let sb = DualFsTestSandbox::with_hooks(vec![h0, h1, h2]);
     let _ = sb.lookup_root("trigger_ordering");
     let logged = order.lock().unwrap();
-    assert_eq!(&*logged, &[0, 1, 2], "hooks should fire in registration order");
+    assert_eq!(
+        &*logged,
+        &[0, 1, 2],
+        "hooks should fire in registration order"
+    );
 }
 
 #[test]
@@ -254,7 +266,15 @@ fn test_hook_observer_phases_fire_and_forget() {
     // Create a file to trigger after_commit (create fires after_commit for dentry registration).
     let (entry, handle) = sb.fuse_create_root("observer.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     assert!(
         tracker.after_commit_called.load(Ordering::SeqCst),
@@ -289,7 +309,15 @@ fn test_hook_cannot_mutate_core_state() {
     // Create a file and verify state is intact — the hook could only observe, not corrupt.
     let (entry, handle) = sb.fuse_create_root("test_mut.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let lookup = sb.lookup_root("test_mut.txt");
     assert!(lookup.is_ok(), "filesystem state should be intact");

--- a/crates/filesystem/lib/backends/dualfs/tests/test_init_binary.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_init_binary.rs
@@ -28,13 +28,26 @@ fn test_init_krun_read() {
     let sb = DualFsTestSandbox::new();
     let (handle, _opts) = sb
         .fs
-        .open(DualFsTestSandbox::ctx(), INIT_INODE, false, libc::O_RDONLY as u32)
+        .open(
+            DualFsTestSandbox::ctx(),
+            INIT_INODE,
+            false,
+            libc::O_RDONLY as u32,
+        )
         .unwrap();
     let handle = handle.unwrap();
     let data = sb.fuse_read(INIT_INODE, handle, 4096, 0).unwrap();
     assert!(!data.is_empty(), "init.krun should return data on read");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), INIT_INODE, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            INIT_INODE,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -43,7 +56,12 @@ fn test_init_krun_write_fails() {
     let sb = DualFsTestSandbox::new();
     let (handle, _opts) = sb
         .fs
-        .open(DualFsTestSandbox::ctx(), INIT_INODE, false, libc::O_RDONLY as u32)
+        .open(
+            DualFsTestSandbox::ctx(),
+            INIT_INODE,
+            false,
+            libc::O_RDONLY as u32,
+        )
         .unwrap();
     let handle = handle.unwrap();
     let mut reader = MockZeroCopyReader::new(vec![0u8; 10]);
@@ -61,7 +79,15 @@ fn test_init_krun_write_fails() {
     );
     DualFsTestSandbox::assert_errno(result, LINUX_EACCES);
     sb.fs
-        .release(DualFsTestSandbox::ctx(), INIT_INODE, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            INIT_INODE,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 

--- a/crates/filesystem/lib/backends/dualfs/tests/test_integration.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_integration.rs
@@ -27,21 +27,45 @@ fn test_profile_memfs_memfs_backend_a_only() {
     let data = sb.fuse_read(ino1, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"content_1");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), ino1, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            ino1,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     let handle = sb.fuse_open(ino2, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(ino2, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"content_2");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), ino2, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            ino2,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     let handle = sb.fuse_open(ino3, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(ino3, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"nested_content");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), ino3, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            ino3,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Readdir at root should show only backend_a files (plus . .. init.krun).
@@ -65,19 +89,33 @@ fn test_profile_memfs_memfs_read_b_write_a() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"read_from_b");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Writing to backend_b file should materialize to backend_a.
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"written_to_a", 0)
         .unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"written_to_a");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Creating new files goes to backend_a.
@@ -108,29 +146,39 @@ fn test_non_target_backend_unchanged() {
 
     // Read the original content.
     let entry = sb.lookup_root("original.txt").unwrap();
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data_before = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data_before[..], b"original_content");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Write to trigger materialization to backend_a.
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"modified_content", 0)
         .unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Re-read: should see the modified content (from backend_a).
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data_after = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(
         &data_after[..],
@@ -138,7 +186,15 @@ fn test_non_target_backend_unchanged() {
         "after materialization, reads should come from backend_a"
     );
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Guest inode should remain stable.
@@ -176,7 +232,15 @@ fn test_hook_observer_sees_profiled_dispatch() {
     // Create a file. This triggers the dispatch pipeline.
     let (entry, handle) = sb.fuse_create_root("hook_test.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // The after_dispatch hook may not fire for create (it depends on whether create
@@ -233,7 +297,15 @@ fn test_profile_symmetric_memfs_memfs() {
     let data = sb.fuse_read(e_a.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"a_data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), e_a.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            e_a.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Read from backend_b-only file (default policy reads backend_b directly).
@@ -241,7 +313,15 @@ fn test_profile_symmetric_memfs_memfs() {
     let data = sb.fuse_read(e_b.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"b_data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), e_b.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            e_b.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // With BackendBFirst precedence (default), the shared file lookup finds backend_b's
@@ -249,10 +329,19 @@ fn test_profile_symmetric_memfs_memfs() {
     let handle = sb.fuse_open(e_shared.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(e_shared.inode, handle, 4096, 0).unwrap();
     assert_eq!(
-        &data[..], b"from_b",
+        &data[..],
+        b"from_b",
         "with BackendBFirst precedence (default), shared file should return backend_b content"
     );
     sb.fs
-        .release(DualFsTestSandbox::ctx(), e_shared.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            e_shared.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }

--- a/crates/filesystem/lib/backends/dualfs/tests/test_lookup.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_lookup.rs
@@ -5,7 +5,15 @@ fn test_lookup_backend_a_file() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("a_only.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let e = sb.lookup_root("a_only.txt").unwrap();
     assert_eq!(e.inode, entry.inode);
@@ -34,7 +42,15 @@ fn test_lookup_precedence_a_over_b() {
     // Also create in backend_a via DualFs.
     let (entry_a, handle_a) = sb.fuse_create_root("shared_a.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry_a.inode, 0, handle_a, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry_a.inode,
+            0,
+            handle_a,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // The backend_b file should be discoverable.
     let entry_b = sb.lookup_root("shared.txt").unwrap();
@@ -56,7 +72,11 @@ fn test_lookup_whiteout_hides_backend_b() {
     // Lookup to register, then unlink -> creates whiteout.
     let _entry = sb.lookup_root("hidden.txt").unwrap();
     sb.fs
-        .unlink(DualFsTestSandbox::ctx(), ROOT_INODE, &DualFsTestSandbox::cstr("hidden.txt"))
+        .unlink(
+            DualFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &DualFsTestSandbox::cstr("hidden.txt"),
+        )
         .unwrap();
     // Now lookup should fail.
     let result = sb.lookup_root("hidden.txt");
@@ -79,7 +99,10 @@ fn test_lookup_nested_path() {
 #[test]
 fn test_lookup_root_is_merged() {
     let sb = DualFsTestSandbox::new();
-    let (st, _) = sb.fs.getattr(DualFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
+    let (st, _) = sb
+        .fs
+        .getattr(DualFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
     let mode = st.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFDIR as u32);
 }
@@ -91,7 +114,10 @@ fn test_lookup_guest_inode_stable() {
     });
     let e1 = sb.lookup_root("stable.txt").unwrap();
     let e2 = sb.lookup_root("stable.txt").unwrap();
-    assert_eq!(e1.inode, e2.inode, "same file should return same guest inode");
+    assert_eq!(
+        e1.inode, e2.inode,
+        "same file should return same guest inode"
+    );
 }
 
 #[test]
@@ -185,7 +211,15 @@ fn test_lookup_dedup_backend_a() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("dedup_a.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let e1 = sb.lookup_root("dedup_a.txt").unwrap();
     let e2 = sb.lookup_root("dedup_a.txt").unwrap();

--- a/crates/filesystem/lib/backends/dualfs/tests/test_materialize.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_materialize.rs
@@ -11,14 +11,30 @@ fn test_materialize_regular_file() {
     let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"replaced", 0).unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Read back through DualFs — same-length overwrite replaces content exactly.
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"replaced");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -34,7 +50,15 @@ fn test_materialize_preserves_content() {
     let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     // Just close — materialization should have copied content.
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Read back.
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
@@ -42,9 +66,20 @@ fn test_materialize_preserves_content() {
         .fuse_read(entry.inode, handle, (1024 * 1024 + 1) as u32, 0)
         .unwrap();
     assert_eq!(data.len(), 1024 * 1024);
-    assert!(data.iter().all(|&b| b == 0xCD), "content should be preserved");
+    assert!(
+        data.iter().all(|&b| b == 0xCD),
+        "content should be preserved"
+    );
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -75,7 +110,15 @@ fn test_materialize_preserves_metadata() {
     // Trigger materialization.
     let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     let (st_after, _) = sb
@@ -130,7 +173,9 @@ fn test_materialize_directory() {
     });
     let dir_entry = sb.lookup_root("b_dir").unwrap();
     // Create a file in the backend_b dir -> forces dir promotion.
-    let (file_entry, handle) = sb.fuse_create(dir_entry.inode, "new_child.txt", 0o644).unwrap();
+    let (file_entry, handle) = sb
+        .fuse_create(dir_entry.inode, "new_child.txt", 0o644)
+        .unwrap();
     sb.fs
         .release(
             DualFsTestSandbox::ctx(),
@@ -163,14 +208,30 @@ fn test_materialize_ancestor_chain() {
     let handle = sb.fuse_open(c.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(c.inode, handle, b"modified", 0).unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), c.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            c.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Verify file is readable.
     let handle = sb.fuse_open(c.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(c.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"modified");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), c.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            c.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -185,20 +246,44 @@ fn test_materialize_idempotent() {
     let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"first", 0).unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Second write -> already materialized, should still work.
     let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"second", 0).unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Read back -> should see "second".
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"second");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -219,7 +304,10 @@ fn test_materialize_symlink() {
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFLNK as u32);
     // Readlink should return the target.
-    let link = sb.fs.readlink(DualFsTestSandbox::ctx(), entry.inode).unwrap();
+    let link = sb
+        .fs
+        .readlink(DualFsTestSandbox::ctx(), entry.inode)
+        .unwrap();
     assert_eq!(link, b"/some/target");
 }
 
@@ -253,9 +341,19 @@ fn test_materialize_guest_inode_stable() {
     let entry_before = sb.lookup_root("stable.txt").unwrap();
     let inode_before = entry_before.inode;
     // Trigger materialization.
-    let handle = sb.fuse_open(entry_before.inode, libc::O_RDWR as u32).unwrap();
+    let handle = sb
+        .fuse_open(entry_before.inode, libc::O_RDWR as u32)
+        .unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry_before.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry_before.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Guest inode should remain the same.
     let entry_after = sb.lookup_root("stable.txt").unwrap();
@@ -287,7 +385,15 @@ fn test_materialize_serialized() {
             let result = h.join().unwrap();
             if let Ok(handle) = result {
                 sb.fs
-                    .release(DualFsTestSandbox::ctx(), inode, 0, handle, false, false, None)
+                    .release(
+                        DualFsTestSandbox::ctx(),
+                        inode,
+                        0,
+                        handle,
+                        false,
+                        false,
+                        None,
+                    )
                     .unwrap();
             }
         }
@@ -298,7 +404,15 @@ fn test_materialize_serialized() {
     let data = sb.fuse_read(inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"concurrent data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 

--- a/crates/filesystem/lib/backends/dualfs/tests/test_metadata.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_metadata.rs
@@ -114,13 +114,29 @@ fn test_setattr_triggers_materialization() {
             SetattrValid::MODE,
         )
         .unwrap();
-    assert_eq!(st.st_mode as u32 & 0o777, 0o600, "mode should be updated after materialization");
+    assert_eq!(
+        st.st_mode as u32 & 0o777,
+        0o600,
+        "mode should be updated after materialization"
+    );
     // File should still be readable.
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
-    assert_eq!(&data[..], b"original", "data should be preserved after materialization");
+    assert_eq!(
+        &data[..],
+        b"original",
+        "data should be preserved after materialization"
+    );
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -137,8 +153,14 @@ fn test_getattr_metadata_backend() {
     let ino_a = sb
         .create_file_with_content(ROOT_INODE, "meta_a.txt", b"hello_a")
         .unwrap();
-    let (st_a, _) = sb.fs.getattr(DualFsTestSandbox::ctx(), ino_a, None).unwrap();
-    assert_eq!(st_a.st_ino, ino_a, "getattr should rewrite st_ino to guest inode");
+    let (st_a, _) = sb
+        .fs
+        .getattr(DualFsTestSandbox::ctx(), ino_a, None)
+        .unwrap();
+    assert_eq!(
+        st_a.st_ino, ino_a,
+        "getattr should rewrite st_ino to guest inode"
+    );
     let mode_a = st_a.st_mode as u32;
     assert_eq!(
         mode_a & libc::S_IFMT as u32,
@@ -156,22 +178,30 @@ fn test_getattr_metadata_backend() {
         .fs
         .getattr(DualFsTestSandbox::ctx(), entry_b.inode, None)
         .unwrap();
-    assert_eq!(st_b.st_ino, entry_b.inode, "getattr should rewrite st_ino to guest inode");
+    assert_eq!(
+        st_b.st_ino, entry_b.inode,
+        "getattr should rewrite st_ino to guest inode"
+    );
     let mode_b = st_b.st_mode as u32;
     assert_eq!(
         mode_b & libc::S_IFMT as u32,
         libc::S_IFREG as u32,
         "should be a regular file from backend_b"
     );
-    assert!(
-        st_b.st_size >= 14,
-        "size should reflect backend_b content"
-    );
+    assert!(st_b.st_size >= 14, "size should reflect backend_b content");
 
     // Test 3: after materialization, getattr should still work and reflect backend_a attrs.
     let handle = sb2.fuse_open(entry_b.inode, libc::O_RDWR as u32).unwrap();
     sb2.fs
-        .release(DualFsTestSandbox::ctx(), entry_b.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry_b.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let (st_after, _) = sb2
         .fs

--- a/crates/filesystem/lib/backends/dualfs/tests/test_policies.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_policies.rs
@@ -7,7 +7,15 @@ fn test_backend_a_only_create() {
     let sb = DualFsTestSandbox::with_policy(BackendAOnly);
     let (entry, handle) = sb.fuse_create_root("a_file.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let e = sb.lookup_root("a_file.txt").unwrap();
     assert_eq!(e.inode, entry.inode);
@@ -26,12 +34,22 @@ fn test_backend_a_only_lookup() {
 fn test_backend_a_only_write() {
     let sb = DualFsTestSandbox::with_policy(BackendAOnly);
     let (entry, handle) = sb.fuse_create_root("write_a.txt").unwrap();
-    let written = sb.fuse_write(entry.inode, handle, b"backend_a_data", 0).unwrap();
+    let written = sb
+        .fuse_write(entry.inode, handle, b"backend_a_data", 0)
+        .unwrap();
     assert_eq!(written, 14);
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"backend_a_data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -40,12 +58,9 @@ fn test_backend_a_only_write() {
 #[test]
 fn test_backend_a_fallback_lookup() {
     // Should try backend_a first (BackendAFirst precedence).
-    let sb = DualFsTestSandbox::with_policy_and_backend_b(
-        BackendAFallbackToBackendBRead,
-        |b| {
-            memfs_create_file(b, 1, "b_only.txt", b"from b");
-        },
-    );
+    let sb = DualFsTestSandbox::with_policy_and_backend_b(BackendAFallbackToBackendBRead, |b| {
+        memfs_create_file(b, 1, "b_only.txt", b"from b");
+    });
     // File only in backend_b -> fallback should find it.
     let entry = sb.lookup_root("b_only.txt").unwrap();
     assert!(entry.inode >= 3, "fallback should find backend_b file");
@@ -56,7 +71,15 @@ fn test_backend_a_fallback_create() {
     let sb = DualFsTestSandbox::with_policy(BackendAFallbackToBackendBRead);
     let (entry, handle) = sb.fuse_create_root("new.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let e = sb.lookup_root("new.txt").unwrap();
     assert_eq!(e.inode, entry.inode, "create should go to backend_a");
@@ -70,7 +93,15 @@ fn test_read_b_write_a_create() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("created.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let e = sb.lookup_root("created.txt").unwrap();
     assert_eq!(e.inode, entry.inode);
@@ -98,7 +129,15 @@ fn test_read_b_write_a_open_write() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"modified");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -113,7 +152,15 @@ fn test_read_b_write_a_open_read() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"backend_b_content");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -121,12 +168,9 @@ fn test_read_b_write_a_open_read() {
 
 #[test]
 fn test_merge_reads_readdir() {
-    let sb = DualFsTestSandbox::with_policy_and_backend_b(
-        MergeReadsBackendAPrecedence,
-        |b| {
-            memfs_create_file(b, 1, "b_merge.txt", b"from b");
-        },
-    );
+    let sb = DualFsTestSandbox::with_policy_and_backend_b(MergeReadsBackendAPrecedence, |b| {
+        memfs_create_file(b, 1, "b_merge.txt", b"from b");
+    });
     sb.create_file_with_content(ROOT_INODE, "a_merge.txt", b"from a")
         .unwrap();
     let names = sb.readdir_names(ROOT_INODE).unwrap();
@@ -156,11 +200,27 @@ fn test_policy_determinism() {
     let sb = DualFsTestSandbox::new();
     let (entry1, h1) = sb.fuse_create_root("det1.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry1.inode, 0, h1, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry1.inode,
+            0,
+            h1,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     let (entry2, h2) = sb.fuse_create_root("det2.txt").unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry2.inode, 0, h2, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry2.inode,
+            0,
+            h2,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Both should be in backend_a (default policy).
     let e1 = sb.lookup_root("det1.txt").unwrap();

--- a/crates/filesystem/lib/backends/dualfs/tests/test_remove_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_remove_ops.rs
@@ -103,7 +103,15 @@ fn test_unlink_merged_file() {
     let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"modified", 0).unwrap();
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Unlink — removes backend_a copy.
     sb.fs
@@ -121,7 +129,15 @@ fn test_unlink_merged_file() {
     // Content reflects materialized data since the node maps through backend dispatch.
     assert_eq!(&data[..], b"modified");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry2.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry2.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 

--- a/crates/filesystem/lib/backends/dualfs/tests/test_rename.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_rename.rs
@@ -150,7 +150,10 @@ fn test_rename_creates_whiteout() {
         .unwrap();
     // Old name still visible through backend_b (no whiteout is created).
     let entry_old = sb.lookup_root("b_file.txt");
-    assert!(entry_old.is_ok(), "backend_b file still visible after rename");
+    assert!(
+        entry_old.is_ok(),
+        "backend_b file still visible after rename"
+    );
     // New name should also exist.
     let entry = sb.lookup_root("renamed.txt").unwrap();
     assert!(entry.inode >= 3);
@@ -178,7 +181,15 @@ fn test_rename_backend_b_to_backend_a() {
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"backend_b_data");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 

--- a/crates/filesystem/lib/backends/dualfs/tests/test_special_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_special_ops.rs
@@ -5,10 +5,20 @@ fn test_fsync() {
     let sb = DualFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("sync.txt").unwrap();
     sb.fuse_write(entry.inode, handle, b"data", 0).unwrap();
-    let result = sb.fs.fsync(DualFsTestSandbox::ctx(), entry.inode, false, handle);
+    let result = sb
+        .fs
+        .fsync(DualFsTestSandbox::ctx(), entry.inode, false, handle);
     assert!(result.is_ok(), "fsync should succeed");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -21,10 +31,20 @@ fn test_fsync_handle_bound_dispatch() {
     let entry = sb.lookup_root("b_sync.txt").unwrap();
     let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     // fsync should dispatch to backend_b (handle-bound).
-    let result = sb.fs.fsync(DualFsTestSandbox::ctx(), entry.inode, false, handle);
+    let result = sb
+        .fs
+        .fsync(DualFsTestSandbox::ctx(), entry.inode, false, handle);
     assert!(result.is_ok(), "fsync on backend_b handle should succeed");
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -39,9 +59,20 @@ fn test_fallocate() {
         .fs
         .getattr(DualFsTestSandbox::ctx(), entry.inode, None)
         .unwrap();
-    assert!(st.st_size >= 1024, "file size should be at least 1024 after fallocate");
+    assert!(
+        st.st_size >= 1024,
+        "file size should be at least 1024 after fallocate"
+    );
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -57,7 +88,15 @@ fn test_lseek() {
         .unwrap();
     assert_eq!(offset, 0);
     sb.fs
-        .release(DualFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            DualFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -94,7 +133,10 @@ fn test_statfs_policy_independent() {
     // statfs always merges both backends regardless of policy.
     let sb = DualFsTestSandbox::with_policy(BackendAOnly);
     let st = sb.fs.statfs(DualFsTestSandbox::ctx(), ROOT_INODE).unwrap();
-    assert!(st.f_bsize > 0, "statfs should work even with BackendAOnly policy");
+    assert!(
+        st.f_bsize > 0,
+        "statfs should work even with BackendAOnly policy"
+    );
     assert!(st.f_frsize > 0, "fragment size should be positive");
     #[cfg(target_os = "linux")]
     assert!(st.f_blocks > 0, "merged blocks should be positive");

--- a/crates/filesystem/lib/backends/dualfs/tests/test_xattr.rs
+++ b/crates/filesystem/lib/backends/dualfs/tests/test_xattr.rs
@@ -87,9 +87,7 @@ fn test_removexattr() {
     sb.fs
         .removexattr(DualFsTestSandbox::ctx(), ino, &xname)
         .unwrap();
-    let result = sb
-        .fs
-        .getxattr(DualFsTestSandbox::ctx(), ino, &xname, 256);
+    let result = sb.fs.getxattr(DualFsTestSandbox::ctx(), ino, &xname, 256);
     DualFsTestSandbox::assert_errno(result, LINUX_ENODATA);
 }
 

--- a/crates/filesystem/lib/backends/dualfs/types.rs
+++ b/crates/filesystem/lib/backends/dualfs/types.rs
@@ -3,10 +3,14 @@
 //! Defines guest-visible inode state, handle types, namespace tables,
 //! and configuration. DualFs owns no storage — all data lives in child backends.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    sync::{
+        Arc, Mutex, RwLock,
+        atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use super::policy::DualDispatchPlan;
 
@@ -167,6 +171,7 @@ pub(crate) struct DualState {
     pub dentries: RwLock<BTreeMap<(u64, Vec<u8>), u64>>,
 
     /// Reverse dentry index: guest_inode -> { (parent, name), ... }
+    #[allow(clippy::type_complexity)]
     pub alias_index: RwLock<BTreeMap<u64, BTreeSet<(u64, Vec<u8>)>>>,
 
     /// Backend_a inode -> guest inode dedup map.
@@ -201,11 +206,12 @@ pub(crate) struct DualState {
 }
 
 /// Cache policy for FUSE caching.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CachePolicy {
     /// Never cache.
     Never,
     /// Cache based on FUSE defaults.
+    #[default]
     Auto,
     /// Always cache.
     Always,
@@ -280,8 +286,9 @@ impl DualHandle {
     #[allow(dead_code)]
     pub(crate) fn guest_inode(&self) -> u64 {
         match self {
-            DualHandle::BackendA { guest_inode, .. }
-            | DualHandle::BackendB { guest_inode, .. } => *guest_inode,
+            DualHandle::BackendA { guest_inode, .. } | DualHandle::BackendB { guest_inode, .. } => {
+                *guest_inode
+            }
         }
     }
 
@@ -331,10 +338,7 @@ impl DualState {
     }
 
     /// Get the inode map for a given backend.
-    pub(crate) fn inode_map(
-        &self,
-        backend: BackendId,
-    ) -> &RwLock<BTreeMap<u64, u64>> {
+    pub(crate) fn inode_map(&self, backend: BackendId) -> &RwLock<BTreeMap<u64, u64>> {
         match backend {
             BackendId::BackendA => &self.backend_a_inode_map,
             BackendId::BackendB => &self.backend_b_inode_map,
@@ -342,7 +346,12 @@ impl DualState {
     }
 
     /// Check if a name is hidden for a specific backend.
-    pub(crate) fn is_whited_out(&self, parent: u64, name: &[u8], hidden_backend: BackendId) -> bool {
+    pub(crate) fn is_whited_out(
+        &self,
+        parent: u64,
+        name: &[u8],
+        hidden_backend: BackendId,
+    ) -> bool {
         self.whiteouts
             .read()
             .unwrap()
@@ -403,18 +412,30 @@ impl NodeState {
         match (self, backend) {
             (NodeState::Root { backend_a_root, .. }, BackendId::BackendA) => Some(*backend_a_root),
             (NodeState::Root { backend_b_root, .. }, BackendId::BackendB) => Some(*backend_b_root),
-            (NodeState::BackendA { backend_a_inode, .. }, BackendId::BackendA) => {
-                Some(*backend_a_inode)
-            }
-            (NodeState::BackendB { backend_b_inode, .. }, BackendId::BackendB) => {
-                Some(*backend_b_inode)
-            }
-            (NodeState::MergedDir { backend_a_inode, .. }, BackendId::BackendA) => {
-                Some(*backend_a_inode)
-            }
-            (NodeState::MergedDir { backend_b_inode, .. }, BackendId::BackendB) => {
-                Some(*backend_b_inode)
-            }
+            (
+                NodeState::BackendA {
+                    backend_a_inode, ..
+                },
+                BackendId::BackendA,
+            ) => Some(*backend_a_inode),
+            (
+                NodeState::BackendB {
+                    backend_b_inode, ..
+                },
+                BackendId::BackendB,
+            ) => Some(*backend_b_inode),
+            (
+                NodeState::MergedDir {
+                    backend_a_inode, ..
+                },
+                BackendId::BackendA,
+            ) => Some(*backend_a_inode),
+            (
+                NodeState::MergedDir {
+                    backend_b_inode, ..
+                },
+                BackendId::BackendB,
+            ) => Some(*backend_b_inode),
             _ => None,
         }
     }
@@ -430,23 +451,17 @@ impl NodeState {
 
     /// Check if this is a pure single-backed directory on the given backend.
     pub(crate) fn is_pure_on(&self, backend: BackendId) -> bool {
-        match (self, backend) {
-            (NodeState::BackendA { .. }, BackendId::BackendA) => true,
-            (NodeState::BackendB { .. }, BackendId::BackendB) => true,
-            _ => false,
-        }
+        matches!(
+            (self, backend),
+            (NodeState::BackendA { .. }, BackendId::BackendA)
+                | (NodeState::BackendB { .. }, BackendId::BackendB)
+        )
     }
 }
 
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
-
-impl Default for CachePolicy {
-    fn default() -> Self {
-        CachePolicy::Auto
-    }
-}
 
 impl Default for DualFsConfig {
     fn default() -> Self {

--- a/crates/filesystem/lib/backends/dualfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/xattr_ops.rs
@@ -1,14 +1,14 @@
 //! Extended attribute operations: getxattr, listxattr, setxattr, removexattr.
 
-use std::ffi::CStr;
-use std::io;
+use std::{ffi::CStr, io};
 
-use super::lookup::{backend, get_node, mark_metadata_authority, resolve_active_backend_inode};
-use super::policy::{DualNamespaceView, HintBag, OpKind, RequestCtx};
-use super::types::BackendId;
-use super::DualFs;
-use crate::backends::shared::init_binary;
-use crate::{Context, GetxattrReply, ListxattrReply};
+use super::{
+    DualFs,
+    lookup::{backend, get_node, mark_metadata_authority, resolve_active_backend_inode},
+    policy::{DualNamespaceView, HintBag, OpKind, RequestCtx},
+    types::BackendId,
+};
+use crate::{Context, GetxattrReply, ListxattrReply, backends::shared::init_binary};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -82,10 +82,10 @@ pub(crate) fn do_setxattr(
 
     // Materialize if needed.
     let current_backend = node.state.read().unwrap().current_backend();
-    if let Some(current) = current_backend {
-        if current != target {
-            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
-        }
+    if let Some(current) = current_backend
+        && current != target
+    {
+        super::materialize::do_materialize(fs, ctx, ino, current, target)?;
     }
 
     let target_inode = super::lookup::resolve_backend_inode(&fs.state, ino, target)
@@ -98,12 +98,7 @@ pub(crate) fn do_setxattr(
 }
 
 /// Handle removexattr. Full pipeline with policy routing.
-pub(crate) fn do_removexattr(
-    fs: &DualFs,
-    ctx: Context,
-    ino: u64,
-    name: &CStr,
-) -> io::Result<()> {
+pub(crate) fn do_removexattr(fs: &DualFs, ctx: Context, ino: u64, name: &CStr) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
         return Err(io::Error::from_raw_os_error(libc::EACCES));
     }
@@ -125,10 +120,10 @@ pub(crate) fn do_removexattr(
 
     // Materialize if needed.
     let current_backend = node.state.read().unwrap().current_backend();
-    if let Some(current) = current_backend {
-        if current != target {
-            super::materialize::do_materialize(fs, ctx, ino, current, target)?;
-        }
+    if let Some(current) = current_backend
+        && current != target
+    {
+        super::materialize::do_materialize(fs, ctx, ino, current, target)?;
     }
 
     let target_inode = super::lookup::resolve_backend_inode(&fs.state, ino, target)

--- a/crates/filesystem/lib/backends/memfs/builder.rs
+++ b/crates/filesystem/lib/backends/memfs/builder.rs
@@ -7,17 +7,20 @@
 //!     .build()?
 //! ```
 
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io;
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io,
+    sync::{
+        Arc, Mutex, RwLock,
+        atomic::{AtomicBool, AtomicU64},
+    },
+    time::Duration,
+};
 
-use super::MemFs;
-use super::inode;
-use super::types::{
-    CachePolicy, InodeContent, InodeMeta, MemFsConfig, MemNode, ROOT_INODE,
+use super::{
+    MemFs, inode,
+    types::{CachePolicy, InodeContent, InodeMeta, MemFsConfig, MemNode, ROOT_INODE},
 };
 use crate::backends::shared::init_binary;
 
@@ -133,7 +136,7 @@ impl MemFsBuilder {
             nodes: RwLock::new(nodes),
             file_handles: RwLock::new(BTreeMap::new()),
             dir_handles: RwLock::new(BTreeMap::new()),
-            next_inode: AtomicU64::new(3), // 1=root, 2=init
+            next_inode: AtomicU64::new(3),  // 1=root, 2=init
             next_handle: AtomicU64::new(1), // 0=init handle
             used_bytes: AtomicU64::new(0),
             inode_count: AtomicU64::new(1), // root

--- a/crates/filesystem/lib/backends/memfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/create_ops.rs
@@ -1,17 +1,23 @@
 //! Creation operations: create, mkdir, mknod, symlink, link.
 
-use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
-use std::{ffi::CStr, io};
+use std::{
+    collections::BTreeMap,
+    ffi::CStr,
+    io,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
-use super::MemFs;
-use super::inode;
-use super::types::{FileHandle, InodeContent, InodeMeta, MemNode, ROOT_INODE};
-use crate::backends::shared::init_binary;
-use crate::backends::shared::name_validation;
-use crate::backends::shared::platform;
-use crate::{Context, Entry, Extensions, OpenOptions};
+use super::{
+    MemFs, inode,
+    types::{FileHandle, InodeContent, InodeMeta, MemNode, ROOT_INODE},
+};
+use crate::{
+    Context, Entry, Extensions, OpenOptions,
+    backends::shared::{init_binary, name_validation, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -69,15 +75,13 @@ pub(crate) fn do_create(
             let mut ch = children.write().unwrap();
             if ch.contains_key(&name_bytes) {
                 // Undo inode allocation.
-                fs.inode_count
-                    .fetch_sub(1, Ordering::Relaxed);
+                fs.inode_count.fetch_sub(1, Ordering::Relaxed);
                 return Err(platform::eexist());
             }
             ch.insert(name_bytes, ino);
         }
         _ => {
-            fs.inode_count
-                .fetch_sub(1, Ordering::Relaxed);
+            fs.inode_count.fetch_sub(1, Ordering::Relaxed);
             return Err(platform::enotdir());
         }
     }
@@ -94,10 +98,10 @@ pub(crate) fn do_create(
 
     // Create file handle.
     let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
+    let handle_flags = super::normalize_handle_flags(fs.writeback.load(Ordering::Relaxed), flags);
     let fh = Arc::new(FileHandle {
-        inode: ino,
-        node: node.clone(),
-        flags,
+        node: Arc::clone(&node),
+        flags: handle_flags,
     });
     fs.file_handles.write().unwrap().insert(handle, fh);
 
@@ -154,15 +158,13 @@ pub(crate) fn do_mkdir(
         InodeContent::Directory { children, .. } => {
             let mut ch = children.write().unwrap();
             if ch.contains_key(&name_bytes) {
-                fs.inode_count
-                    .fetch_sub(1, Ordering::Relaxed);
+                fs.inode_count.fetch_sub(1, Ordering::Relaxed);
                 return Err(platform::eexist());
             }
             ch.insert(name_bytes, ino);
         }
         _ => {
-            fs.inode_count
-                .fetch_sub(1, Ordering::Relaxed);
+            fs.inode_count.fetch_sub(1, Ordering::Relaxed);
             return Err(platform::enotdir());
         }
     }
@@ -222,8 +224,7 @@ pub(crate) fn do_mknod(
             (file_type, InodeContent::Special)
         }
         _ => {
-            fs.inode_count
-                .fetch_sub(1, Ordering::Relaxed);
+            fs.inode_count.fetch_sub(1, Ordering::Relaxed);
             return Err(platform::einval());
         }
     };
@@ -253,15 +254,13 @@ pub(crate) fn do_mknod(
         InodeContent::Directory { children, .. } => {
             let mut ch = children.write().unwrap();
             if ch.contains_key(&name_bytes) {
-                fs.inode_count
-                    .fetch_sub(1, Ordering::Relaxed);
+                fs.inode_count.fetch_sub(1, Ordering::Relaxed);
                 return Err(platform::eexist());
             }
             ch.insert(name_bytes, ino);
         }
         _ => {
-            fs.inode_count
-                .fetch_sub(1, Ordering::Relaxed);
+            fs.inode_count.fetch_sub(1, Ordering::Relaxed);
             return Err(platform::enotdir());
         }
     }
@@ -324,15 +323,13 @@ pub(crate) fn do_symlink(
         InodeContent::Directory { children, .. } => {
             let mut ch = children.write().unwrap();
             if ch.contains_key(&name_bytes) {
-                fs.inode_count
-                    .fetch_sub(1, Ordering::Relaxed);
+                fs.inode_count.fetch_sub(1, Ordering::Relaxed);
                 return Err(platform::eexist());
             }
             ch.insert(name_bytes, ino);
         }
         _ => {
-            fs.inode_count
-                .fetch_sub(1, Ordering::Relaxed);
+            fs.inode_count.fetch_sub(1, Ordering::Relaxed);
             return Err(platform::enotdir());
         }
     }

--- a/crates/filesystem/lib/backends/memfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/dir_ops.rs
@@ -4,16 +4,19 @@
 //! immutable for the handle's lifetime. Names use the bounded-leak technique
 //! for `DirEntry<'static>` lifetime requirements.
 
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
-use std::io;
+use std::{
+    io,
+    sync::{Arc, Mutex, atomic::Ordering},
+};
 
-use super::MemFs;
-use super::inode;
-use super::types::{DirHandle, DirSnapshot, InodeContent, MemDirEntry, ROOT_INODE};
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, DirEntry, Entry, OpenOptions};
+use super::{
+    MemFs, inode,
+    types::{DirHandle, DirSnapshot, InodeContent, MemDirEntry, ROOT_INODE},
+};
+use crate::{
+    Context, DirEntry, Entry, OpenOptions,
+    backends::shared::{init_binary, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -34,7 +37,6 @@ pub(crate) fn do_opendir(
 
     let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
     let dh = Arc::new(DirHandle {
-        inode: ino,
         node: Arc::clone(&node),
         snapshot: Mutex::new(None),
     });
@@ -181,11 +183,7 @@ fn serve_snapshot_entries(
 }
 
 /// Build a point-in-time snapshot of a directory's entries.
-fn build_snapshot(
-    fs: &MemFs,
-    ino: u64,
-    node: &super::types::MemNode,
-) -> io::Result<DirSnapshot> {
+fn build_snapshot(fs: &MemFs, ino: u64, node: &super::types::MemNode) -> io::Result<DirSnapshot> {
     let children = match &node.content {
         InodeContent::Directory { children, .. } => children.read().unwrap(),
         _ => return Err(platform::enotdir()),

--- a/crates/filesystem/lib/backends/memfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/file_ops.rs
@@ -4,17 +4,20 @@
 //! staging file (memfd/tmpfile) to bridge the ZeroCopy traits, which
 //! operate on file descriptors rather than byte slices.
 
-use std::os::fd::AsRawFd;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::{cmp, io};
+use std::{
+    cmp, io,
+    os::fd::AsRawFd,
+    sync::{Arc, atomic::Ordering},
+};
 
-use super::MemFs;
-use super::inode;
-use super::types::{FileHandle, InodeContent};
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+use super::{
+    MemFs, inode,
+    types::{FileHandle, InodeContent},
+};
+use crate::{
+    Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::{init_binary, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -38,35 +41,27 @@ pub(crate) fn do_open(
         return Err(platform::eisdir());
     }
 
-    let mut open_flags = flags as i32;
-
-    // Writeback cache adjustments.
-    if fs.writeback.load(Ordering::Relaxed) {
-        if open_flags & libc::O_WRONLY != 0 {
-            open_flags = (open_flags & !libc::O_WRONLY) | libc::O_RDWR;
-        }
-        open_flags &= !libc::O_APPEND;
-    }
+    let open_flags = super::normalize_handle_flags(fs.writeback.load(Ordering::Relaxed), flags);
 
     // Handle O_TRUNC: truncate file data.
-    if open_flags & libc::O_TRUNC != 0 {
-        if let InodeContent::RegularFile { ref data } = node.content {
-            let mut data = data.write().unwrap();
-            let old_len = data.len() as u64;
-            data.clear();
-            if old_len > 0 {
-                inode::release_bytes(fs, old_len);
-            }
-            let mut meta = node.meta.write().unwrap();
-            meta.size = 0;
-            let now = inode::current_time();
-            meta.mtime = now;
-            meta.ctime = now;
+    if open_flags & super::GUEST_O_TRUNC != 0
+        && let InodeContent::RegularFile { ref data } = node.content
+    {
+        let mut data = data.write().unwrap();
+        let old_len = data.len() as u64;
+        data.clear();
+        if old_len > 0 {
+            inode::release_bytes(fs, old_len);
         }
+        let mut meta = node.meta.write().unwrap();
+        meta.size = 0;
+        let now = inode::current_time();
+        meta.mtime = now;
+        meta.ctime = now;
     }
 
     // Handle kill_priv: clear SUID/SGID on truncate.
-    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
+    if kill_priv && (open_flags & super::GUEST_O_TRUNC != 0) {
         let mut meta = node.meta.write().unwrap();
         if meta.mode & (libc::S_ISUID as u32 | libc::S_ISGID as u32) != 0 {
             meta.mode &= !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
@@ -76,9 +71,8 @@ pub(crate) fn do_open(
 
     let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
     let fh = Arc::new(FileHandle {
-        inode: ino,
         node: Arc::clone(&node),
-        flags: open_flags as u32,
+        flags: open_flags,
     });
 
     fs.file_handles.write().unwrap().insert(handle, fh);
@@ -135,12 +129,13 @@ pub(crate) fn do_read(
         return Err(platform::linux_error(io::Error::last_os_error()));
     }
 
-    w.write_from(&*staging, count, 0)
+    w.write_from(&staging, count, 0)
 }
 
 /// Write data to a file.
 ///
 /// Uses the staging file to bridge ZeroCopyReader data to the in-memory buffer.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn do_write(
     fs: &MemFs,
     _ctx: Context,
@@ -162,18 +157,21 @@ pub(crate) fn do_write(
         InodeContent::RegularFile { data } => data,
         _ => return Err(platform::eisdir()),
     };
+    let append_mode = fh.flags & super::GUEST_O_APPEND != 0;
 
     // Validate that the write won't exceed stat64 representable size.
-    let requested_end = (offset as u64)
-        .checked_add(size as u64)
-        .ok_or_else(platform::einval)?;
-    if requested_end > i64::MAX as u64 {
-        return Err(platform::efbig());
+    if !append_mode {
+        let requested_end = offset
+            .checked_add(size as u64)
+            .ok_or_else(platform::einval)?;
+        if requested_end > i64::MAX as u64 {
+            return Err(platform::efbig());
+        }
     }
 
     // Read from guest into staging file.
     let staging = fs.staging_file.lock().unwrap();
-    let count = r.read_to(&*staging, size as usize, 0)?;
+    let count = r.read_to(&staging, size as usize, 0)?;
 
     if count == 0 {
         return Ok(0);
@@ -195,26 +193,28 @@ pub(crate) fn do_write(
     drop(staging);
 
     let count = read_back as usize;
-    let start = offset as usize;
-    let new_end = start
-        .checked_add(count)
-        .ok_or_else(platform::efbig)?;
 
-    // Reserve capacity for growth.
-    {
-        let current_len = data_lock.read().unwrap().len();
-        if new_end > current_len {
-            let delta = (new_end - current_len) as u64;
-            inode::reserve_bytes(fs, delta)?;
-        }
-    }
-
-    // Write to in-memory data.
+    // Write to in-memory data. Append mode must observe the current EOF under
+    // the write lock so concurrent appenders serialize correctly.
     {
         let mut data = data_lock.write().unwrap();
+        let start = if append_mode {
+            data.len()
+        } else {
+            usize::try_from(offset).map_err(|_| platform::efbig())?
+        };
+        let new_end = start.checked_add(count).ok_or_else(platform::efbig)?;
+
+        if (new_end as u64) > i64::MAX as u64 {
+            return Err(platform::efbig());
+        }
+
         if new_end > data.len() {
+            let delta = (new_end - data.len()) as u64;
+            inode::reserve_bytes(fs, delta)?;
             data.resize(new_end, 0);
         }
+
         data[start..new_end].copy_from_slice(&buf[..count]);
 
         // Update metadata.
@@ -247,12 +247,7 @@ pub(crate) fn do_readlink(fs: &MemFs, _ctx: Context, ino: u64) -> io::Result<Vec
 }
 
 /// Flush pending data for a file handle.
-pub(crate) fn do_flush(
-    _fs: &MemFs,
-    _ctx: Context,
-    ino: u64,
-    _handle: u64,
-) -> io::Result<()> {
+pub(crate) fn do_flush(_fs: &MemFs, _ctx: Context, ino: u64, _handle: u64) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
         return Ok(());
     }
@@ -261,12 +256,7 @@ pub(crate) fn do_flush(
 }
 
 /// Release an open file handle.
-pub(crate) fn do_release(
-    fs: &MemFs,
-    _ctx: Context,
-    ino: u64,
-    handle: u64,
-) -> io::Result<()> {
+pub(crate) fn do_release(fs: &MemFs, _ctx: Context, ino: u64, handle: u64) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
         return Ok(());
     }
@@ -274,12 +264,13 @@ pub(crate) fn do_release(
     if let Some(fh) = fs.file_handles.write().unwrap().remove(&handle) {
         // If this was the last reference to a regular file already evicted
         // from the nodes table, release the capacity.
-        if fh.node.kind == libc::S_IFREG as u32 && Arc::strong_count(&fh.node) == 1 {
-            if let InodeContent::RegularFile { ref data } = fh.node.content {
-                let size = data.read().unwrap().len() as u64;
-                if size > 0 {
-                    inode::release_bytes(fs, size);
-                }
+        if fh.node.kind == libc::S_IFREG as u32
+            && Arc::strong_count(&fh.node) == 1
+            && let InodeContent::RegularFile { ref data } = fh.node.content
+        {
+            let size = data.read().unwrap().len() as u64;
+            if size > 0 {
+                inode::release_bytes(fs, size);
             }
         }
     }

--- a/crates/filesystem/lib/backends/memfs/inode.rs
+++ b/crates/filesystem/lib/backends/memfs/inode.rs
@@ -1,13 +1,15 @@
 //! Inode management: allocation, lookup, forget, stat building, capacity tracking.
 
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::{
+    io,
+    sync::{Arc, atomic::Ordering},
+};
 
-use super::MemFs;
-use super::types::{InodeContent, InodeMeta, MemNode, Timespec};
-use crate::backends::shared::platform;
-use crate::{Entry, stat64};
+use super::{
+    MemFs,
+    types::{InodeContent, InodeMeta, MemNode, Timespec},
+};
+use crate::{Entry, backends::shared::platform, stat64};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -21,8 +23,8 @@ pub(crate) fn current_time() -> Timespec {
     };
     unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut tp) };
     Timespec {
-        sec: tp.tv_sec as i64,
-        nsec: tp.tv_nsec as i64,
+        sec: tp.tv_sec,
+        nsec: tp.tv_nsec,
     }
 }
 
@@ -159,12 +161,12 @@ fn evict_inode(fs: &MemFs, ino: u64) {
     let removed = fs.nodes.write().unwrap().remove(&ino);
     if let Some(node) = removed {
         // Only release bytes if this is the last Arc holder (no open handles).
-        if Arc::strong_count(&node) == 1 {
-            if let InodeContent::RegularFile { ref data } = node.content {
-                let size = data.read().unwrap().len() as u64;
-                if size > 0 {
-                    release_bytes(fs, size);
-                }
+        if Arc::strong_count(&node) == 1
+            && let InodeContent::RegularFile { ref data } = node.content
+        {
+            let size = data.read().unwrap().len() as u64;
+            if size > 0 {
+                release_bytes(fs, size);
             }
         }
         fs.inode_count.fetch_sub(1, Ordering::Relaxed);

--- a/crates/filesystem/lib/backends/memfs/metadata.rs
+++ b/crates/filesystem/lib/backends/memfs/metadata.rs
@@ -3,15 +3,14 @@
 //! All stat results are built directly from in-memory metadata.
 //! No xattr-based stat virtualization is needed — MemFs owns all metadata.
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
-use super::MemFs;
-use super::inode;
-use super::types::InodeContent;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, SetattrValid, stat64};
+use super::{MemFs, inode, types::InodeContent};
+use crate::{
+    Context, SetattrValid,
+    backends::shared::{init_binary, platform},
+    stat64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/lib/backends/memfs/mod.rs
+++ b/crates/filesystem/lib/backends/memfs/mod.rs
@@ -17,21 +17,33 @@ mod special;
 pub mod types;
 mod xattr_ops;
 
-use std::collections::BTreeMap;
-use std::ffi::CStr;
-use std::fs::File;
-use std::io;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Mutex, RwLock};
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    ffi::CStr,
+    fs::File,
+    io,
+    sync::{
+        Mutex, RwLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use types::{DirHandle, FileHandle, MemNode, ROOT_INODE};
 
-use crate::backends::shared::init_binary;
 use crate::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, backends::shared::init_binary,
+    stat64, statvfs64,
 };
+
+// Guest Linux open flag constants. MemFs interprets flags directly instead of
+// translating them through host syscalls, so it must use guest values on every
+// host platform.
+pub(crate) const GUEST_O_WRONLY: u32 = 1;
+pub(crate) const GUEST_O_RDWR: u32 = 2;
+pub(crate) const GUEST_O_TRUNC: u32 = 0x200;
+pub(crate) const GUEST_O_APPEND: u32 = 0x400;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -105,6 +117,23 @@ impl MemFs {
     }
 }
 
+/// Normalize Linux open flags for a MemFs handle.
+///
+/// When writeback is active, the guest kernel owns append positioning, so the
+/// backend must not apply append semantics a second time.
+pub(crate) fn normalize_handle_flags(writeback: bool, flags: u32) -> u32 {
+    let mut flags = flags;
+
+    if writeback {
+        if flags & GUEST_O_WRONLY != 0 {
+            flags = (flags & !GUEST_O_WRONLY) | GUEST_O_RDWR;
+        }
+        flags &= !GUEST_O_APPEND;
+    }
+
+    flags
+}
+
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
@@ -155,7 +184,8 @@ impl DynFileSystem for MemFs {
         let child_ino = match &parent_node.content {
             types::InodeContent::Directory { children, .. } => {
                 let ch = children.read().unwrap();
-                *ch.get(name_bytes).ok_or_else(crate::backends::shared::platform::enoent)?
+                *ch.get(name_bytes)
+                    .ok_or_else(crate::backends::shared::platform::enoent)?
             }
             _ => return Err(crate::backends::shared::platform::enotdir()),
         };
@@ -263,13 +293,7 @@ impl DynFileSystem for MemFs {
         remove_ops::do_rename(self, ctx, olddir, oldname, newdir, newname, flags)
     }
 
-    fn link(
-        &self,
-        ctx: Context,
-        ino: u64,
-        newparent: u64,
-        newname: &CStr,
-    ) -> io::Result<Entry> {
+    fn link(&self, ctx: Context, ino: u64, newparent: u64, newname: &CStr) -> io::Result<Entry> {
         create_ops::do_link(self, ctx, ino, newparent, newname)
     }
 
@@ -295,7 +319,9 @@ impl DynFileSystem for MemFs {
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
-        create_ops::do_create(self, ctx, parent, name, mode, kill_priv, flags, umask, extensions)
+        create_ops::do_create(
+            self, ctx, parent, name, mode, kill_priv, flags, umask, extensions,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/filesystem/lib/backends/memfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/remove_ops.rs
@@ -1,29 +1,26 @@
 //! Deletion operations: unlink, rmdir, rename.
 
-use std::ffi::CStr;
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::{
+    ffi::CStr,
+    io,
+    sync::{Arc, atomic::Ordering},
+};
 
-use super::MemFs;
-use super::inode;
-use super::types::{InodeContent, ROOT_INODE};
-use crate::backends::shared::init_binary;
-use crate::backends::shared::name_validation;
-use crate::backends::shared::platform;
-use crate::Context;
+use super::{
+    MemFs, inode,
+    types::{InodeContent, ROOT_INODE},
+};
+use crate::{
+    Context,
+    backends::shared::{init_binary, name_validation, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
 
 /// Unlink a file (remove directory entry).
-pub(crate) fn do_unlink(
-    fs: &MemFs,
-    _ctx: Context,
-    parent: u64,
-    name: &CStr,
-) -> io::Result<()> {
+pub(crate) fn do_unlink(fs: &MemFs, _ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
     name_validation::validate_memfs_name(name)?;
 
     if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
@@ -74,12 +71,7 @@ pub(crate) fn do_unlink(
 }
 
 /// Remove an empty directory.
-pub(crate) fn do_rmdir(
-    fs: &MemFs,
-    _ctx: Context,
-    parent: u64,
-    name: &CStr,
-) -> io::Result<()> {
+pub(crate) fn do_rmdir(fs: &MemFs, _ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
     name_validation::validate_memfs_name(name)?;
 
     if parent == ROOT_INODE && init_binary::is_init_name(name.to_bytes()) {
@@ -107,10 +99,10 @@ pub(crate) fn do_rmdir(
     }
 
     // Verify it's empty.
-    if let InodeContent::Directory { children, .. } = &child_node.content {
-        if !children.read().unwrap().is_empty() {
-            return Err(platform::enotempty());
-        }
+    if let InodeContent::Directory { children, .. } = &child_node.content
+        && !children.read().unwrap().is_empty()
+    {
+        return Err(platform::enotempty());
     }
 
     // Now remove from parent.
@@ -234,16 +226,18 @@ pub(crate) fn do_rename(
         }
 
         // Update parent pointers for directories.
-        if source_is_dir && olddir != newdir {
-            if let InodeContent::Directory { parent, .. } = &source_node.content {
-                parent.store(newdir, Ordering::Relaxed);
-            }
+        if source_is_dir
+            && olddir != newdir
+            && let InodeContent::Directory { parent, .. } = &source_node.content
+        {
+            parent.store(newdir, Ordering::Relaxed);
         }
         let dest_is_dir = dest_node.kind == libc::S_IFDIR as u32;
-        if dest_is_dir && olddir != newdir {
-            if let InodeContent::Directory { parent, .. } = &dest_node.content {
-                parent.store(olddir, Ordering::Relaxed);
-            }
+        if dest_is_dir
+            && olddir != newdir
+            && let InodeContent::Directory { parent, .. } = &dest_node.content
+        {
+            parent.store(olddir, Ordering::Relaxed);
         }
 
         // Update timestamps.
@@ -289,12 +283,11 @@ pub(crate) fn do_rename(
         }
 
         // If destination is a directory, it must be empty.
-        if dest_is_dir {
-            if let InodeContent::Directory { children, .. } = &dest_node.content {
-                if !children.read().unwrap().is_empty() {
-                    return Err(platform::enotempty());
-                }
-            }
+        if dest_is_dir
+            && let InodeContent::Directory { children, .. } = &dest_node.content
+            && !children.read().unwrap().is_empty()
+        {
+            return Err(platform::enotempty());
         }
 
         // Decrement destination nlink.

--- a/crates/filesystem/lib/backends/memfs/special.rs
+++ b/crates/filesystem/lib/backends/memfs/special.rs
@@ -1,14 +1,13 @@
 //! Special operations: statfs, lseek, fallocate, fsync, fsyncdir.
 
-use std::io;
-use std::sync::atomic::Ordering;
+use std::{io, sync::atomic::Ordering};
 
-use super::MemFs;
-use super::inode;
-use super::types::InodeContent;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, statvfs64};
+use super::{MemFs, inode, types::InodeContent};
+use crate::{
+    Context,
+    backends::shared::{init_binary, platform},
+    statvfs64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -149,9 +148,7 @@ pub(crate) fn do_fallocate(
 
     if mode == 0 {
         // Allocate space: extend file if needed.
-        let new_end = offset
-            .checked_add(length)
-            .ok_or_else(platform::einval)?;
+        let new_end = offset.checked_add(length).ok_or_else(platform::einval)?;
         if new_end > i64::MAX as u64 {
             return Err(platform::efbig());
         }
@@ -172,7 +169,7 @@ pub(crate) fn do_fallocate(
         if let InodeContent::RegularFile { ref data } = fh.node.content {
             let mut d = data.write().unwrap();
             let start = std::cmp::min(offset as usize, d.len());
-            let end_offset = offset.checked_add(length).unwrap_or(u64::MAX);
+            let end_offset = offset.saturating_add(length);
             let end = std::cmp::min(end_offset as usize, d.len());
             if start < end {
                 d[start..end].fill(0);

--- a/crates/filesystem/lib/backends/memfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/mod.rs
@@ -13,10 +13,7 @@ mod test_rename;
 mod test_special_ops;
 mod test_xattr;
 
-use std::ffi::CString;
-use std::fs::File;
-use std::io;
-use std::os::fd::AsRawFd;
+use std::{ffi::CString, fs::File, io, os::fd::AsRawFd};
 
 use super::*;
 use crate::{
@@ -113,8 +110,14 @@ impl MemFsTestSandbox {
     }
 
     fn fuse_mkdir(&self, parent: u64, name: &str, mode: u32) -> io::Result<Entry> {
-        self.fs
-            .mkdir(Self::ctx(), parent, &Self::cstr(name), mode, 0, Extensions::default())
+        self.fs.mkdir(
+            Self::ctx(),
+            parent,
+            &Self::cstr(name),
+            mode,
+            0,
+            Extensions::default(),
+        )
     }
 
     fn fuse_mkdir_root(&self, name: &str) -> io::Result<Entry> {

--- a/crates/filesystem/lib/backends/memfs/tests/test_bootstrap.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_bootstrap.rs
@@ -6,8 +6,13 @@ use super::*;
 fn test_build_default() {
     let fs = MemFs::builder().build().unwrap();
     fs.init(FsOptions::empty()).unwrap();
-    let (st, _) = fs.getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
-    assert_eq!(st.st_mode as u32 & libc::S_IFMT as u32, libc::S_IFDIR as u32);
+    let (st, _) = fs
+        .getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
+    assert_eq!(
+        st.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFDIR as u32
+    );
 }
 
 #[test]
@@ -78,7 +83,10 @@ fn test_init_no_writeback() {
 #[test]
 fn test_root_exists_after_init() {
     let sb = MemFsTestSandbox::new();
-    let (st, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
+    let (st, _) = sb
+        .fs
+        .getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
     let mode = st.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFDIR as u32);
     assert_eq!(mode & 0o777, 0o755);
@@ -89,7 +97,10 @@ fn test_root_exists_after_init() {
 #[test]
 fn test_root_nlink() {
     let sb = MemFsTestSandbox::new();
-    let (st, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
+    let (st, _) = sb
+        .fs
+        .getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
     #[cfg(target_os = "linux")]
     assert_eq!(st.st_nlink, 2);
     #[cfg(target_os = "macos")]

--- a/crates/filesystem/lib/backends/memfs/tests/test_capacity.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_capacity.rs
@@ -35,13 +35,7 @@ fn test_capacity_truncate_reclaims() {
     let mut attr: stat64 = unsafe { std::mem::zeroed() };
     attr.st_size = 0;
     sb.fs
-        .setattr(
-            MemFsTestSandbox::ctx(),
-            ino,
-            attr,
-            None,
-            SetattrValid::SIZE,
-        )
+        .setattr(MemFsTestSandbox::ctx(), ino, attr, None, SetattrValid::SIZE)
         .unwrap();
 
     let used_after = sb.fs.used_bytes.load(Ordering::Relaxed);
@@ -113,9 +107,12 @@ fn test_capacity_unlink_open_file() {
 #[test]
 fn test_capacity_multiple_files() {
     let sb = MemFsTestSandbox::with_capacity(1024);
-    sb.create_file_with_content(ROOT_INODE, "a.txt", &[0u8; 256]).unwrap();
-    sb.create_file_with_content(ROOT_INODE, "b.txt", &[0u8; 256]).unwrap();
-    sb.create_file_with_content(ROOT_INODE, "c.txt", &[0u8; 256]).unwrap();
+    sb.create_file_with_content(ROOT_INODE, "a.txt", &[0u8; 256])
+        .unwrap();
+    sb.create_file_with_content(ROOT_INODE, "b.txt", &[0u8; 256])
+        .unwrap();
+    sb.create_file_with_content(ROOT_INODE, "c.txt", &[0u8; 256])
+        .unwrap();
 
     let used = sb.fs.used_bytes.load(Ordering::Relaxed);
     assert_eq!(used, 768);
@@ -145,7 +142,15 @@ fn test_inode_limit_unlink_reclaims() {
     let (entry, handle) = sb.fuse_create_root("temp.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     sb.fuse_create_root("temp2.txt").unwrap();
 

--- a/crates/filesystem/lib/backends/memfs/tests/test_concurrency.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_concurrency.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::sync::{Arc, atomic::Ordering};
 
 use super::*;
 
@@ -26,10 +25,7 @@ fn test_concurrent_writes_same_file() {
     // Each 100-byte region should be filled with its writer's byte value.
     for i in 0..8u64 {
         let region = &data[(i * 100) as usize..((i + 1) * 100) as usize];
-        assert!(
-            region.iter().all(|&b| b == i as u8),
-            "region {i} corrupted"
-        );
+        assert!(region.iter().all(|&b| b == i as u8), "region {i} corrupted");
     }
 }
 
@@ -91,7 +87,15 @@ fn test_concurrent_forget_lookup() {
     let (entry, handle) = sb.fuse_create_root("contested.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     std::thread::scope(|s| {

--- a/crates/filesystem/lib/backends/memfs/tests/test_create_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_create_ops.rs
@@ -15,7 +15,8 @@ fn test_create_file_with_content() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("data.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"hello world", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"hello world", 0)
+        .unwrap();
     let data = sb.fuse_read(entry.inode, handle, 1024, 0).unwrap();
     assert_eq!(&data[..], b"hello world");
 }
@@ -23,16 +24,19 @@ fn test_create_file_with_content() {
 #[test]
 fn test_create_with_umask() {
     let sb = MemFsTestSandbox::new();
-    let (entry, _handle, _opts) = sb.fs.create(
-        MemFsTestSandbox::ctx(),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("masked.txt"),
-        0o777,
-        false,
-        libc::O_RDWR as u32,
-        0o022,
-        Extensions::default(),
-    ).unwrap();
+    let (entry, _handle, _opts) = sb
+        .fs
+        .create(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("masked.txt"),
+            0o777,
+            false,
+            libc::O_RDWR as u32,
+            0o022,
+            Extensions::default(),
+        )
+        .unwrap();
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & 0o777, 0o755);
 }
@@ -57,7 +61,10 @@ fn test_create_duplicate() {
 fn test_mkdir() {
     let sb = MemFsTestSandbox::new();
     // Get root nlink before.
-    let (st_before, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
+    let (st_before, _) = sb
+        .fs
+        .getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
     let nlink_before = st_before.st_nlink;
 
     let entry = sb.fuse_mkdir_root("mydir").unwrap();
@@ -69,7 +76,10 @@ fn test_mkdir() {
     assert_eq!(entry.attr.st_nlink, 2);
 
     // Parent nlink should have been incremented.
-    let (st_after, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None).unwrap();
+    let (st_after, _) = sb
+        .fs
+        .getattr(MemFsTestSandbox::ctx(), ROOT_INODE, None)
+        .unwrap();
     assert_eq!(st_after.st_nlink, nlink_before + 1);
 }
 
@@ -87,15 +97,18 @@ fn test_mkdir_nested() {
 #[test]
 fn test_mknod_fifo() {
     let sb = MemFsTestSandbox::new();
-    let entry = sb.fs.mknod(
-        MemFsTestSandbox::ctx(),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("myfifo"),
-        libc::S_IFIFO as u32 | 0o644,
-        0,
-        0,
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("myfifo"),
+            libc::S_IFIFO as u32 | 0o644,
+            0,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFIFO as u32);
 }
@@ -103,15 +116,18 @@ fn test_mknod_fifo() {
 #[test]
 fn test_mknod_socket() {
     let sb = MemFsTestSandbox::new();
-    let entry = sb.fs.mknod(
-        MemFsTestSandbox::ctx(),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("mysock"),
-        libc::S_IFSOCK as u32 | 0o644,
-        0,
-        0,
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("mysock"),
+            libc::S_IFSOCK as u32 | 0o644,
+            0,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFSOCK as u32);
 }
@@ -119,15 +135,18 @@ fn test_mknod_socket() {
 #[test]
 fn test_mknod_block_device() {
     let sb = MemFsTestSandbox::new();
-    let entry = sb.fs.mknod(
-        MemFsTestSandbox::ctx(),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("blkdev"),
-        libc::S_IFBLK as u32 | 0o660,
-        42,
-        0,
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("blkdev"),
+            libc::S_IFBLK as u32 | 0o660,
+            42,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFBLK as u32);
     #[cfg(target_os = "linux")]
@@ -139,15 +158,18 @@ fn test_mknod_block_device() {
 #[test]
 fn test_mknod_char_device() {
     let sb = MemFsTestSandbox::new();
-    let entry = sb.fs.mknod(
-        MemFsTestSandbox::ctx(),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("chrdev"),
-        libc::S_IFCHR as u32 | 0o660,
-        99,
-        0,
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("chrdev"),
+            libc::S_IFCHR as u32 | 0o660,
+            99,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFCHR as u32);
     #[cfg(target_os = "linux")]
@@ -159,16 +181,22 @@ fn test_mknod_char_device() {
 #[test]
 fn test_symlink() {
     let sb = MemFsTestSandbox::new();
-    let entry = sb.fs.symlink(
-        MemFsTestSandbox::ctx(),
-        &MemFsTestSandbox::cstr("/target/path"),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("mylink"),
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .symlink(
+            MemFsTestSandbox::ctx(),
+            &MemFsTestSandbox::cstr("/target/path"),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("mylink"),
+            Extensions::default(),
+        )
+        .unwrap();
     let mode = entry.attr.st_mode as u32;
     assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFLNK as u32);
-    let target = sb.fs.readlink(MemFsTestSandbox::ctx(), entry.inode).unwrap();
+    let target = sb
+        .fs
+        .readlink(MemFsTestSandbox::ctx(), entry.inode)
+        .unwrap();
     assert_eq!(&target[..], b"/target/path");
 }
 
@@ -176,13 +204,16 @@ fn test_symlink() {
 fn test_symlink_size() {
     let sb = MemFsTestSandbox::new();
     let target = "/some/long/target/path";
-    let entry = sb.fs.symlink(
-        MemFsTestSandbox::ctx(),
-        &MemFsTestSandbox::cstr(target),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("sizelink"),
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .symlink(
+            MemFsTestSandbox::ctx(),
+            &MemFsTestSandbox::cstr(target),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("sizelink"),
+            Extensions::default(),
+        )
+        .unwrap();
     assert_eq!(entry.attr.st_size, target.len() as i64);
 }
 
@@ -192,19 +223,33 @@ fn test_link() {
     let (entry, handle) = sb.fuse_create_root("original.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
-    let link_entry = sb.fs.link(
-        MemFsTestSandbox::ctx(),
-        entry.inode,
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("hardlink.txt"),
-    ).unwrap();
+    let link_entry = sb
+        .fs
+        .link(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("hardlink.txt"),
+        )
+        .unwrap();
     // Same inode.
     assert_eq!(link_entry.inode, entry.inode);
     // nlink should be 2 now.
-    let (st, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), entry.inode, None).unwrap();
+    let (st, _) = sb
+        .fs
+        .getattr(MemFsTestSandbox::ctx(), entry.inode, None)
+        .unwrap();
     #[cfg(target_os = "linux")]
     assert_eq!(st.st_nlink, 2);
     #[cfg(target_os = "macos")]
@@ -231,18 +276,30 @@ fn test_link_shared_content() {
     // Create a file and write through it.
     let (entry, handle) = sb.fuse_create_root("original.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"shared data", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"shared data", 0)
+        .unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Create a hardlink to the same inode.
-    let link_entry = sb.fs.link(
-        MemFsTestSandbox::ctx(),
-        entry.inode,
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("hardlink.txt"),
-    ).unwrap();
+    let link_entry = sb
+        .fs
+        .link(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("hardlink.txt"),
+        )
+        .unwrap();
     assert_eq!(link_entry.inode, entry.inode);
 
     // Open the hardlink and read — should see the same content.
@@ -252,9 +309,18 @@ fn test_link_shared_content() {
     assert_eq!(&data[..], b"shared data");
 
     // Write new content through the hardlink.
-    sb.fuse_write(link_entry.inode, handle2, b"updated", 0).unwrap();
+    sb.fuse_write(link_entry.inode, handle2, b"updated", 0)
+        .unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), link_entry.inode, 0, handle2, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            link_entry.inode,
+            0,
+            handle2,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Open the original name and verify the update is visible.

--- a/crates/filesystem/lib/backends/memfs/tests/test_dir_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_dir_ops.rs
@@ -30,17 +30,22 @@ fn test_readdir_types() {
     let sb = MemFsTestSandbox::new();
     sb.fuse_create_root("reg.txt").unwrap();
     sb.fuse_mkdir_root("dir").unwrap();
-    sb.fs.symlink(
-        MemFsTestSandbox::ctx(),
-        &MemFsTestSandbox::cstr("/target"),
-        ROOT_INODE,
-        &MemFsTestSandbox::cstr("link"),
-        Extensions::default(),
-    ).unwrap();
+    sb.fs
+        .symlink(
+            MemFsTestSandbox::ctx(),
+            &MemFsTestSandbox::cstr("/target"),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("link"),
+            Extensions::default(),
+        )
+        .unwrap();
 
     let (handle, _) = sb.fuse_opendir(ROOT_INODE).unwrap();
     let handle = handle.unwrap();
-    let entries = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let entries = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
 
     for e in &entries {
         let name = String::from_utf8_lossy(e.name).to_string();
@@ -53,32 +58,65 @@ fn test_readdir_types() {
             _ => {}
         }
     }
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 }
 
 #[test]
 fn test_readdir_special_types() {
     let sb = MemFsTestSandbox::new();
-    sb.fs.mknod(
-        MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("fifo"),
-        libc::S_IFIFO as u32 | 0o644, 0, 0, Extensions::default(),
-    ).unwrap();
-    sb.fs.mknod(
-        MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("sock"),
-        libc::S_IFSOCK as u32 | 0o644, 0, 0, Extensions::default(),
-    ).unwrap();
-    sb.fs.mknod(
-        MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("blk"),
-        libc::S_IFBLK as u32 | 0o660, 42, 0, Extensions::default(),
-    ).unwrap();
-    sb.fs.mknod(
-        MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("chr"),
-        libc::S_IFCHR as u32 | 0o660, 99, 0, Extensions::default(),
-    ).unwrap();
+    sb.fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("fifo"),
+            libc::S_IFIFO as u32 | 0o644,
+            0,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
+    sb.fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("sock"),
+            libc::S_IFSOCK as u32 | 0o644,
+            0,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
+    sb.fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("blk"),
+            libc::S_IFBLK as u32 | 0o660,
+            42,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
+    sb.fs
+        .mknod(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("chr"),
+            libc::S_IFCHR as u32 | 0o660,
+            99,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
 
     let (handle, _) = sb.fuse_opendir(ROOT_INODE).unwrap();
     let handle = handle.unwrap();
-    let entries = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let entries = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
 
     for e in &entries {
         let name = String::from_utf8_lossy(e.name).to_string();
@@ -90,7 +128,9 @@ fn test_readdir_special_types() {
             _ => {}
         }
     }
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 }
 
 #[test]
@@ -104,14 +144,22 @@ fn test_readdir_offset() {
     let handle = handle.unwrap();
 
     // Get all entries.
-    let all = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let all = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
     assert!(all.len() >= 3);
 
     // Read from offset 2 (skip first 2 entries).
-    let from_offset = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 2).unwrap();
+    let from_offset = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 2)
+        .unwrap();
     assert!(from_offset.len() < all.len());
 
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 }
 
 #[test]
@@ -138,16 +186,24 @@ fn test_readdir_snapshot_immutable() {
     // Open dir handle and trigger snapshot.
     let (handle, _) = sb.fuse_opendir(ROOT_INODE).unwrap();
     let handle = handle.unwrap();
-    let entries_before = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let entries_before = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
 
     // Now create another file.
     sb.fuse_create_root("after.txt").unwrap();
 
     // Readdir with same handle should return same snapshot (no "after.txt").
-    let entries_after = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let entries_after = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
     assert_eq!(entries_before.len(), entries_after.len());
 
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 }
 
 #[test]
@@ -157,10 +213,16 @@ fn test_readdirplus_basic() {
 
     let (handle, _) = sb.fuse_opendir(ROOT_INODE).unwrap();
     let handle = handle.unwrap();
-    let entries = sb.fs.readdirplus(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let entries = sb
+        .fs
+        .readdirplus(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
 
     // Should have at least the created file and init.krun (. and .. are skipped in readdirplus).
-    let names: Vec<String> = entries.iter().map(|(de, _)| String::from_utf8_lossy(de.name).to_string()).collect();
+    let names: Vec<String> = entries
+        .iter()
+        .map(|(de, _)| String::from_utf8_lossy(de.name).to_string())
+        .collect();
     assert!(names.contains(&"plus.txt".to_string()));
     assert!(names.contains(&"init.krun".to_string()));
 
@@ -168,11 +230,16 @@ fn test_readdirplus_basic() {
     for (de, entry) in &entries {
         let name = String::from_utf8_lossy(de.name).to_string();
         if name == "plus.txt" {
-            assert_eq!(entry.attr.st_mode as u32 & libc::S_IFMT as u32, libc::S_IFREG as u32);
+            assert_eq!(
+                entry.attr.st_mode as u32 & libc::S_IFMT as u32,
+                libc::S_IFREG as u32
+            );
         }
     }
 
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 }
 
 #[test]
@@ -180,7 +247,10 @@ fn test_readdirplus_init_krun() {
     let sb = MemFsTestSandbox::new();
     let (handle, _) = sb.fuse_opendir(ROOT_INODE).unwrap();
     let handle = handle.unwrap();
-    let entries = sb.fs.readdirplus(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0).unwrap();
+    let entries = sb
+        .fs
+        .readdirplus(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
 
     let init_entry = entries.iter().find(|(de, _)| de.name == b"init.krun");
     assert!(init_entry.is_some(), "init.krun should be in readdirplus");
@@ -188,7 +258,9 @@ fn test_readdirplus_init_krun() {
     assert_eq!(entry.inode, INIT_INODE);
     assert_eq!(entry.attr.st_mode as u32 & 0o777, 0o755);
 
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 }
 
 #[test]
@@ -196,10 +268,14 @@ fn test_releasedir() {
     let sb = MemFsTestSandbox::new();
     let (handle, _) = sb.fuse_opendir(ROOT_INODE).unwrap();
     let handle = handle.unwrap();
-    sb.fs.releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle).unwrap();
+    sb.fs
+        .releasedir(MemFsTestSandbox::ctx(), ROOT_INODE, 0, handle)
+        .unwrap();
 
     // After release, readdir with same handle should fail.
-    let result = sb.fs.readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0);
+    let result = sb
+        .fs
+        .readdir(MemFsTestSandbox::ctx(), ROOT_INODE, handle, 65536, 0);
     MemFsTestSandbox::assert_errno(result, LINUX_EBADF);
 }
 

--- a/crates/filesystem/lib/backends/memfs/tests/test_file_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_file_ops.rs
@@ -1,11 +1,16 @@
 use super::*;
 
+const LINUX_O_APPEND: u32 = 0x400;
+const LINUX_O_TRUNC: u32 = 0x200;
+const LINUX_O_WRONLY: u32 = 1;
+
 #[test]
 fn test_read_basic() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("read_basic.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"hello world", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"hello world", 0)
+        .unwrap();
     let data = sb.fuse_read(entry.inode, handle, 1024, 0).unwrap();
     assert_eq!(&data[..], b"hello world");
 }
@@ -15,7 +20,8 @@ fn test_read_partial() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("partial.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"hello world", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"hello world", 0)
+        .unwrap();
     let data = sb.fuse_read(entry.inode, handle, 5, 6).unwrap();
     assert_eq!(&data[..], b"world");
 }
@@ -76,6 +82,37 @@ fn test_write_multiple() {
 }
 
 #[test]
+fn test_write_append_ignores_offset() {
+    let sb = MemFsTestSandbox::new();
+    let (entry, handle) = sb.fuse_create_root("append.txt").unwrap();
+    let handle = handle.unwrap();
+    sb.fuse_write(entry.inode, handle, b"hello", 0).unwrap();
+    sb.fs
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+
+    let (append_handle, _) = sb
+        .fuse_open(entry.inode, LINUX_O_WRONLY | LINUX_O_APPEND)
+        .unwrap();
+    let append_handle = append_handle.unwrap();
+    sb.fuse_write(entry.inode, append_handle, b" world", 0)
+        .unwrap();
+
+    let (read_handle, _) = sb.fuse_open(entry.inode, 0).unwrap();
+    let read_handle = read_handle.unwrap();
+    let data = sb.fuse_read(entry.inode, read_handle, 1024, 0).unwrap();
+    assert_eq!(&data[..], b"hello world");
+}
+
+#[test]
 fn test_write_large() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("large.bin").unwrap();
@@ -83,7 +120,9 @@ fn test_write_large() {
     let big_data: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
     let n = sb.fuse_write(entry.inode, handle, &big_data, 0).unwrap();
     assert_eq!(n, big_data.len());
-    let read_back = sb.fuse_read(entry.inode, handle, big_data.len() as u32, 0).unwrap();
+    let read_back = sb
+        .fuse_read(entry.inode, handle, big_data.len() as u32, 0)
+        .unwrap();
     assert_eq!(read_back.len(), big_data.len());
     assert_eq!(&read_back[..], &big_data[..]);
 }
@@ -121,13 +160,22 @@ fn test_open_truncate() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("truncate.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"initial content", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"initial content", 0)
+        .unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
-    // Open with O_TRUNC (use libc constant for platform portability).
-    let (new_handle, _) = sb.fuse_open(entry.inode, libc::O_TRUNC as u32).unwrap();
+    // Open with the guest Linux O_TRUNC flag.
+    let (new_handle, _) = sb.fuse_open(entry.inode, LINUX_O_TRUNC).unwrap();
     let new_handle = new_handle.unwrap();
     let data = sb.fuse_read(entry.inode, new_handle, 1024, 0).unwrap();
     assert_eq!(data.len(), 0);
@@ -148,7 +196,15 @@ fn test_release_handle() {
     let handle = handle.unwrap();
     sb.fuse_write(entry.inode, handle, b"data", 0).unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // After release, using the old handle should fail.
     let result = sb.fuse_read(entry.inode, handle, 1024, 0);

--- a/crates/filesystem/lib/backends/memfs/tests/test_lookup.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_lookup.rs
@@ -74,11 +74,23 @@ fn test_lookup_after_forget() {
     let (entry, handle) = sb.fuse_create_root("ephemeral.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     // Unlink file.
     sb.fs
-        .unlink(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("ephemeral.txt"))
+        .unlink(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("ephemeral.txt"),
+        )
         .unwrap();
     // Forget the lookup ref from create.
     sb.fs.forget(MemFsTestSandbox::ctx(), entry.inode, 1);

--- a/crates/filesystem/lib/backends/memfs/tests/test_metadata.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_metadata.rs
@@ -161,13 +161,7 @@ fn test_setattr_size_truncate() {
     let mut attr: stat64 = unsafe { std::mem::zeroed() };
     attr.st_size = 5;
     sb.fs
-        .setattr(
-            MemFsTestSandbox::ctx(),
-            ino,
-            attr,
-            None,
-            SetattrValid::SIZE,
-        )
+        .setattr(MemFsTestSandbox::ctx(), ino, attr, None, SetattrValid::SIZE)
         .unwrap();
 
     let (st, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), ino, None).unwrap();
@@ -190,13 +184,7 @@ fn test_setattr_size_extend() {
     let mut attr: stat64 = unsafe { std::mem::zeroed() };
     attr.st_size = 10;
     sb.fs
-        .setattr(
-            MemFsTestSandbox::ctx(),
-            ino,
-            attr,
-            None,
-            SetattrValid::SIZE,
-        )
+        .setattr(MemFsTestSandbox::ctx(), ino, attr, None, SetattrValid::SIZE)
         .unwrap();
 
     let (st, _) = sb.fs.getattr(MemFsTestSandbox::ctx(), ino, None).unwrap();
@@ -413,11 +401,9 @@ fn test_access_other() {
     assert!(result.is_ok());
 
     // The owner (uid=1000) should be denied — owner bits are 0.
-    let result = sb.fs.access(
-        MemFsTestSandbox::ctx(),
-        entry.inode,
-        libc::R_OK as u32,
-    );
+    let result = sb
+        .fs
+        .access(MemFsTestSandbox::ctx(), entry.inode, libc::R_OK as u32);
     MemFsTestSandbox::assert_errno(result, LINUX_EACCES);
 }
 
@@ -427,10 +413,14 @@ fn test_access_f_ok() {
     let (entry, _) = sb.fuse_create_root("exists.txt").unwrap();
 
     // F_OK on an existing inode should succeed.
-    let result = sb.fs.access(MemFsTestSandbox::ctx(), entry.inode, libc::F_OK as u32);
+    let result = sb
+        .fs
+        .access(MemFsTestSandbox::ctx(), entry.inode, libc::F_OK as u32);
     assert!(result.is_ok());
 
     // F_OK on a nonexistent inode should fail with EBADF (unknown inode).
-    let result = sb.fs.access(MemFsTestSandbox::ctx(), 999999, libc::F_OK as u32);
+    let result = sb
+        .fs
+        .access(MemFsTestSandbox::ctx(), 999999, libc::F_OK as u32);
     MemFsTestSandbox::assert_errno(result, LINUX_EBADF);
 }

--- a/crates/filesystem/lib/backends/memfs/tests/test_refcount.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_refcount.rs
@@ -6,7 +6,15 @@ fn test_forget_removes_path() {
     let (entry, handle) = sb.fuse_create_root("forget_me.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Unlink sets nlink=0.
@@ -32,7 +40,15 @@ fn test_forget_partial() {
     let (entry, handle) = sb.fuse_create_root("partial.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Three more lookups (create gives 1, so total refs = 4).
@@ -54,7 +70,15 @@ fn test_nlink_zero_lookup_refs_positive() {
     let (entry, handle) = sb.fuse_create_root("nlink_test.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Do an extra lookup to increase refs (create=1, lookup=1 => refs=2).
@@ -86,7 +110,8 @@ fn test_handle_pins_node() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("pinned.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"pinned data", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"pinned data", 0)
+        .unwrap();
 
     // Unlink and forget.
     sb.fs
@@ -189,7 +214,19 @@ fn test_batch_forget() {
     );
 
     // All should be evicted.
-    assert!(sb.fs.getattr(MemFsTestSandbox::ctx(), e1.inode, None).is_err());
-    assert!(sb.fs.getattr(MemFsTestSandbox::ctx(), e2.inode, None).is_err());
-    assert!(sb.fs.getattr(MemFsTestSandbox::ctx(), e3.inode, None).is_err());
+    assert!(
+        sb.fs
+            .getattr(MemFsTestSandbox::ctx(), e1.inode, None)
+            .is_err()
+    );
+    assert!(
+        sb.fs
+            .getattr(MemFsTestSandbox::ctx(), e2.inode, None)
+            .is_err()
+    );
+    assert!(
+        sb.fs
+            .getattr(MemFsTestSandbox::ctx(), e3.inode, None)
+            .is_err()
+    );
 }

--- a/crates/filesystem/lib/backends/memfs/tests/test_remove_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_remove_ops.rs
@@ -6,10 +6,22 @@ fn test_unlink_file() {
     let (entry, handle) = sb.fuse_create_root("doomed.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     sb.fs
-        .unlink(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("doomed.txt"))
+        .unlink(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("doomed.txt"),
+        )
         .unwrap();
     let result = sb.lookup_root("doomed.txt");
     MemFsTestSandbox::assert_errno(result, LINUX_ENOENT);
@@ -32,7 +44,15 @@ fn test_unlink_decrements_nlink() {
     let (entry, handle) = sb.fuse_create_root("linked.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 
     // Create a hard link.
@@ -57,7 +77,11 @@ fn test_unlink_decrements_nlink() {
 
     // Unlink one.
     sb.fs
-        .unlink(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("linked.txt"))
+        .unlink(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("linked.txt"),
+        )
         .unwrap();
 
     // nlink should be 1.
@@ -77,10 +101,22 @@ fn test_unlink_last_link() {
     let (entry, handle) = sb.fuse_create_root("last.txt").unwrap();
     let handle = handle.unwrap();
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
     sb.fs
-        .unlink(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("last.txt"))
+        .unlink(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("last.txt"),
+        )
         .unwrap();
     // Forget the lookup ref from create.
     sb.fs.forget(MemFsTestSandbox::ctx(), entry.inode, 1);
@@ -94,11 +130,16 @@ fn test_unlink_open_file() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("open_unlink.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"still here", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"still here", 0)
+        .unwrap();
 
     // Unlink while handle is still open.
     sb.fs
-        .unlink(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("open_unlink.txt"))
+        .unlink(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("open_unlink.txt"),
+        )
         .unwrap();
 
     // Handle should still work.
@@ -107,7 +148,15 @@ fn test_unlink_open_file() {
 
     // Clean up.
     sb.fs
-        .release(MemFsTestSandbox::ctx(), entry.inode, 0, handle, false, false, None)
+        .release(
+            MemFsTestSandbox::ctx(),
+            entry.inode,
+            0,
+            handle,
+            false,
+            false,
+            None,
+        )
         .unwrap();
 }
 
@@ -116,7 +165,11 @@ fn test_rmdir_empty() {
     let sb = MemFsTestSandbox::new();
     sb.fuse_mkdir_root("empty_dir").unwrap();
     sb.fs
-        .rmdir(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("empty_dir"))
+        .rmdir(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("empty_dir"),
+        )
         .unwrap();
     let result = sb.lookup_root("empty_dir");
     MemFsTestSandbox::assert_errno(result, LINUX_ENOENT);
@@ -165,7 +218,11 @@ fn test_rmdir_decrements_parent_nlink() {
     assert_eq!(st_mid.st_nlink, nlink_before + 1);
 
     sb.fs
-        .rmdir(MemFsTestSandbox::ctx(), ROOT_INODE, &MemFsTestSandbox::cstr("child_dir"))
+        .rmdir(
+            MemFsTestSandbox::ctx(),
+            ROOT_INODE,
+            &MemFsTestSandbox::cstr("child_dir"),
+        )
         .unwrap();
     let (st_after, _) = sb
         .fs

--- a/crates/filesystem/lib/backends/memfs/tests/test_rename.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_rename.rs
@@ -98,8 +98,11 @@ fn test_rename_nonempty_dir() {
 #[test]
 fn test_rename_replace_file() {
     let sb = MemFsTestSandbox::new();
-    let ino_a = sb.create_file_with_content(ROOT_INODE, "a.txt", b"data_a").unwrap();
-    sb.create_file_with_content(ROOT_INODE, "b.txt", b"data_b").unwrap();
+    let ino_a = sb
+        .create_file_with_content(ROOT_INODE, "a.txt", b"data_a")
+        .unwrap();
+    sb.create_file_with_content(ROOT_INODE, "b.txt", b"data_b")
+        .unwrap();
     sb.fs
         .rename(
             MemFsTestSandbox::ctx(),
@@ -142,7 +145,8 @@ fn test_rename_replace_nonempty_dir() {
     let sb = MemFsTestSandbox::new();
     sb.fuse_mkdir_root("src_dir").unwrap();
     let dst_dir = sb.fuse_mkdir_root("dst_dir").unwrap();
-    sb.fuse_create(dst_dir.inode, "occupant.txt", 0o644).unwrap();
+    sb.fuse_create(dst_dir.inode, "occupant.txt", 0o644)
+        .unwrap();
     let result = sb.fs.rename(
         MemFsTestSandbox::ctx(),
         ROOT_INODE,
@@ -173,8 +177,12 @@ fn test_rename_noreplace() {
 #[test]
 fn test_rename_exchange() {
     let sb = MemFsTestSandbox::new();
-    let ino_a = sb.create_file_with_content(ROOT_INODE, "swap_a.txt", b"data_a").unwrap();
-    let ino_b = sb.create_file_with_content(ROOT_INODE, "swap_b.txt", b"data_b").unwrap();
+    let ino_a = sb
+        .create_file_with_content(ROOT_INODE, "swap_a.txt", b"data_a")
+        .unwrap();
+    let ino_b = sb
+        .create_file_with_content(ROOT_INODE, "swap_b.txt", b"data_b")
+        .unwrap();
     sb.fs
         .rename(
             MemFsTestSandbox::ctx(),

--- a/crates/filesystem/lib/backends/memfs/tests/test_special_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/tests/test_special_ops.rs
@@ -47,7 +47,8 @@ fn test_fallocate_within_size() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("falloc_noop.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"hello world", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"hello world", 0)
+        .unwrap();
     // fallocate within existing size should be a no-op.
     sb.fs
         .fallocate(MemFsTestSandbox::ctx(), entry.inode, handle, 0, 0, 5)
@@ -64,7 +65,8 @@ fn test_lseek_data() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("lseek_data.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"some data here", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"some data here", 0)
+        .unwrap();
     // SEEK_DATA from offset 0 should return 0 (data starts at beginning).
     let pos = sb
         .fs
@@ -78,7 +80,8 @@ fn test_lseek_hole() {
     let sb = MemFsTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("lseek_hole.txt").unwrap();
     let handle = handle.unwrap();
-    sb.fuse_write(entry.inode, handle, b"file content", 0).unwrap();
+    sb.fuse_write(entry.inode, handle, b"file content", 0)
+        .unwrap();
     // SEEK_HOLE from offset 0 should return file size.
     let pos = sb
         .fs
@@ -90,10 +93,7 @@ fn test_lseek_hole() {
 #[test]
 fn test_statfs() {
     let sb = MemFsTestSandbox::new();
-    let st = sb
-        .fs
-        .statfs(MemFsTestSandbox::ctx(), ROOT_INODE)
-        .unwrap();
+    let st = sb.fs.statfs(MemFsTestSandbox::ctx(), ROOT_INODE).unwrap();
     assert!(st.f_bsize > 0);
     assert!(st.f_namemax > 0);
 }
@@ -101,11 +101,9 @@ fn test_statfs() {
 #[test]
 fn test_statfs_capacity() {
     let sb = MemFsTestSandbox::with_capacity(1024 * 1024); // 1MB
-    sb.create_file_with_content(ROOT_INODE, "some.txt", &[0u8; 4096]).unwrap();
-    let st = sb
-        .fs
-        .statfs(MemFsTestSandbox::ctx(), ROOT_INODE)
+    sb.create_file_with_content(ROOT_INODE, "some.txt", &[0u8; 4096])
         .unwrap();
+    let st = sb.fs.statfs(MemFsTestSandbox::ctx(), ROOT_INODE).unwrap();
     // Free blocks should be less than total blocks.
     assert!(st.f_bfree < st.f_blocks);
 }

--- a/crates/filesystem/lib/backends/memfs/types.rs
+++ b/crates/filesystem/lib/backends/memfs/types.rs
@@ -1,9 +1,10 @@
 //! Type definitions for the in-memory filesystem backend.
 
-use std::collections::BTreeMap;
-use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex, RwLock, atomic::AtomicU64},
+    time::Duration,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -128,21 +129,15 @@ pub(crate) enum InodeContent {
 
 /// Open file handle.
 pub(crate) struct FileHandle {
-    /// Inode this handle refers to.
-    pub inode: u64,
-
     /// Reference to the node (keeps it alive after unlink).
     pub node: Arc<MemNode>,
 
-    /// Open flags.
+    /// Open flags. MemFs uses these to honor handle-bound semantics like append mode.
     pub flags: u32,
 }
 
 /// Open directory handle.
 pub(crate) struct DirHandle {
-    /// Inode this handle refers to.
-    pub inode: u64,
-
     /// Reference to the node (keeps it alive after rmdir).
     pub node: Arc<MemNode>,
 

--- a/crates/filesystem/lib/backends/memfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/xattr_ops.rs
@@ -3,14 +3,13 @@
 //! Xattrs are stored entirely in memory as raw byte key-value pairs.
 //! No internal xattrs are used — MemFs stores metadata directly.
 
-use std::ffi::CStr;
-use std::io;
+use std::{ffi::CStr, io};
 
-use super::MemFs;
-use super::inode;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, GetxattrReply, ListxattrReply};
+use super::{MemFs, inode};
+use crate::{
+    Context, GetxattrReply, ListxattrReply,
+    backends::shared::{init_binary, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -118,12 +117,7 @@ pub(crate) fn do_listxattr(
 }
 
 /// Remove an extended attribute.
-pub(crate) fn do_removexattr(
-    fs: &MemFs,
-    _ctx: Context,
-    ino: u64,
-    name: &CStr,
-) -> io::Result<()> {
+pub(crate) fn do_removexattr(fs: &MemFs, _ctx: Context, ino: u64, name: &CStr) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
         return Err(platform::eacces());
     }

--- a/crates/filesystem/lib/backends/overlayfs/builder.rs
+++ b/crates/filesystem/lib/backends/overlayfs/builder.rs
@@ -9,19 +9,25 @@
 //!     .build()?
 //! ```
 
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io;
-use std::os::fd::FromRawFd;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::RwLock;
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io,
+    os::fd::FromRawFd,
+    path::PathBuf,
+    sync::{
+        RwLock,
+        atomic::{AtomicBool, AtomicU64},
+    },
+    time::Duration,
+};
 
-use super::OverlayFs;
-use microsandbox_utils::index::MmapIndex;
-use super::types::{CachePolicy, Layer, NameTable, OverlayConfig};
+use super::{
+    OverlayFs,
+    types::{CachePolicy, Layer, NameTable, OverlayConfig},
+};
 use crate::backends::shared::{init_binary, platform, stat_override};
+use microsandbox_utils::index::MmapIndex;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -274,12 +280,8 @@ impl OverlayFsBuilder {
 
 /// Open a directory path as an fd.
 fn open_dir(path: &std::path::Path) -> io::Result<File> {
-    let cpath = std::ffi::CString::new(
-        path.to_str()
-            .ok_or_else(platform::einval)?
-            .as_bytes(),
-    )
-    .map_err(|_| platform::einval())?;
+    let cpath = std::ffi::CString::new(path.to_str().ok_or_else(platform::einval)?.as_bytes())
+        .map_err(|_| platform::einval())?;
 
     let fd = unsafe {
         libc::open(

--- a/crates/filesystem/lib/backends/overlayfs/copy_up.rs
+++ b/crates/filesystem/lib/backends/overlayfs/copy_up.rs
@@ -12,23 +12,24 @@
 //! `primary_parent`/`primary_name`, and each ancestor is ensured upper
 //! before proceeding to the next.
 
-use std::ffi::CStr;
 #[cfg(target_os = "linux")]
 use std::fs::File;
-use std::io;
-use std::os::fd::{AsRawFd, RawFd};
 #[cfg(target_os = "linux")]
 use std::os::fd::FromRawFd;
-use std::sync::atomic::Ordering;
+use std::{
+    ffi::CStr,
+    io,
+    os::fd::{AsRawFd, RawFd},
+    sync::atomic::Ordering,
+};
 
-use super::OverlayFs;
-use super::inode;
-use super::origin;
-use super::types::{NodeState, OverlayNode, ROOT_INODE};
-use crate::backends::shared::inode_table::InodeAltKey;
-use crate::backends::shared::platform;
+use super::{
+    OverlayFs, inode, origin,
+    types::{NodeState, OverlayNode, ROOT_INODE},
+};
 #[cfg(target_os = "linux")]
 use crate::backends::shared::stat_override;
+use crate::backends::shared::{inode_table::InodeAltKey, platform};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -171,13 +172,13 @@ fn copy_up_regular(
             idx.get(origin_id).copied()
         };
 
-        if let Some(existing_ino) = existing_upper_ino {
-            if existing_ino != node.inode {
-                // Another alias was already copied up — create hardlink.
-                if try_link_to_existing(fs, existing_ino, upper_parent_fd, name)? {
-                    transition_to_upper(fs, node, upper_parent_fd, name)?;
-                    return Ok(());
-                }
+        if let Some(existing_ino) = existing_upper_ino
+            && existing_ino != node.inode
+        {
+            // Another alias was already copied up — create hardlink.
+            if try_link_to_existing(fs, existing_ino, upper_parent_fd, name)? {
+                transition_to_upper(fs, node, upper_parent_fd, name)?;
+                return Ok(());
             }
         }
     }
@@ -340,9 +341,8 @@ fn copy_up_symlink(
                 libc::close(fd);
             });
 
-            let written = unsafe {
-                libc::write(temp_fd, buf.as_ptr() as *const libc::c_void, buf.len())
-            };
+            let written =
+                unsafe { libc::write(temp_fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
             if written < 0 || (written as usize) != buf.len() {
                 unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
                 return Err(platform::eio());
@@ -350,9 +350,7 @@ fn copy_up_symlink(
 
             // Create stat override (real symlinks don't have overlay xattrs).
             let mode = libc::S_IFLNK as u32 | (st.st_mode as u32 & 0o7777);
-            if let Err(e) =
-                stat_override::set_override(temp_fd, st.st_uid, st.st_gid, mode, 0)
-            {
+            if let Err(e) = stat_override::set_override(temp_fd, st.st_uid, st.st_gid, mode, 0) {
                 unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
                 return Err(e);
             }
@@ -411,8 +409,13 @@ fn copy_up_symlink(
 
         // Stage: create symlink in staging_dir, not directly in upper.
         let temp_name = create_temp_symlink_name(fs);
-        let ret =
-            unsafe { libc::symlinkat(target.as_ptr(), fs.staging_fd.as_raw_fd(), temp_name.as_ptr()) };
+        let ret = unsafe {
+            libc::symlinkat(
+                target.as_ptr(),
+                fs.staging_fd.as_raw_fd(),
+                temp_name.as_ptr(),
+            )
+        };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
@@ -590,10 +593,7 @@ fn stage_and_install(
 /// Build the ancestor chain from an inode to root, returned in root-to-leaf order.
 ///
 /// Each element is (ancestor_inode, name_bytes). The chain excludes the root itself.
-fn build_ancestor_chain(
-    fs: &OverlayFs,
-    node: &OverlayNode,
-) -> io::Result<Vec<(u64, Vec<u8>)>> {
+fn build_ancestor_chain(fs: &OverlayFs, node: &OverlayNode) -> io::Result<Vec<(u64, Vec<u8>)>> {
     let mut chain = Vec::new();
     let mut current_ino = node.primary_parent.load(Ordering::Acquire);
 
@@ -852,14 +852,7 @@ fn copy_file_data(src_fd: RawFd, dst_fd: RawFd, size: u64) -> io::Result<()> {
         while remaining > 0 {
             let to_copy = std::cmp::min(remaining, COPY_BUF_SIZE as u64) as usize;
             let ret = unsafe {
-                libc::copy_file_range(
-                    src_fd,
-                    &mut off_in,
-                    dst_fd,
-                    &mut off_out,
-                    to_copy,
-                    0,
-                )
+                libc::copy_file_range(src_fd, &mut off_in, dst_fd, &mut off_out, to_copy, 0)
             };
             if ret < 0 {
                 let err = io::Error::last_os_error();
@@ -1072,9 +1065,8 @@ fn list_xattrs(fd: RawFd) -> io::Result<Option<Vec<u8>>> {
         };
 
         #[cfg(target_os = "macos")]
-        let ret = unsafe {
-            libc::flistxattr(fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len(), 0)
-        };
+        let ret =
+            unsafe { libc::flistxattr(fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len(), 0) };
 
         if ret < 0 {
             let err = io::Error::last_os_error();

--- a/crates/filesystem/lib/backends/overlayfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/create_ops.rs
@@ -15,22 +15,18 @@
 //! On Linux, symlinks are file-backed (regular file with S_IFLNK in xattr).
 //! On macOS, real symlinks are used with xattr via O_SYMLINK.
 
-use std::ffi::CStr;
-use std::io;
-use std::os::fd::FromRawFd;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::{
+    ffi::CStr,
+    io,
+    os::fd::FromRawFd,
+    sync::{Arc, RwLock, atomic::Ordering},
+};
 
-use super::OverlayFs;
-use super::copy_up;
-use super::inode;
-use super::types::FileHandle;
-use super::whiteout;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::name_validation;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, Entry, Extensions, OpenOptions};
+use super::{OverlayFs, copy_up, inode, types::FileHandle, whiteout};
+use crate::{
+    Context, Entry, Extensions, OpenOptions,
+    backends::shared::{init_binary, name_validation, platform, stat_override},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -98,15 +94,18 @@ pub(crate) fn do_create(
 
     // Reopen for the handle — strip O_CREAT since the file already exists.
     let open_fd = inode::open_node_fd(fs, entry.inode, open_flags & !libc::O_CREAT)?;
-    let fd_guard = scopeguard::guard(open_fd, |fd| unsafe { libc::close(fd); });
+    let fd_guard = scopeguard::guard(open_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // kill_priv handling.
-    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
-        if let Ok(Some(ovr)) = stat_override::get_override(*fd_guard) {
-            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
-            if new_mode != ovr.mode {
-                stat_override::set_override(*fd_guard, ovr.uid, ovr.gid, new_mode, ovr.rdev)?;
-            }
+    if kill_priv
+        && (open_flags & libc::O_TRUNC != 0)
+        && let Ok(Some(ovr)) = stat_override::get_override(*fd_guard)
+    {
+        let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+        if new_mode != ovr.mode {
+            stat_override::set_override(*fd_guard, ovr.uid, ovr.gid, new_mode, ovr.rdev)?;
         }
     }
 
@@ -388,7 +387,10 @@ pub(crate) fn do_link(
 
     #[cfg(target_os = "macos")]
     {
-        if let super::types::NodeState::Upper { ino: node_ino, dev, .. } = &*state {
+        if let super::types::NodeState::Upper {
+            ino: node_ino, dev, ..
+        } = &*state
+        {
             let src_path = format!("/.vol/{dev}/{node_ino}\0");
             let ret = unsafe {
                 libc::linkat(

--- a/crates/filesystem/lib/backends/overlayfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/dir_ops.rs
@@ -12,18 +12,20 @@
 //! Same bounded-leak pattern as passthrough: names for `DirEntry<'static>` are
 //! collected into a single contiguous buffer, leaked once per readdir call.
 
-use std::collections::HashSet;
-use std::io;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashSet,
+    io,
+    sync::{Arc, Mutex, atomic::Ordering},
+};
 
-use super::OverlayFs;
-use super::inode;
-use super::layer;
-use super::types::{DirHandle, DirSnapshot, MergedDirEntry, ROOT_INODE};
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, DirEntry, Entry, OpenOptions};
+use super::{
+    OverlayFs, inode, layer,
+    types::{DirHandle, DirSnapshot, MergedDirEntry, ROOT_INODE},
+};
+use crate::{
+    Context, DirEntry, Entry, OpenOptions,
+    backends::shared::{init_binary, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -263,11 +265,10 @@ fn build_snapshot(fs: &OverlayFs, ino: u64) -> io::Result<DirSnapshot> {
         for lower in fs.lowers.iter().rev() {
             // Index fast path: iterate index entries directly (no getdents64).
             if let Some(ref idx) = lower.lower_index {
-                let dir_rec =
-                    match inode::find_dir_record_for_parent(fs, idx, lower.index, &node) {
-                        Some(rec) => rec,
-                        None => continue,
-                    };
+                let dir_rec = match inode::find_dir_record_for_parent(fs, idx, lower.index, &node) {
+                    Some(rec) => rec,
+                    None => continue,
+                };
 
                 // Add tombstone names from index.
                 for name in idx.tombstone_names(dir_rec) {
@@ -276,9 +277,7 @@ fn build_snapshot(fs: &OverlayFs, ino: u64) -> io::Result<DirSnapshot> {
 
                 let layer_opaque = idx.is_opaque(dir_rec);
                 for entry_rec in idx.dir_entries(dir_rec) {
-                    let name = idx
-                        .get_str(entry_rec.name_off, entry_rec.name_len)
-                        .to_vec();
+                    let name = idx.get_str(entry_rec.name_off, entry_rec.name_len).to_vec();
 
                     if entry_rec.flags & microsandbox_utils::index::ENTRY_FLAG_WHITEOUT != 0 {
                         seen.insert(name);
@@ -310,7 +309,9 @@ fn build_snapshot(fs: &OverlayFs, ino: u64) -> io::Result<DirSnapshot> {
                 Some(fd) => fd,
                 None => continue,
             };
-            let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe { libc::close(fd); });
+            let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe {
+                libc::close(fd);
+            });
 
             let raw_entries = layer::read_dir_entries_raw(lower_fd)?;
 
@@ -418,11 +419,10 @@ pub(crate) fn is_merged_dir_empty(fs: &OverlayFs, ino: u64) -> io::Result<bool> 
         for lower in fs.lowers.iter().rev() {
             // Index fast path.
             if let Some(ref idx) = lower.lower_index {
-                let dir_rec =
-                    match inode::find_dir_record_for_parent(fs, idx, lower.index, &node) {
-                        Some(rec) => rec,
-                        None => continue,
-                    };
+                let dir_rec = match inode::find_dir_record_for_parent(fs, idx, lower.index, &node) {
+                    Some(rec) => rec,
+                    None => continue,
+                };
 
                 for name in idx.tombstone_names(dir_rec) {
                     seen.insert(name.to_vec());
@@ -430,9 +430,7 @@ pub(crate) fn is_merged_dir_empty(fs: &OverlayFs, ino: u64) -> io::Result<bool> 
 
                 let layer_opaque = idx.is_opaque(dir_rec);
                 for entry_rec in idx.dir_entries(dir_rec) {
-                    let name = idx
-                        .get_str(entry_rec.name_off, entry_rec.name_len)
-                        .to_vec();
+                    let name = idx.get_str(entry_rec.name_off, entry_rec.name_len).to_vec();
 
                     if entry_rec.flags & microsandbox_utils::index::ENTRY_FLAG_WHITEOUT != 0 {
                         seen.insert(name);
@@ -458,7 +456,9 @@ pub(crate) fn is_merged_dir_empty(fs: &OverlayFs, ino: u64) -> io::Result<bool> 
                 Some(fd) => fd,
                 None => continue,
             };
-            let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe { libc::close(fd); });
+            let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe {
+                libc::close(fd);
+            });
 
             let raw_entries = layer::read_dir_entries_raw(lower_fd)?;
 

--- a/crates/filesystem/lib/backends/overlayfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/file_ops.rs
@@ -3,19 +3,20 @@
 //! Write-mode opens trigger copy-up of lower-layer files to the upper layer.
 //! Subsequent reads and writes operate on the upper copy.
 
-use std::io;
-use std::os::fd::{AsRawFd, FromRawFd};
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    sync::{Arc, RwLock, atomic::Ordering},
+};
 
-use super::OverlayFs;
-use super::copy_up;
-use super::inode;
-use super::types::{FileHandle, NodeState};
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+use super::{
+    OverlayFs, copy_up, inode,
+    types::{FileHandle, NodeState},
+};
+use crate::{
+    Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::{init_binary, platform, stat_override},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -57,15 +58,18 @@ pub(crate) fn do_open(
     }
 
     let fd = inode::open_node_fd(fs, ino, open_flags)?;
-    let fd_guard = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+    let fd_guard = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // kill_priv: clear SUID/SGID on open+truncate.
-    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
-        if let Ok(Some(ovr)) = stat_override::get_override(*fd_guard) {
-            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
-            if new_mode != ovr.mode {
-                stat_override::set_override(*fd_guard, ovr.uid, ovr.gid, new_mode, ovr.rdev)?;
-            }
+    if kill_priv
+        && (open_flags & libc::O_TRUNC != 0)
+        && let Ok(Some(ovr)) = stat_override::get_override(*fd_guard)
+    {
+        let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+        if new_mode != ovr.mode {
+            stat_override::set_override(*fd_guard, ovr.uid, ovr.gid, new_mode, ovr.rdev)?;
         }
     }
 
@@ -105,6 +109,7 @@ pub(crate) fn do_read(
 ///
 /// The file must already be on the upper layer (do_open triggers copy-up for
 /// write opens). kill_priv clears SUID/SGID on first write.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn do_write(
     fs: &OverlayFs,
     _ctx: Context,
@@ -125,12 +130,10 @@ pub(crate) fn do_write(
     let f = data.file.read().unwrap();
 
     // kill_priv: clear SUID/SGID before first write.
-    if kill_priv {
-        if let Ok(Some(ovr)) = stat_override::get_override(f.as_raw_fd()) {
-            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
-            if new_mode != ovr.mode {
-                stat_override::set_override(f.as_raw_fd(), ovr.uid, ovr.gid, new_mode, ovr.rdev)?;
-            }
+    if kill_priv && let Ok(Some(ovr)) = stat_override::get_override(f.as_raw_fd()) {
+        let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+        if new_mode != ovr.mode {
+            stat_override::set_override(f.as_raw_fd(), ovr.uid, ovr.gid, new_mode, ovr.rdev)?;
         }
     }
 
@@ -166,7 +169,9 @@ pub(crate) fn do_readlink(fs: &OverlayFs, _ctx: Context, ino: u64) -> io::Result
             }
             (dup, platform::fstat(fd)?)
         };
-        let _close_dup = scopeguard::guard(dup_fd, |fd| unsafe { libc::close(fd); });
+        let _close_dup = scopeguard::guard(dup_fd, |fd| unsafe {
+            libc::close(fd);
+        });
 
         if st.st_mode & libc::S_IFMT == libc::S_IFLNK {
             // Real symlink — read target via /proc/self/fd/<dup'd O_PATH>.
@@ -234,7 +239,9 @@ pub(crate) fn do_readlink(fs: &OverlayFs, _ctx: Context, ino: u64) -> io::Result
         let (node_dev, node_ino) = {
             let state = node.state.read().unwrap();
             match &*state {
-                NodeState::Lower { ino, dev, .. } | NodeState::Upper { ino, dev, .. } => (*dev, *ino),
+                NodeState::Lower { ino, dev, .. } | NodeState::Upper { ino, dev, .. } => {
+                    (*dev, *ino)
+                }
                 _ => return Err(platform::einval()),
             }
         };
@@ -256,12 +263,7 @@ pub(crate) fn do_readlink(fs: &OverlayFs, _ctx: Context, ino: u64) -> io::Result
 }
 
 /// Flush pending data for a file handle.
-pub(crate) fn do_flush(
-    fs: &OverlayFs,
-    _ctx: Context,
-    ino: u64,
-    handle: u64,
-) -> io::Result<()> {
+pub(crate) fn do_flush(fs: &OverlayFs, _ctx: Context, ino: u64, handle: u64) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
         return Ok(());
     }
@@ -282,12 +284,7 @@ pub(crate) fn do_flush(
 }
 
 /// Release an open file handle.
-pub(crate) fn do_release(
-    fs: &OverlayFs,
-    _ctx: Context,
-    ino: u64,
-    handle: u64,
-) -> io::Result<()> {
+pub(crate) fn do_release(fs: &OverlayFs, _ctx: Context, ino: u64, handle: u64) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
         return Ok(());
     }

--- a/crates/filesystem/lib/backends/overlayfs/inode.rs
+++ b/crates/filesystem/lib/backends/overlayfs/inode.rs
@@ -12,23 +12,25 @@
 //! On Linux, nodes in Lower/Upper state hold an O_PATH fd pinning the inode.
 //! On macOS, nodes store (dev, ino) and open fds on demand via `/.vol/<dev>/<ino>`.
 
-use std::collections::HashSet;
-use std::ffi::{CStr, CString};
-use std::fs::File;
-use std::io;
-use std::os::fd::{AsRawFd, FromRawFd, RawFd};
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex, RwLock};
-
-use super::layer;
-use super::origin::LowerOriginId;
-use super::types::{
-    Dentry, Layer, NameId, NodeState, OverlayNode, ROOT_INODE,
+use std::{
+    collections::HashSet,
+    ffi::{CStr, CString},
+    fs::File,
+    io,
+    os::fd::{AsRawFd, FromRawFd, RawFd},
+    sync::{Arc, Mutex, RwLock, atomic::Ordering},
 };
-use super::OverlayFs;
-use crate::backends::shared::inode_table::InodeAltKey;
-use crate::backends::shared::{init_binary, platform, stat_override};
-use crate::{Entry, stat64};
+
+use super::{
+    OverlayFs, layer,
+    origin::LowerOriginId,
+    types::{Dentry, Layer, NameId, NodeState, OverlayNode, ROOT_INODE},
+};
+use crate::{
+    Entry,
+    backends::shared::{init_binary, inode_table::InodeAltKey, platform, stat_override},
+    stat64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -133,21 +135,20 @@ pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
 
     let root_name = fs.names.intern(b"");
     // Seed dir_record_cache for root: DirRecord 0 on the topmost indexed lower layer.
-    let root_dir_record_cache = fs
-        .lowers
-        .iter()
-        .rev()
-        .find_map(|l| {
-            l.lower_index.as_ref().and_then(|idx| {
-                idx.find_dir(b"").map(|(dir_idx, _)| (l.index, dir_idx as u32))
-            })
-        });
+    let root_dir_record_cache = fs.lowers.iter().rev().find_map(|l| {
+        l.lower_index.as_ref().and_then(|idx| {
+            idx.find_dir(b"")
+                .map(|(dir_idx, _)| (l.index, dir_idx as u32))
+        })
+    });
 
     let root_node = Arc::new(OverlayNode {
         inode: ROOT_INODE,
         kind: libc::S_IFDIR as u32,
         lookup_refs: std::sync::atomic::AtomicU64::new(2), // libfuse convention
-        state: RwLock::new(NodeState::Root { upper_fd: root_file }),
+        state: RwLock::new(NodeState::Root {
+            upper_fd: root_file,
+        }),
         opaque: std::sync::atomic::AtomicBool::new(false),
         copy_up_lock: Mutex::new(()),
         origin: None,
@@ -177,7 +178,11 @@ pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
             )
         };
         if ret >= 0 {
-            let alt_key = InodeAltKey::new(stx.stx_ino, stx.stx_dev_major as u64 * 256 + stx.stx_dev_minor as u64, stx.stx_mnt_id);
+            let alt_key = InodeAltKey::new(
+                stx.stx_ino,
+                stx.stx_dev_major as u64 * 256 + stx.stx_dev_minor as u64,
+                stx.stx_mnt_id,
+            );
             let mut upper_alt = fs.upper_alt_keys.write().unwrap();
             upper_alt.insert(alt_key, ROOT_INODE);
         }
@@ -212,9 +217,8 @@ pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
 ///
 /// Must complete before the first guest operation.
 fn bfs_hydrate_upper(fs: &OverlayFs) -> io::Result<()> {
+    use super::{origin, types::RedirectState};
     use std::collections::VecDeque;
-    use super::origin;
-    use super::types::RedirectState;
 
     let upper_fd = fs.upper.root_fd.as_raw_fd();
     let root_dir_fd = dup_fd_raw(upper_fd)?;
@@ -375,12 +379,7 @@ fn bfs_hydrate_upper(fs: &OverlayFs) -> io::Result<()> {
 ///
 /// Allocates a guest inode, creates an OverlayNode with Upper state, and
 /// registers it in nodes/dentries/upper_alt_keys. Returns the guest inode.
-fn hydrate_upper_entry(
-    fs: &OverlayFs,
-    parent_ino: u64,
-    name: &CStr,
-    fd: RawFd,
-) -> io::Result<u64> {
+fn hydrate_upper_entry(fs: &OverlayFs, parent_ino: u64, name: &CStr, fd: RawFd) -> io::Result<u64> {
     let name_id = fs.names.intern(name.to_bytes());
 
     // Check if already registered via upper_alt_keys.
@@ -417,12 +416,7 @@ fn hydrate_upper_entry(
                 }
                 drop(nodes);
                 let mut dentries = fs.dentries.write().unwrap();
-                dentries.insert(
-                    (parent_ino, name_id),
-                    Dentry {
-                        node: existing_ino,
-                    },
-                );
+                dentries.insert((parent_ino, name_id), Dentry { node: existing_ino });
                 return Ok(existing_ino);
             }
         }
@@ -471,12 +465,10 @@ fn hydrate_upper_entry(
         // Register.
         fs.nodes.write().unwrap().insert(inode, node);
         fs.upper_alt_keys.write().unwrap().insert(alt_key, inode);
-        fs.dentries.write().unwrap().insert(
-            (parent_ino, name_id),
-            Dentry {
-                node: inode,
-            },
-        );
+        fs.dentries
+            .write()
+            .unwrap()
+            .insert((parent_ino, name_id), Dentry { node: inode });
 
         return Ok(inode);
     }
@@ -496,12 +488,7 @@ fn hydrate_upper_entry(
                 }
                 drop(nodes);
                 let mut dentries = fs.dentries.write().unwrap();
-                dentries.insert(
-                    (parent_ino, name_id),
-                    Dentry {
-                        node: existing_ino,
-                    },
-                );
+                dentries.insert((parent_ino, name_id), Dentry { node: existing_ino });
                 return Ok(existing_ino);
             }
         }
@@ -528,12 +515,10 @@ fn hydrate_upper_entry(
 
         fs.nodes.write().unwrap().insert(inode, node);
         fs.upper_alt_keys.write().unwrap().insert(alt_key, inode);
-        fs.dentries.write().unwrap().insert(
-            (parent_ino, name_id),
-            Dentry {
-                node: inode,
-            },
-        );
+        fs.dentries
+            .write()
+            .unwrap()
+            .insert((parent_ino, name_id), Dentry { node: inode });
 
         Ok(inode)
     }
@@ -622,11 +607,11 @@ pub(crate) fn do_lookup(fs: &OverlayFs, parent: u64, name: &CStr) -> io::Result<
                 let name_bytes_lazy = parent_name_bytes.get_or_insert_with(|| {
                     get_parent_lower_path(fs, &parent_node).unwrap_or_default()
                 });
-                let lower_parent_fd =
-                    match open_lower_parent(lower, &parent_node, name_bytes_lazy) {
-                        Some(fd) => fd,
-                        None => continue,
-                    };
+                let lower_parent_fd = match open_lower_parent(lower, &parent_node, name_bytes_lazy)
+                {
+                    Some(fd) => fd,
+                    None => continue,
+                };
 
                 match platform::fstatat_nofollow(lower_parent_fd.raw(), name) {
                     Ok(st) => {
@@ -635,15 +620,12 @@ pub(crate) fn do_lookup(fs: &OverlayFs, parent: u64, name: &CStr) -> io::Result<
                         // Cache dir_record_idx on the new child node if it's a directory.
                         if entry_rec.dir_record_idx
                             != microsandbox_utils::index::DIR_RECORD_IDX_NONE
+                            && let Ok(ref entry) = result
                         {
-                            if let Ok(ref entry) = result {
-                                let nodes = fs.nodes.read().unwrap();
-                                if let Some(child_node) = nodes.get(&entry.inode) {
-                                    let mut cache =
-                                        child_node.dir_record_cache.write().unwrap();
-                                    *cache =
-                                        Some((lower.index, entry_rec.dir_record_idx));
-                                }
+                            let nodes = fs.nodes.read().unwrap();
+                            if let Some(child_node) = nodes.get(&entry.inode) {
+                                let mut cache = child_node.dir_record_cache.write().unwrap();
+                                *cache = Some((lower.index, entry_rec.dir_record_idx));
                             }
                         }
 
@@ -662,9 +644,8 @@ pub(crate) fn do_lookup(fs: &OverlayFs, parent: u64, name: &CStr) -> io::Result<
         }
 
         // Syscall fallback path (no index).
-        let name_bytes_lazy = parent_name_bytes.get_or_insert_with(|| {
-            get_parent_lower_path(fs, &parent_node).unwrap_or_default()
-        });
+        let name_bytes_lazy = parent_name_bytes
+            .get_or_insert_with(|| get_parent_lower_path(fs, &parent_node).unwrap_or_default());
         let lower_parent_fd = match open_lower_parent(lower, &parent_node, name_bytes_lazy) {
             Some(fd) => fd,
             None => continue,
@@ -694,13 +675,10 @@ pub(crate) fn do_lookup(fs: &OverlayFs, parent: u64, name: &CStr) -> io::Result<
 }
 
 /// RESOLVE step for an upper layer entry.
-fn resolve_upper(
-    fs: &OverlayFs,
-    parent: u64,
-    name: &CStr,
-    fd: RawFd,
-) -> io::Result<Entry> {
-    let _close_guard = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+fn resolve_upper(fs: &OverlayFs, parent: u64, name: &CStr, fd: RawFd) -> io::Result<Entry> {
+    let _close_guard = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Get stat.
     let st = platform::fstat(fd)?;
@@ -723,7 +701,11 @@ fn resolve_upper(
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
-        InodeAltKey::new(stx.stx_ino, stx.stx_dev_major as u64 * 256 + stx.stx_dev_minor as u64, stx.stx_mnt_id)
+        InodeAltKey::new(
+            stx.stx_ino,
+            stx.stx_dev_major as u64 * 256 + stx.stx_dev_minor as u64,
+            stx.stx_mnt_id,
+        )
     };
 
     #[cfg(target_os = "macos")]
@@ -742,14 +724,14 @@ fn resolve_upper(
                 // Register dentry for this (parent, name) → existing node.
                 drop(nodes);
                 let mut dentries = fs.dentries.write().unwrap();
-                dentries.insert(
-                    (parent, name_id),
-                    Dentry {
-                        node: existing_ino,
-                    },
-                );
+                dentries.insert((parent, name_id), Dentry { node: existing_ino });
 
-                return make_entry(existing_ino, patched, fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+                return make_entry(
+                    existing_ino,
+                    patched,
+                    fs.cfg.entry_timeout,
+                    fs.cfg.attr_timeout,
+                );
             }
         }
     }
@@ -806,13 +788,13 @@ fn resolve_upper(
             let nodes = fs.nodes.read().unwrap();
             nodes.get(&parent).cloned().unwrap()
         };
-        if let Some(upper_parent_fd_node) = get_upper_dir_fd(fs, &parent_node) {
-            if let Ok(child_dir_fd) = layer::open_subdir(upper_parent_fd_node.raw(), name) {
-                if layer::check_opaque(child_dir_fd).unwrap_or(false) {
-                    node.opaque.store(true, Ordering::Release);
-                }
-                unsafe { libc::close(child_dir_fd) };
+        if let Some(upper_parent_fd_node) = get_upper_dir_fd(fs, &parent_node)
+            && let Ok(child_dir_fd) = layer::open_subdir(upper_parent_fd_node.raw(), name)
+        {
+            if layer::check_opaque(child_dir_fd).unwrap_or(false) {
+                node.opaque.store(true, Ordering::Release);
             }
+            unsafe { libc::close(child_dir_fd) };
         }
     }
 
@@ -827,12 +809,7 @@ fn resolve_upper(
     }
     {
         let mut dentries = fs.dentries.write().unwrap();
-        dentries.insert(
-            (parent, name_id),
-            Dentry {
-                node: inode,
-            },
-        );
+        dentries.insert((parent, name_id), Dentry { node: inode });
     }
 
     make_entry(inode, patched, fs.cfg.entry_timeout, fs.cfg.attr_timeout)
@@ -849,11 +826,13 @@ fn resolve_lower(
     // Open fd to get xattr override. On Linux, keep the fd for reuse as the
     // O_PATH pinning fd (avoids a redundant second open_lower_child_fd call).
     let lower_fd = open_lower_child_fd(lower_layer, parent, name, fs)?;
-    let _close = scopeguard::guard(lower_fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(lower_fd, |fd| unsafe {
+        libc::close(fd);
+    });
     let patched = stat_override::patched_stat(lower_fd, st)?;
 
     // Construct origin ID for hardlink unification.
-    let origin_id = LowerOriginId::new(lower_layer.index, st.st_ino as u64);
+    let origin_id = LowerOriginId::new(lower_layer.index, st.st_ino);
     let name_id = fs.names.intern(name.to_bytes());
 
     // Check if this origin was already copied up (cross-copy-up dedup).
@@ -868,14 +847,14 @@ fn resolve_lower(
                 // Register new dentry for the existing upper node.
                 drop(nodes);
                 let mut dentries = fs.dentries.write().unwrap();
-                dentries.insert(
-                    (parent, name_id),
-                    Dentry {
-                        node: existing_ino,
-                    },
-                );
+                dentries.insert((parent, name_id), Dentry { node: existing_ino });
 
-                return make_entry(existing_ino, patched, fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+                return make_entry(
+                    existing_ino,
+                    patched,
+                    fs.cfg.entry_timeout,
+                    fs.cfg.attr_timeout,
+                );
             }
         }
     }
@@ -891,14 +870,14 @@ fn resolve_lower(
                 // Register new dentry for same node.
                 drop(nodes);
                 let mut dentries = fs.dentries.write().unwrap();
-                dentries.insert(
-                    (parent, name_id),
-                    Dentry {
-                        node: existing_ino,
-                    },
-                );
+                dentries.insert((parent, name_id), Dentry { node: existing_ino });
 
-                return make_entry(existing_ino, patched, fs.cfg.entry_timeout, fs.cfg.attr_timeout);
+                return make_entry(
+                    existing_ino,
+                    patched,
+                    fs.cfg.entry_timeout,
+                    fs.cfg.attr_timeout,
+                );
             }
         }
     }
@@ -934,7 +913,7 @@ fn resolve_lower(
     #[cfg(target_os = "macos")]
     let state = NodeState::Lower {
         layer_idx: lower_layer.index,
-        ino: st.st_ino as u64,
+        ino: st.st_ino,
         dev: st.st_dev as u64,
     };
 
@@ -958,13 +937,13 @@ fn resolve_lower(
     });
 
     // Check opaque for lower directories.
-    if kind == libc::S_IFDIR as u32 {
-        if let Some(lower_dir_fd) = open_lower_dir(lower_layer, parent, name, fs) {
-            if layer::check_opaque(lower_dir_fd).unwrap_or(false) {
-                node.opaque.store(true, Ordering::Release);
-            }
-            unsafe { libc::close(lower_dir_fd) };
+    if kind == libc::S_IFDIR as u32
+        && let Some(lower_dir_fd) = open_lower_dir(lower_layer, parent, name, fs)
+    {
+        if layer::check_opaque(lower_dir_fd).unwrap_or(false) {
+            node.opaque.store(true, Ordering::Release);
         }
+        unsafe { libc::close(lower_dir_fd) };
     }
 
     // Register in tables.
@@ -978,12 +957,7 @@ fn resolve_lower(
     }
     {
         let mut dentries = fs.dentries.write().unwrap();
-        dentries.insert(
-            (parent, name_id),
-            Dentry {
-                node: inode,
-            },
-        );
+        dentries.insert((parent, name_id), Dentry { node: inode });
     }
 
     make_entry(inode, patched, fs.cfg.entry_timeout, fs.cfg.attr_timeout)
@@ -1069,13 +1043,12 @@ pub(crate) fn forget_one_locked(
 ///
 /// Must be called AFTER releasing nodes/dentries write locks to avoid
 /// lock ordering deadlocks.
-fn cleanup_dedup_maps(
-    fs: &OverlayFs,
-    inode: u64,
-    origin: Option<LowerOriginId>,
-) {
+fn cleanup_dedup_maps(fs: &OverlayFs, inode: u64, origin: Option<LowerOriginId>) {
     // Remove from upper_alt_keys (scan — alt_key not stored on node).
-    fs.upper_alt_keys.write().unwrap().retain(|_, &mut v| v != inode);
+    fs.upper_alt_keys
+        .write()
+        .unwrap()
+        .retain(|_, &mut v| v != inode);
 
     // Remove from origin-based maps if the node had an origin.
     if let Some(origin_id) = origin {
@@ -1087,14 +1060,14 @@ fn cleanup_dedup_maps(
 /// Batch-clean dedup maps after multiple inodes are removed.
 ///
 /// Called from batch_forget after releasing nodes/dentries locks.
-pub(crate) fn cleanup_dedup_maps_batch(
-    fs: &OverlayFs,
-    removed: &[(u64, Option<LowerOriginId>)],
-) {
+pub(crate) fn cleanup_dedup_maps_batch(fs: &OverlayFs, removed: &[(u64, Option<LowerOriginId>)]) {
     // Collect removed inodes for efficient set lookup.
     let removed_set: HashSet<u64> = removed.iter().map(|(ino, _)| *ino).collect();
 
-    fs.upper_alt_keys.write().unwrap().retain(|_, v| !removed_set.contains(v));
+    fs.upper_alt_keys
+        .write()
+        .unwrap()
+        .retain(|_, v| !removed_set.contains(v));
 
     let mut origin_keys = fs.lower_origin_keys.write().unwrap();
     let mut origin_idx = fs.origin_index.write().unwrap();
@@ -1135,7 +1108,9 @@ pub(crate) fn stat_node(fs: &OverlayFs, inode: u64) -> io::Result<stat64> {
         NodeState::Lower { ino, dev, .. } | NodeState::Upper { ino, dev, .. } => {
             let path = vol_path(*dev, *ino);
             let fd = open_macos_vol(&path)?;
-            let _close = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+            let _close = scopeguard::guard(fd, |fd| unsafe {
+                libc::close(fd);
+            });
             let st = platform::fstat(fd)?;
             stat_override::patched_stat(fd, st)
         }
@@ -1165,12 +1140,8 @@ pub(crate) fn open_node_fd(fs: &OverlayFs, inode: u64, flags: i32) -> io::Result
         #[cfg(target_os = "macos")]
         NodeState::Lower { ino, dev, .. } | NodeState::Upper { ino, dev, .. } => {
             let path = vol_path(*dev, *ino);
-            let fd = unsafe {
-                libc::open(
-                    path.as_ptr(),
-                    flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-                )
-            };
+            let fd =
+                unsafe { libc::open(path.as_ptr(), flags | libc::O_CLOEXEC | libc::O_NOFOLLOW) };
             if fd < 0 {
                 return Err(platform::linux_error(io::Error::last_os_error()));
             }
@@ -1251,7 +1222,10 @@ pub(crate) fn get_upper_dir_fd(fs: &OverlayFs, parent_node: &OverlayNode) -> Opt
 ///
 /// Returns empty Vec for root nodes or nodes whose parent can be
 /// opened directly via their fd (same-layer Lower).
-pub(crate) fn get_parent_lower_path(fs: &OverlayFs, parent_node: &OverlayNode) -> io::Result<Vec<Vec<u8>>> {
+pub(crate) fn get_parent_lower_path(
+    fs: &OverlayFs,
+    parent_node: &OverlayNode,
+) -> io::Result<Vec<Vec<u8>>> {
     // Check redirect first.
     let redirect = parent_node.redirect.read().unwrap();
     if let Some(ref redir) = *redirect {
@@ -1453,8 +1427,8 @@ fn open_lower_child_fd(
     };
 
     let path_components = get_parent_lower_path(fs, &parent_node)?;
-    let parent_fd_node = open_lower_parent(layer, &parent_node, &path_components)
-        .ok_or_else(platform::enoent)?;
+    let parent_fd_node =
+        open_lower_parent(layer, &parent_node, &path_components).ok_or_else(platform::enoent)?;
 
     #[cfg(target_os = "linux")]
     return layer::open_child_beneath(
@@ -1493,12 +1467,7 @@ fn open_lower_child_fd(
 }
 
 /// Try to open a lower child as a directory.
-fn open_lower_dir(
-    layer: &Layer,
-    parent: u64,
-    name: &CStr,
-    fs: &OverlayFs,
-) -> Option<RawFd> {
+fn open_lower_dir(layer: &Layer, parent: u64, name: &CStr, fs: &OverlayFs) -> Option<RawFd> {
     let parent_node = {
         let nodes = fs.nodes.read().unwrap();
         nodes.get(&parent).cloned()?
@@ -1528,7 +1497,11 @@ pub(crate) fn dup_fd_raw(fd: RawFd) -> io::Result<RawFd> {
 
 /// Reopen an O_PATH fd for I/O via /proc/self/fd (Linux only).
 #[cfg(target_os = "linux")]
-pub(crate) fn reopen_fd_linux(proc_self_fd: &File, o_path_fd: RawFd, flags: i32) -> io::Result<RawFd> {
+pub(crate) fn reopen_fd_linux(
+    proc_self_fd: &File,
+    o_path_fd: RawFd,
+    flags: i32,
+) -> io::Result<RawFd> {
     let mut buf = [0u8; 20];
     let fd_str = format_fd_cstr(o_path_fd, &mut buf);
     let fd = unsafe {
@@ -1634,11 +1607,11 @@ pub(crate) fn find_dir_record_for_parent<'a>(
     // Fast path: check cache.
     {
         let cache = parent_node.dir_record_cache.read().unwrap();
-        if let Some((cached_layer, cached_idx)) = *cache {
-            if cached_layer == layer_idx {
-                let dirs = index.dir_records();
-                return dirs.get(cached_idx as usize);
-            }
+        if let Some((cached_layer, cached_idx)) = *cache
+            && cached_layer == layer_idx
+        {
+            let dirs = index.dir_records();
+            return dirs.get(cached_idx as usize);
         }
     }
 
@@ -1654,4 +1627,3 @@ pub(crate) fn find_dir_record_for_parent<'a>(
 
     Some(dir_rec)
 }
-

--- a/crates/filesystem/lib/backends/overlayfs/layer.rs
+++ b/crates/filesystem/lib/backends/overlayfs/layer.rs
@@ -3,9 +3,7 @@
 //! These functions operate on individual layer directories and are used by the
 //! lookup and readdir algorithms to implement overlay merge semantics.
 
-use std::ffi::CStr;
-use std::io;
-use std::os::fd::RawFd;
+use std::{ffi::CStr, io, os::fd::RawFd};
 
 use crate::backends::shared::platform;
 

--- a/crates/filesystem/lib/backends/overlayfs/metadata.rs
+++ b/crates/filesystem/lib/backends/overlayfs/metadata.rs
@@ -7,16 +7,14 @@
 //! setattr triggers copy-up, then applies changes: UID/GID/mode via xattr,
 //! size via ftruncate, timestamps via futimens.
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
-use super::OverlayFs;
-use super::copy_up;
-use super::inode;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, SetattrValid, stat64};
+use super::{OverlayFs, copy_up, inode};
+use crate::{
+    Context, SetattrValid,
+    backends::shared::{init_binary, platform, stat_override},
+    stat64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/lib/backends/overlayfs/mod.rs
+++ b/crates/filesystem/lib/backends/overlayfs/mod.rs
@@ -23,22 +23,26 @@ pub mod types;
 mod whiteout;
 mod xattr_ops;
 
-use std::collections::BTreeMap;
-use std::ffi::CStr;
-use std::fs::File;
-use std::io;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    ffi::CStr,
+    fs::File,
+    io,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use origin::LowerOriginId;
 use types::{Dentry, DirHandle, FileHandle, Layer, NameTable, OverlayNode, ROOT_INODE};
 
-use crate::backends::shared::inode_table::InodeAltKey;
-use crate::backends::shared::init_binary;
 use crate::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::{init_binary, inode_table::InodeAltKey},
+    stat64, statvfs64,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -199,7 +203,9 @@ impl DynFileSystem for OverlayFs {
                 if ino == init_binary::INIT_INODE {
                     continue;
                 }
-                if let Some(origin) = inode::forget_one_locked(&mut nodes, &mut dentries, ino, count) {
+                if let Some(origin) =
+                    inode::forget_one_locked(&mut nodes, &mut dentries, ino, count)
+                {
                     removed.push((ino, origin));
                 }
             }
@@ -292,13 +298,7 @@ impl DynFileSystem for OverlayFs {
         remove_ops::do_rename(self, ctx, olddir, oldname, newdir, newname, flags)
     }
 
-    fn link(
-        &self,
-        ctx: Context,
-        ino: u64,
-        newparent: u64,
-        newname: &CStr,
-    ) -> io::Result<Entry> {
+    fn link(&self, ctx: Context, ino: u64, newparent: u64, newname: &CStr) -> io::Result<Entry> {
         create_ops::do_link(self, ctx, ino, newparent, newname)
     }
 
@@ -324,7 +324,9 @@ impl DynFileSystem for OverlayFs {
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
-        create_ops::do_create(self, ctx, parent, name, mode, kill_priv, flags, umask, extensions)
+        create_ops::do_create(
+            self, ctx, parent, name, mode, kill_priv, flags, umask, extensions,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/filesystem/lib/backends/overlayfs/origin.rs
+++ b/crates/filesystem/lib/backends/overlayfs/origin.rs
@@ -11,9 +11,7 @@
 //! xattr (12 bytes: `[u32_le layer_idx][u64_le object_id]`). At mount time, BFS
 //! hydration reads these xattrs to rebuild the `origin_index`.
 
-use std::ffi::CStr;
-use std::io;
-use std::os::fd::RawFd;
+use std::{ffi::CStr, io, os::fd::RawFd};
 
 use crate::backends::shared::platform;
 
@@ -69,7 +67,10 @@ impl LowerOriginId {
 ///
 /// Format: `[u32_le layer_idx][u64_le object_id]`
 fn serialize_origin(origin: &LowerOriginId) -> [u8; ORIGIN_XATTR_SIZE] {
-    debug_assert!(origin.layer_idx <= u32::MAX as usize, "layer_idx overflows u32");
+    debug_assert!(
+        origin.layer_idx <= u32::MAX as usize,
+        "layer_idx overflows u32"
+    );
     let mut buf = [0u8; ORIGIN_XATTR_SIZE];
     buf[..4].copy_from_slice(&(origin.layer_idx as u32).to_le_bytes());
     buf[4..12].copy_from_slice(&origin.object_id.to_le_bytes());
@@ -182,12 +183,18 @@ pub(crate) fn get_origin_xattr(fd: RawFd) -> io::Result<Option<LowerOriginId>> {
 ///
 /// Format: `[u16_le count][u16_le len][bytes][u16_le len][bytes]...`
 fn serialize_redirect(components: &[Vec<u8>]) -> Vec<u8> {
-    debug_assert!(components.len() <= u16::MAX as usize, "too many redirect components");
+    debug_assert!(
+        components.len() <= u16::MAX as usize,
+        "too many redirect components"
+    );
     let total_size = 2 + components.iter().map(|c| 2 + c.len()).sum::<usize>();
     let mut buf = Vec::with_capacity(total_size);
     buf.extend_from_slice(&(components.len() as u16).to_le_bytes());
     for component in components {
-        debug_assert!(component.len() <= u16::MAX as usize, "redirect component too long");
+        debug_assert!(
+            component.len() <= u16::MAX as usize,
+            "redirect component too long"
+        );
         buf.extend_from_slice(&(component.len() as u16).to_le_bytes());
         buf.extend_from_slice(component);
     }

--- a/crates/filesystem/lib/backends/overlayfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/remove_ops.rs
@@ -11,22 +11,17 @@
 //! layer presence, redirect xattrs are written before the swap to preserve
 //! lower-child visibility at the new positions.
 
-use std::ffi::CStr;
-use std::io;
-use std::sync::atomic::Ordering;
+use std::{ffi::CStr, io, sync::atomic::Ordering};
 
-use super::OverlayFs;
-use super::copy_up;
-use super::dir_ops;
-use super::inode;
-use super::layer;
-use super::origin;
-use super::types::{NodeState, RedirectState, ROOT_INODE};
-use super::whiteout;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::name_validation;
-use crate::backends::shared::platform;
-use crate::Context;
+use super::{
+    OverlayFs, copy_up, dir_ops, inode, layer, origin,
+    types::{NodeState, ROOT_INODE, RedirectState},
+    whiteout,
+};
+use crate::{
+    Context,
+    backends::shared::{init_binary, name_validation, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -50,12 +45,7 @@ const KNOWN_RENAME_FLAGS: u32 = RENAME_NOREPLACE | RENAME_EXCHANGE;
 /// Resolves the target using overlay-visible semantics to verify it exists
 /// and is not a directory. Ensures the parent is on upper, unlinks the upper
 /// entry if present, and creates a whiteout if the name exists on lower layers.
-pub(crate) fn do_unlink(
-    fs: &OverlayFs,
-    _ctx: Context,
-    parent: u64,
-    name: &CStr,
-) -> io::Result<()> {
+pub(crate) fn do_unlink(fs: &OverlayFs, _ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -109,12 +99,7 @@ pub(crate) fn do_unlink(
 /// Resolves the target using overlay-visible semantics to verify it exists,
 /// is a directory, and is empty across all layers. Ensures the parent is on
 /// upper, removes the upper entry and creates a whiteout if needed.
-pub(crate) fn do_rmdir(
-    fs: &OverlayFs,
-    _ctx: Context,
-    parent: u64,
-    name: &CStr,
-) -> io::Result<()> {
+pub(crate) fn do_rmdir(fs: &OverlayFs, _ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -230,10 +215,8 @@ pub(crate) fn do_rename(
     // RENAME_NOREPLACE: fail if the destination already exists in the
     // merged overlay view. The host renameat2 only sees the upper layer,
     // so a lower-visible destination would be silently overwritten.
-    if flags & RENAME_NOREPLACE != 0 {
-        if dest_entry.is_ok() {
-            return Err(platform::eexist());
-        }
+    if flags & RENAME_NOREPLACE != 0 && dest_entry.is_ok() {
+        return Err(platform::eexist());
     }
 
     if let Ok(ref de) = dest_entry {
@@ -246,10 +229,8 @@ pub(crate) fn do_rename(
         if source_is_dir && !dest_is_dir {
             return Err(platform::enotdir());
         }
-        if source_is_dir && dest_is_dir {
-            if !dir_ops::is_merged_dir_empty(fs, de.inode)? {
-                return Err(platform::enotempty());
-            }
+        if source_is_dir && dest_is_dir && !dir_ops::is_merged_dir_empty(fs, de.inode)? {
+            return Err(platform::enotempty());
         }
     }
 
@@ -262,36 +243,48 @@ pub(crate) fn do_rename(
     }
 
     // Handle directory rename with redirect support.
-    if let Some(ref node) = source_node {
-        if source_is_dir {
-            let is_lower = {
-                let state = node.state.read().unwrap();
-                matches!(&*state, NodeState::Lower { .. })
-            };
+    if let Some(ref node) = source_node
+        && source_is_dir
+    {
+        let is_lower = {
+            let state = node.state.read().unwrap();
+            matches!(&*state, NodeState::Lower { .. })
+        };
 
-            if is_lower {
-                return rename_lower_directory(
-                    fs, node, olddir, oldname, oldname_id, newdir, newname,
-                    &dest_entry,
-                );
-            }
-
-            // Check if this is a merged directory (has lower presence or redirect).
-            // An opaque pure-upper dir is masking someone else's lower subtree,
-            // not merged with it — it must stay on the pure-upper rename path.
-            let has_redirect = node.redirect.read().unwrap().is_some();
-            let is_opaque = node.opaque.load(Ordering::Acquire);
-            let has_lower =
-                !is_opaque && whiteout::has_lower_entry(fs, olddir, oldname.to_bytes())?;
-            if has_redirect || has_lower {
-                return rename_merged_directory(
-                    fs, node, olddir, oldname, oldname_id, newdir, newname, flags,
-                    &dest_entry,
-                );
-            }
-
-            // Pure-upper directory: fall through to simple renameat below.
+        if is_lower {
+            return rename_lower_directory(
+                fs,
+                node,
+                olddir,
+                oldname,
+                oldname_id,
+                newdir,
+                newname,
+                &dest_entry,
+            );
         }
+
+        // Check if this is a merged directory (has lower presence or redirect).
+        // An opaque pure-upper dir is masking someone else's lower subtree,
+        // not merged with it — it must stay on the pure-upper rename path.
+        let has_redirect = node.redirect.read().unwrap().is_some();
+        let is_opaque = node.opaque.load(Ordering::Acquire);
+        let has_lower = !is_opaque && whiteout::has_lower_entry(fs, olddir, oldname.to_bytes())?;
+        if has_redirect || has_lower {
+            return rename_merged_directory(
+                fs,
+                node,
+                olddir,
+                oldname,
+                oldname_id,
+                newdir,
+                newname,
+                flags,
+                &dest_entry,
+            );
+        }
+
+        // Pure-upper directory: fall through to simple renameat below.
     }
 
     // Copy-up source if needed (files and pure-upper dirs).
@@ -333,20 +326,29 @@ pub(crate) fn do_rename(
 
     // For pure-upper directory rename: if destination had lower presence,
     // mark the directory opaque to suppress those lower entries.
-    if let Some(ref node) = source_node {
-        if source_is_dir {
-            let dest_has_lower = whiteout::has_lower_entry(fs, newdir, newname.to_bytes())?;
-            if dest_has_lower {
-                let dir_fd = open_dir_by_name(new_parent_fd, newname)?;
-                let _close = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
-                create_opaque_marker(dir_fd)?;
-                node.opaque.store(true, Ordering::Release);
-            }
+    if let Some(ref node) = source_node
+        && source_is_dir
+    {
+        let dest_has_lower = whiteout::has_lower_entry(fs, newdir, newname.to_bytes())?;
+        if dest_has_lower {
+            let dir_fd = open_dir_by_name(new_parent_fd, newname)?;
+            let _close = scopeguard::guard(dir_fd, |fd| unsafe {
+                libc::close(fd);
+            });
+            create_opaque_marker(dir_fd)?;
+            node.opaque.store(true, Ordering::Release);
         }
     }
 
     // Update dentry cache.
-    update_dentry_cache(fs, olddir, oldname_id, newdir, newname, source_node.as_deref());
+    update_dentry_cache(
+        fs,
+        olddir,
+        oldname_id,
+        newdir,
+        newname,
+        source_node.as_deref(),
+    );
 
     Ok(())
 }
@@ -380,10 +382,8 @@ fn do_rename_exchange(
     inode::forget_one(fs, source_entry.inode, 1);
     inode::forget_one(fs, dest_entry.inode, 1);
 
-    let src_is_dir =
-        source_entry.attr.st_mode as u32 & libc::S_IFMT as u32 == libc::S_IFDIR as u32;
-    let dst_is_dir =
-        dest_entry.attr.st_mode as u32 & libc::S_IFMT as u32 == libc::S_IFDIR as u32;
+    let src_is_dir = source_entry.attr.st_mode as u32 & libc::S_IFMT as u32 == libc::S_IFDIR as u32;
+    let dst_is_dir = dest_entry.attr.st_mode as u32 & libc::S_IFMT as u32 == libc::S_IFDIR as u32;
 
     // For directory entries, determine if they need redirect metadata after
     // exchange. A directory needs a redirect if it has any lower-layer presence
@@ -414,39 +414,57 @@ fn do_rename_exchange(
     copy_up::ensure_upper(fs, newdir)?;
 
     let old_parent_fd = copy_up::open_upper_parent_fd(fs, olddir)?;
-    let _close_old = scopeguard::guard(old_parent_fd, |fd| unsafe { libc::close(fd); });
+    let _close_old = scopeguard::guard(old_parent_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     let new_parent_fd = copy_up::open_upper_parent_fd(fs, newdir)?;
-    let _close_new = scopeguard::guard(new_parent_fd, |fd| unsafe { libc::close(fd); });
+    let _close_new = scopeguard::guard(new_parent_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Write redirect xattrs BEFORE the exchange so the metadata is in place
     // when the directories land at their new positions.
     if let Some(ref redirect_path) = src_redirect {
         let dir_fd = open_dir_by_name(old_parent_fd, oldname)?;
-        let _close = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+        let _close = scopeguard::guard(dir_fd, |fd| unsafe {
+            libc::close(fd);
+        });
         origin::set_redirect_xattr(dir_fd, redirect_path)?;
     }
     if let Some(ref redirect_path) = dst_redirect {
         let dir_fd = open_dir_by_name(new_parent_fd, newname)?;
-        let _close = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+        let _close = scopeguard::guard(dir_fd, |fd| unsafe {
+            libc::close(fd);
+        });
         origin::set_redirect_xattr(dir_fd, redirect_path)?;
     }
 
     // Perform the atomic exchange on upper.
-    do_renameat(old_parent_fd, oldname, new_parent_fd, newname, RENAME_EXCHANGE)?;
+    do_renameat(
+        old_parent_fd,
+        oldname,
+        new_parent_fd,
+        newname,
+        RENAME_EXCHANGE,
+    )?;
 
     // Post-exchange opaque marking:
     // Source (now at newname): if the destination position had lower entries
     // and source has no redirect, mark opaque to suppress those entries.
     if src_is_dir && new_has_lower && src_redirect.is_none() {
         let dir_fd = open_dir_by_name(new_parent_fd, newname)?;
-        let _close = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+        let _close = scopeguard::guard(dir_fd, |fd| unsafe {
+            libc::close(fd);
+        });
         create_opaque_marker(dir_fd)?;
     }
     // Dest (now at oldname): same logic in reverse.
     if dst_is_dir && old_has_lower && dst_redirect.is_none() {
         let dir_fd = open_dir_by_name(old_parent_fd, oldname)?;
-        let _close = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+        let _close = scopeguard::guard(dir_fd, |fd| unsafe {
+            libc::close(fd);
+        });
         create_opaque_marker(dir_fd)?;
     }
 
@@ -462,8 +480,9 @@ fn do_rename_exchange(
                 src_node.opaque.store(true, Ordering::Release);
             }
             if let Some(redirect_path) = src_redirect {
-                *src_node.redirect.write().unwrap() =
-                    Some(RedirectState { lower_path: redirect_path });
+                *src_node.redirect.write().unwrap() = Some(RedirectState {
+                    lower_path: redirect_path,
+                });
             }
             src_node.primary_parent.store(newdir, Ordering::Release);
             *src_node.primary_name.write().unwrap() = newname_id;
@@ -473,8 +492,9 @@ fn do_rename_exchange(
                 dst_node.opaque.store(true, Ordering::Release);
             }
             if let Some(redirect_path) = dst_redirect {
-                *dst_node.redirect.write().unwrap() =
-                    Some(RedirectState { lower_path: redirect_path });
+                *dst_node.redirect.write().unwrap() = Some(RedirectState {
+                    lower_path: redirect_path,
+                });
             }
             dst_node.primary_parent.store(olddir, Ordering::Release);
             *dst_node.primary_name.write().unwrap() = oldname_id;
@@ -535,9 +555,7 @@ fn compute_exchange_redirect(
     // Upper directory — check if it has lower presence (merged).
     // An opaque pure-upper dir is masking someone else's lower subtree at this
     // position, not merged with it. It should not get a redirect.
-    if !node.opaque.load(Ordering::Acquire)
-        && whiteout::has_lower_entry(fs, parent_ino, name)?
-    {
+    if !node.opaque.load(Ordering::Acquire) && whiteout::has_lower_entry(fs, parent_ino, name)? {
         return Ok(Some(compute_redirect_path(fs, &node, parent_ino, name)?));
     }
 
@@ -553,6 +571,7 @@ fn compute_exchange_redirect(
 /// Creates a new directory on the upper layer at the destination, attaches a
 /// redirect xattr pointing to the source's lower path, and creates a whiteout
 /// at the old location.
+#[allow(clippy::too_many_arguments)]
 fn rename_lower_directory(
     fs: &OverlayFs,
     node: &std::sync::Arc<super::types::OverlayNode>,
@@ -571,10 +590,14 @@ fn rename_lower_directory(
     copy_up::ensure_upper(fs, newdir)?;
 
     let old_parent_fd = copy_up::open_upper_parent_fd(fs, olddir)?;
-    let _close_old = scopeguard::guard(old_parent_fd, |fd| unsafe { libc::close(fd); });
+    let _close_old = scopeguard::guard(old_parent_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     let new_parent_fd = copy_up::open_upper_parent_fd(fs, newdir)?;
-    let _close_new = scopeguard::guard(new_parent_fd, |fd| unsafe { libc::close(fd); });
+    let _close_new = scopeguard::guard(new_parent_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Remove whiteout at destination.
     whiteout::remove_whiteout(new_parent_fd, newname.to_bytes())?;
@@ -597,11 +620,15 @@ fn rename_lower_directory(
     // Copy all xattrs from lower source to the new upper directory
     // (same contract as copy_up_directory: stat override + user xattrs).
     let lower_fd = inode::open_node_fd(fs, node.inode, libc::O_RDONLY)?;
-    let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe { libc::close(fd); });
+    let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Open the newly created upper directory to write xattrs and redirect.
     let dir_fd = open_dir_by_name(new_parent_fd, newname)?;
-    let _close_dir = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+    let _close_dir = scopeguard::guard(dir_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     copy_up::copy_xattrs(lower_fd, dir_fd)?;
 
@@ -629,6 +656,7 @@ fn rename_lower_directory(
 ///
 /// Moves the upper fragment via renameat and updates the redirect xattr to
 /// point to the original lower path.
+#[allow(clippy::too_many_arguments)]
 fn rename_merged_directory(
     fs: &OverlayFs,
     node: &std::sync::Arc<super::types::OverlayNode>,
@@ -648,10 +676,14 @@ fn rename_merged_directory(
     copy_up::ensure_upper(fs, newdir)?;
 
     let old_parent_fd = copy_up::open_upper_parent_fd(fs, olddir)?;
-    let _close_old = scopeguard::guard(old_parent_fd, |fd| unsafe { libc::close(fd); });
+    let _close_old = scopeguard::guard(old_parent_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     let new_parent_fd = copy_up::open_upper_parent_fd(fs, newdir)?;
-    let _close_new = scopeguard::guard(new_parent_fd, |fd| unsafe { libc::close(fd); });
+    let _close_new = scopeguard::guard(new_parent_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Remove whiteout at destination.
     whiteout::remove_whiteout(new_parent_fd, newname.to_bytes())?;
@@ -667,7 +699,9 @@ fn rename_merged_directory(
 
     // Open the renamed directory to update redirect xattr.
     let dir_fd = open_dir_by_name(new_parent_fd, newname)?;
-    let _close_dir = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+    let _close_dir = scopeguard::guard(dir_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Write/update redirect xattr.
     origin::set_redirect_xattr(dir_fd, &redirect_path)?;
@@ -843,9 +877,7 @@ fn update_dentry_cache(
         // Insert new dentry.
         dentries.insert(
             (newdir, newname_id),
-            super::types::Dentry {
-                node: dentry.node,
-            },
+            super::types::Dentry { node: dentry.node },
         );
     }
 }
@@ -904,7 +936,9 @@ fn remove_upper_dir_artifacts(parent_fd: i32, name: &CStr) -> io::Result<()> {
         Err(e) if platform::is_enoent(&e) => return Ok(()),
         Err(e) => return Err(e),
     };
-    let _close = scopeguard::guard(dir_fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(dir_fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     let entries = layer::read_dir_entries_raw(dir_fd)?;
 

--- a/crates/filesystem/lib/backends/overlayfs/special.rs
+++ b/crates/filesystem/lib/backends/overlayfs/special.rs
@@ -1,12 +1,13 @@
 //! Special operations: statfs, fsync, fsyncdir, lseek, fallocate, copyfilerange.
 
-use std::io;
-use std::os::fd::AsRawFd;
+use std::{io, os::fd::AsRawFd};
 
 use super::OverlayFs;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, statvfs64};
+use crate::{
+    Context,
+    backends::shared::{init_binary, platform},
+    statvfs64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -90,7 +91,9 @@ pub(crate) fn do_fsyncdir(
 
     // Open the directory for syncing.
     let fd = super::inode::open_node_fd(fs, ino, libc::O_RDONLY)?;
-    let _close = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     #[cfg(target_os = "linux")]
     let ret = if datasync {

--- a/crates/filesystem/lib/backends/overlayfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/mod.rs
@@ -17,11 +17,13 @@ mod test_rename;
 mod test_special_ops;
 mod test_xattr;
 
-use std::ffi::CString;
-use std::fs::File;
-use std::io;
-use std::os::fd::AsRawFd;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::CString,
+    fs::File,
+    io,
+    os::fd::AsRawFd,
+    path::{Path, PathBuf},
+};
 
 use tempfile::TempDir;
 
@@ -120,11 +122,7 @@ impl OverlayTestSandbox {
         for lower in &lower_roots {
             builder = builder.layer(lower);
         }
-        let fs = builder
-            .writable(&upper)
-            .staging(&staging)
-            .build()
-            .unwrap();
+        let fs = builder.writable(&upper).staging(&staging).build().unwrap();
 
         fs.init(FsOptions::empty()).unwrap();
 

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_bootstrap.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_bootstrap.rs
@@ -32,10 +32,7 @@ fn test_build_no_staging_dir_fails() {
     let upper = tmp.path().join("upper");
     std::fs::create_dir(&lower).unwrap();
     std::fs::create_dir(&upper).unwrap();
-    let result = OverlayFs::builder()
-        .layer(&lower)
-        .writable(&upper)
-        .build();
+    let result = OverlayFs::builder().layer(&lower).writable(&upper).build();
     assert!(result.is_err(), "should fail without staging dir");
 }
 

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_create_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_create_ops.rs
@@ -78,13 +78,16 @@ fn test_create_in_lower_dir() {
 #[cfg(target_os = "linux")]
 fn test_symlink() {
     let sb = OverlayTestSandbox::new();
-    let entry = sb.fs.symlink(
-        sb.ctx(),
-        &OverlayTestSandbox::cstr("/target/path"),
-        ROOT_INODE,
-        &OverlayTestSandbox::cstr("mylink"),
-        Extensions::default(),
-    ).unwrap();
+    let entry = sb
+        .fs
+        .symlink(
+            sb.ctx(),
+            &OverlayTestSandbox::cstr("/target/path"),
+            ROOT_INODE,
+            &OverlayTestSandbox::cstr("mylink"),
+            Extensions::default(),
+        )
+        .unwrap();
     assert!(entry.inode >= 3);
     let target = sb.fs.readlink(sb.ctx(), entry.inode).unwrap();
     assert_eq!(&target[..], b"/target/path");
@@ -95,12 +98,15 @@ fn test_link_upper_file() {
     let sb = OverlayTestSandbox::new();
     let (entry, handle) = sb.fuse_create_root("original.txt").unwrap();
     sb.fuse_write(entry.inode, handle, b"link data", 0).unwrap();
-    let link_entry = sb.fs.link(
-        sb.ctx(),
-        entry.inode,
-        ROOT_INODE,
-        &OverlayTestSandbox::cstr("hard_link.txt"),
-    ).unwrap();
+    let link_entry = sb
+        .fs
+        .link(
+            sb.ctx(),
+            entry.inode,
+            ROOT_INODE,
+            &OverlayTestSandbox::cstr("hard_link.txt"),
+        )
+        .unwrap();
     assert!(link_entry.inode >= 3);
     // Read via the link.
     let link_handle = sb

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_file_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_file_ops.rs
@@ -27,9 +27,7 @@ fn test_write_triggers_copy_up() {
         std::fs::write(lower.join("lower_file.txt"), b"original").unwrap();
     });
     let entry = sb.lookup_root("lower_file.txt").unwrap();
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     // Write triggers copy-up.
     sb.fuse_write(entry.inode, handle, b"modified", 0).unwrap();
     // File should now exist on upper.
@@ -46,9 +44,7 @@ fn test_copy_up_preserves_data() {
     });
     let entry = sb.lookup_root("data.txt").unwrap();
     // Read the original data first.
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let original = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&original[..], b"preserve me");
     sb.fs
@@ -56,9 +52,7 @@ fn test_copy_up_preserves_data() {
         .unwrap();
 
     // Open for write (triggers copy-up), then read back.
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     // Write at offset 11 so original data is preserved.
     sb.fuse_write(entry.inode, handle, b" more", 11).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
@@ -71,9 +65,7 @@ fn test_write_after_copy_up() {
         std::fs::write(lower.join("file.txt"), b"old").unwrap();
     });
     let entry = sb.lookup_root("file.txt").unwrap();
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"new data", 0).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"new data");

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_index.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_index.rs
@@ -1,7 +1,9 @@
 //! Tests for the sidecar index (MmapIndex) and index-accelerated overlay operations.
 
-use std::ffi::CString;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::CString,
+    path::{Path, PathBuf},
+};
 
 use microsandbox_utils::index::{
     DIR_FLAG_OPAQUE, DIR_RECORD_IDX_NONE, ENTRY_FLAG_WHITEOUT, INDEX_MAGIC, INDEX_VERSION,
@@ -125,10 +127,7 @@ fn readdir_entries(fs: &OverlayFs, ino: u64) -> Vec<(Vec<u8>, u32)> {
     let (handle, _) = fs.opendir(ctx(), ino, 0).unwrap();
     let handle = handle.unwrap();
     let entries = fs.readdir(ctx(), ino, handle, 65536, 0).unwrap();
-    let result: Vec<(Vec<u8>, u32)> = entries
-        .iter()
-        .map(|e| (e.name.to_vec(), e.type_))
-        .collect();
+    let result: Vec<(Vec<u8>, u32)> = entries.iter().map(|e| (e.name.to_vec(), e.type_)).collect();
     fs.releasedir(ctx(), ino, 0, handle).unwrap();
     result
 }
@@ -274,10 +273,7 @@ fn test_find_entry_exists() {
 
 #[test]
 fn test_find_entry_missing() {
-    let data = IndexBuilder::new()
-        .dir("")
-        .file("", "bar", 0o644)
-        .build();
+    let data = IndexBuilder::new().dir("").file("", "bar", 0o644).build();
     let (_tmp, path) = write_index(&data);
     let idx = MmapIndex::open(&path).unwrap();
     let (_, dir) = idx.find_dir(b"").unwrap();
@@ -316,10 +312,7 @@ fn test_find_entry_binary_search_boundaries() {
 
 #[test]
 fn test_find_entry_single_entry_dir() {
-    let data = IndexBuilder::new()
-        .dir("")
-        .file("", "only", 0o644)
-        .build();
+    let data = IndexBuilder::new().dir("").file("", "only", 0o644).build();
     let (_tmp, path) = write_index(&data);
     let idx = MmapIndex::open(&path).unwrap();
     let (_, dir) = idx.find_dir(b"").unwrap();
@@ -389,10 +382,7 @@ fn test_is_opaque_false() {
 
 #[test]
 fn test_has_whiteout_true() {
-    let data = IndexBuilder::new()
-        .dir("")
-        .whiteout("", "deleted")
-        .build();
+    let data = IndexBuilder::new().dir("").whiteout("", "deleted").build();
     let (_tmp, path) = write_index(&data);
     let idx = MmapIndex::open(&path).unwrap();
     let (_, dir) = idx.find_dir(b"").unwrap();
@@ -575,7 +565,10 @@ fn test_builder_layer_no_index() {
 fn test_builder_layer_with_valid_index() {
     let tmp = tempfile::tempdir().unwrap();
     let (lower, upper, staging, index_path) = setup_dirs(&tmp);
-    IndexBuilder::new().dir("").build_to_file(&index_path).unwrap();
+    IndexBuilder::new()
+        .dir("")
+        .build_to_file(&index_path)
+        .unwrap();
     let fs = OverlayFs::builder()
         .layer_with_index(&lower, &index_path)
         .writable(&upper)
@@ -671,7 +664,8 @@ fn test_index_lookup_hit() {
     IndexBuilder::new()
         .dir("")
         .file("", "hello.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let entry = fs.lookup(ctx(), ROOT_INODE, &cstr("hello.txt")).unwrap();
@@ -686,7 +680,10 @@ fn test_index_lookup_miss() {
     let (lower, upper, staging, index_path) = setup_dirs(&tmp);
 
     // Index lists no entries — lookup should fail.
-    IndexBuilder::new().dir("").build_to_file(&index_path).unwrap();
+    IndexBuilder::new()
+        .dir("")
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let result = fs.lookup(ctx(), ROOT_INODE, &cstr("nonexistent.txt"));
@@ -704,7 +701,8 @@ fn test_index_lookup_whiteout() {
     IndexBuilder::new()
         .dir("")
         .whiteout("", "deleted.txt")
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let result = fs.lookup(ctx(), ROOT_INODE, &cstr("deleted.txt"));
@@ -730,12 +728,14 @@ fn test_index_lookup_opaque_stops_search() {
     IndexBuilder::new()
         .dir("")
         .file("", "hidden.txt", 0o644)
-        .build_to_file(&index0).unwrap();
+        .build_to_file(&index0)
+        .unwrap();
 
     // Layer 1 (top) is opaque — should block search into layer 0.
     IndexBuilder::new()
         .opaque_dir("")
-        .build_to_file(&index1).unwrap();
+        .build_to_file(&index1)
+        .unwrap();
 
     let fs = OverlayFs::builder()
         .layer_with_index(&lower0, &index0)
@@ -767,7 +767,8 @@ fn test_index_lookup_nested_dir() {
         .subdir("a", "b", 0o755)
         .subdir("a/b", "c", 0o755)
         .file("a/b/c", "deep.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let a = fs.lookup(ctx(), ROOT_INODE, &cstr("a")).unwrap();
@@ -791,7 +792,8 @@ fn test_index_lookup_dir_record_idx_caching() {
         .subdir("", "mydir", 0o755)
         .file("mydir", "file_a", 0o644)
         .file("mydir", "file_b", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("mydir")).unwrap();
@@ -804,7 +806,10 @@ fn test_index_lookup_dir_record_idx_caching() {
         let nodes = fs.nodes.read().unwrap();
         let node = nodes.get(&dir.inode).unwrap();
         let cache = node.dir_record_cache.read().unwrap();
-        assert!(cache.is_some(), "dir_record_cache should be populated after first lookup");
+        assert!(
+            cache.is_some(),
+            "dir_record_cache should be populated after first lookup"
+        );
     }
 
     // Second lookup should use the cached DirRecord (still succeeds).
@@ -829,7 +834,8 @@ fn test_index_lookup_cross_layer() {
     IndexBuilder::new()
         .dir("")
         .file("", "bottom.txt", 0o644)
-        .build_to_file(&index0).unwrap();
+        .build_to_file(&index0)
+        .unwrap();
 
     // Layer 1 (top) has no entries — index should skip it.
     IndexBuilder::new().dir("").build_to_file(&index1).unwrap();
@@ -857,13 +863,16 @@ fn test_index_lookup_shadowed_by_upper() {
     IndexBuilder::new()
         .dir("")
         .file("", "file.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let entry = fs.lookup(ctx(), ROOT_INODE, &cstr("file.txt")).unwrap();
 
     // Read the file — should get upper data.
-    let (handle, _) = fs.open(ctx(), entry.inode, false, libc::O_RDONLY as u32).unwrap();
+    let (handle, _) = fs
+        .open(ctx(), entry.inode, false, libc::O_RDONLY as u32)
+        .unwrap();
     let handle = handle.unwrap();
     let mut writer = MockZeroCopyWriter::new();
     let n = fs
@@ -885,7 +894,8 @@ fn test_index_lookup_upper_whiteout_over_indexed_lower() {
     IndexBuilder::new()
         .dir("")
         .file("", "victim.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let result = fs.lookup(ctx(), ROOT_INODE, &cstr("victim.txt"));
@@ -903,7 +913,10 @@ fn test_index_lookup_absent_dir_not_indexed() {
     // Index describes root but has no entry for "known". The index is authoritative,
     // so the overlay won't fall back to syscalls — "known" returns ENOENT even though
     // it exists on disk.
-    IndexBuilder::new().dir("").build_to_file(&index_path).unwrap();
+    IndexBuilder::new()
+        .dir("")
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let result = fs.lookup(ctx(), ROOT_INODE, &cstr("known"));
@@ -932,7 +945,8 @@ fn test_index_lookup_matches_syscall_path() {
         .subdir("", "etc", 0o755)
         .file("", "hello.txt", 0o644)
         .file("etc", "passwd", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     // With index.
     let fs_idx = mount_indexed(&lower, &index_path, &upper1, &staging1);
@@ -991,7 +1005,8 @@ fn test_index_readdir_basic() {
         .file("", "delta", 0o644)
         .file("", "epsilon", 0o644)
         .file("", "gamma", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let names = readdir_names(&fs, ROOT_INODE);
@@ -1016,7 +1031,8 @@ fn test_index_readdir_skips_whiteouts() {
         .file("", "also_visible", 0o644)
         .whiteout("", "hidden")
         .file("", "visible", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let names = readdir_names(&fs, ROOT_INODE);
@@ -1035,11 +1051,15 @@ fn test_index_readdir_dedup_with_upper() {
     IndexBuilder::new()
         .dir("")
         .file("", "shared.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let names = readdir_names(&fs, ROOT_INODE);
-    let count = names.iter().filter(|n| n.as_slice() == b"shared.txt").count();
+    let count = names
+        .iter()
+        .filter(|n| n.as_slice() == b"shared.txt")
+        .count();
     assert_eq!(count, 1, "shared.txt should appear exactly once");
 }
 
@@ -1053,7 +1073,8 @@ fn test_index_readdir_whiteout_masks_indexed_entry() {
     IndexBuilder::new()
         .dir("")
         .file("", "victim.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let names = readdir_names(&fs, ROOT_INODE);
@@ -1072,7 +1093,8 @@ fn test_index_readdir_opaque_stops_lower() {
     IndexBuilder::new()
         .dir("")
         .file("", "lower_only.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let names = readdir_names(&fs, ROOT_INODE);
@@ -1102,12 +1124,14 @@ fn test_index_readdir_multi_layer() {
         .dir("")
         .file("", "base.txt", 0o644)
         .file("", "shared.txt", 0o644)
-        .build_to_file(&index0).unwrap();
+        .build_to_file(&index0)
+        .unwrap();
     IndexBuilder::new()
         .dir("")
         .file("", "shared.txt", 0o644)
         .file("", "top.txt", 0o644)
-        .build_to_file(&index1).unwrap();
+        .build_to_file(&index1)
+        .unwrap();
 
     let fs = OverlayFs::builder()
         .layer_with_index(&lower0, &index0)
@@ -1122,7 +1146,10 @@ fn test_index_readdir_multi_layer() {
     assert!(names.iter().any(|n| n == b"base.txt"));
     assert!(names.iter().any(|n| n == b"top.txt"));
     // shared.txt should appear only once (top layer wins).
-    let count = names.iter().filter(|n| n.as_slice() == b"shared.txt").count();
+    let count = names
+        .iter()
+        .filter(|n| n.as_slice() == b"shared.txt")
+        .count();
     assert_eq!(count, 1);
 }
 
@@ -1139,7 +1166,8 @@ fn test_index_readdir_tombstones() {
         .file("", "tombstoned", 0o644)
         .tombstone("", "tombstoned")
         .file("", "visible", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let names = readdir_names(&fs, ROOT_INODE);
@@ -1158,7 +1186,8 @@ fn test_index_readdir_empty_dir() {
         .dir("")
         .dir("emptydir")
         .subdir("", "emptydir", 0o755)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("emptydir")).unwrap();
@@ -1194,7 +1223,8 @@ fn test_index_readdir_matches_syscall_path() {
         .file("", "aaa", 0o644)
         .file("", "bbb", 0o644)
         .file("", "ccc", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs_idx = mount_indexed(&lower, &index_path, &upper1, &staging1);
     let fs_plain = mount_plain(&lower, &upper2, &staging2);
@@ -1300,7 +1330,8 @@ fn test_index_mixed_indexed_unindexed() {
     IndexBuilder::new()
         .dir("")
         .file("", "from_indexed.txt", 0o644)
-        .build_to_file(&index0).unwrap();
+        .build_to_file(&index0)
+        .unwrap();
 
     let fs = OverlayFs::builder()
         .layer_with_index(&lower0, &index0) // indexed
@@ -1312,8 +1343,12 @@ fn test_index_mixed_indexed_unindexed() {
     fs.init(FsOptions::empty()).unwrap();
 
     // Both files should be findable.
-    let e1 = fs.lookup(ctx(), ROOT_INODE, &cstr("from_indexed.txt")).unwrap();
-    let e2 = fs.lookup(ctx(), ROOT_INODE, &cstr("from_plain.txt")).unwrap();
+    let e1 = fs
+        .lookup(ctx(), ROOT_INODE, &cstr("from_indexed.txt"))
+        .unwrap();
+    let e2 = fs
+        .lookup(ctx(), ROOT_INODE, &cstr("from_plain.txt"))
+        .unwrap();
     assert_ne!(e1.inode, 0);
     assert_ne!(e2.inode, 0);
 }
@@ -1322,7 +1357,10 @@ fn test_index_mixed_indexed_unindexed() {
 fn test_index_does_not_affect_upper_ops() {
     let tmp = tempfile::tempdir().unwrap();
     let (lower, upper, staging, index_path) = setup_dirs(&tmp);
-    IndexBuilder::new().dir("").build_to_file(&index_path).unwrap();
+    IndexBuilder::new()
+        .dir("")
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
 
@@ -1343,8 +1381,19 @@ fn test_index_does_not_affect_upper_ops() {
 
     // Write to it.
     let mut reader = MockZeroCopyReader::new(b"hello".to_vec());
-    fs.write(ctx(), entry.inode, handle, &mut reader, 5, 0, None, false, false, 0)
-        .unwrap();
+    fs.write(
+        ctx(),
+        entry.inode,
+        handle,
+        &mut reader,
+        5,
+        0,
+        None,
+        false,
+        false,
+        0,
+    )
+    .unwrap();
 
     // Release and re-lookup.
     fs.release(ctx(), entry.inode, 0, handle, false, false, None)
@@ -1362,7 +1411,8 @@ fn test_index_copy_up_from_indexed_lower() {
     IndexBuilder::new()
         .dir("")
         .file("", "file.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
 
@@ -1377,8 +1427,19 @@ fn test_index_copy_up_from_indexed_lower() {
 
     // Write new data.
     let mut reader = MockZeroCopyReader::new(b"modified".to_vec());
-    fs.write(ctx(), entry.inode, handle, &mut reader, 8, 0, None, false, false, 0)
-        .unwrap();
+    fs.write(
+        ctx(),
+        entry.inode,
+        handle,
+        &mut reader,
+        8,
+        0,
+        None,
+        false,
+        false,
+        0,
+    )
+    .unwrap();
 
     // Read back.
     let mut writer = MockZeroCopyWriter::new();
@@ -1407,7 +1468,8 @@ fn test_index_empty_check_truly_empty() {
         .dir("")
         .dir("emptydir")
         .subdir("", "emptydir", 0o755)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("emptydir")).unwrap();
@@ -1428,7 +1490,8 @@ fn test_index_empty_check_has_entry() {
         .dir("notempty")
         .subdir("", "notempty", 0o755)
         .file("notempty", "file.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("notempty")).unwrap();
@@ -1448,7 +1511,8 @@ fn test_index_empty_check_only_whiteouts() {
         .dir("wh_only")
         .subdir("", "wh_only", 0o755)
         .whiteout("wh_only", "deleted")
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("wh_only")).unwrap();
@@ -1473,7 +1537,8 @@ fn test_index_empty_check_entry_masked() {
         .dir("masked")
         .subdir("", "masked", 0o755)
         .file("masked", "file.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("masked")).unwrap();
@@ -1497,7 +1562,8 @@ fn test_index_empty_check_opaque_upper() {
         .dir("opq")
         .subdir("", "opq", 0o755)
         .file("opq", "lower_file.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let dir = fs.lookup(ctx(), ROOT_INODE, &cstr("opq")).unwrap();
@@ -1515,7 +1581,10 @@ fn test_index_empty_check_opaque_upper() {
 fn test_overlay_path_root() {
     let tmp = tempfile::tempdir().unwrap();
     let (lower, upper, staging, index_path) = setup_dirs(&tmp);
-    IndexBuilder::new().dir("").build_to_file(&index_path).unwrap();
+    IndexBuilder::new()
+        .dir("")
+        .build_to_file(&index_path)
+        .unwrap();
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
 
     let nodes = fs.nodes.read().unwrap();
@@ -1534,7 +1603,8 @@ fn test_overlay_path_one_level() {
         .dir("")
         .dir("etc")
         .subdir("", "etc", 0o755)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let entry = fs.lookup(ctx(), ROOT_INODE, &cstr("etc")).unwrap();
@@ -1557,7 +1627,8 @@ fn test_overlay_path_nested() {
         .dir("usr/bin")
         .subdir("", "usr", 0o755)
         .subdir("usr", "bin", 0o755)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let usr = fs.lookup(ctx(), ROOT_INODE, &cstr("usr")).unwrap();
@@ -1583,7 +1654,8 @@ fn test_index_stale_single_layer() {
     IndexBuilder::new()
         .dir("")
         .file("", "ghost.txt", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
     let result = fs.lookup(ctx(), ROOT_INODE, &cstr("ghost.txt"));
@@ -1613,7 +1685,8 @@ fn test_index_stale_fallthrough_to_next_layer() {
     IndexBuilder::new()
         .dir("")
         .file("", "real.txt", 0o644)
-        .build_to_file(&index1).unwrap();
+        .build_to_file(&index1)
+        .unwrap();
 
     let fs = OverlayFs::builder()
         .layer(&lower0) // bottom, no index
@@ -1647,7 +1720,8 @@ fn test_index_without_root_dir_record() {
     IndexBuilder::new()
         .dir("etc")
         .file("etc", "hosts", 0o644)
-        .build_to_file(&index_path).unwrap();
+        .build_to_file(&index_path)
+        .unwrap();
 
     let fs = mount_indexed(&lower, &index_path, &upper, &staging);
 
@@ -1656,7 +1730,10 @@ fn test_index_without_root_dir_record() {
         let nodes = fs.nodes.read().unwrap();
         let root_node = nodes.get(&ROOT_INODE).unwrap();
         let cache = root_node.dir_record_cache.read().unwrap();
-        assert!(cache.is_none(), "root cache should be None when index has no root dir");
+        assert!(
+            cache.is_none(),
+            "root cache should be None when index has no root dir"
+        );
     }
 
     // "top.txt" exists on disk but the index has no root dir, so the index

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_lookup.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_lookup.rs
@@ -134,7 +134,10 @@ fn test_lookup_refcount_and_forget() {
     // After two lookups, refcount is 2. Forget once — inode should still exist.
     sb.fs.forget(sb.ctx(), e1.inode, 1);
     let result = sb.fs.getattr(sb.ctx(), e1.inode, None);
-    assert!(result.is_ok(), "inode should still exist after partial forget");
+    assert!(
+        result.is_ok(),
+        "inode should still exist after partial forget"
+    );
 }
 
 #[test]

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_metadata.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_metadata.rs
@@ -45,13 +45,10 @@ fn test_setattr_mode() {
     let entry = sb.lookup_root("file.txt").unwrap();
     let mut attr: crate::stat64 = unsafe { std::mem::zeroed() };
     attr.st_mode = 0o755;
-    let (st, _) = sb.fs.setattr(
-        sb.ctx(),
-        entry.inode,
-        attr,
-        None,
-        SetattrValid::MODE,
-    ).unwrap();
+    let (st, _) = sb
+        .fs
+        .setattr(sb.ctx(), entry.inode, attr, None, SetattrValid::MODE)
+        .unwrap();
     assert_eq!(st.st_mode as u32 & 0o7777, 0o755);
     // Should have been copied up to upper.
     assert!(sb.upper_has_file("file.txt"));
@@ -65,13 +62,9 @@ fn test_setattr_size_truncate() {
         .unwrap();
     let mut attr: crate::stat64 = unsafe { std::mem::zeroed() };
     attr.st_size = 5;
-    sb.fs.setattr(
-        sb.ctx(),
-        entry.inode,
-        attr,
-        None,
-        SetattrValid::SIZE,
-    ).unwrap();
+    sb.fs
+        .setattr(sb.ctx(), entry.inode, attr, None, SetattrValid::SIZE)
+        .unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(data.len(), 5);
     assert_eq!(&data[..], b"hello");
@@ -84,13 +77,16 @@ fn test_setattr_timestamps() {
     let mut attr: crate::stat64 = unsafe { std::mem::zeroed() };
     attr.st_atime = 1000;
     attr.st_mtime = 2000;
-    let (st, _) = sb.fs.setattr(
-        sb.ctx(),
-        entry.inode,
-        attr,
-        None,
-        SetattrValid::ATIME | SetattrValid::MTIME,
-    ).unwrap();
+    let (st, _) = sb
+        .fs
+        .setattr(
+            sb.ctx(),
+            entry.inode,
+            attr,
+            None,
+            SetattrValid::ATIME | SetattrValid::MTIME,
+        )
+        .unwrap();
     assert_eq!(st.st_atime, 1000);
     assert_eq!(st.st_mtime, 2000);
 }
@@ -98,7 +94,9 @@ fn test_setattr_timestamps() {
 #[test]
 fn test_access_root() {
     let sb = OverlayTestSandbox::new();
-    sb.fs.access(sb.ctx(), ROOT_INODE, libc::F_OK as u32).unwrap();
+    sb.fs
+        .access(sb.ctx(), ROOT_INODE, libc::F_OK as u32)
+        .unwrap();
 }
 
 #[test]
@@ -107,7 +105,9 @@ fn test_access_lower_file() {
         std::fs::write(lower.join("accessible.txt"), b"data").unwrap();
     });
     let entry = sb.lookup_root("accessible.txt").unwrap();
-    sb.fs.access(sb.ctx(), entry.inode, libc::F_OK as u32).unwrap();
+    sb.fs
+        .access(sb.ctx(), entry.inode, libc::F_OK as u32)
+        .unwrap();
 }
 
 #[test]

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_multi_layer.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_multi_layer.rs
@@ -116,9 +116,7 @@ fn test_write_in_multi_layer() {
         std::fs::write(lowers[0].join("deep.txt"), b"deep").unwrap();
     });
     let entry = sb.lookup_root("deep.txt").unwrap();
-    let handle = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fuse_write(entry.inode, handle, b"MODIFIED", 0).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"MODIFIED");

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_readdir.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_readdir.rs
@@ -50,7 +50,10 @@ fn test_readdir_upper_shadows_lower() {
     });
     let names = sb.readdir_names(ROOT_INODE).unwrap();
     // Should appear exactly once.
-    let count = names.iter().filter(|n| n.as_slice() == b"shared.txt").count();
+    let count = names
+        .iter()
+        .filter(|n| n.as_slice() == b"shared.txt")
+        .count();
     assert_eq!(count, 1, "same name should appear exactly once");
 }
 

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_remove_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_remove_ops.rs
@@ -42,11 +42,7 @@ fn test_unlink_lower_lookup_enoent() {
     });
     sb.lookup_root("gone.txt").unwrap();
     sb.fs
-        .unlink(
-            sb.ctx(),
-            ROOT_INODE,
-            &OverlayTestSandbox::cstr("gone.txt"),
-        )
+        .unlink(sb.ctx(), ROOT_INODE, &OverlayTestSandbox::cstr("gone.txt"))
         .unwrap();
     let result = sb.lookup_root("gone.txt");
     OverlayTestSandbox::assert_errno(result, LINUX_ENOENT);
@@ -77,11 +73,7 @@ fn test_rmdir_upper_empty() {
     let sb = OverlayTestSandbox::new();
     sb.fuse_mkdir_root("empty_dir").unwrap();
     sb.fs
-        .rmdir(
-            sb.ctx(),
-            ROOT_INODE,
-            &OverlayTestSandbox::cstr("empty_dir"),
-        )
+        .rmdir(sb.ctx(), ROOT_INODE, &OverlayTestSandbox::cstr("empty_dir"))
         .unwrap();
     let result = sb.lookup_root("empty_dir");
     OverlayTestSandbox::assert_errno(result, LINUX_ENOENT);
@@ -94,11 +86,7 @@ fn test_rmdir_lower_empty() {
     });
     sb.lookup_root("lower_dir").unwrap();
     sb.fs
-        .rmdir(
-            sb.ctx(),
-            ROOT_INODE,
-            &OverlayTestSandbox::cstr("lower_dir"),
-        )
+        .rmdir(sb.ctx(), ROOT_INODE, &OverlayTestSandbox::cstr("lower_dir"))
         .unwrap();
     let result = sb.lookup_root("lower_dir");
     OverlayTestSandbox::assert_errno(result, LINUX_ENOENT);

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_rename.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_rename.rs
@@ -42,10 +42,14 @@ fn test_rename_lower_file() {
     // New name should exist with data preserved through copy-up + rename.
     let new_entry = sb.lookup_root("renamed.txt").unwrap();
     assert!(new_entry.inode >= 3);
-    let handle = sb.fuse_open(new_entry.inode, libc::O_RDONLY as u32).unwrap();
+    let handle = sb
+        .fuse_open(new_entry.inode, libc::O_RDONLY as u32)
+        .unwrap();
     let data = sb.fuse_read(new_entry.inode, handle, 1024, 0).unwrap();
     assert_eq!(&data, b"lower data");
-    sb.fs.release(sb.ctx(), new_entry.inode, 0, handle, false, false, Some(0)).unwrap();
+    sb.fs
+        .release(sb.ctx(), new_entry.inode, 0, handle, false, false, Some(0))
+        .unwrap();
 }
 
 #[test]
@@ -216,9 +220,7 @@ fn test_rename_lower_dir_children_accessible() {
     let child = sb.lookup(new_dir.inode, "file.txt").unwrap();
     assert!(child.inode >= 3);
     // Read the child's data to verify it's intact.
-    let handle = sb
-        .fuse_open(child.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let handle = sb.fuse_open(child.inode, libc::O_RDONLY as u32).unwrap();
     let data = sb.fuse_read(child.inode, handle, 4096, 0).unwrap();
     assert_eq!(&data[..], b"child content");
 }
@@ -472,7 +474,8 @@ fn test_rename_exchange_opaque_dir_no_redirect() {
     // Create a pure-upper dir and rename it onto the empty lower dir.
     // This marks it opaque (suppressing the lower "slot" dir).
     let new_dir = sb.fuse_mkdir_root("temp_dir").unwrap();
-    sb.fuse_create(new_dir.inode, "upper_child.txt", 0o644).unwrap();
+    sb.fuse_create(new_dir.inode, "upper_child.txt", 0o644)
+        .unwrap();
     sb.fs
         .rename(
             sb.ctx(),

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_special_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_special_ops.rs
@@ -52,7 +52,10 @@ fn test_init_binary_read() {
     let sb = OverlayTestSandbox::new();
     let entry = sb.lookup_root("init.krun").unwrap();
     assert_eq!(entry.inode, INIT_INODE);
-    let (handle, _opts) = sb.fs.open(sb.ctx(), INIT_INODE, false, libc::O_RDONLY as u32).unwrap();
+    let (handle, _opts) = sb
+        .fs
+        .open(sb.ctx(), INIT_INODE, false, libc::O_RDONLY as u32)
+        .unwrap();
     let handle = handle.unwrap();
     let data = sb.fuse_read(INIT_INODE, handle, 4096, 0).unwrap();
     assert!(!data.is_empty(), "init binary should return data");

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_xattr.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_xattr.rs
@@ -54,9 +54,7 @@ fn test_removexattr() {
     sb.fs
         .setxattr(sb.ctx(), entry.inode, &key, b"val", 0)
         .unwrap();
-    sb.fs
-        .removexattr(sb.ctx(), entry.inode, &key)
-        .unwrap();
+    sb.fs.removexattr(sb.ctx(), entry.inode, &key).unwrap();
     let result = sb.fs.getxattr(sb.ctx(), entry.inode, &key, 256);
     OverlayTestSandbox::assert_errno(result, LINUX_ENODATA);
 }

--- a/crates/filesystem/lib/backends/overlayfs/types.rs
+++ b/crates/filesystem/lib/backends/overlayfs/types.rs
@@ -3,11 +3,15 @@
 //! All core types used across overlay modules are defined here to avoid
 //! circular dependencies between modules.
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::{Mutex, RwLock};
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    fs::File,
+    sync::{
+        Mutex, RwLock,
+        atomic::{AtomicBool, AtomicU64},
+    },
+    time::Duration,
+};
 
 use super::origin::LowerOriginId;
 

--- a/crates/filesystem/lib/backends/overlayfs/whiteout.rs
+++ b/crates/filesystem/lib/backends/overlayfs/whiteout.rs
@@ -12,13 +12,9 @@
 //! these names are stored in the `user.containers.overlay_tombstones` xattr
 //! on the parent directory as a length-prefixed binary blob.
 
-use std::ffi::CStr;
-use std::io;
-use std::os::fd::RawFd;
+use std::{ffi::CStr, io, os::fd::RawFd};
 
-use super::OverlayFs;
-use super::inode;
-use super::layer;
+use super::{OverlayFs, inode, layer};
 use crate::backends::shared::platform;
 
 //--------------------------------------------------------------------------------------------------
@@ -133,7 +129,8 @@ pub(crate) fn has_lower_entry(fs: &OverlayFs, parent_inode: u64, name: &[u8]) ->
 
     // Check each lower layer (top-down).
     for lower in fs.lowers.iter().rev() {
-        let lower_parent_fd = match inode::open_lower_parent(lower, &parent_node, &path_components) {
+        let lower_parent_fd = match inode::open_lower_parent(lower, &parent_node, &path_components)
+        {
             Some(fd) => fd,
             None => continue,
         };
@@ -174,7 +171,7 @@ pub(crate) fn check_overflow_whiteout(parent_fd: RawFd, name: &[u8]) -> io::Resu
     };
 
     let entries = parse_tombstone_blob(&blob)?;
-    Ok(entries.iter().any(|e| *e == name))
+    Ok(entries.contains(&name))
 }
 
 /// Add a long name to the parent's overflow tombstone xattr.
@@ -190,7 +187,7 @@ fn create_overflow_whiteout(parent_fd: RawFd, name: &[u8]) -> io::Result<()> {
         Ok(Some(existing)) => {
             // Validate existing blob and check for duplicates.
             let entries = parse_tombstone_blob(&existing)?;
-            if entries.iter().any(|e| *e == name) {
+            if entries.contains(&name) {
                 return Ok(()); // Already tombstoned.
             }
             existing
@@ -426,9 +423,7 @@ fn remove_tombstone_xattr(fd: RawFd) -> io::Result<()> {
     {
         let path = format!("/proc/self/fd/{fd}");
         let path_cstr = std::ffi::CString::new(path).map_err(|_| platform::eio())?;
-        let ret = unsafe {
-            libc::removexattr(path_cstr.as_ptr(), TOMBSTONES_XATTR_KEY.as_ptr())
-        };
+        let ret = unsafe { libc::removexattr(path_cstr.as_ptr(), TOMBSTONES_XATTR_KEY.as_ptr()) };
         if ret < 0 {
             let err = io::Error::last_os_error();
             let errno = err.raw_os_error().unwrap_or(0);
@@ -441,9 +436,7 @@ fn remove_tombstone_xattr(fd: RawFd) -> io::Result<()> {
 
     #[cfg(target_os = "macos")]
     {
-        let ret = unsafe {
-            libc::fremovexattr(fd, TOMBSTONES_XATTR_KEY.as_ptr(), 0)
-        };
+        let ret = unsafe { libc::fremovexattr(fd, TOMBSTONES_XATTR_KEY.as_ptr(), 0) };
         if ret < 0 {
             let err = io::Error::last_os_error();
             let errno = err.raw_os_error().unwrap_or(0);
@@ -467,5 +460,3 @@ fn remove_tombstone_xattr(fd: RawFd) -> io::Result<()> {
 pub(crate) fn remove_tombstone_xattr_if_present(fd: RawFd) {
     let _ = remove_tombstone_xattr(fd);
 }
-
-

--- a/crates/filesystem/lib/backends/overlayfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/xattr_ops.rs
@@ -14,23 +14,22 @@
 //!
 //! setxattr and removexattr trigger copy-up before modification.
 
-use std::ffi::CStr;
-use std::io;
+use std::{ffi::CStr, io};
 
-use super::OverlayFs;
-use super::copy_up;
-use super::inode;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, GetxattrReply, ListxattrReply};
+use super::{OverlayFs, copy_up, inode};
+use crate::{
+    Context, GetxattrReply, ListxattrReply,
+    backends::shared::{init_binary, platform, stat_override},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-use super::origin::{ORIGIN_XATTR_KEY, REDIRECT_XATTR_KEY};
-use super::whiteout::TOMBSTONES_XATTR_KEY;
+use super::{
+    origin::{ORIGIN_XATTR_KEY, REDIRECT_XATTR_KEY},
+    whiteout::TOMBSTONES_XATTR_KEY,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -70,7 +69,9 @@ pub(crate) fn do_getxattr(
     }
 
     let fd = inode::open_node_fd(fs, ino, libc::O_RDONLY)?;
-    let _close = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Build /proc/self/fd path once for all reads (Linux).
     #[cfg(target_os = "linux")]
@@ -140,7 +141,9 @@ pub(crate) fn do_listxattr(
     }
 
     let fd = inode::open_node_fd(fs, ino, libc::O_RDONLY)?;
-    let _close = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     // Build /proc/self/fd path once for all reads (Linux).
     #[cfg(target_os = "linux")]
@@ -204,7 +207,7 @@ pub(crate) fn do_listxattr(
         }
 
         // Exhausted retries — the xattr list keeps changing.
-        return Err(platform::eio());
+        Err(platform::eio())
     } else {
         let mut buf = vec![0u8; size as usize];
 
@@ -253,7 +256,9 @@ pub(crate) fn do_setxattr(
     copy_up::ensure_upper(fs, ino)?;
 
     let fd = inode::open_node_fd(fs, ino, libc::O_RDONLY)?;
-    let _close = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     #[cfg(target_os = "linux")]
     {
@@ -313,17 +318,14 @@ pub(crate) fn do_removexattr(
     copy_up::ensure_upper(fs, ino)?;
 
     let fd = inode::open_node_fd(fs, ino, libc::O_RDONLY)?;
-    let _close = scopeguard::guard(fd, |fd| unsafe { libc::close(fd); });
+    let _close = scopeguard::guard(fd, |fd| unsafe {
+        libc::close(fd);
+    });
 
     #[cfg(target_os = "linux")]
     {
         let path = format!("/proc/self/fd/{fd}\0");
-        let ret = unsafe {
-            libc::removexattr(
-                path.as_ptr() as *const libc::c_char,
-                name.as_ptr(),
-            )
-        };
+        let ret = unsafe { libc::removexattr(path.as_ptr() as *const libc::c_char, name.as_ptr()) };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
@@ -331,9 +333,7 @@ pub(crate) fn do_removexattr(
 
     #[cfg(target_os = "macos")]
     {
-        let ret = unsafe {
-            libc::fremovexattr(fd, name.as_ptr(), 0)
-        };
+        let ret = unsafe { libc::fremovexattr(fd, name.as_ptr(), 0) };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }

--- a/crates/filesystem/lib/backends/passthroughfs/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/builder.rs
@@ -8,18 +8,23 @@
 //!     .build()?
 //! ```
 
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io;
-use std::os::fd::{AsRawFd, FromRawFd};
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::RwLock;
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    path::PathBuf,
+    sync::{
+        RwLock,
+        atomic::{AtomicBool, AtomicU64},
+    },
+    time::Duration,
+};
 
 use super::{CachePolicy, PassthroughFs};
-use crate::backends::shared::inode_table::MultikeyBTreeMap;
-use crate::backends::shared::{init_binary, platform, stat_override};
+use crate::backends::shared::{
+    init_binary, inode_table::MultikeyBTreeMap, platform, stat_override,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -98,18 +103,14 @@ impl PassthroughFsBuilder {
 
     /// Build the PassthroughFs instance.
     pub fn build(self) -> io::Result<PassthroughFs> {
-        let root_dir = self.root_dir.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "root_dir not set")
-        })?;
+        let root_dir = self
+            .root_dir
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "root_dir not set"))?;
 
         // Open the root directory.
-        let root_path = std::ffi::CString::new(
-            root_dir
-                .to_str()
-                .ok_or_else(platform::einval)?
-                .as_bytes(),
-        )
-        .map_err(|_| platform::einval())?;
+        let root_path =
+            std::ffi::CString::new(root_dir.to_str().ok_or_else(platform::einval)?.as_bytes())
+                .map_err(|_| platform::einval())?;
 
         let root_fd_raw = unsafe {
             libc::open(

--- a/crates/filesystem/lib/backends/passthroughfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/create_ops.rs
@@ -18,20 +18,20 @@
 //! xattr mode (file-backed symlinks), because Linux `user.*` xattrs cannot be set on symlinks.
 //! On macOS, real symlinks are used with `XATTR_NOFOLLOW` for xattr operations.
 
-use std::ffi::CStr;
-use std::io;
-use std::os::fd::FromRawFd;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::{
+    ffi::CStr,
+    io,
+    os::fd::FromRawFd,
+    sync::{Arc, RwLock, atomic::Ordering},
+};
 
-use super::PassthroughFs;
-use super::inode;
-use crate::backends::shared::handle_table::HandleData;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::name_validation;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, Entry, Extensions, OpenOptions};
+use super::{PassthroughFs, inode};
+use crate::{
+    Context, Entry, Extensions, OpenOptions,
+    backends::shared::{
+        handle_table::HandleData, init_binary, name_validation, platform, stat_override,
+    },
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -98,12 +98,13 @@ pub(crate) fn do_create(
     let open_fd = inode::open_inode_fd(fs, entry.inode, open_flags & !libc::O_CREAT)?;
 
     // Clear SUID/SGID on create+truncate of existing file (HANDLE_KILLPRIV_V2).
-    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
-        if let Ok(Some(ovr)) = stat_override::get_override(open_fd) {
-            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
-            if new_mode != ovr.mode {
-                let _ = stat_override::set_override(open_fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
-            }
+    if kill_priv
+        && (open_flags & libc::O_TRUNC != 0)
+        && let Ok(Some(ovr)) = stat_override::get_override(open_fd)
+    {
+        let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+        if new_mode != ovr.mode {
+            let _ = stat_override::set_override(open_fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
         }
     }
 

--- a/crates/filesystem/lib/backends/passthroughfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/dir_ops.rs
@@ -16,17 +16,17 @@
 //! each entry already gets a full `do_lookup` that reads the override xattr — making d_type
 //! correction free.
 
-use std::io;
-use std::os::fd::{AsRawFd, FromRawFd};
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    sync::{Arc, RwLock, atomic::Ordering},
+};
 
-use super::PassthroughFs;
-use super::inode;
-use crate::backends::shared::handle_table::HandleData;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, DirEntry, Entry, OpenOptions};
+use super::{PassthroughFs, inode};
+use crate::{
+    Context, DirEntry, Entry, OpenOptions,
+    backends::shared::{handle_table::HandleData, init_binary, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/lib/backends/passthroughfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/file_ops.rs
@@ -13,18 +13,17 @@
 //! coherency. `do_open` adjusts `O_WRONLY` → `O_RDWR` and strips `O_APPEND` (which races with
 //! the kernel's cached view of the file).
 
-use std::io;
-use std::os::fd::{AsRawFd, FromRawFd};
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    sync::{Arc, RwLock, atomic::Ordering},
+};
 
-use super::PassthroughFs;
-use super::inode;
-use crate::backends::shared::handle_table::HandleData;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter};
+use super::{PassthroughFs, inode};
+use crate::{
+    Context, OpenOptions, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::{handle_table::HandleData, init_binary, platform, stat_override},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -62,12 +61,13 @@ pub(crate) fn do_open(
     let fd = inode::open_inode_fd(fs, inode, open_flags)?;
 
     // Clear SUID/SGID on open+truncate (HANDLE_KILLPRIV_V2).
-    if kill_priv && (open_flags & libc::O_TRUNC != 0) {
-        if let Ok(Some(ovr)) = stat_override::get_override(fd) {
-            let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
-            if new_mode != ovr.mode {
-                let _ = stat_override::set_override(fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
-            }
+    if kill_priv
+        && (open_flags & libc::O_TRUNC != 0)
+        && let Ok(Some(ovr)) = stat_override::get_override(fd)
+    {
+        let new_mode = ovr.mode & !(libc::S_ISUID as u32 | libc::S_ISGID as u32);
+        if new_mode != ovr.mode {
+            let _ = stat_override::set_override(fd, ovr.uid, ovr.gid, new_mode, ovr.rdev);
         }
     }
 
@@ -108,6 +108,7 @@ pub(crate) fn do_read(
 /// When `kill_priv` is true (HANDLE_KILLPRIV_V2 negotiated), clears SUID/SGID
 /// bits from the override xattr after a successful write — the guest kernel
 /// expects the filesystem to handle this.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn do_write(
     fs: &PassthroughFs,
     _ctx: Context,

--- a/crates/filesystem/lib/backends/passthroughfs/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/inode.rs
@@ -17,16 +17,22 @@
 //! escaping the exported root. Using `openat` relative to `/proc/self/fd` with `O_NOFOLLOW`
 //! ensures the kernel resolves the fd reference without following any symlinks.
 
-use std::ffi::{CStr, CString};
-use std::io;
-use std::os::fd::AsRawFd;
-use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::{
+    ffi::{CStr, CString},
+    io,
+    os::fd::AsRawFd,
+    sync::{Arc, atomic::Ordering},
+};
 
 use super::PassthroughFs;
-use crate::backends::shared::inode_table::{InodeAltKey, InodeData, MultikeyBTreeMap};
-use crate::backends::shared::platform;
-use crate::{Entry, stat64};
+use crate::{
+    Entry,
+    backends::shared::{
+        inode_table::{InodeAltKey, InodeData, MultikeyBTreeMap},
+        platform,
+    },
+    stat64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/filesystem/lib/backends/passthroughfs/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/metadata.rs
@@ -11,15 +11,14 @@
 //! (the host process lacks `CAP_CHOWN`). Size changes use real `ftruncate`, and timestamp
 //! changes use real `futimens`.
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
-use super::PassthroughFs;
-use super::inode;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, SetattrValid, stat64};
+use super::{PassthroughFs, inode};
+use crate::{
+    Context, SetattrValid,
+    backends::shared::{init_binary, platform, stat_override},
+    stat64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/lib/backends/passthroughfs/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/mod.rs
@@ -14,24 +14,30 @@ mod remove_ops;
 mod special;
 mod xattr_ops;
 
-use std::collections::BTreeMap;
-use std::ffi::CStr;
-use std::fs::File;
-use std::io;
-use std::os::fd::{AsRawFd, FromRawFd};
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    ffi::CStr,
+    fs::File,
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    path::PathBuf,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
-use crate::backends::shared::handle_table::HandleData;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::inode_table::{InodeAltKey, InodeData, MultikeyBTreeMap};
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
 use crate::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    backends::shared::{
+        handle_table::HandleData,
+        init_binary,
+        inode_table::{InodeAltKey, InodeData, MultikeyBTreeMap},
+        platform, stat_override,
+    },
+    stat64, statvfs64,
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/filesystem/lib/backends/passthroughfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/remove_ops.rs
@@ -4,15 +4,13 @@
 //! On Linux, `renameat2` is used for flag support (RENAME_NOREPLACE, RENAME_EXCHANGE).
 //! On macOS, `renameatx_np` is used with translated flag values.
 
-use std::ffi::CStr;
-use std::io;
+use std::{ffi::CStr, io};
 
-use super::PassthroughFs;
-use super::inode;
-use crate::Context;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::name_validation;
-use crate::backends::shared::platform;
+use super::{PassthroughFs, inode};
+use crate::{
+    Context,
+    backends::shared::{init_binary, name_validation, platform},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -66,10 +64,8 @@ pub(crate) fn do_unlink(
         // Look up the inode by stat identity from the pre-unlink fd.
         let st = platform::fstat(fd);
         if let Ok(st) = st {
-            let alt_key = crate::backends::shared::inode_table::InodeAltKey::new(
-                st.st_ino as u64,
-                st.st_dev as u64,
-            );
+            let alt_key =
+                crate::backends::shared::inode_table::InodeAltKey::new(st.st_ino, st.st_dev as u64);
             let inodes = fs.inodes.read().unwrap();
             if let Some(data) = inodes.get_alt(&alt_key) {
                 use std::sync::atomic::Ordering;

--- a/crates/filesystem/lib/backends/passthroughfs/special.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/special.rs
@@ -11,13 +11,14 @@
 //! On macOS, uses `fcntl(F_PREALLOCATE)` + `ftruncate` since `fallocate64` doesn't exist.
 //! Tries contiguous allocation first, falls back to non-contiguous.
 
-use std::io;
-use std::os::fd::AsRawFd;
+use std::{io, os::fd::AsRawFd};
 
 use super::PassthroughFs;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::{Context, statvfs64};
+use crate::{
+    Context,
+    backends::shared::{init_binary, platform},
+    statvfs64,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/lib/backends/passthroughfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/mod.rs
@@ -17,11 +17,7 @@ mod test_special_ops;
 mod test_vol_lookup;
 mod test_xattr_ops;
 
-use std::ffi::CString;
-use std::fs::File;
-use std::io;
-use std::os::fd::AsRawFd;
-use std::path::PathBuf;
+use std::{ffi::CString, fs::File, io, os::fd::AsRawFd, path::PathBuf};
 
 use tempfile::TempDir;
 

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_bootstrap.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_bootstrap.rs
@@ -1,6 +1,4 @@
-use std::path::PathBuf;
-use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::{path::PathBuf, sync::atomic::Ordering, time::Duration};
 
 use super::*;
 

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_corrupt_xattr.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_corrupt_xattr.rs
@@ -1,5 +1,4 @@
-use std::ffi::CString;
-use std::os::fd::AsRawFd;
+use std::{ffi::CString, os::fd::AsRawFd};
 
 use super::*;
 use crate::backends::shared::stat_override::OVERRIDE_XATTR_KEY;

--- a/crates/filesystem/lib/backends/passthroughfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/xattr_ops.rs
@@ -17,15 +17,13 @@
 //! kernel count would leak the hidden xattr's existence (the guest could compare the
 //! unfiltered count with the filtered list to infer the xattr exists).
 
-use std::ffi::CStr;
-use std::io;
+use std::{ffi::CStr, io};
 
-use super::PassthroughFs;
-use super::inode;
-use crate::backends::shared::init_binary;
-use crate::backends::shared::platform;
-use crate::backends::shared::stat_override;
-use crate::{Context, GetxattrReply, ListxattrReply};
+use super::{PassthroughFs, inode};
+use crate::{
+    Context, GetxattrReply, ListxattrReply,
+    backends::shared::{init_binary, platform, stat_override},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Functions

--- a/crates/filesystem/lib/backends/proxy/adapters.rs
+++ b/crates/filesystem/lib/backends/proxy/adapters.rs
@@ -6,9 +6,7 @@
 //! `SliceReader` presents a `&[u8]` slice as a `ZeroCopyReader`,
 //! used to feed transformed data from the `on_write` hook to the inner backend.
 
-use std::fs::File;
-use std::io;
-use std::os::fd::AsRawFd;
+use std::{fs::File, io, os::fd::AsRawFd};
 
 use crate::{ZeroCopyReader, ZeroCopyWriter};
 

--- a/crates/filesystem/lib/backends/proxy/builder.rs
+++ b/crates/filesystem/lib/backends/proxy/builder.rs
@@ -1,8 +1,10 @@
 //! ProxyFs builder.
 
-use std::collections::HashMap;
-use std::io;
-use std::sync::{Mutex, RwLock};
+use std::{
+    collections::HashMap,
+    io,
+    sync::{Mutex, RwLock},
+};
 
 use super::{AccessMode, ProxyFs};
 use crate::DynFileSystem;
@@ -12,6 +14,7 @@ use crate::DynFileSystem;
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for constructing a [`ProxyFs`].
+#[allow(clippy::type_complexity)]
 pub struct ProxyFsBuilder {
     inner: Box<dyn DynFileSystem>,
     on_access: Option<Box<dyn Fn(&str, AccessMode) -> Result<(), io::Error> + Send + Sync>>,
@@ -114,8 +117,7 @@ fn create_staging_file() -> io::Result<std::fs::File> {
         }
         // Pre-allocate a 128KB buffer for typical FUSE read/write chunks.
         let buf = vec![0u8; 128 * 1024];
-        let written =
-            unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
+        let written = unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
         if written < 0 {
             let err = io::Error::last_os_error();
             unsafe { libc::close(fd) };

--- a/crates/filesystem/lib/backends/proxy/hooks.rs
+++ b/crates/filesystem/lib/backends/proxy/hooks.rs
@@ -5,11 +5,12 @@
 //! - `on_read`: After inner.read() to transform data before returning to guest.
 //! - `on_write`: After reading from guest, before inner.write() to transform data.
 
-use std::io;
-use std::os::fd::AsRawFd;
+use std::{io, os::fd::AsRawFd};
 
-use super::adapters::{SliceReader, VecWriter};
-use super::{AccessMode, ProxyFs};
+use super::{
+    AccessMode, ProxyFs,
+    adapters::{SliceReader, VecWriter},
+};
 use crate::{ZeroCopyReader, ZeroCopyWriter};
 
 //--------------------------------------------------------------------------------------------------
@@ -50,11 +51,7 @@ pub(crate) fn check_access(fs: &ProxyFs, inode: u64, flags: u32) -> io::Result<(
 }
 
 /// Check access for a path (used by create where the file doesn't exist yet).
-pub(crate) fn check_access_by_path(
-    fs: &ProxyFs,
-    path: &str,
-    mode: AccessMode,
-) -> io::Result<()> {
+pub(crate) fn check_access_by_path(fs: &ProxyFs, path: &str, mode: AccessMode) -> io::Result<()> {
     if let Some(ref on_access) = fs.on_access {
         on_access(path, mode)?;
     }
@@ -123,7 +120,7 @@ pub(crate) fn do_intercepted_read(
         return Err(io::Error::last_os_error());
     }
 
-    w.write_from(&*staging, transformed.len(), 0)
+    w.write_from(&staging, transformed.len(), 0)
 }
 
 /// Intercepted write: capture guest input, transform via hook, write to inner.
@@ -154,7 +151,7 @@ pub(crate) fn do_intercepted_write(
 
     // Step 1: Read guest data via staging file.
     let staging = fs.staging_file.as_ref().unwrap().lock().unwrap();
-    let count = r.read_to(&*staging, size as usize, 0)?;
+    let count = r.read_to(&staging, size as usize, 0)?;
 
     if count == 0 {
         return Ok(0);

--- a/crates/filesystem/lib/backends/proxy/mod.rs
+++ b/crates/filesystem/lib/backends/proxy/mod.rs
@@ -13,11 +13,13 @@ pub(crate) mod builder;
 mod hooks;
 mod path_tracking;
 
-use std::collections::HashMap;
-use std::ffi::CStr;
-use std::fs::File;
-use std::io;
-use std::sync::{Mutex, RwLock};
+use std::{
+    collections::HashMap,
+    ffi::CStr,
+    fs::File,
+    io,
+    sync::{Mutex, RwLock},
+};
 
 use crate::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
@@ -33,6 +35,7 @@ use crate::{
 /// Wraps any [`DynFileSystem`] and intercepts specific FUSE operations for
 /// user-supplied hooks. All non-intercepted operations are delegated
 /// transparently to the inner backend.
+#[allow(clippy::type_complexity)]
 pub struct ProxyFs {
     /// The wrapped filesystem backend.
     inner: Box<dyn DynFileSystem>,
@@ -144,7 +147,9 @@ impl DynFileSystem for ProxyFs {
         name: &CStr,
         extensions: Extensions,
     ) -> io::Result<Entry> {
-        let entry = self.inner.symlink(ctx, linkname, parent, name, extensions)?;
+        let entry = self
+            .inner
+            .symlink(ctx, linkname, parent, name, extensions)?;
         let path = path_tracking::build_path(self, parent, name);
         path_tracking::register_path(self, entry.inode, path);
         Ok(entry)
@@ -161,7 +166,9 @@ impl DynFileSystem for ProxyFs {
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<Entry> {
-        let entry = self.inner.mknod(ctx, parent, name, mode, rdev, umask, extensions)?;
+        let entry = self
+            .inner
+            .mknod(ctx, parent, name, mode, rdev, umask, extensions)?;
         let path = path_tracking::build_path(self, parent, name);
         path_tracking::register_path(self, entry.inode, path);
         Ok(entry)
@@ -176,7 +183,9 @@ impl DynFileSystem for ProxyFs {
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<Entry> {
-        let entry = self.inner.mkdir(ctx, parent, name, mode, umask, extensions)?;
+        let entry = self
+            .inner
+            .mkdir(ctx, parent, name, mode, umask, extensions)?;
         let path = path_tracking::build_path(self, parent, name);
         path_tracking::register_path(self, entry.inode, path);
         Ok(entry)
@@ -200,20 +209,15 @@ impl DynFileSystem for ProxyFs {
         flags: u32,
     ) -> io::Result<()> {
         let renamed_inode = path_tracking::resolve_inode(self, olddir, oldname);
-        self.inner.rename(ctx, olddir, oldname, newdir, newname, flags)?;
+        self.inner
+            .rename(ctx, olddir, oldname, newdir, newname, flags)?;
         if let Some(ino) = renamed_inode {
             path_tracking::update_paths_after_rename(self, olddir, oldname, newdir, newname, ino);
         }
         Ok(())
     }
 
-    fn link(
-        &self,
-        ctx: Context,
-        ino: u64,
-        newparent: u64,
-        newname: &CStr,
-    ) -> io::Result<Entry> {
+    fn link(&self, ctx: Context, ino: u64, newparent: u64, newname: &CStr) -> io::Result<Entry> {
         let entry = self.inner.link(ctx, ino, newparent, newname)?;
         let path = path_tracking::build_path(self, newparent, newname);
         path_tracking::register_path(self, entry.inode, path);
@@ -250,9 +254,9 @@ impl DynFileSystem for ProxyFs {
         let path = path_tracking::build_path(self, parent, name);
         hooks::check_access_by_path(self, &path, AccessMode::Write)?;
 
-        let (entry, handle, opts) =
-            self.inner
-                .create(ctx, parent, name, mode, kill_priv, flags, umask, extensions)?;
+        let (entry, handle, opts) = self
+            .inner
+            .create(ctx, parent, name, mode, kill_priv, flags, umask, extensions)?;
 
         path_tracking::register_path(self, entry.inode, path.clone());
         if let Some(h) = handle {
@@ -342,8 +346,7 @@ impl DynFileSystem for ProxyFs {
         offset: u64,
         length: u64,
     ) -> io::Result<()> {
-        self.inner
-            .fallocate(ctx, ino, handle, mode, offset, length)
+        self.inner.fallocate(ctx, ino, handle, mode, offset, length)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/filesystem/lib/backends/proxy/tests/mod.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/mod.rs
@@ -12,17 +12,18 @@ mod test_read_hook;
 mod test_roundtrip;
 mod test_write_hook;
 
-use std::ffi::CString;
-use std::fs::File;
-use std::io;
-use std::os::fd::AsRawFd;
-use std::sync::{Arc, Mutex};
+use std::{
+    ffi::CString,
+    fs::File,
+    io,
+    os::fd::AsRawFd,
+    sync::{Arc, Mutex},
+};
 
 use super::*;
-use crate::backends::memfs::MemFs;
 use crate::{
     Context, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter, backends::memfs::MemFs,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -364,12 +365,7 @@ impl ProxyFsTestSandbox {
     }
 
     /// Create a file and write content. Returns the inode.
-    fn create_file_with_content(
-        &self,
-        parent: u64,
-        name: &str,
-        data: &[u8],
-    ) -> io::Result<u64> {
+    fn create_file_with_content(&self, parent: u64, name: &str, data: &[u8]) -> io::Result<u64> {
         let (entry, handle) = self.fuse_create(parent, name, 0o644)?;
         let handle = handle.unwrap();
         self.fuse_write(entry.inode, handle, data, 0)?;

--- a/crates/filesystem/lib/backends/proxy/tests/test_access_hook.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_access_hook.rs
@@ -7,9 +7,7 @@ fn test_access_allow_all() {
     let (entry, handle) = sb.fuse_create_root("allowed.txt").unwrap();
     let handle = handle.unwrap();
     // Open the file.
-    let (open_handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (open_handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     assert!(open_handle.is_some());
     // Release handles.
     sb.fs
@@ -38,7 +36,12 @@ fn test_access_allow_all() {
     let (dir_handle, _opts) = sb.fuse_opendir(ROOT_INODE).unwrap();
     assert!(dir_handle.is_some());
     sb.fs
-        .releasedir(ProxyFsTestSandbox::ctx(), ROOT_INODE, 0, dir_handle.unwrap())
+        .releasedir(
+            ProxyFsTestSandbox::ctx(),
+            ROOT_INODE,
+            0,
+            dir_handle.unwrap(),
+        )
         .unwrap();
 }
 
@@ -105,7 +108,12 @@ fn test_access_deny_write_allow_read() {
     let (dir_handle, _opts) = sb.fuse_opendir(ROOT_INODE).unwrap();
     assert!(dir_handle.is_some());
     sb.fs
-        .releasedir(ProxyFsTestSandbox::ctx(), ROOT_INODE, 0, dir_handle.unwrap())
+        .releasedir(
+            ProxyFsTestSandbox::ctx(),
+            ROOT_INODE,
+            0,
+            dir_handle.unwrap(),
+        )
         .unwrap();
 }
 
@@ -238,9 +246,7 @@ fn test_access_open_flags_mapping() {
     sb.access_log.lock().unwrap().clear();
 
     // O_RDONLY → Read
-    let (h1, _) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (h1, _) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -254,9 +260,7 @@ fn test_access_open_flags_mapping() {
         .unwrap();
 
     // O_WRONLY → Write
-    let (h2, _) = sb
-        .fuse_open(entry.inode, libc::O_WRONLY as u32)
-        .unwrap();
+    let (h2, _) = sb.fuse_open(entry.inode, libc::O_WRONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -270,9 +274,7 @@ fn test_access_open_flags_mapping() {
         .unwrap();
 
     // O_RDWR → Read + Write
-    let (h3, _) = sb
-        .fuse_open(entry.inode, libc::O_RDWR as u32)
-        .unwrap();
+    let (h3, _) = sb.fuse_open(entry.inode, libc::O_RDWR as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -291,11 +293,7 @@ fn test_access_open_flags_mapping() {
     // O_WRONLY logs one Write.
     assert_eq!(log[1].1, AccessMode::Write, "O_WRONLY should map to Write");
     // O_RDWR logs Read then Write.
-    assert_eq!(
-        log[2].1,
-        AccessMode::Read,
-        "O_RDWR should first check Read"
-    );
+    assert_eq!(log[2].1, AccessMode::Read, "O_RDWR should first check Read");
     assert_eq!(
         log[3].1,
         AccessMode::Write,
@@ -358,9 +356,7 @@ fn test_access_hook_receives_correct_path() {
     sb.access_log.lock().unwrap().clear();
 
     // Open the file.
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),

--- a/crates/filesystem/lib/backends/proxy/tests/test_concurrency.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_concurrency.rs
@@ -12,9 +12,7 @@ fn test_concurrent_reads_with_hook() {
         let mut handles = Vec::new();
         for _ in 0..8 {
             handles.push(s.spawn(move || {
-                let (handle, _opts) = sb
-                    .fuse_open(ino, libc::O_RDONLY as u32)
-                    .unwrap();
+                let (handle, _opts) = sb.fuse_open(ino, libc::O_RDONLY as u32).unwrap();
                 let handle = handle.unwrap();
                 let data = sb.fuse_read(ino, handle, 4096, 0).unwrap();
                 sb.fs
@@ -133,9 +131,7 @@ fn test_concurrent_access_checks() {
         let mut handles = Vec::new();
         for &ino in &inodes {
             handles.push(s.spawn(move || {
-                let (handle, _opts) = sb
-                    .fuse_open(ino, libc::O_RDONLY as u32)
-                    .unwrap();
+                let (handle, _opts) = sb.fuse_open(ino, libc::O_RDONLY as u32).unwrap();
                 let handle = handle.unwrap();
                 sb.fs
                     .release(

--- a/crates/filesystem/lib/backends/proxy/tests/test_delegation.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_delegation.rs
@@ -192,7 +192,10 @@ fn test_delegation_symlink_readlink() {
         )
         .unwrap();
     assert!(entry.inode >= 3);
-    let target = sb.fs.readlink(ProxyFsTestSandbox::ctx(), entry.inode).unwrap();
+    let target = sb
+        .fs
+        .readlink(ProxyFsTestSandbox::ctx(), entry.inode)
+        .unwrap();
     assert_eq!(&target[..], b"/target/path");
 }
 
@@ -221,7 +224,9 @@ fn test_delegation_mknod() {
 #[test]
 fn test_delegation_link() {
     let sb = ProxyFsTestSandbox::new();
-    let ino = sb.create_file_with_content(ROOT_INODE, "original.txt", b"link data").unwrap();
+    let ino = sb
+        .create_file_with_content(ROOT_INODE, "original.txt", b"link data")
+        .unwrap();
     let link_entry = sb
         .fs
         .link(
@@ -255,9 +260,6 @@ fn test_delegation_init() {
 #[test]
 fn test_delegation_statfs() {
     let sb = ProxyFsTestSandbox::new();
-    let st = sb
-        .fs
-        .statfs(ProxyFsTestSandbox::ctx(), ROOT_INODE)
-        .unwrap();
+    let st = sb.fs.statfs(ProxyFsTestSandbox::ctx(), ROOT_INODE).unwrap();
     assert!(st.f_bsize > 0);
 }

--- a/crates/filesystem/lib/backends/proxy/tests/test_path_tracking.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_path_tracking.rs
@@ -40,9 +40,7 @@ fn test_path_lookup_populates() {
     let _ = sb.lookup_root("looked_up.txt").unwrap();
     sb.access_log.lock().unwrap().clear();
     // Open — should get path from path table.
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -82,9 +80,7 @@ fn test_path_nested() {
         .unwrap();
     let _ = sb.lookup(dir_b.inode, "c").unwrap();
     sb.access_log.lock().unwrap().clear();
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -167,9 +163,7 @@ fn test_path_mknod_populates() {
         )
         .unwrap();
     sb.access_log.lock().unwrap().clear();
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -244,9 +238,7 @@ fn test_path_link_updates() {
         .unwrap();
     sb.access_log.lock().unwrap().clear();
     // Open the linked inode — path should be updated to "linked".
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -353,9 +345,7 @@ fn test_path_rename_directory_updates_descendants() {
 
     sb.access_log.lock().unwrap().clear();
     // Open the child — path should be "renamed/child.txt".
-    let (handle, _opts) = sb
-        .fuse_open(child.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(child.inode, libc::O_RDONLY as u32).unwrap();
     sb.fs
         .release(
             ProxyFsTestSandbox::ctx(),
@@ -369,8 +359,7 @@ fn test_path_rename_directory_updates_descendants() {
         .unwrap();
     let log = sb.access_log.lock().unwrap();
     assert!(
-        log.iter()
-            .any(|(path, _)| path == "renamed/child.txt"),
+        log.iter().any(|(path, _)| path == "renamed/child.txt"),
         "renaming parent should update child path to 'renamed/child.txt', got: {:?}",
         log.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>()
     );
@@ -395,8 +384,7 @@ fn test_path_forget_removes() {
     let _ = sb.lookup_root("forgettable").unwrap();
 
     // Forget the inode.
-    sb.fs
-        .forget(ProxyFsTestSandbox::ctx(), entry.inode, 1);
+    sb.fs.forget(ProxyFsTestSandbox::ctx(), entry.inode, 1);
 
     sb.access_log.lock().unwrap().clear();
     // After forget, the path should be removed from the table.
@@ -444,9 +432,7 @@ fn test_path_open_copies_to_handle() {
         .unwrap();
     // Lookup to register path.
     let entry = sb.lookup(dir.inode, "hfile.txt").unwrap();
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let handle = handle.unwrap();
     let _data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     let log = sb.read_log.lock().unwrap();
@@ -496,8 +482,7 @@ fn test_path_release_removes_handle() {
     let _data = sb.fuse_read(ino, handle2, 4096, 0).unwrap();
     let log = sb.read_log.lock().unwrap();
     assert!(
-        log.iter()
-            .any(|(path, _)| path == "release_test.txt"),
+        log.iter().any(|(path, _)| path == "release_test.txt"),
         "new handle after release should have correct path"
     );
 }
@@ -555,9 +540,7 @@ fn test_path_unknown_inode_fallback() {
     // For the "unknown" case, it's hard to construct without internal access.
     // Instead, verify the fallback produces empty string for handle_paths.
     // We accept that this test verifies the default behavior.
-    let (handle, _opts) = sb
-        .fuse_open(entry2.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry2.inode, libc::O_RDONLY as u32).unwrap();
     let handle = handle.unwrap();
     // Write some data first so read has something.
     sb.fuse_write(entry2.inode, handle, b"data", 0).unwrap();
@@ -574,9 +557,7 @@ fn test_path_unknown_inode_fallback() {
         .unwrap();
 
     // Re-open for read.
-    let (handle2, _opts) = sb
-        .fuse_open(entry2.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle2, _opts) = sb.fuse_open(entry2.inode, libc::O_RDONLY as u32).unwrap();
     let handle2 = handle2.unwrap();
     read_log.lock().unwrap().clear();
     let _data = sb.fuse_read(entry2.inode, handle2, 4096, 0).unwrap();
@@ -618,15 +599,9 @@ fn test_path_concurrent_rename_read() {
             if let Ok((handle, _)) = sb.fuse_open(ino, libc::O_RDONLY as u32) {
                 if let Some(h) = handle {
                     let _ = sb.fuse_read(ino, h, 4096, 0);
-                    let _ = sb.fs.release(
-                        ProxyFsTestSandbox::ctx(),
-                        ino,
-                        0,
-                        h,
-                        false,
-                        false,
-                        None,
-                    );
+                    let _ = sb
+                        .fs
+                        .release(ProxyFsTestSandbox::ctx(), ino, 0, h, false, false, None);
                 }
             }
         });

--- a/crates/filesystem/lib/backends/proxy/tests/test_read_hook.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_read_hook.rs
@@ -91,9 +91,7 @@ fn test_read_hook_receives_path() {
         .unwrap();
     // Need to lookup to register path since create_file_with_content does create+release.
     let entry = sb.lookup(dir.inode, "nested.txt").unwrap();
-    let (handle, _opts) = sb
-        .fuse_open(entry.inode, libc::O_RDONLY as u32)
-        .unwrap();
+    let (handle, _opts) = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
     let handle = handle.unwrap();
     let _data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     let log = sb.read_log.lock().unwrap();

--- a/crates/filesystem/lib/backends/proxy/tests/test_roundtrip.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_roundtrip.rs
@@ -29,7 +29,8 @@ fn test_roundtrip_xor_cipher() {
     sb.fuse_write(entry.inode, handle, original, 0).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(
-        &data[..], original,
+        &data[..],
+        original,
         "XOR encrypt on write + XOR decrypt on read should recover original"
     );
 }
@@ -50,7 +51,8 @@ fn test_roundtrip_byte_shift() {
     sb.fuse_write(entry.inode, handle, original, 0).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(
-        &data[..], original,
+        &data[..],
+        original,
         "shift encode on write + shift decode on read should recover original"
     );
 }
@@ -68,9 +70,7 @@ fn test_roundtrip_compress_decompress() {
         while i < data.len() {
             let b = data[i];
             let mut count = 1u8;
-            while i + (count as usize) < data.len()
-                && data[i + count as usize] == b
-                && count < 255
+            while i + (count as usize) < data.len() && data[i + count as usize] == b && count < 255
             {
                 count += 1;
             }
@@ -102,7 +102,8 @@ fn test_roundtrip_compress_decompress() {
     sb.fuse_write(entry.inode, handle, original, 0).unwrap();
     let data = sb.fuse_read(entry.inode, handle, 4096, 0).unwrap();
     assert_eq!(
-        &data[..], &original[..],
+        &data[..],
+        &original[..],
         "RLE encode/decode roundtrip should recover original"
     );
 }
@@ -160,8 +161,7 @@ fn test_inner_stores_transformed() {
     let log = write_log.lock().unwrap();
     let expected_transformed: Vec<u8> = b"hello".iter().map(|b| b ^ 0xFF).collect();
     assert!(
-        log.iter()
-            .any(|(_, data)| *data == expected_transformed),
+        log.iter().any(|(_, data)| *data == expected_transformed),
         "inner should store XOR-transformed data"
     );
 

--- a/crates/filesystem/lib/backends/proxy/tests/test_write_hook.rs
+++ b/crates/filesystem/lib/backends/proxy/tests/test_write_hook.rs
@@ -80,9 +80,7 @@ fn test_write_return_value() {
     });
     let (entry, handle) = sb.fuse_create_root("retval.txt").unwrap();
     let handle = handle.unwrap();
-    let written = sb
-        .fuse_write(entry.inode, handle, b"hello", 0)
-        .unwrap();
+    let written = sb.fuse_write(entry.inode, handle, b"hello", 0).unwrap();
     assert_eq!(
         written, 5,
         "write should return guest bytes consumed (5), not transformed length (10)"

--- a/crates/filesystem/lib/backends/shared/handle_table.rs
+++ b/crates/filesystem/lib/backends/shared/handle_table.rs
@@ -1,7 +1,6 @@
 //! Handle table for open file descriptors.
 
-use std::fs::File;
-use std::sync::RwLock;
+use std::{fs::File, sync::RwLock};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/filesystem/lib/backends/shared/init_binary.rs
+++ b/crates/filesystem/lib/backends/shared/init_binary.rs
@@ -10,12 +10,9 @@
 //! Reads use `ZeroCopyWriter::write_from` for zero-copy transfer from the backing file
 //! to the FUSE response buffer, avoiding intermediate copies of the binary data.
 
-use std::fs::File;
-use std::io;
-use std::time::Duration;
+use std::{fs::File, io, time::Duration};
 
-use crate::agentd::AGENTD_BYTES;
-use crate::{Entry, ZeroCopyWriter, stat64};
+use crate::{Entry, ZeroCopyWriter, agentd::AGENTD_BYTES, stat64};
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/crates/filesystem/lib/backends/shared/inode_table.rs
+++ b/crates/filesystem/lib/backends/shared/inode_table.rs
@@ -3,11 +3,9 @@
 //! Provides [`MultikeyBTreeMap`] (a BTreeMap with two key types), [`InodeData`]
 //! for per-inode state, and [`InodeAltKey`] for host-identity-based deduplication.
 
-use std::borrow::Borrow;
-use std::collections::BTreeMap;
 #[cfg(target_os = "macos")]
 use std::sync::atomic::AtomicI64;
-use std::sync::atomic::AtomicU64;
+use std::{borrow::Borrow, collections::BTreeMap, sync::atomic::AtomicU64};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/filesystem/lib/backends/shared/name_validation.rs
+++ b/crates/filesystem/lib/backends/shared/name_validation.rs
@@ -3,8 +3,7 @@
 //! Every operation that accepts a guest-provided directory entry name must
 //! call [`validate_name`] to prevent path traversal attacks.
 
-use std::ffi::CStr;
-use std::io;
+use std::{ffi::CStr, io};
 
 use super::platform;
 

--- a/crates/filesystem/lib/backends/shared/platform.rs
+++ b/crates/filesystem/lib/backends/shared/platform.rs
@@ -16,8 +16,7 @@
 //! atomically. Availability is probed at init time and cached in `PassthroughFs::has_openat2`.
 //! Falls back to `openat(O_NOFOLLOW)` on older kernels.
 
-use std::io;
-use std::os::fd::RawFd;
+use std::{io, os::fd::RawFd};
 
 use crate::stat64;
 
@@ -323,11 +322,6 @@ pub(crate) fn enxio() -> io::Error {
 /// Create an `io::Error` with Linux `ERANGE`.
 pub(crate) fn erange() -> io::Error {
     io::Error::from_raw_os_error(34) // LINUX_ERANGE
-}
-
-/// Create an `io::Error` with Linux `EXDEV`.
-pub(crate) fn exdev() -> io::Error {
-    io::Error::from_raw_os_error(LINUX_EXDEV)
 }
 
 /// Check if an error is ENOENT.

--- a/crates/filesystem/lib/backends/shared/stat_override.rs
+++ b/crates/filesystem/lib/backends/shared/stat_override.rs
@@ -17,9 +17,7 @@
 //! skips the xattr read for real host symlinks (detected via `S_IFLNK` in the unpatched stat).
 //! File-backed symlinks (regular files with S_IFLNK in xattr) are handled normally.
 
-use std::ffi::CStr;
-use std::io;
-use std::os::fd::RawFd;
+use std::{ffi::CStr, io, os::fd::RawFd};
 
 use crate::stat64;
 

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -14,14 +14,16 @@ pub mod backends;
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
-pub use backends::dualfs::{
-    BackendAFallbackToBackendBRead, BackendAOnly, CachePolicy as DualCachePolicy, DualFs,
-    DualFsConfig, MergeReadsBackendAPrecedence, ReadBackendBWriteBackendA,
+pub use backends::{
+    dualfs::{
+        BackendAFallbackToBackendBRead, BackendAOnly, CachePolicy as DualCachePolicy, DualFs,
+        DualFsConfig, MergeReadsBackendAPrecedence, ReadBackendBWriteBackendA,
+    },
+    memfs::{CachePolicy as MemCachePolicy, MemFs, MemFsConfig},
+    overlayfs::{CachePolicy as OverlayCachePolicy, OverlayConfig, OverlayFs},
+    passthroughfs::{CachePolicy, PassthroughConfig, PassthroughFs, PassthroughFsBuilder},
+    proxy::{AccessMode, ProxyFs, ProxyFsBuilder},
 };
-pub use backends::memfs::{CachePolicy as MemCachePolicy, MemFs, MemFsConfig};
-pub use backends::overlayfs::{CachePolicy as OverlayCachePolicy, OverlayConfig, OverlayFs};
-pub use backends::passthroughfs::{CachePolicy, PassthroughConfig, PassthroughFs, PassthroughFsBuilder};
-pub use backends::proxy::{AccessMode, ProxyFs, ProxyFsBuilder};
 pub use msb_krun::backends::fs::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
     OpenOptions, RemovemappingOne, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -16,29 +16,29 @@ name = "microsandbox"
 path = "lib/lib.rs"
 
 [features]
-prebuilt = ["microsandbox-filesystem/prebuilt", "dep:ureq"]
+prebuilt = ["dep:ureq", "microsandbox-filesystem/prebuilt"]
 
 [dependencies]
-microsandbox-db = { path = "../db" }
-microsandbox-filesystem = { path = "../filesystem" }
-microsandbox-migration = { path = "../migration" }
-microsandbox-protocol = { path = "../protocol" }
-microsandbox-runtime = { path = "../runtime" }
-microsandbox-utils = { path = "../utils" }
 bytes.workspace = true
 chrono.workspace = true
 crossterm.workspace = true
 dirs.workspace = true
 futures.workspace = true
 libc.workspace = true
+microsandbox-db = { path = "../db" }
+microsandbox-filesystem = { path = "../filesystem" }
+microsandbox-migration = { path = "../migration" }
+microsandbox-protocol = { path = "../protocol" }
+microsandbox-runtime = { path = "../runtime" }
+microsandbox-utils = { path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 reqwest.workspace = true
 scopeguard.workspace = true
 sea-orm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 typed-builder.workspace = true
 which.workspace = true

--- a/crates/microsandbox/lib/agent/bridge.rs
+++ b/crates/microsandbox/lib/agent/bridge.rs
@@ -8,17 +8,25 @@
 //! (`request()`, `wait_ready()`) simply read one message and drop the receiver.
 //! Multi-message callers (`subscribe()`) keep reading until the session ends.
 
-use std::collections::HashMap;
-use std::os::unix::io::RawFd;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::{
+    collections::HashMap,
+    os::unix::io::RawFd,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+};
 
-use microsandbox_protocol::codec;
-use microsandbox_protocol::core::Ready;
-use microsandbox_protocol::message::{Message, MessageType};
-use tokio::io::AsyncRead;
-use tokio::sync::{Mutex, mpsc};
-use tokio::task::JoinHandle;
+use microsandbox_protocol::{
+    codec,
+    core::Ready,
+    message::{Message, MessageType},
+};
+use tokio::{
+    io::AsyncRead,
+    sync::{Mutex, mpsc},
+    task::JoinHandle,
+};
 
 use crate::MicrosandboxResult;
 

--- a/crates/microsandbox/lib/agent/stream.rs
+++ b/crates/microsandbox/lib/agent/stream.rs
@@ -4,13 +4,14 @@
 //! non-blocking async I/O. Used by [`AgentBridge`](super::AgentBridge) for
 //! communication with agentd over the virtio-console FD pair.
 
-use std::io;
-use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    io,
+    os::unix::io::{FromRawFd, OwnedFd, RawFd},
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use tokio::io::unix::AsyncFd;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, unix::AsyncFd};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -3,9 +3,12 @@
 //! Configuration is loaded from `~/.microsandbox/config.json` on first access.
 //! All fields have sensible defaults — a missing config file is equivalent to `{}`.
 
-use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
+use microsandbox_runtime::logging::LogLevel;
 use serde::{Deserialize, Serialize};
 
 use crate::MicrosandboxResult;
@@ -30,12 +33,16 @@ pub(crate) const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 /// Global configuration for the microsandbox library.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+#[derive(Default)]
 pub struct GlobalConfig {
     /// Root directory for all microsandbox data.
     pub home: Option<PathBuf>,
 
-    /// Log level.
-    pub log_level: String,
+    /// Default runtime log level for SDK-spawned sandbox processes.
+    ///
+    /// `None` means sandbox runtime processes are silent unless overridden
+    /// per-sandbox.
+    pub log_level: Option<LogLevel>,
 
     /// Database configuration.
     pub database: DatabaseConfig,
@@ -113,7 +120,7 @@ static CONFIG: OnceLock<GlobalConfig> = OnceLock::new();
 impl GlobalConfig {
     /// Get the resolved home directory.
     pub fn home(&self) -> PathBuf {
-        self.home.clone().unwrap_or_else(|| resolve_default_home())
+        self.home.clone().unwrap_or_else(resolve_default_home)
     }
 
     /// Resolve the `sandboxes` directory.
@@ -153,18 +160,6 @@ impl GlobalConfig {
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
 
-impl Default for GlobalConfig {
-    fn default() -> Self {
-        Self {
-            home: None,
-            log_level: "info".into(),
-            database: DatabaseConfig::default(),
-            paths: PathsConfig::default(),
-            sandbox_defaults: SandboxDefaults::default(),
-        }
-    }
-}
-
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
@@ -198,6 +193,7 @@ pub fn config() -> &'static GlobalConfig {
 ///
 /// Must be called before the first call to [`config()`]. Returns `Err` with the
 /// provided config if the global has already been initialized.
+#[allow(clippy::result_large_err)]
 pub fn set_config(config: GlobalConfig) -> Result<(), GlobalConfig> {
     CONFIG.set(config)
 }
@@ -243,22 +239,71 @@ pub fn resolve_msb_path() -> MicrosandboxResult<PathBuf> {
 ///
 /// Resolution order:
 /// 1. `config().paths.libkrunfw`
-/// 2. `{home}/lib/libkrunfw.{so,dylib}`
-pub fn resolve_libkrunfw_path() -> PathBuf {
+/// 2. A sibling of the resolved `msb` binary (for `build/msb`)
+/// 3. `../lib/` next to the resolved `msb` binary (for installed layouts)
+/// 4. `{home}/lib/libkrunfw.{so,dylib}`
+pub fn resolve_libkrunfw_path() -> MicrosandboxResult<PathBuf> {
     if let Some(path) = &config().paths.libkrunfw {
-        return path.clone();
+        if path.is_file() {
+            return Ok(path.clone());
+        }
+        return Err(crate::MicrosandboxError::LibkrunfwNotFound(format!(
+            "configured path does not exist: {}",
+            path.display()
+        )));
     }
 
-    let filename = if cfg!(target_os = "macos") {
-        microsandbox_utils::libkrunfw_filename("macos")
+    let os = if cfg!(target_os = "macos") {
+        "macos"
     } else {
-        microsandbox_utils::libkrunfw_filename("linux")
+        "linux"
     };
-
-    config()
+    let filename = microsandbox_utils::libkrunfw_filename(os);
+    let home_fallback = config()
         .home()
         .join(microsandbox_utils::LIB_SUBDIR)
-        .join(filename)
+        .join(&filename);
+
+    let mut candidates = Vec::new();
+    if let Ok(msb_path) = resolve_msb_path() {
+        candidates.extend(libkrunfw_candidates_from_msb(&msb_path, &filename));
+    }
+    candidates.push(home_fallback);
+
+    if let Some(path) = candidates.iter().find(|path| path.is_file()) {
+        tracing::debug!(path = %path.display(), "resolved libkrunfw path");
+        return Ok(path.clone());
+    }
+
+    let searched = candidates
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(crate::MicrosandboxError::LibkrunfwNotFound(format!(
+        "searched: {searched}"
+    )))
+}
+
+fn libkrunfw_candidates_from_msb(msb_path: &Path, filename: &str) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(msb_dir) = msb_path.parent() {
+        candidates.push(msb_dir.join(filename));
+
+        if let Some(parent) = msb_dir.parent() {
+            candidates.push(parent.join(microsandbox_utils::LIB_SUBDIR).join(filename));
+        }
+    }
+
+    let mut deduped = Vec::new();
+    for path in candidates {
+        if !deduped.iter().any(|existing| existing == &path) {
+            deduped.push(path);
+        }
+    }
+
+    deduped
 }
 
 /// Resolve the default home directory (`~/.microsandbox`).
@@ -294,7 +339,7 @@ mod tests {
         assert_eq!(cfg.sandbox_defaults.cpus, 1);
         assert_eq!(cfg.sandbox_defaults.memory_mib, 512);
         assert_eq!(cfg.sandbox_defaults.shell, "/bin/sh");
-        assert_eq!(cfg.log_level, "info");
+        assert_eq!(cfg.log_level, None);
         assert_eq!(cfg.database.max_connections, 5);
     }
 
@@ -311,6 +356,13 @@ mod tests {
         let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.sandbox_defaults.cpus, 4);
         assert_eq!(cfg.sandbox_defaults.memory_mib, 512);
+    }
+
+    #[test]
+    fn test_deserialize_log_level() {
+        let json = r#"{"log_level":"debug"}"#;
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.log_level, Some(LogLevel::Debug));
     }
 
     #[test]
@@ -338,5 +390,28 @@ mod tests {
     fn test_load_config_from_missing_file() {
         let result = load_config_from(Path::new("/nonexistent/config.json"));
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_libkrunfw_candidates_for_build_msb() {
+        let msb = PathBuf::from("/repo/build/msb");
+        let paths = libkrunfw_candidates_from_msb(&msb, "libkrunfw.5.dylib");
+        assert_eq!(paths[0], PathBuf::from("/repo/build/libkrunfw.5.dylib"));
+        assert_eq!(paths[1], PathBuf::from("/repo/lib/libkrunfw.5.dylib"));
+    }
+
+    #[test]
+    fn test_libkrunfw_candidates_for_target_msb() {
+        let msb = PathBuf::from("/repo/target/debug/msb");
+        let paths = libkrunfw_candidates_from_msb(&msb, "libkrunfw.5.dylib");
+        assert_eq!(
+            paths[0],
+            PathBuf::from("/repo/target/debug/libkrunfw.5.dylib")
+        );
+        assert_eq!(
+            paths[1],
+            PathBuf::from("/repo/target/lib/libkrunfw.5.dylib")
+        );
+        assert_eq!(paths.len(), 2);
     }
 }

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -4,7 +4,6 @@
 //! project-local (`.microsandbox/db/msb.db`) databases. Migrations are
 //! automatically applied on first connection.
 
-#[allow(missing_docs)]
 pub use microsandbox_db::entity;
 
 use std::path::{Path, PathBuf};

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -20,3 +20,4 @@ pub mod size;
 pub mod volume;
 
 pub use error::*;
+pub use microsandbox_runtime::logging::LogLevel;

--- a/crates/microsandbox/lib/runtime/handle.rs
+++ b/crates/microsandbox/lib/runtime/handle.rs
@@ -5,8 +5,10 @@
 
 use std::process::ExitStatus;
 
-use nix::sys::signal::{self, Signal};
-use nix::unistd::Pid;
+use nix::{
+    sys::signal::{self, Signal},
+    unistd::Pid,
+};
 use tokio::process::Child;
 
 use crate::MicrosandboxResult;

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -4,18 +4,21 @@
 //! assembles CLI arguments from [`SandboxConfig`], fork+execs `msb supervisor`,
 //! and reads the startup JSON to obtain child PIDs.
 
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-use std::path::Path;
-use std::process::Stdio;
+use std::{
+    ffi::OsString,
+    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+    path::Path,
+    process::Stdio,
+};
 
 use serde::Deserialize;
-use tokio::io::AsyncBufReadExt;
-use tokio::process::Command;
+use tokio::{io::AsyncBufReadExt, process::Command};
 
-use crate::MicrosandboxResult;
-use crate::config;
-use crate::runtime::handle::SupervisorHandle;
-use crate::sandbox::{RootfsSource, SandboxConfig, VolumeMount};
+use crate::{
+    MicrosandboxResult, config,
+    runtime::handle::SupervisorHandle,
+    sandbox::{RootfsSource, SandboxConfig, VolumeMount},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -46,6 +49,7 @@ struct StartupInfo {
 /// 6. Reads startup JSON from stdout to get child PIDs
 pub async fn spawn_supervisor(
     config: &SandboxConfig,
+    sandbox_id: i32,
 ) -> MicrosandboxResult<(SupervisorHandle, RawFd)> {
     // Create the agent socket pair.
     let (host_fd, guest_fd) = create_socketpair()?;
@@ -53,7 +57,7 @@ pub async fn spawn_supervisor(
 
     // Resolve paths.
     let msb_path = config::resolve_msb_path()?;
-    let libkrunfw_path = config::resolve_libkrunfw_path();
+    let libkrunfw_path = config::resolve_libkrunfw_path()?;
     let global = config::config();
     let sandbox_dir = global.sandboxes_dir().join(&config.name);
     let log_dir = sandbox_dir.join("logs");
@@ -80,101 +84,15 @@ pub async fn spawn_supervisor(
 
     // Build the command.
     let mut cmd = Command::new(&msb_path);
-    cmd.arg("supervisor");
-    cmd.arg("--name").arg(&config.name);
-    cmd.arg("--db-path").arg(&db_path);
-    cmd.arg("--log-dir").arg(&log_dir);
-    cmd.arg("--runtime-dir").arg(&runtime_dir);
-    cmd.arg("--agent-fd").arg(guest_raw_fd.to_string());
-
-    // Supervisor policy args.
-    let sp = &config.supervisor_policy;
-    cmd.arg("--shutdown-mode")
-        .arg(shutdown_mode_str(&sp.shutdown_mode));
-    cmd.arg("--grace-secs").arg(sp.grace_secs.to_string());
-    if let Some(max_dur) = sp.max_duration_secs {
-        cmd.arg("--max-duration").arg(max_dur.to_string());
-    }
-    if let Some(idle) = sp.idle_timeout_secs {
-        cmd.arg("--idle-timeout").arg(idle.to_string());
-    }
-
-    // VM child policy args.
-    let vp = &config.child_policies.vm;
-    cmd.arg("--vm-on-exit").arg(exit_action_str(&vp.on_exit));
-    cmd.arg("--vm-max-restarts")
-        .arg(vp.max_restarts.to_string());
-    cmd.arg("--vm-restart-delay-ms")
-        .arg(vp.restart_delay_ms.to_string());
-    cmd.arg("--vm-restart-window")
-        .arg(vp.restart_window_secs.to_string());
-    cmd.arg("--vm-shutdown-timeout-ms")
-        .arg(vp.shutdown_timeout_ms.to_string());
-
-    // VM configuration args.
-    cmd.arg("--libkrunfw-path").arg(&libkrunfw_path);
-    cmd.arg("--vcpus").arg(config.cpus.to_string());
-    cmd.arg("--memory-mib").arg(config.memory_mib.to_string());
-
-    // Root filesystem layers.
-    match &config.image {
-        RootfsSource::Bind(path) => {
-            cmd.arg("--rootfs-layer").arg(path);
-        }
-        RootfsSource::Oci(_) => {
-            // OCI image resolution is handled in Phase 8.
-            // For now, this would be resolved to layer paths before calling spawn.
-        }
-    }
-
-    // Environment variables.
-    for (key, value) in &config.env {
-        cmd.arg("--env").arg(format!("{key}={value}"));
-    }
-
-    // Volume mounts.
-    for mount in &config.mounts {
-        match mount {
-            VolumeMount::Bind {
-                host,
-                guest,
-                readonly,
-            } => {
-                // Format: "tag:host_path[:ro]" where tag is a sanitized guest path.
-                let tag = guest_mount_tag(guest);
-                let mut arg = format!("{tag}:{}", host.display());
-                if *readonly {
-                    arg.push_str(":ro");
-                }
-                cmd.arg("--mount").arg(arg);
-            }
-            VolumeMount::Named {
-                name,
-                guest,
-                readonly,
-            } => {
-                let vol_path = config::config().volumes_dir().join(name);
-                let tag = guest_mount_tag(guest);
-                let mut arg = format!("{tag}:{}", vol_path.display());
-                if *readonly {
-                    arg.push_str(":ro");
-                }
-                cmd.arg("--mount").arg(arg);
-            }
-            VolumeMount::Tmpfs { .. } => {
-                // Tmpfs mounts are handled by the guest kernel, not virtiofs.
-            }
-            VolumeMount::Backend { .. } => {
-                // Backend mounts are guarded at Sandbox::create() — they cannot
-                // reach this point in the subprocess path. If they do, skip them.
-            }
-        }
-    }
-
-    // Working directory.
-    if let Some(ref workdir) = config.workdir {
-        cmd.arg("--workdir").arg(workdir);
-    }
+    cmd.args(supervisor_cli_args(
+        config,
+        sandbox_id,
+        &db_path,
+        &log_dir,
+        &runtime_dir,
+        guest_raw_fd,
+        &libkrunfw_path,
+    ));
 
     // Capture stdout (for startup JSON), inherit stderr so errors are visible.
     cmd.stdout(Stdio::piped());
@@ -309,5 +227,187 @@ fn exit_action_str(action: &microsandbox_runtime::policy::ExitAction) -> &'stati
         ExitAction::ShutdownAll => "shutdown-all",
         ExitAction::Restart => "restart",
         ExitAction::Ignore => "ignore",
+    }
+}
+
+/// Build the `msb supervisor` CLI args for a sandbox.
+fn supervisor_cli_args(
+    config: &SandboxConfig,
+    sandbox_id: i32,
+    db_path: &Path,
+    log_dir: &Path,
+    runtime_dir: &Path,
+    agent_fd: RawFd,
+    libkrunfw_path: &Path,
+) -> Vec<OsString> {
+    let mut args = vec![OsString::from("supervisor")];
+
+    if let Some(log_level) = config.log_level {
+        args.push(OsString::from(log_level.as_cli_flag()));
+    }
+
+    args.push(OsString::from("--name"));
+    args.push(OsString::from(&config.name));
+    args.push(OsString::from("--sandbox-id"));
+    args.push(OsString::from(sandbox_id.to_string()));
+    args.push(OsString::from("--db-path"));
+    args.push(db_path.as_os_str().to_os_string());
+    args.push(OsString::from("--log-dir"));
+    args.push(log_dir.as_os_str().to_os_string());
+    args.push(OsString::from("--runtime-dir"));
+    args.push(runtime_dir.as_os_str().to_os_string());
+    args.push(OsString::from("--agent-fd"));
+    args.push(OsString::from(agent_fd.to_string()));
+
+    let sp = &config.supervisor_policy;
+    args.push(OsString::from("--shutdown-mode"));
+    args.push(OsString::from(shutdown_mode_str(&sp.shutdown_mode)));
+    args.push(OsString::from("--grace-secs"));
+    args.push(OsString::from(sp.grace_secs.to_string()));
+    if let Some(max_dur) = sp.max_duration_secs {
+        args.push(OsString::from("--max-duration"));
+        args.push(OsString::from(max_dur.to_string()));
+    }
+    if let Some(idle) = sp.idle_timeout_secs {
+        args.push(OsString::from("--idle-timeout"));
+        args.push(OsString::from(idle.to_string()));
+    }
+
+    let vp = &config.child_policies.vm;
+    args.push(OsString::from("--vm-on-exit"));
+    args.push(OsString::from(exit_action_str(&vp.on_exit)));
+    args.push(OsString::from("--vm-max-restarts"));
+    args.push(OsString::from(vp.max_restarts.to_string()));
+    args.push(OsString::from("--vm-restart-delay-ms"));
+    args.push(OsString::from(vp.restart_delay_ms.to_string()));
+    args.push(OsString::from("--vm-restart-window"));
+    args.push(OsString::from(vp.restart_window_secs.to_string()));
+    args.push(OsString::from("--vm-shutdown-timeout-ms"));
+    args.push(OsString::from(vp.shutdown_timeout_ms.to_string()));
+
+    args.push(OsString::from("--libkrunfw-path"));
+    args.push(libkrunfw_path.as_os_str().to_os_string());
+    args.push(OsString::from("--vcpus"));
+    args.push(OsString::from(config.cpus.to_string()));
+    args.push(OsString::from("--memory-mib"));
+    args.push(OsString::from(config.memory_mib.to_string()));
+
+    match &config.image {
+        RootfsSource::Bind(path) => {
+            args.push(OsString::from("--rootfs-layer"));
+            args.push(path.as_os_str().to_os_string());
+        }
+        RootfsSource::Oci(reference) => {
+            unimplemented!("OCI image references are not yet supported: {reference}");
+        }
+    }
+
+    for (key, value) in &config.env {
+        args.push(OsString::from("--env"));
+        args.push(OsString::from(format!("{key}={value}")));
+    }
+
+    for mount in &config.mounts {
+        match mount {
+            VolumeMount::Bind {
+                host,
+                guest,
+                readonly,
+            } => {
+                let tag = guest_mount_tag(guest);
+                let mut arg = format!("{tag}:{}", host.display());
+                if *readonly {
+                    arg.push_str(":ro");
+                }
+                args.push(OsString::from("--mount"));
+                args.push(OsString::from(arg));
+            }
+            VolumeMount::Named {
+                name,
+                guest,
+                readonly,
+            } => {
+                let vol_path = config::config().volumes_dir().join(name);
+                let tag = guest_mount_tag(guest);
+                let mut arg = format!("{tag}:{}", vol_path.display());
+                if *readonly {
+                    arg.push_str(":ro");
+                }
+                args.push(OsString::from("--mount"));
+                args.push(OsString::from(arg));
+            }
+            VolumeMount::Tmpfs { .. } => {
+                // Tmpfs mounts are handled by the guest kernel, not virtiofs.
+            }
+            VolumeMount::Backend { .. } => {
+                // Backend mounts are guarded at Sandbox::create() — they cannot
+                // reach this point in the subprocess path. If they do, skip them.
+            }
+        }
+    }
+
+    if let Some(ref workdir) = config.workdir {
+        args.push(OsString::from("--workdir"));
+        args.push(OsString::from(workdir));
+    }
+
+    args
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::supervisor_cli_args;
+    use crate::{LogLevel, sandbox::SandboxBuilder};
+
+    #[test]
+    fn test_supervisor_cli_args_include_selected_log_level() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .log_level(LogLevel::Debug)
+            .build()
+            .unwrap();
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        assert!(args.iter().any(|arg| arg == "--debug"));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_are_silent_by_default() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .build()
+            .unwrap();
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        assert!(!args.iter().any(|arg| {
+            matches!(
+                arg.to_str(),
+                Some("--error" | "--warn" | "--info" | "--debug" | "--trace")
+            )
+        }));
     }
 }

--- a/crates/microsandbox/lib/sandbox/attach.rs
+++ b/crates/microsandbox/lib/sandbox/attach.rs
@@ -35,6 +35,7 @@ pub struct AttachOptions {
 }
 
 /// Builder for [`AttachOptions`].
+#[derive(Default)]
 pub struct AttachOptionsBuilder {
     options: AttachOptions,
 }
@@ -239,14 +240,6 @@ impl DetachKeys {
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
-
-impl Default for AttachOptionsBuilder {
-    fn default() -> Self {
-        Self {
-            options: AttachOptions::default(),
-        }
-    }
-}
 
 /// Unit type for default shell: `sandbox.attach((), ())`
 impl IntoAttachCmd for () {

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -2,10 +2,11 @@
 
 use microsandbox_runtime::policy::ShutdownMode;
 
-use super::config::SandboxConfig;
-use super::types::{MountBuilder, RootfsSource};
-use crate::MicrosandboxResult;
-use crate::size::Mebibytes;
+use super::{
+    config::SandboxConfig,
+    types::{ImageSource, MountBuilder, RootfsSource},
+};
+use crate::{LogLevel, MicrosandboxResult, size::Mebibytes};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -33,9 +34,32 @@ impl SandboxBuilder {
         }
     }
 
-    /// Set the root filesystem source.
-    pub fn image(mut self, image: impl Into<RootfsSource>) -> Self {
-        self.config.image = image.into();
+    /// Set the root filesystem image source.
+    ///
+    /// Accepts a string or path:
+    /// - **`&str` / `String`**: Paths starting with `/`, `./`, or `../` are treated as local
+    ///   bind mounts. Everything else is treated as an OCI image reference.
+    /// - **`PathBuf`**: Always treated as a local bind mount.
+    ///
+    /// ```ignore
+    /// .image("python:3.12")           // OCI image
+    /// .image("./rootfs")              // local directory (bind mount)
+    /// .image("/abs/path/to/rootfs")   // local directory (bind mount)
+    /// .image(PathBuf::from("./rootfs")) // local directory (bind mount)
+    /// ```
+    ///
+    /// Disk image formats (`.qcow2`, `.raw`, `.vmdk`) are not yet supported and
+    /// will produce a build error.
+    pub fn image(mut self, image: impl Into<ImageSource>) -> Self {
+        let source: ImageSource = image.into();
+        match source.into_rootfs_source() {
+            Ok(rootfs) => self.config.image = rootfs,
+            Err(e) => {
+                if self.build_error.is_none() {
+                    self.build_error = Some(e);
+                }
+            }
+        }
         self
     }
 
@@ -55,6 +79,21 @@ impl SandboxBuilder {
     /// ```
     pub fn memory(mut self, size: impl Into<Mebibytes>) -> Self {
         self.config.memory_mib = size.into().as_u32();
+        self
+    }
+
+    /// Set the runtime log level for sandbox child processes.
+    ///
+    /// This controls the verbosity of `msb supervisor` and `msb microvm`
+    /// for this sandbox only.
+    pub fn log_level(mut self, level: LogLevel) -> Self {
+        self.config.log_level = Some(level);
+        self
+    }
+
+    /// Disable runtime logs for this sandbox, even if a global default exists.
+    pub fn quiet_logs(mut self) -> Self {
+        self.config.log_level = None;
         self
     }
 
@@ -209,5 +248,38 @@ impl From<SandboxConfig> for SandboxBuilder {
             config,
             build_error: None,
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::SandboxBuilder;
+    use crate::LogLevel;
+
+    #[test]
+    fn test_builder_sets_runtime_log_level() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine:3.23")
+            .log_level(LogLevel::Debug)
+            .build()
+            .unwrap();
+
+        assert_eq!(config.log_level, Some(LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_builder_quiet_logs_clears_runtime_log_level() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine:3.23")
+            .log_level(LogLevel::Trace)
+            .quiet_logs()
+            .build()
+            .unwrap();
+
+        assert_eq!(config.log_level, None);
     }
 }

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -2,7 +2,10 @@
 
 use std::collections::HashMap;
 
-use microsandbox_runtime::policy::{ChildPolicies, SupervisorPolicy};
+use microsandbox_runtime::{
+    logging::LogLevel,
+    policy::{ChildPolicies, SupervisorPolicy},
+};
 use serde::{Deserialize, Serialize};
 
 use super::types::{NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig, VolumeMount};
@@ -17,6 +20,10 @@ fn default_cpus() -> u8 {
 
 fn default_memory_mib() -> u32 {
     crate::config::config().sandbox_defaults.memory_mib
+}
+
+fn default_log_level() -> Option<LogLevel> {
+    crate::config::config().log_level
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -43,6 +50,12 @@ pub struct SandboxConfig {
     /// Guest memory in MiB.
     #[serde(default = "default_memory_mib")]
     pub memory_mib: u32,
+
+    /// Runtime log level for `msb supervisor` and `msb microvm`.
+    ///
+    /// `None` means sandbox runtime processes stay silent.
+    #[serde(default = "default_log_level")]
+    pub log_level: Option<LogLevel>,
 
     /// Working directory inside the sandbox.
     #[serde(default)]
@@ -104,6 +117,7 @@ impl Default for SandboxConfig {
             image: RootfsSource::default(),
             cpus: default_cpus(),
             memory_mib: default_memory_mib(),
+            log_level: default_log_level(),
             workdir: None,
             shell: None,
             init: None,

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -1,16 +1,16 @@
 //! Execution types for running commands inside sandboxes.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
-use microsandbox_protocol::exec::{ExecSignal, ExecStdin};
-use microsandbox_protocol::message::{Message, MessageType};
+use microsandbox_protocol::{
+    exec::{ExecSignal, ExecStdin},
+    message::{Message, MessageType},
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
-use crate::MicrosandboxResult;
-use crate::agent::AgentBridge;
+use crate::{MicrosandboxResult, agent::AgentBridge};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -42,6 +42,7 @@ pub struct ExecOptions {
 }
 
 /// Builder for [`ExecOptions`].
+#[derive(Default)]
 pub struct ExecOptionsBuilder {
     options: ExecOptions,
 }
@@ -186,7 +187,6 @@ pub trait IntoExecOptions {
     /// Convert into exec options.
     fn into_exec_options(self) -> ExecOptions;
 }
-
 
 //--------------------------------------------------------------------------------------------------
 // Methods
@@ -422,14 +422,6 @@ impl RlimitResource {
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
 
-impl Default for ExecOptionsBuilder {
-    fn default() -> Self {
-        Self {
-            options: ExecOptions::default(),
-        }
-    }
-}
-
 /// No options: `sandbox.exec("cat", ())`
 impl IntoExecOptions for () {
     fn into_exec_options(self) -> ExecOptions {
@@ -492,4 +484,3 @@ impl TryFrom<&str> for RlimitResource {
         }
     }
 }
-

--- a/crates/microsandbox/lib/sandbox/fs.rs
+++ b/crates/microsandbox/lib/sandbox/fs.rs
@@ -3,19 +3,16 @@
 //! [`SandboxFs`] provides methods to read, write, list, and manipulate files
 //! inside a running sandbox via the `core.fs.*` protocol messages.
 
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use bytes::Bytes;
-use microsandbox_protocol::fs::{
-    FS_CHUNK_SIZE, FsData, FsEntryInfo, FsOp, FsRequest, FsResponse, FsResponseData,
+use microsandbox_protocol::{
+    fs::{FS_CHUNK_SIZE, FsData, FsEntryInfo, FsOp, FsRequest, FsResponse, FsResponseData},
+    message::{Message, MessageType},
 };
-use microsandbox_protocol::message::{Message, MessageType};
 use tokio::sync::mpsc;
 
-use crate::MicrosandboxError;
-use crate::MicrosandboxResult;
-use crate::agent::AgentBridge;
+use crate::{MicrosandboxError, MicrosandboxResult, agent::AgentBridge};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -12,25 +12,25 @@ pub mod exec;
 pub mod fs;
 mod types;
 
-use std::process::ExitStatus;
-use std::sync::Arc;
+use std::{process::ExitStatus, sync::Arc};
 
 use bytes::Bytes;
-use microsandbox_protocol::exec::{
-    ExecExited, ExecRequest, ExecRlimit, ExecStarted, ExecStderr, ExecStdin, ExecStdout,
+use microsandbox_protocol::{
+    exec::{ExecExited, ExecRequest, ExecRlimit, ExecStarted, ExecStderr, ExecStdin, ExecStdout},
+    message::{Message, MessageType},
 };
-use microsandbox_protocol::message::{Message, MessageType};
-use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, Set,
+    sea_query::{Expr, OnConflict},
 };
 use tokio::sync::{Mutex, mpsc};
 
-use crate::MicrosandboxResult;
-use crate::agent::AgentBridge;
-use crate::db::entity::sandbox as sandbox_entity;
-use crate::db::entity::sandbox::SandboxStatus;
-use crate::runtime::{SupervisorHandle, spawn_supervisor};
+use crate::{
+    MicrosandboxResult,
+    agent::AgentBridge,
+    db::entity::{sandbox as sandbox_entity, sandbox::SandboxStatus},
+    runtime::{SupervisorHandle, spawn_supervisor},
+};
 
 use self::exec::{ExecEvent, ExecHandle, ExecOutput, ExecSink, IntoExecOptions, StdinMode};
 
@@ -38,14 +38,18 @@ use self::exec::{ExecEvent, ExecHandle, ExecOutput, ExecSink, IntoExecOptions, S
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
-pub use attach::{AttachOptions, AttachOptionsBuilder, IntoAttachCmd, IntoAttachOptions, SessionInfo};
+pub use attach::{
+    AttachOptions, AttachOptionsBuilder, IntoAttachCmd, IntoAttachOptions, SessionInfo,
+};
 pub use builder::SandboxBuilder;
 pub use config::SandboxConfig;
 pub use exec::{ExecOptionsBuilder, ExitStatus as ExecExitStatus, Rlimit, RlimitResource};
 pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, SandboxFs};
 pub use microsandbox_filesystem::AccessMode;
+pub use microsandbox_runtime::logging::LogLevel;
 pub use types::{
-    MountBuilder, NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig, VolumeMount,
+    ImageSource, MountBuilder, NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig,
+    VolumeMount,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -84,39 +88,36 @@ impl Sandbox {
         // They will be supported when in-process VM mode is available.
         let backend_count = config.mounts.iter().filter(|m| m.is_backend()).count();
         if backend_count > 0 {
-            return Err(crate::MicrosandboxError::InvalidConfig(
-                format!(
-                    "hooked mounts (with on_read/on_write/on_access) are not yet supported \
+            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                "hooked mounts (with on_read/on_write/on_access) are not yet supported \
                      in subprocess mode ({backend_count} backend mount(s) provided). \
                      Backend mounts require in-process VM mode, which is planned for a future release.",
-                ),
-            ));
+            )));
         }
+
+        validate_rootfs_source(&config.image)?;
 
         // Initialize the database.
         let db =
             crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
 
-        // Upsert sandbox record.
-        upsert_sandbox_record(db, &config).await?;
-
-        // Save the name before moving config into create_inner.
-        let name = config.name.clone();
+        // Upsert the sandbox record and keep its stable database ID.
+        let sandbox_id = upsert_sandbox_record(db, &config).await?;
 
         // Spawn supervisor + create bridge. On failure, mark the sandbox
         // as stopped so it doesn't appear as a phantom "Running" entry.
-        match Self::create_inner(config).await {
+        match Self::create_inner(config, sandbox_id).await {
             Ok(sandbox) => Ok(sandbox),
             Err(e) => {
-                let _ = update_sandbox_status(db, &name, SandboxStatus::Stopped).await;
+                let _ = update_sandbox_status(db, sandbox_id, SandboxStatus::Stopped).await;
                 Err(e)
             }
         }
     }
 
     /// Inner create logic separated for error-cleanup wrapper.
-    async fn create_inner(config: SandboxConfig) -> MicrosandboxResult<Self> {
-        let (handle, agent_host_fd) = spawn_supervisor(&config).await?;
+    async fn create_inner(config: SandboxConfig, sandbox_id: i32) -> MicrosandboxResult<Self> {
+        let (handle, agent_host_fd) = spawn_supervisor(&config, sandbox_id).await?;
         let bridge = AgentBridge::new(agent_host_fd)?;
         let ready = bridge.wait_ready().await?;
 
@@ -219,19 +220,8 @@ impl Sandbox {
     }
 
     /// Wait for the supervisor process to exit.
-    ///
-    /// Updates the sandbox status in the database to `Stopped` after exit.
     pub async fn wait(&self) -> MicrosandboxResult<ExitStatus> {
-        let status = self.handle.lock().await.wait().await?;
-
-        // Update the DB status now that the supervisor has exited.
-        if let Ok(db) =
-            crate::db::init_global(Some(crate::config::config().database.max_connections)).await
-        {
-            let _ = update_sandbox_status(db, &self.config.name, SandboxStatus::Stopped).await;
-        }
-
-        Ok(status)
+        self.handle.lock().await.wait().await
     }
 }
 
@@ -573,6 +563,7 @@ impl Sandbox {
 //--------------------------------------------------------------------------------------------------
 
 /// Build an `ExecRequest` by merging sandbox config with caller-provided overrides.
+#[allow(clippy::too_many_arguments)]
 fn build_exec_request(
     config: &SandboxConfig,
     cmd: String,
@@ -657,7 +648,7 @@ async fn event_mapper_task(
 /// Update the sandbox status in the database.
 async fn update_sandbox_status(
     db: &sea_orm::DatabaseConnection,
-    name: &str,
+    sandbox_id: i32,
     status: SandboxStatus,
 ) -> MicrosandboxResult<()> {
     sandbox_entity::Entity::update_many()
@@ -666,18 +657,42 @@ async fn update_sandbox_status(
             sandbox_entity::Column::UpdatedAt,
             Expr::value(chrono::Utc::now().naive_utc()),
         )
-        .filter(sandbox_entity::Column::Name.eq(name))
+        .filter(sandbox_entity::Column::Id.eq(sandbox_id))
         .exec(db)
         .await?;
 
     Ok(())
 }
 
-/// Insert or update the sandbox record in the database.
+/// Validate rootfs configuration that depends on host filesystem state.
+fn validate_rootfs_source(rootfs: &RootfsSource) -> MicrosandboxResult<()> {
+    match rootfs {
+        RootfsSource::Bind(path) => {
+            if !path.exists() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "rootfs bind path does not exist: {}",
+                    path.display()
+                )));
+            }
+
+            if !path.is_dir() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "rootfs bind path is not a directory: {}",
+                    path.display()
+                )));
+            }
+        }
+        RootfsSource::Oci(_) => {}
+    }
+
+    Ok(())
+}
+
+/// Insert or update the sandbox record in the database and return its ID.
 async fn upsert_sandbox_record(
     db: &sea_orm::DatabaseConnection,
     config: &SandboxConfig,
-) -> MicrosandboxResult<()> {
+) -> MicrosandboxResult<i32> {
     let now = chrono::Utc::now().naive_utc();
     let config_json = serde_json::to_string(config)?;
 
@@ -703,5 +718,78 @@ async fn upsert_sandbox_record(
         .exec(db)
         .await?;
 
-    Ok(())
+    sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Name.eq(&config.name))
+        .one(db)
+        .await?
+        .map(|model| model.id)
+        .ok_or_else(|| {
+            crate::MicrosandboxError::Custom(format!(
+                "sandbox '{}' missing after upsert",
+                config.name
+            ))
+        })
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::{RootfsSource, validate_rootfs_source};
+
+    fn unique_temp_path(suffix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("microsandbox-rootfs-{suffix}-{nanos}"))
+    }
+
+    #[test]
+    fn test_validate_rootfs_source_missing_bind_path() {
+        let path = unique_temp_path("missing");
+        let err = validate_rootfs_source(&RootfsSource::Bind(path.clone())).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "invalid config: rootfs bind path does not exist: {}",
+                path.display()
+            )
+        );
+    }
+
+    #[test]
+    fn test_validate_rootfs_source_bind_path_must_be_directory() {
+        let path = unique_temp_path("file");
+        fs::write(&path, b"not a directory").unwrap();
+
+        let err = validate_rootfs_source(&RootfsSource::Bind(path.clone())).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "invalid config: rootfs bind path is not a directory: {}",
+                path.display()
+            )
+        );
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_validate_rootfs_source_existing_bind_directory() {
+        let path = unique_temp_path("dir");
+        fs::create_dir(&path).unwrap();
+
+        validate_rootfs_source(&RootfsSource::Bind(path.clone())).unwrap();
+
+        fs::remove_dir(path).unwrap();
+    }
 }

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -2,10 +2,11 @@
 //!
 //! These types are referenced by [`SandboxConfig`](super::SandboxConfig).
 
-use std::io;
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 
-use microsandbox_filesystem::{AccessMode, DynFileSystem, PassthroughConfig, PassthroughFs, ProxyFs};
+use microsandbox_filesystem::{
+    AccessMode, DynFileSystem, PassthroughConfig, PassthroughFs, ProxyFs,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::size::Mebibytes;
@@ -23,6 +24,28 @@ pub enum RootfsSource {
     /// Use an OCI image reference (e.g. `python:3.12`).
     Oci(String),
 }
+
+/// Intermediate type for parsing user input into a [`RootfsSource`].
+///
+/// Accepts `&str`, `String`, or `PathBuf` and resolves to the correct
+/// [`RootfsSource`] variant:
+///
+/// - **`PathBuf`** → always [`RootfsSource::Bind`].
+/// - **`&str` / `String`** → local path if prefixed with `/`, `./`, or `../`;
+///   otherwise [`RootfsSource::Oci`].
+///
+/// Disk image formats (`.qcow2`, `.raw`, `.vmdk`) are detected but not yet
+/// supported and will return an error from [`into_rootfs_source`](Self::into_rootfs_source).
+pub enum ImageSource {
+    /// A string that needs to be resolved.
+    Text(String),
+
+    /// An explicit path (always local).
+    Path(PathBuf),
+}
+
+/// Extensions that indicate unsupported disk image formats.
+const UNSUPPORTED_DISK_IMAGE_EXTENSIONS: &[&str] = &["qcow2", "raw", "vmdk"];
 
 /// A volume mount specification for a sandbox.
 pub enum VolumeMount {
@@ -77,6 +100,7 @@ pub enum VolumeMount {
 /// the builder produces a [`VolumeMount::Backend`] with a [`ProxyFs`]-wrapped
 /// backend. Otherwise it produces a [`VolumeMount::Bind`], [`VolumeMount::Named`],
 /// or [`VolumeMount::Tmpfs`].
+#[allow(clippy::type_complexity)]
 pub struct MountBuilder {
     guest: String,
     mount: MountKind,
@@ -260,8 +284,8 @@ impl MountBuilder {
     /// Build a [`VolumeMount::Backend`] with a [`ProxyFs`]-wrapped backend.
     fn build_backend(self) -> crate::MicrosandboxResult<VolumeMount> {
         let root_dir = match self.mount {
-            MountKind::Bind(ref host) => host.clone(),
-            MountKind::Named(ref name) => crate::config::config().volumes_dir().join(name),
+            MountKind::Bind(host) => host,
+            MountKind::Named(name) => crate::config::config().volumes_dir().join(name),
             MountKind::Tmpfs => {
                 return Err(crate::MicrosandboxError::InvalidConfig(
                     "hooks are not supported on tmpfs mounts (tmpfs is handled by the guest kernel)"
@@ -281,10 +305,9 @@ impl MountBuilder {
             ..Default::default()
         };
         let inner = PassthroughFs::new(cfg).map_err(|e| {
-            crate::MicrosandboxError::Io(io::Error::new(
-                io::ErrorKind::Other,
-                format!("failed to create passthrough backend: {e}"),
-            ))
+            crate::MicrosandboxError::Io(io::Error::other(format!(
+                "failed to create passthrough backend: {e}"
+            )))
         })?;
 
         // Wrap in ProxyFs with hooks.
@@ -298,7 +321,9 @@ impl MountBuilder {
         if let Some(hook) = self.on_write {
             proxy_builder = proxy_builder.on_write(hook);
         }
-        let proxy = proxy_builder.build().map_err(crate::MicrosandboxError::Io)?;
+        let proxy = proxy_builder
+            .build()
+            .map_err(crate::MicrosandboxError::Io)?;
 
         Ok(VolumeMount::Backend {
             guest: self.guest,
@@ -326,6 +351,46 @@ impl VolumeMount {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Methods: ImageSource
+//--------------------------------------------------------------------------------------------------
+
+impl ImageSource {
+    /// Resolve into a [`RootfsSource`].
+    ///
+    /// Returns an error for unsupported disk image formats (`.qcow2`, `.raw`, `.vmdk`).
+    pub fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
+        match self {
+            Self::Path(path) => {
+                Self::check_unsupported_extension(path.to_string_lossy().as_ref())?;
+                Ok(RootfsSource::Bind(path))
+            }
+            Self::Text(s) => {
+                if s.starts_with('/') || s.starts_with("./") || s.starts_with("../") {
+                    Self::check_unsupported_extension(&s)?;
+                    Ok(RootfsSource::Bind(PathBuf::from(s)))
+                } else {
+                    Ok(RootfsSource::Oci(s))
+                }
+            }
+        }
+    }
+
+    /// Return an error if the path has an unsupported disk image extension.
+    fn check_unsupported_extension(path: &str) -> crate::MicrosandboxResult<()> {
+        if let Some(ext) = std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            && UNSUPPORTED_DISK_IMAGE_EXTENSIONS.contains(&ext)
+        {
+            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                "disk image format '.{ext}' is not yet supported: {path}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
 
@@ -335,21 +400,21 @@ impl Default for RootfsSource {
     }
 }
 
-impl From<&str> for RootfsSource {
+impl From<&str> for ImageSource {
     fn from(s: &str) -> Self {
-        Self::Oci(s.to_string())
+        Self::Text(s.to_string())
     }
 }
 
-impl From<String> for RootfsSource {
+impl From<String> for ImageSource {
     fn from(s: String) -> Self {
-        Self::Oci(s)
+        Self::Text(s)
     }
 }
 
-impl From<PathBuf> for RootfsSource {
+impl From<PathBuf> for ImageSource {
     fn from(p: PathBuf) -> Self {
-        Self::Bind(p)
+        Self::Path(p)
     }
 }
 

--- a/crates/microsandbox/lib/volume/fs.rs
+++ b/crates/microsandbox/lib/volume/fs.rs
@@ -8,9 +8,10 @@ use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 
-use crate::MicrosandboxError;
-use crate::MicrosandboxResult;
-use crate::sandbox::fs::{FsEntry, FsEntryKind, FsMetadata};
+use crate::{
+    MicrosandboxError, MicrosandboxResult,
+    sandbox::fs::{FsEntry, FsEntryKind, FsMetadata},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/microsandbox/lib/volume/mod.rs
+++ b/crates/microsandbox/lib/volume/mod.rs
@@ -7,15 +7,14 @@ pub mod fs;
 
 use std::path::PathBuf;
 
-use sea_orm::sea_query::OnConflict;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, Set,
+    sea_query::OnConflict,
 };
 
-use crate::MicrosandboxError;
-use crate::MicrosandboxResult;
-use crate::db::entity::volume as volume_entity;
-use crate::size::Mebibytes;
+use crate::{
+    MicrosandboxError, MicrosandboxResult, db::entity::volume as volume_entity, size::Mebibytes,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -15,7 +15,7 @@ ciborium.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { version = "1.42", default-features = false, features = ["io-util"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { version = "1.42", features = ["full"] }

--- a/crates/protocol/lib/codec.rs
+++ b/crates/protocol/lib/codec.rs
@@ -2,8 +2,10 @@
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-use crate::error::{ProtocolError, ProtocolResult};
-use crate::message::Message;
+use crate::{
+    error::{ProtocolError, ProtocolResult},
+    message::Message,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants

--- a/crates/runtime/lib/drain.rs
+++ b/crates/runtime/lib/drain.rs
@@ -5,8 +5,7 @@
 //! it cannot be cancelled. The drain progresses through phases based on the
 //! supervisor's `ShutdownMode`.
 
-use crate::policy::ShutdownMode;
-use crate::termination::TerminationReason;
+use crate::{policy::ShutdownMode, termination::TerminationReason};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/runtime/lib/logging.rs
+++ b/crates/runtime/lib/logging.rs
@@ -1,14 +1,38 @@
 //! Log file management with rotation for capturing VM console output.
 
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
 
 use crate::RuntimeResult;
 
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
+
+/// CLI-selectable tracing verbosity level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Emit only error logs.
+    Error,
+
+    /// Emit warning and error logs.
+    Warn,
+
+    /// Emit info, warning, and error logs.
+    Info,
+
+    /// Emit debug and higher-severity logs.
+    Debug,
+
+    /// Emit trace and higher-severity logs.
+    Trace,
+}
 
 /// A simple rotating log writer.
 ///
@@ -38,6 +62,30 @@ const MAX_ROTATED_FILES: u32 = 3;
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
+
+impl LogLevel {
+    /// Return the CLI flag corresponding to this level.
+    pub const fn as_cli_flag(self) -> &'static str {
+        match self {
+            Self::Error => "--error",
+            Self::Warn => "--warn",
+            Self::Info => "--info",
+            Self::Debug => "--debug",
+            Self::Trace => "--trace",
+        }
+    }
+
+    /// Return the tracing level corresponding to this selection.
+    pub const fn as_tracing_level(self) -> tracing::Level {
+        match self {
+            Self::Error => tracing::Level::ERROR,
+            Self::Warn => tracing::Level::WARN,
+            Self::Info => tracing::Level::INFO,
+            Self::Debug => tracing::Level::DEBUG,
+            Self::Trace => tracing::Level::TRACE,
+        }
+    }
+}
 
 impl RotatingLog {
     /// Create a new rotating log writer.
@@ -105,5 +153,23 @@ impl RotatingLog {
         self.written = 0;
 
         Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::LogLevel;
+
+    #[test]
+    fn test_log_level_cli_flags() {
+        assert_eq!(LogLevel::Error.as_cli_flag(), "--error");
+        assert_eq!(LogLevel::Warn.as_cli_flag(), "--warn");
+        assert_eq!(LogLevel::Info.as_cli_flag(), "--info");
+        assert_eq!(LogLevel::Debug.as_cli_flag(), "--debug");
+        assert_eq!(LogLevel::Trace.as_cli_flag(), "--trace");
     }
 }

--- a/crates/runtime/lib/monitor.rs
+++ b/crates/runtime/lib/monitor.rs
@@ -4,11 +4,9 @@
 //! policy and restart state. The supervisor polls children and applies policies
 //! on exit.
 
-use nix::sys::signal::Signal;
-use nix::unistd::Pid;
+use nix::{sys::signal::Signal, unistd::Pid};
 
-use crate::RuntimeResult;
-use crate::policy::ChildPolicy;
+use crate::{RuntimeResult, policy::ChildPolicy};
 
 //--------------------------------------------------------------------------------------------------
 // Types

--- a/crates/runtime/lib/supervisor.rs
+++ b/crates/runtime/lib/supervisor.rs
@@ -8,30 +8,37 @@
 //! The supervisor does NOT handle agent protocol communication — that stays
 //! in the user application process via AgentBridge.
 
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::time::Duration;
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
 
 use microsandbox_db::entity::{
     microvm as microvm_entity, sandbox as sandbox_entity, supervisor as supervisor_entity,
 };
 use nix::sys::signal::Signal;
-use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait,
-    QueryFilter, Set,
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    sea_query::Expr,
 };
 use serde::Serialize;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tokio::signal::unix::SignalKind;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    signal::unix::SignalKind,
+};
 
-use crate::RuntimeResult;
-use crate::drain::{DrainPhase, DrainState};
-use crate::heartbeat::HeartbeatReader;
-use crate::monitor::ChildProcess;
-use crate::policy::{ChildPolicies, ExitAction, SupervisorPolicy};
-use crate::termination::TerminationReason;
-use crate::vm::VmConfig;
+use crate::{
+    RuntimeResult,
+    drain::{DrainPhase, DrainState},
+    heartbeat::HeartbeatReader,
+    logging::LogLevel,
+    monitor::ChildProcess,
+    policy::{ChildPolicies, ExitAction, SupervisorPolicy},
+    termination::TerminationReason,
+    vm::VmConfig,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -42,6 +49,12 @@ use crate::vm::VmConfig;
 pub struct SupervisorConfig {
     /// Name of the sandbox.
     pub sandbox_name: String,
+
+    /// Database ID of the sandbox row.
+    pub sandbox_id: i32,
+
+    /// Selected tracing verbosity to apply to the supervisor and its children.
+    pub log_level: Option<LogLevel>,
 
     /// Path to the sandbox database file.
     pub sandbox_db_path: PathBuf,
@@ -98,11 +111,8 @@ pub async fn run(config: SupervisorConfig) -> RuntimeResult<()> {
     // Connect to the database.
     let db = connect_db(&config.sandbox_db_path).await?;
 
-    // Resolve sandbox ID once (used by both insert functions).
-    let sandbox_id = get_sandbox_id(&db, &config.sandbox_name).await?;
-
     // Create supervisor record.
-    let supervisor_db_id = insert_supervisor_record(&db, sandbox_id).await?;
+    let supervisor_db_id = insert_supervisor_record(&db, config.sandbox_id).await?;
 
     // Set up runtime directory.
     std::fs::create_dir_all(&config.runtime_dir)?;
@@ -118,15 +128,8 @@ pub async fn run(config: SupervisorConfig) -> RuntimeResult<()> {
     })?;
 
     // Create microvm record.
-    let microvm_db_id = insert_microvm_record(&db, sandbox_id, supervisor_db_id, vm_pid).await?;
-
-    // Update sandbox status to Running.
-    update_sandbox_status(
-        &db,
-        &config.sandbox_name,
-        sandbox_entity::SandboxStatus::Running,
-    )
-    .await?;
+    let microvm_db_id =
+        insert_microvm_record(&db, config.sandbox_id, supervisor_db_id, vm_pid).await?;
 
     // Write startup info to stdout (the parent reads this).
     let startup = StartupInfo {
@@ -354,7 +357,7 @@ pub async fn run(config: SupervisorConfig) -> RuntimeResult<()> {
         | TerminationReason::MaxDurationExceeded => sandbox_entity::SandboxStatus::Stopped,
         _ => sandbox_entity::SandboxStatus::Crashed,
     };
-    update_sandbox_status(&db, &config.sandbox_name, final_status).await?;
+    update_sandbox_status(&db, config.sandbox_id, final_status).await?;
 
     tracing::info!(
         sandbox = %config.sandbox_name,
@@ -375,52 +378,7 @@ fn spawn_vm_process(
     config: &SupervisorConfig,
 ) -> RuntimeResult<tokio::process::Child> {
     let mut cmd = tokio::process::Command::new(msb_path);
-    cmd.arg("microvm");
-
-    cmd.arg("--libkrunfw-path")
-        .arg(&config.vm_config.libkrunfw_path);
-    cmd.arg("--vcpus").arg(config.vm_config.vcpus.to_string());
-    cmd.arg("--memory-mib")
-        .arg(config.vm_config.memory_mib.to_string());
-
-    for layer in &config.vm_config.rootfs_layers {
-        cmd.arg("--rootfs-layer").arg(layer);
-    }
-
-    for mount in &config.vm_config.mounts {
-        cmd.arg("--mount").arg(mount);
-    }
-
-    // Inject the runtime directory as a virtiofs mount so the guest can access
-    // scripts and write heartbeat at the canonical mount point (/.msb).
-    cmd.arg("--mount").arg(format!(
-        "{}:{}",
-        microsandbox_protocol::RUNTIME_FS_TAG,
-        config.runtime_dir.display()
-    ));
-
-    if let Some(ref init_path) = config.vm_config.init_path {
-        cmd.arg("--init-path").arg(init_path);
-    }
-
-    for env_var in &config.vm_config.env {
-        cmd.arg("--env").arg(env_var);
-    }
-
-    if let Some(ref workdir) = config.vm_config.workdir {
-        cmd.arg("--workdir").arg(workdir);
-    }
-
-    if let Some(ref exec_path) = config.vm_config.exec_path {
-        cmd.arg("--exec-path").arg(exec_path);
-    }
-
-    cmd.arg("--agent-fd").arg(config.agent_fd.to_string());
-
-    if !config.vm_config.exec_args.is_empty() {
-        cmd.arg("--");
-        cmd.args(&config.vm_config.exec_args);
-    }
+    cmd.args(microvm_cli_args(config));
 
     // Spawn in its own process group for clean signal delivery.
     cmd.process_group(0);
@@ -451,10 +409,76 @@ fn spawn_vm_process(
     Ok(child)
 }
 
+fn microvm_cli_args(config: &SupervisorConfig) -> Vec<OsString> {
+    let mut args = Vec::new();
+    args.push(OsString::from("microvm"));
+
+    if let Some(log_level) = config.log_level {
+        args.push(OsString::from(log_level.as_cli_flag()));
+    }
+
+    args.push(OsString::from("--libkrunfw-path"));
+    args.push(config.vm_config.libkrunfw_path.clone().into_os_string());
+    args.push(OsString::from("--vcpus"));
+    args.push(OsString::from(config.vm_config.vcpus.to_string()));
+    args.push(OsString::from("--memory-mib"));
+    args.push(OsString::from(config.vm_config.memory_mib.to_string()));
+
+    for layer in &config.vm_config.rootfs_layers {
+        args.push(OsString::from("--rootfs-layer"));
+        args.push(layer.clone().into_os_string());
+    }
+
+    for mount in &config.vm_config.mounts {
+        args.push(OsString::from("--mount"));
+        args.push(OsString::from(mount));
+    }
+
+    // Inject the runtime directory as a virtiofs mount so the guest can access
+    // scripts and write heartbeat at the canonical mount point (/.msb).
+    args.push(OsString::from("--mount"));
+    args.push(OsString::from(format!(
+        "{}:{}",
+        microsandbox_protocol::RUNTIME_FS_TAG,
+        config.runtime_dir.display()
+    )));
+
+    if let Some(ref init_path) = config.vm_config.init_path {
+        args.push(OsString::from("--init-path"));
+        args.push(init_path.clone().into_os_string());
+    }
+
+    for env_var in &config.vm_config.env {
+        args.push(OsString::from("--env"));
+        args.push(OsString::from(env_var));
+    }
+
+    if let Some(ref workdir) = config.vm_config.workdir {
+        args.push(OsString::from("--workdir"));
+        args.push(workdir.clone().into_os_string());
+    }
+
+    if let Some(ref exec_path) = config.vm_config.exec_path {
+        args.push(OsString::from("--exec-path"));
+        args.push(exec_path.clone().into_os_string());
+    }
+
+    args.push(OsString::from("--agent-fd"));
+    args.push(OsString::from(config.agent_fd.to_string()));
+
+    if !config.vm_config.exec_args.is_empty() {
+        args.push(OsString::from("--"));
+        args.extend(config.vm_config.exec_args.iter().map(OsString::from));
+    }
+
+    args
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions: Drain Management
 //--------------------------------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn try_start_drain(
     reason: TerminationReason,
     msg: &str,
@@ -533,20 +557,12 @@ fn spawn_log_tasks(
 ) {
     if let Some(stdout) = stdout {
         let path = log_dir.join("vm.stdout.log");
-        tokio::spawn(pipe_to_log(
-            stdout,
-            path,
-            forward.then(|| tokio::io::stdout()),
-        ));
+        tokio::spawn(pipe_to_log(stdout, path, forward.then(tokio::io::stdout)));
     }
 
     if let Some(stderr) = stderr {
         let path = log_dir.join("vm.stderr.log");
-        tokio::spawn(pipe_to_log(
-            stderr,
-            path,
-            forward.then(|| tokio::io::stderr()),
-        ));
+        tokio::spawn(pipe_to_log(stderr, path, forward.then(tokio::io::stderr)));
     }
 }
 
@@ -621,8 +637,8 @@ async fn insert_supervisor_record(db: &DatabaseConnection, sandbox_id: i32) -> R
         ..Default::default()
     };
 
-    let result = model.insert(db).await?;
-    Ok(result.id)
+    let result = supervisor_entity::Entity::insert(model).exec(db).await?;
+    Ok(result.last_insert_id)
 }
 
 async fn insert_microvm_record(
@@ -644,13 +660,13 @@ async fn insert_microvm_record(
         ..Default::default()
     };
 
-    let result = model.insert(db).await?;
-    Ok(result.id)
+    let result = microvm_entity::Entity::insert(model).exec(db).await?;
+    Ok(result.last_insert_id)
 }
 
 async fn update_sandbox_status(
     db: &DatabaseConnection,
-    sandbox_name: &str,
+    sandbox_id: i32,
     status: sandbox_entity::SandboxStatus,
 ) -> RuntimeResult<()> {
     let result = sandbox_entity::Entity::update_many()
@@ -659,15 +675,12 @@ async fn update_sandbox_status(
             sandbox_entity::Column::UpdatedAt,
             Expr::value(chrono::Utc::now().naive_utc()),
         )
-        .filter(sandbox_entity::Column::Name.eq(sandbox_name))
+        .filter(sandbox_entity::Column::Id.eq(sandbox_id))
         .exec(db)
         .await?;
 
     if result.rows_affected == 0 {
-        tracing::warn!(
-            sandbox = sandbox_name,
-            "update_sandbox_status matched zero rows"
-        );
+        tracing::warn!(sandbox_id, "update_sandbox_status matched zero rows");
     }
 
     Ok(())
@@ -720,16 +733,71 @@ async fn update_supervisor_record(
     Ok(())
 }
 
-async fn get_sandbox_id(db: &DatabaseConnection, sandbox_name: &str) -> RuntimeResult<i32> {
-    let model = sandbox_entity::Entity::find()
-        .filter(sandbox_entity::Column::Name.eq(sandbox_name))
-        .one(db)
-        .await?
-        .ok_or_else(|| {
-            crate::RuntimeError::Custom(
-                format!("sandbox '{}' not found in database", sandbox_name,),
-            )
-        })?;
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
 
-    Ok(model.id)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{ChildPolicies, SupervisorPolicy};
+
+    fn test_supervisor_config(log_level: Option<LogLevel>) -> SupervisorConfig {
+        SupervisorConfig {
+            sandbox_name: "test".into(),
+            sandbox_id: 1,
+            log_level,
+            sandbox_db_path: PathBuf::from("/tmp/test.db"),
+            log_dir: PathBuf::from("/tmp/logs"),
+            runtime_dir: PathBuf::from("/tmp/runtime"),
+            agent_fd: 7,
+            forward_output: false,
+            child_policies: ChildPolicies::default(),
+            supervisor_policy: SupervisorPolicy::default(),
+            vm_config: VmConfig {
+                libkrunfw_path: PathBuf::from("/tmp/libkrunfw.dylib"),
+                vcpus: 1,
+                memory_mib: 512,
+                rootfs_layers: vec![PathBuf::from("/tmp/rootfs")],
+                mounts: vec!["data:/tmp/data".into()],
+                backends: Vec::new(),
+                init_path: None,
+                env: vec!["FOO=bar".into()],
+                workdir: Some(PathBuf::from("/work")),
+                exec_path: Some(PathBuf::from("/bin/sh")),
+                exec_args: vec!["-lc".into(), "echo hi".into()],
+                net_fd: None,
+                agent_fd: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_microvm_cli_args_include_selected_log_level() {
+        let args = microvm_cli_args(&test_supervisor_config(Some(LogLevel::Debug)));
+        let rendered = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(rendered[0], "microvm");
+        assert!(rendered.contains(&"--debug".to_string()));
+        assert!(rendered.contains(&"--agent-fd".to_string()));
+    }
+
+    #[test]
+    fn test_microvm_cli_args_are_silent_by_default() {
+        let args = microvm_cli_args(&test_supervisor_config(None));
+        let rendered = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(rendered[0], "microvm");
+        assert!(!rendered.iter().any(|arg| arg == "--error"));
+        assert!(!rendered.iter().any(|arg| arg == "--warn"));
+        assert!(!rendered.iter().any(|arg| arg == "--info"));
+        assert!(!rendered.iter().any(|arg| arg == "--debug"));
+        assert!(!rendered.iter().any(|arg| arg == "--trace"));
+    }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -4,8 +4,10 @@
 //! from msb_krun and never returns. The calling process is effectively
 //! replaced by the VMM event loop, which calls `_exit()` on guest shutdown.
 
-use std::os::fd::{FromRawFd, OwnedFd, RawFd};
-use std::path::PathBuf;
+use std::{
+    os::fd::{FromRawFd, OwnedFd, RawFd},
+    path::PathBuf,
+};
 
 use microsandbox_filesystem::{DynFileSystem, PassthroughConfig, PassthroughFs};
 use msb_krun::{NetBackend, VmBuilder};

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -11,6 +11,6 @@ edition.workspace = true
 path = "lib/lib.rs"
 
 [dependencies]
-libc.workspace = true
 crc32c.workspace = true
+libc.workspace = true
 scopeguard.workspace = true

--- a/crates/utils/lib/index/reader.rs
+++ b/crates/utils/lib/index/reader.rs
@@ -132,20 +132,16 @@ impl MmapIndex {
         let header = self.header();
         let offset = size_of::<IndexHeader>();
         let count = header.dir_count as usize;
-        unsafe {
-            std::slice::from_raw_parts(self.ptr.add(offset) as *const DirRecord, count)
-        }
+        unsafe { std::slice::from_raw_parts(self.ptr.add(offset) as *const DirRecord, count) }
     }
 
     /// Get the entry records table.
     fn entry_records(&self) -> &[EntryRecord] {
         let header = self.header();
-        let offset = size_of::<IndexHeader>()
-            + (header.dir_count as usize) * size_of::<DirRecord>();
+        let offset =
+            size_of::<IndexHeader>() + (header.dir_count as usize) * size_of::<DirRecord>();
         let count = header.entry_count as usize;
-        unsafe {
-            std::slice::from_raw_parts(self.ptr.add(offset) as *const EntryRecord, count)
-        }
+        unsafe { std::slice::from_raw_parts(self.ptr.add(offset) as *const EntryRecord, count) }
     }
 
     /// Get a string from the string pool by offset and length.
@@ -174,9 +170,7 @@ impl MmapIndex {
     pub fn find_dir(&self, path: &[u8]) -> Option<(usize, &DirRecord)> {
         let dirs = self.dir_records();
         let idx = dirs
-            .binary_search_by(|rec| {
-                self.get_str(rec.path_off, rec.path_len).cmp(path)
-            })
+            .binary_search_by(|rec| self.get_str(rec.path_off, rec.path_len).cmp(path))
             .ok()?;
         Some((idx, &dirs[idx]))
     }
@@ -187,9 +181,7 @@ impl MmapIndex {
     pub fn find_entry<'a>(&'a self, dir: &DirRecord, name: &[u8]) -> Option<&'a EntryRecord> {
         let entries = self.dir_entries(dir);
         let idx = entries
-            .binary_search_by(|rec| {
-                self.get_str(rec.name_off, rec.name_len).cmp(name)
-            })
+            .binary_search_by(|rec| self.get_str(rec.name_off, rec.name_len).cmp(name))
             .ok()?;
         Some(&entries[idx])
     }
@@ -232,9 +224,7 @@ impl MmapIndex {
         let start = self.pool_offset + dir.tombstone_off as usize;
         // We don't know the exact end, but it's bounded by the file length.
         let data = if start < self.len {
-            unsafe {
-                std::slice::from_raw_parts(self.ptr.add(start), self.len - start)
-            }
+            unsafe { std::slice::from_raw_parts(self.ptr.add(start), self.len - start) }
         } else {
             &[]
         };
@@ -250,9 +240,7 @@ impl MmapIndex {
         let header = self.header();
         let count = header.hardlink_ref_count as usize;
         let offset = self.pool_offset - count * size_of::<HardlinkRef>();
-        unsafe {
-            std::slice::from_raw_parts(self.ptr.add(offset) as *const HardlinkRef, count)
-        }
+        unsafe { std::slice::from_raw_parts(self.ptr.add(offset) as *const HardlinkRef, count) }
     }
 
     /// Find all aliases of a hardlinked file by host inode number.

--- a/crates/utils/lib/index/types.rs
+++ b/crates/utils/lib/index/types.rs
@@ -11,7 +11,7 @@
 //--------------------------------------------------------------------------------------------------
 
 /// Magic bytes: "MSBi" in little-endian.
-pub const INDEX_MAGIC: u32 = 0x694253_4D;
+pub const INDEX_MAGIC: u32 = 0x6942_534D;
 
 /// Current wire format version.
 pub const INDEX_VERSION: u32 = 1;

--- a/crates/utils/lib/index/writer.rs
+++ b/crates/utils/lib/index/writer.rs
@@ -4,12 +4,11 @@
 //! to generate per-layer sidecar indexes, and by tests to construct valid/corrupt
 //! index data.
 
-use std::io;
-use std::path::Path;
+use std::{io, path::Path};
 
 use super::{
-    DIR_FLAG_OPAQUE, DIR_RECORD_IDX_NONE, DirRecord, ENTRY_FLAG_WHITEOUT, EntryRecord,
-    HardlinkRef, INDEX_MAGIC, INDEX_VERSION, IndexHeader,
+    DIR_FLAG_OPAQUE, DIR_RECORD_IDX_NONE, DirRecord, ENTRY_FLAG_WHITEOUT, EntryRecord, HardlinkRef,
+    INDEX_MAGIC, INDEX_VERSION, IndexHeader,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -321,20 +320,19 @@ impl IndexBuilder {
                 let (name_off, name_len) = entry_name_offsets[dir_idx][entry_idx];
 
                 // Auto-compute dir_record_idx for directory entries.
-                let dir_record_idx =
-                    if entry.mode & libc::S_IFMT as u32 == libc::S_IFDIR as u32 {
-                        let child_path = if dir.path.is_empty() {
-                            entry.name.clone()
-                        } else {
-                            format!("{}/{}", dir.path, entry.name)
-                        };
-                        sorted_paths
-                            .binary_search(&child_path.as_str())
-                            .map(|i| i as u32)
-                            .unwrap_or(DIR_RECORD_IDX_NONE)
+                let dir_record_idx = if entry.mode & libc::S_IFMT as u32 == libc::S_IFDIR as u32 {
+                    let child_path = if dir.path.is_empty() {
+                        entry.name.clone()
                     } else {
-                        DIR_RECORD_IDX_NONE
+                        format!("{}/{}", dir.path, entry.name)
                     };
+                    sorted_paths
+                        .binary_search(&child_path.as_str())
+                        .map(|i| i as u32)
+                        .unwrap_or(DIR_RECORD_IDX_NONE)
+                } else {
+                    DIR_RECORD_IDX_NONE
+                };
 
                 buf.extend_from_slice(&entry.host_ino.to_le_bytes());
                 buf.extend_from_slice(&entry.size.to_le_bytes());
@@ -372,5 +370,15 @@ impl IndexBuilder {
     /// Write valid index to a file.
     pub fn build_to_file(self, path: &Path) -> io::Result<()> {
         std::fs::write(path, self.build())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for IndexBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,10 +22,10 @@ That's it. You don't need `just build-deps` unless you've never built agentd and
 
 ## Running examples
 
-All examples are run from the **repo root**. Point `MSB_PATH` to your freshly built `msb` binary:
+All examples are run from the **repo root**. Point `MSB_PATH` to the binary produced by `just build`:
 
 ```sh
-MSB_PATH="$PWD/target/debug/msb" cargo run -p <example-name>
+MSB_PATH="$PWD/build/msb" cargo run -p <example-name>
 ```
 
 ## Examples

--- a/examples/basic/bin/main.rs
+++ b/examples/basic/bin/main.rs
@@ -2,24 +2,12 @@
 //!
 //! See [examples/README.md](../../README.md) for prerequisites and usage.
 
-use std::path::PathBuf;
-
 use microsandbox::sandbox::Sandbox;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rootfs_path = std::env::var("ROOTFS_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            format!(
-                "{}/rootfs-alpine/{}",
-                env!("CARGO_MANIFEST_DIR"),
-                std::env::consts::ARCH,
-            )
-            .into()
-        });
-
-    eprintln!("Creating sandbox (rootfs={rootfs_path:?})");
+    let rootfs_path = rootfs_path();
+    println!("Creating sandbox (rootfs={rootfs_path:?})");
 
     // Create a sandbox with a bind-mounted rootfs.
     let sandbox = Sandbox::builder("basic-example")
@@ -46,6 +34,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sandbox.stop().await?;
     sandbox.wait().await?;
 
-    eprintln!("Sandbox stopped.");
+    println!("Sandbox stopped.");
     Ok(())
+}
+
+fn rootfs_path() -> String {
+    format!(
+        "{}/rootfs-alpine/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        std::env::consts::ARCH,
+    )
 }

--- a/justfile
+++ b/justfile
@@ -28,6 +28,47 @@ build-agentd:
     docker cp "$id:/agentd" build/agentd
     touch build/agentd
 
+# Check for libkrunfw and build it only if not found in build/, ~/.microsandbox/lib/, or system paths.
+[linux]
+_ensure-libkrunfw:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Check build/ directory.
+    if [ -f build/libkrunfw.so.{{ LIBKRUNFW_VERSION }} ]; then
+        echo "Found libkrunfw in build/"
+        exit 0
+    fi
+    # Check ~/.microsandbox/lib/.
+    if [ -f ~/.microsandbox/lib/libkrunfw.so.{{ LIBKRUNFW_VERSION }} ]; then
+        echo "Found libkrunfw in ~/.microsandbox/lib/"
+        exit 0
+    fi
+    # Check system library paths via ldconfig.
+    if ldconfig -p 2>/dev/null | grep -q libkrunfw; then
+        echo "Found libkrunfw in system library paths"
+        exit 0
+    fi
+    echo "libkrunfw not found — building from source..."
+    just build-libkrunfw
+
+# Check for libkrunfw and build it only if not found in build/, ~/.microsandbox/lib/, or system paths.
+[macos]
+_ensure-libkrunfw:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Check build/ directory.
+    if [ -f build/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib ]; then
+        echo "Found libkrunfw in build/"
+        exit 0
+    fi
+    # Check ~/.microsandbox/lib/.
+    if [ -f ~/.microsandbox/lib/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib ]; then
+        echo "Found libkrunfw in ~/.microsandbox/lib/"
+        exit 0
+    fi
+    echo "libkrunfw not found — building from source..."
+    just build-libkrunfw
+
 # Build libkrunfw on Linux. Requires: kernel build dependencies (gcc, make, flex, bison, etc.).
 [linux]
 build-libkrunfw:
@@ -56,16 +97,16 @@ build-libkrunfw:
     cd build
     ln -sf libkrunfw.{{ LIBKRUNFW_ABI }}.dylib libkrunfw.dylib
 
-# Build the msb CLI binary (release mode). Rebuilds agentd first if needed.
+# Build the msb CLI binary (release mode). Rebuilds agentd and ensures libkrunfw is available.
 [linux]
-build: build-agentd
+build: build-agentd _ensure-libkrunfw
     cargo build --release -p microsandbox-cli
     mkdir -p build
     cp target/release/msb build/msb
 
-# Build and sign the msb CLI binary (release mode). Rebuilds agentd first if needed.
+# Build and sign the msb CLI binary (release mode). Rebuilds agentd and ensures libkrunfw is available.
 [macos]
-build: build-agentd
+build: build-agentd _ensure-libkrunfw
     cargo build --release -p microsandbox-cli
     mkdir -p build
     cp target/release/msb build/msb


### PR DESCRIPTION
## Summary

- Add `ImageSource` intermediate type that smartly resolves user input (strings, paths) into the correct `RootfsSource` variant (`Bind` for local directories, `Oci` for container image references)
- Introduce `RootfsSource` enum to cleanly distinguish between bind-mounted host directories and OCI image references in sandbox configuration
- Refactor filesystem backends (memfs, dualfs, overlayfs, passthroughfs, proxy) with improved error handling, builder patterns, and test coverage
- Update runtime supervisor and CLI with structured log level arguments and improved spawn logic

## Changes

- Added `ImageSource` enum in `crates/microsandbox/lib/sandbox/types.rs` with `From` impls for `&str`, `String`, and `PathBuf`, plus unsupported disk image format detection (`.qcow2`, `.raw`, `.vmdk`)
- Added `RootfsSource` enum (`Bind(PathBuf)` / `Oci(String)`) replacing raw string-based image configuration
- Updated `SandboxBuilder::image()` to accept `impl Into<ImageSource>` for ergonomic API usage
- Added rootfs validation in `Sandbox::create()` to check bind paths exist and are directories
- Added `crates/cli/lib/log_args.rs` for structured CLI log level argument handling
- Refactored filesystem backend builders across all backends (memfs, dualfs, overlayfs, passthroughfs, proxy) with updated signatures and improved error propagation
- Updated `crates/microsandbox/lib/runtime/spawn.rs` with improved supervisor spawn logic
- Updated `crates/runtime/lib/supervisor.rs` with refactored supervision and logging
- Updated `crates/runtime/lib/logging.rs` with enhanced runtime logging configuration
- Modified workspace `Cargo.toml` with dependency reordering and new workspace dependency entries (`sea-orm`, `sea-orm-migration`)
- Updated `crates/agentd/Cargo.toml` and `Cargo.lock` with dependency changes
- Updated `examples/basic/bin/main.rs` to use the new `ImageSource` API
- Enhanced `justfile` with additional build and development recipes
- Protected `microsandbox` branch in `.pre-commit-config.yaml`

## Test Plan

- Run `cargo build` to verify successful compilation across all workspace crates
- Run `cargo test -p microsandbox` to verify sandbox builder and rootfs validation tests pass
- Run `cargo test -p microsandbox-filesystem` to verify filesystem backend tests pass (memfs, dualfs, overlayfs, passthroughfs, proxy)
- Verify `ImageSource` resolution: strings with `/`, `./`, `../` prefixes resolve to `RootfsSource::Bind`; other strings resolve to `RootfsSource::Oci`
- Verify unsupported disk image formats (`.qcow2`, `.raw`, `.vmdk`) return appropriate errors
- Verify `PathBuf` inputs always resolve to `RootfsSource::Bind`