### PR TITLE
feat(image): add OCI image pulling with OverlayFs rootfs support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +208,12 @@ dependencies = [
  "dunce",
  "fs_extra",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -508,6 +542,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +574,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -686,6 +759,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -719,6 +793,37 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -878,6 +983,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1037,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1080,6 +1211,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,12 +1430,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1546,6 +1714,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,12 +1906,13 @@ dependencies = [
  "libc",
  "microsandbox-db",
  "microsandbox-filesystem",
+ "microsandbox-image",
  "microsandbox-migration",
  "microsandbox-protocol",
  "microsandbox-runtime",
  "microsandbox-utils",
  "nix",
- "reqwest",
+ "reqwest 0.13.2",
  "scopeguard",
  "sea-orm",
  "serde",
@@ -1776,6 +1960,26 @@ dependencies = [
 [[package]]
 name = "microsandbox-image"
 version = "0.2.6"
+dependencies = [
+ "astral-tokio-tar",
+ "async-compression",
+ "futures",
+ "hex",
+ "libc",
+ "microsandbox-utils",
+ "oci-client",
+ "oci-spec",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "xattr",
+]
 
 [[package]]
 name = "microsandbox-migration"
@@ -1816,6 +2020,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2024,6 +2229,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2330,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,10 +2396,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2271,6 +2585,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2574,11 +2894,50 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2611,7 +2970,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2870,7 +3229,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.18",
  "time",
  "tracing",
@@ -3252,7 +3611,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bytes",
  "chrono",
@@ -3332,7 +3691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.11.0",
  "byteorder",
@@ -3379,7 +3738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.11.0",
  "byteorder",
@@ -3476,6 +3835,24 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -3699,6 +4076,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3902,6 +4289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,7 +4351,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -3975,7 +4368,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -4196,6 +4589,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4702,6 +5108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/cli/lib/microvm_cmd.rs
+++ b/crates/cli/lib/microvm_cmd.rs
@@ -27,9 +27,21 @@ pub struct MicrovmArgs {
     #[arg(long, default_value_t = 512)]
     pub memory_mib: u32,
 
-    /// Root filesystem layer paths (repeatable).
+    /// Root filesystem path for direct passthrough mounts.
     #[arg(long)]
-    pub rootfs_layer: Vec<PathBuf>,
+    pub rootfs_path: Option<PathBuf>,
+
+    /// Root filesystem lower layer paths for OverlayFs (repeatable).
+    #[arg(long)]
+    pub rootfs_lower: Vec<PathBuf>,
+
+    /// Writable upper layer directory for OverlayFs rootfs.
+    #[arg(long)]
+    pub rootfs_upper: Option<PathBuf>,
+
+    /// Staging directory for OverlayFs rootfs.
+    #[arg(long)]
+    pub rootfs_staging: Option<PathBuf>,
 
     /// Additional mounts as `tag:host_path` (repeatable).
     #[arg(long)]
@@ -76,7 +88,10 @@ pub fn run(args: MicrovmArgs) -> RuntimeResult<()> {
         libkrunfw_path: args.libkrunfw_path,
         vcpus: args.vcpus,
         memory_mib: args.memory_mib,
-        rootfs_layers: args.rootfs_layer,
+        rootfs_path: args.rootfs_path,
+        rootfs_lowers: args.rootfs_lower,
+        rootfs_upper: args.rootfs_upper,
+        rootfs_staging: args.rootfs_staging,
         mounts: args.mount,
         backends: vec![],
         init_path: args.init_path,

--- a/crates/cli/lib/supervisor_cmd.rs
+++ b/crates/cli/lib/supervisor_cmd.rs
@@ -100,9 +100,21 @@ pub struct SupervisorArgs {
     #[arg(long, default_value_t = 512)]
     pub memory_mib: u32,
 
-    /// Root filesystem layer paths (repeatable).
+    /// Root filesystem path for direct passthrough mounts.
     #[arg(long)]
-    pub rootfs_layer: Vec<PathBuf>,
+    pub rootfs_path: Option<PathBuf>,
+
+    /// Root filesystem lower layer paths for OverlayFs (repeatable).
+    #[arg(long)]
+    pub rootfs_lower: Vec<PathBuf>,
+
+    /// Writable upper layer directory for OverlayFs rootfs.
+    #[arg(long)]
+    pub rootfs_upper: Option<PathBuf>,
+
+    /// Staging directory for OverlayFs rootfs.
+    #[arg(long)]
+    pub rootfs_staging: Option<PathBuf>,
 
     /// Additional mounts as `tag:host_path` (repeatable).
     #[arg(long)]
@@ -157,7 +169,10 @@ pub async fn run(args: SupervisorArgs, log_level: Option<LogLevel>) -> RuntimeRe
         libkrunfw_path: args.libkrunfw_path,
         vcpus: args.vcpus,
         memory_mib: args.memory_mib,
-        rootfs_layers: args.rootfs_layer,
+        rootfs_path: args.rootfs_path,
+        rootfs_lowers: args.rootfs_lower,
+        rootfs_upper: args.rootfs_upper,
+        rootfs_staging: args.rootfs_staging,
         mounts: args.mount,
         backends: vec![],
         init_path: args.init_path,

--- a/crates/db/lib/entity/mod.rs
+++ b/crates/db/lib/entity/mod.rs
@@ -9,6 +9,7 @@ pub mod manifest_layer;
 pub mod microvm;
 pub mod msbnet;
 pub mod sandbox;
+pub mod sandbox_image;
 pub mod sandbox_metric;
 pub mod snapshot;
 pub mod supervisor;

--- a/crates/db/lib/entity/sandbox_image.rs
+++ b/crates/db/lib/entity/sandbox_image.rs
@@ -1,0 +1,64 @@
+//! Entity definition for the `sandbox_image` join table.
+//!
+//! Links sandboxes to their pinned images, enabling safe image GC
+//! (images referenced by running sandboxes cannot be deleted).
+
+use sea_orm::entity::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The sandbox-image join entity model.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "sandbox_image")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub sandbox_id: i32,
+    pub image_id: i32,
+    pub manifest_digest: String,
+    pub created_at: Option<DateTime>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Relations
+//--------------------------------------------------------------------------------------------------
+
+/// Relations for the sandbox_image entity.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    /// Belongs to a sandbox.
+    #[sea_orm(
+        belongs_to = "super::sandbox::Entity",
+        from = "Column::SandboxId",
+        to = "super::sandbox::Column::Id"
+    )]
+    Sandbox,
+
+    /// Belongs to an image.
+    #[sea_orm(
+        belongs_to = "super::image::Entity",
+        from = "Column::ImageId",
+        to = "super::image::Column::Id"
+    )]
+    Image,
+}
+
+impl Related<super::sandbox::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sandbox.def()
+    }
+}
+
+impl Related<super::image::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Image.def()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "microsandbox-image"
+description = "OCI image pulling, layer extraction, and caching for microsandbox."
 version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -8,3 +9,25 @@ edition.workspace = true
 
 [lib]
 path = "lib/lib.rs"
+
+[dependencies]
+astral-tokio-tar = { workspace = true }
+async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
+futures.workspace = true
+hex.workspace = true
+libc.workspace = true
+microsandbox-utils = { path = "../utils" }
+oci-client.workspace = true
+oci-spec.workspace = true
+scopeguard.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "rt", "sync"] }
+tokio-util.workspace = true
+tracing.workspace = true
+xattr.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/image/lib/auth.rs
+++ b/crates/image/lib/auth.rs
@@ -1,0 +1,43 @@
+//! Registry authentication.
+
+use serde::{Deserialize, Serialize};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Authentication credentials for OCI registry access.
+///
+/// Resolution chain (in [`Registry`](crate::Registry)):
+/// 1. Explicit [`RegistryAuth`] via [`Registry::with_auth()`](crate::Registry::with_auth)
+/// 2. Global config `registries.auth` (`password_env` or `secret_name`)
+/// 3. [`Anonymous`](Self::Anonymous) fallback
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub enum RegistryAuth {
+    /// No authentication. Works for public registries.
+    #[default]
+    Anonymous,
+
+    /// Username + password authentication.
+    Basic {
+        /// Registry username.
+        username: String,
+        /// Registry password or token.
+        password: String,
+    },
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl From<&RegistryAuth> for oci_client::secrets::RegistryAuth {
+    fn from(auth: &RegistryAuth) -> Self {
+        match auth {
+            RegistryAuth::Anonymous => oci_client::secrets::RegistryAuth::Anonymous,
+            RegistryAuth::Basic { username, password } => {
+                oci_client::secrets::RegistryAuth::Basic(username.clone(), password.clone())
+            }
+        }
+    }
+}

--- a/crates/image/lib/config.rs
+++ b/crates/image/lib/config.rs
@@ -1,0 +1,86 @@
+//! OCI image configuration parsing.
+
+use std::collections::HashMap;
+
+use crate::error::ImageError;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Runtime configuration parsed from an OCI image config blob.
+///
+/// These are defaults — [`SandboxBuilder`] fields override them.
+/// Fields are `Option` where the OCI spec allows omission.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ImageConfig {
+    /// Environment variables (`KEY=VALUE` format).
+    pub env: Vec<String>,
+
+    /// Default command.
+    pub cmd: Option<Vec<String>>,
+
+    /// Entrypoint.
+    pub entrypoint: Option<Vec<String>>,
+
+    /// Working directory for the default process.
+    pub working_dir: Option<String>,
+
+    /// Default user (`uid`, `uid:gid`, `username`, or `username:group`).
+    pub user: Option<String>,
+
+    /// Ports the image declares as exposed (informational only).
+    pub exposed_ports: Vec<String>,
+
+    /// Volume mount points declared by the image (informational).
+    pub volumes: Vec<String>,
+
+    /// Image labels (key-value metadata).
+    pub labels: HashMap<String, String>,
+
+    /// Signal to send for graceful shutdown (e.g., `SIGTERM`).
+    pub stop_signal: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ImageConfig {
+    /// Parse from raw OCI config JSON bytes, returning the config and diff_ids.
+    pub fn parse(bytes: &[u8]) -> Result<(Self, Vec<String>), ImageError> {
+        let oci_config: oci_spec::image::ImageConfiguration = serde_json::from_slice(bytes)
+            .map_err(|e| ImageError::ConfigParse(format!("failed to parse image config: {e}")))?;
+
+        let config = oci_config.config();
+
+        let image_config = Self {
+            env: config
+                .as_ref()
+                .and_then(|c| c.env().clone())
+                .unwrap_or_default(),
+            cmd: config.as_ref().and_then(|c| c.cmd().clone()),
+            entrypoint: config.as_ref().and_then(|c| c.entrypoint().clone()),
+            working_dir: config.as_ref().and_then(|c| c.working_dir().clone()),
+            user: config.as_ref().and_then(|c| c.user().clone()),
+            exposed_ports: config
+                .as_ref()
+                .and_then(|c| c.exposed_ports().clone())
+                .unwrap_or_default(),
+            volumes: config
+                .as_ref()
+                .and_then(|c| c.volumes().clone())
+                .unwrap_or_default(),
+            labels: config
+                .as_ref()
+                .and_then(|c| c.labels().as_ref())
+                .cloned()
+                .unwrap_or_default(),
+            stop_signal: config.as_ref().and_then(|c| c.stop_signal().clone()),
+        };
+
+        let diff_ids = oci_config.rootfs().diff_ids().to_vec();
+
+        Ok((image_config, diff_ids))
+    }
+}

--- a/crates/image/lib/digest.rs
+++ b/crates/image/lib/digest.rs
@@ -1,0 +1,119 @@
+//! OCI content-addressable digest type.
+
+use std::{fmt, str::FromStr};
+
+use crate::error::ImageError;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI content-addressable digest (e.g., `sha256:e3b0c44298fc1c14...`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Digest {
+    /// Hash algorithm (e.g., `sha256`).
+    algorithm: String,
+    /// Hex-encoded hash value.
+    hex: String,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Digest {
+    /// Create a new digest from algorithm and hex components.
+    pub fn new(algorithm: impl Into<String>, hex: impl Into<String>) -> Self {
+        Self {
+            algorithm: algorithm.into(),
+            hex: hex.into(),
+        }
+    }
+
+    /// Hash algorithm (e.g., `sha256`).
+    pub fn algorithm(&self) -> &str {
+        &self.algorithm
+    }
+
+    /// Hex-encoded hash value.
+    pub fn hex(&self) -> &str {
+        &self.hex
+    }
+
+    /// Filesystem-safe representation for use in paths.
+    ///
+    /// Replaces `:` with `_` (e.g., `sha256_abc123...`).
+    pub fn to_path_safe(&self) -> String {
+        format!("{}_{}", self.algorithm, self.hex)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl FromStr for Digest {
+    type Err = ImageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (algo, hex) = s.split_once(':').ok_or_else(|| {
+            ImageError::ManifestParse(format!("invalid digest (missing ':'): {s}"))
+        })?;
+
+        if algo.is_empty() || hex.is_empty() {
+            return Err(ImageError::ManifestParse(format!(
+                "invalid digest (empty component): {s}"
+            )));
+        }
+
+        Ok(Self {
+            algorithm: algo.to_string(),
+            hex: hex.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.algorithm, self.hex)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_digest() {
+        let d: Digest = "sha256:abc123".parse().unwrap();
+        assert_eq!(d.algorithm(), "sha256");
+        assert_eq!(d.hex(), "abc123");
+    }
+
+    #[test]
+    fn test_display() {
+        let d = Digest::new("sha256", "abc123");
+        assert_eq!(d.to_string(), "sha256:abc123");
+    }
+
+    #[test]
+    fn test_path_safe() {
+        let d = Digest::new("sha256", "abc123");
+        assert_eq!(d.to_path_safe(), "sha256_abc123");
+    }
+
+    #[test]
+    fn test_parse_missing_colon() {
+        assert!("sha256abc123".parse::<Digest>().is_err());
+    }
+
+    #[test]
+    fn test_parse_empty_components() {
+        assert!(":abc123".parse::<Digest>().is_err());
+        assert!("sha256:".parse::<Digest>().is_err());
+    }
+}

--- a/crates/image/lib/error.rs
+++ b/crates/image/lib/error.rs
@@ -1,0 +1,89 @@
+//! Error types for image operations.
+
+use std::path::PathBuf;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Errors that can occur during image operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ImageError {
+    /// Network or registry communication error.
+    #[error("registry error: {0}")]
+    Registry(#[from] oci_client::errors::OciDistributionError),
+
+    /// No manifest found matching the requested platform.
+    #[error("no manifest for platform {os}/{arch} in {reference}")]
+    PlatformNotFound {
+        /// The image reference.
+        reference: String,
+        /// Requested OS.
+        os: String,
+        /// Requested architecture.
+        arch: String,
+    },
+
+    /// OCI manifest or index parsing failed.
+    #[error("manifest parse error: {0}")]
+    ManifestParse(String),
+
+    /// OCI image config parsing failed.
+    #[error("config parse error: {0}")]
+    ConfigParse(String),
+
+    /// Layer download hash mismatch (possible corruption or tampering).
+    #[error("digest mismatch for layer {digest}: expected {expected}, got {actual}")]
+    DigestMismatch {
+        /// The layer digest.
+        digest: String,
+        /// Expected hash.
+        expected: String,
+        /// Actual computed hash.
+        actual: String,
+    },
+
+    /// Layer extraction failed.
+    #[error("extraction failed for layer {digest}: {message}")]
+    Extraction {
+        /// The layer digest.
+        digest: String,
+        /// Error detail.
+        message: String,
+        /// The underlying error.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
+    /// Sidecar index generation failed.
+    #[error("index generation failed for layer {0}: {1}")]
+    IndexBuild(String, #[source] std::io::Error),
+
+    /// Cache I/O error.
+    #[error("cache error at {}: {source}", path.display())]
+    Cache {
+        /// The path that caused the error.
+        path: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Image not found in local cache (PullPolicy::Never).
+    #[error("image not cached: {reference}")]
+    NotCached {
+        /// The image reference.
+        reference: String,
+    },
+
+    /// General I/O error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+//--------------------------------------------------------------------------------------------------
+// Type Aliases
+//--------------------------------------------------------------------------------------------------
+
+/// Result type for image operations.
+pub type ImageResult<T> = Result<T, ImageError>;

--- a/crates/image/lib/layer/extraction.rs
+++ b/crates/image/lib/layer/extraction.rs
@@ -1,0 +1,624 @@
+//! Layer extraction pipeline.
+//!
+//! Two-pass async extraction using `async-compression` + `astral-tokio-tar`.
+//! Handles stat virtualization via `user.containers.override_stat` xattr,
+//! platform-aware symlinks, special file handling, and whiteout markers.
+
+use std::{
+    io::Read,
+    path::{Component, Path, PathBuf},
+};
+
+use async_compression::tokio::bufread::{GzipDecoder, ZstdDecoder};
+use tokio::io::{AsyncRead, BufReader};
+use tokio_tar as tar;
+
+use super::OVERRIDE_XATTR_KEY;
+use crate::error::{ImageError, ImageResult};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Binary format version for OverrideStat.
+const OVERRIDE_STAT_VERSION: u8 = 1;
+
+/// Maximum total extracted size (10 GiB).
+const MAX_TOTAL_SIZE: u64 = 10 * 1024 * 1024 * 1024;
+
+/// Maximum single file size (5 GiB).
+const MAX_FILE_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+
+/// Maximum number of tar entries.
+const MAX_ENTRY_COUNT: u64 = 1_000_000;
+
+/// Maximum path depth.
+const MAX_PATH_DEPTH: usize = 128;
+
+/// File type bits (from libc).
+const S_IFREG: u32 = libc::S_IFREG as u32;
+const S_IFDIR: u32 = libc::S_IFDIR as u32;
+const S_IFLNK: u32 = libc::S_IFLNK as u32;
+const S_IFBLK: u32 = libc::S_IFBLK as u32;
+const S_IFCHR: u32 = libc::S_IFCHR as u32;
+const S_IFIFO: u32 = libc::S_IFIFO as u32;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Deferred hardlink to create in the second pass.
+struct DeferredHardlink {
+    path: PathBuf,
+    target: PathBuf,
+}
+
+/// Compression format for a layer blob.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LayerCompression {
+    Plain,
+    Gzip,
+    Zstd,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Extract a compressed layer tarball to a directory.
+///
+/// Two-pass extraction:
+/// 1. Files, directories, symlinks, and special files (with xattr stat virtualization).
+/// 2. Hard links (targets must exist from pass 1).
+pub(crate) async fn extract_layer(
+    tar_path: &Path,
+    dest: &Path,
+    parent_layers: &[PathBuf],
+    media_type: Option<&str>,
+) -> ImageResult<()> {
+    use tar::Archive;
+
+    let compression = detect_layer_compression(tar_path, media_type)?;
+
+    let file = tokio::fs::File::open(tar_path)
+        .await
+        .map_err(|e| ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!("failed to open tarball: {e}"),
+            source: Some(Box::new(e)),
+        })?;
+    let archive_reader: Box<dyn AsyncRead + Unpin + Send> = match compression {
+        LayerCompression::Plain => Box::new(BufReader::new(file)),
+        LayerCompression::Gzip => Box::new(BufReader::new(GzipDecoder::new(BufReader::new(file)))),
+        LayerCompression::Zstd => Box::new(BufReader::new(ZstdDecoder::new(BufReader::new(file)))),
+    };
+    let mut archive = Archive::new(archive_reader);
+
+    let mut deferred_hardlinks: Vec<DeferredHardlink> = Vec::new();
+    let mut total_size: u64 = 0;
+    let mut entry_count: u64 = 0;
+
+    let mut entries = archive.entries().map_err(|e| ImageError::Extraction {
+        digest: tar_path.display().to_string(),
+        message: format!("failed to read tar entries: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+
+    use futures::StreamExt;
+
+    // Pass 1: Regular files, directories, symlinks, special files.
+    while let Some(entry_result) = entries.next().await {
+        let mut entry = entry_result.map_err(|e| ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!("failed to read tar entry: {e}"),
+            source: Some(Box::new(e)),
+        })?;
+
+        entry_count += 1;
+        if entry_count > MAX_ENTRY_COUNT {
+            return Err(ImageError::Extraction {
+                digest: tar_path.display().to_string(),
+                message: format!("exceeded max entry count ({MAX_ENTRY_COUNT})"),
+                source: None,
+            });
+        }
+
+        let header = entry.header().clone();
+        let entry_path = entry
+            .path()
+            .map_err(|e| ImageError::Extraction {
+                digest: tar_path.display().to_string(),
+                message: format!("invalid entry path: {e}"),
+                source: Some(Box::new(e)),
+            })?
+            .into_owned();
+
+        // Validate path.
+        let full_path = validate_entry_path(dest, &entry_path, tar_path)?;
+
+        let uid = header.uid().unwrap_or(0) as u32;
+        let gid = header.gid().unwrap_or(0) as u32;
+        let tar_mode = header.mode().unwrap_or(0o644);
+        let size = header.size().unwrap_or(0);
+
+        let entry_type = header.entry_type();
+
+        // Check for hardlink — defer to pass 2.
+        if entry_type == tar::EntryType::Link {
+            if let Ok(Some(link_target)) = entry.link_name() {
+                let target_full = validate_entry_path(dest, &link_target, tar_path)?;
+                deferred_hardlinks.push(DeferredHardlink {
+                    path: full_path,
+                    target: target_full,
+                });
+            }
+            continue;
+        }
+
+        if entry_type == tar::EntryType::Directory {
+            // Directory.
+            if !full_path.exists() {
+                std::fs::create_dir_all(&full_path).map_err(|e| extraction_err(tar_path, e))?;
+            }
+            // Set host permissions: u+rwx minimum.
+            set_host_permissions(&full_path, 0o700)?;
+            // Set stat xattr.
+            let mode = S_IFDIR | (tar_mode & 0o7777);
+            set_override_stat(&full_path, uid, gid, mode, 0)?;
+        } else if entry_type == tar::EntryType::Symlink {
+            let link_target = entry
+                .link_name()
+                .map_err(|e| extraction_err(tar_path, e))?
+                .map(|p| p.into_owned())
+                .unwrap_or_default();
+
+            // Ensure parent directory exists.
+            ensure_parent_dir(&full_path, dest, parent_layers)?;
+
+            let mode = S_IFLNK | 0o777;
+
+            if cfg!(target_os = "linux") {
+                // Linux: store as regular file with content = target path.
+                // (xattrs can't be set on symlinks on most Linux filesystems.)
+                if let Some(parent) = full_path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| extraction_err(tar_path, e))?;
+                }
+                // Remove any existing entry (could be a directory from a lower layer).
+                let _ = std::fs::remove_dir_all(&full_path);
+                let _ = std::fs::remove_file(&full_path);
+                std::fs::write(&full_path, link_target.as_os_str().as_encoded_bytes())
+                    .map_err(|e| extraction_err(tar_path, e))?;
+                set_host_permissions(&full_path, 0o600)?;
+                set_override_stat(&full_path, uid, gid, mode, 0)?;
+            } else {
+                // macOS: real symlink with XATTR_NOFOLLOW.
+                if let Some(parent) = full_path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| extraction_err(tar_path, e))?;
+                }
+                // Remove any existing file at the target.
+                let _ = std::fs::remove_file(&full_path);
+                std::os::unix::fs::symlink(&link_target, &full_path)
+                    .map_err(|e| extraction_err(tar_path, e))?;
+                set_override_stat_symlink(&full_path, uid, gid, mode, 0)?;
+            }
+        } else if entry_type == tar::EntryType::Regular || entry_type == tar::EntryType::Continuous
+        {
+            // Regular file.
+            if size > MAX_FILE_SIZE {
+                return Err(ImageError::Extraction {
+                    digest: tar_path.display().to_string(),
+                    message: format!("file too large: {} bytes (max {MAX_FILE_SIZE})", size),
+                    source: None,
+                });
+            }
+            total_size += size;
+            if total_size > MAX_TOTAL_SIZE {
+                return Err(ImageError::Extraction {
+                    digest: tar_path.display().to_string(),
+                    message: format!("total extraction size exceeded {MAX_TOTAL_SIZE} bytes"),
+                    source: None,
+                });
+            }
+
+            ensure_parent_dir(&full_path, dest, parent_layers)?;
+
+            let mut file = tokio::fs::File::create(&full_path)
+                .await
+                .map_err(|e| extraction_err(tar_path, e))?;
+            tokio::io::copy(&mut entry, &mut file)
+                .await
+                .map_err(|e| extraction_err(tar_path, e))?;
+            drop(file);
+
+            set_host_permissions(&full_path, 0o600)?;
+            let mode = S_IFREG | (tar_mode & 0o7777);
+            set_override_stat(&full_path, uid, gid, mode, 0)?;
+        } else if entry_type == tar::EntryType::Block || entry_type == tar::EntryType::Char {
+            // Block/char device: store as empty regular file with device info in xattr.
+            ensure_parent_dir(&full_path, dest, parent_layers)?;
+            std::fs::write(&full_path, b"").map_err(|e| extraction_err(tar_path, e))?;
+            set_host_permissions(&full_path, 0o600)?;
+
+            let major = header.device_major().unwrap_or(None).unwrap_or(0);
+            let minor = header.device_minor().unwrap_or(None).unwrap_or(0);
+            let rdev = makedev(major, minor);
+            let type_bits = if entry_type == tar::EntryType::Block {
+                S_IFBLK
+            } else {
+                S_IFCHR
+            };
+            let mode = type_bits | (tar_mode & 0o7777);
+            set_override_stat(&full_path, uid, gid, mode, rdev)?;
+        } else if entry_type == tar::EntryType::Fifo {
+            // FIFO: store as empty regular file.
+            ensure_parent_dir(&full_path, dest, parent_layers)?;
+            std::fs::write(&full_path, b"").map_err(|e| extraction_err(tar_path, e))?;
+            set_host_permissions(&full_path, 0o600)?;
+            let mode = S_IFIFO | (tar_mode & 0o7777);
+            set_override_stat(&full_path, uid, gid, mode, 0)?;
+        }
+        // Skip other types (GNUSparse, XHeader, etc.)
+    }
+
+    // Pass 2: Hard links.
+    for hl in deferred_hardlinks {
+        if !hl.target.exists() {
+            tracing::warn!(
+                target = %hl.target.display(),
+                link = %hl.path.display(),
+                "hardlink target not found, skipping"
+            );
+            continue;
+        }
+        ensure_parent_dir(&hl.path, dest, parent_layers)?;
+        let _ = std::fs::remove_file(&hl.path);
+        std::fs::hard_link(&hl.target, &hl.path).map_err(|e| ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!(
+                "failed to create hardlink {} -> {}: {e}",
+                hl.path.display(),
+                hl.target.display()
+            ),
+            source: Some(Box::new(e)),
+        })?;
+    }
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Validate a tar entry path to prevent path traversal.
+fn validate_entry_path(dest: &Path, entry_path: &Path, tar_path: &Path) -> ImageResult<PathBuf> {
+    // Reject absolute paths.
+    if entry_path.is_absolute() {
+        return Err(ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!("absolute path in tar entry: {}", entry_path.display()),
+            source: None,
+        });
+    }
+
+    // Reject .. components.
+    let mut depth = 0usize;
+    for component in entry_path.components() {
+        match component {
+            Component::ParentDir => {
+                return Err(ImageError::Extraction {
+                    digest: tar_path.display().to_string(),
+                    message: format!("path traversal in tar entry: {}", entry_path.display()),
+                    source: None,
+                });
+            }
+            Component::Normal(_) => {
+                depth += 1;
+                if depth > MAX_PATH_DEPTH {
+                    return Err(ImageError::Extraction {
+                        digest: tar_path.display().to_string(),
+                        message: format!(
+                            "path too deep ({depth} components): {}",
+                            entry_path.display()
+                        ),
+                        source: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let full_path = dest.join(entry_path);
+    ensure_host_path_contained(dest, &full_path, tar_path)?;
+    Ok(full_path)
+}
+
+/// Ensure parent directories exist, searching parent layers if needed.
+fn ensure_parent_dir(path: &Path, dest: &Path, parent_layers: &[PathBuf]) -> ImageResult<()> {
+    if let Some(parent) = path.parent() {
+        if parent.exists() {
+            return Ok(());
+        }
+
+        // Walk up to find the first missing ancestor.
+        let mut missing = Vec::new();
+        let mut current = parent.to_path_buf();
+        while !current.exists() && current != *dest {
+            missing.push(current.clone());
+            if let Some(p) = current.parent() {
+                current = p.to_path_buf();
+            } else {
+                break;
+            }
+        }
+
+        // Create missing directories, copying xattrs from parent layers if found.
+        for dir in missing.into_iter().rev() {
+            std::fs::create_dir_all(&dir).map_err(|e| ImageError::Extraction {
+                digest: String::new(),
+                message: format!("failed to create dir {}: {e}", dir.display()),
+                source: Some(Box::new(e)),
+            })?;
+
+            // Try to copy xattrs from a parent layer.
+            if let Ok(rel) = dir.strip_prefix(dest) {
+                for parent_dir in parent_layers.iter().rev() {
+                    let parent_path = parent_dir.join(rel);
+                    if parent_path.exists() {
+                        // Copy the override stat xattr.
+                        if let Ok(Some(data)) = xattr::get(&parent_path, OVERRIDE_XATTR_KEY) {
+                            let _ = xattr::set(&dir, OVERRIDE_XATTR_KEY, &data);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            set_host_permissions(&dir, 0o700)?;
+        }
+    }
+    Ok(())
+}
+
+/// Set host file permissions (minimum readable/writable by owner).
+fn set_host_permissions(path: &Path, mode: u32) -> ImageResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| {
+        ImageError::Extraction {
+            digest: String::new(),
+            message: format!("failed to set permissions on {}: {e}", path.display()),
+            source: Some(Box::new(e)),
+        }
+    })
+}
+
+/// Serialize an `OverrideStat` into a 20-byte xattr value.
+fn override_stat_bytes(uid: u32, gid: u32, mode: u32, rdev: u32) -> [u8; 20] {
+    let mut buf = [0u8; 20];
+    buf[0] = OVERRIDE_STAT_VERSION;
+    // buf[1..4] is padding (already zeroed)
+    buf[4..8].copy_from_slice(&uid.to_le_bytes());
+    buf[8..12].copy_from_slice(&gid.to_le_bytes());
+    buf[12..16].copy_from_slice(&mode.to_le_bytes());
+    buf[16..20].copy_from_slice(&rdev.to_le_bytes());
+    buf
+}
+
+/// Set the `user.containers.override_stat` xattr on a regular file or directory.
+fn set_override_stat(path: &Path, uid: u32, gid: u32, mode: u32, rdev: u32) -> ImageResult<()> {
+    let bytes = override_stat_bytes(uid, gid, mode, rdev);
+
+    xattr::set(path, OVERRIDE_XATTR_KEY, &bytes).map_err(|e| ImageError::Extraction {
+        digest: String::new(),
+        message: format!("failed to set xattr on {}: {e}", path.display()),
+        source: Some(Box::new(e)),
+    })
+}
+
+/// Set the override stat xattr on a symlink (macOS only, uses XATTR_NOFOLLOW).
+#[cfg(target_os = "macos")]
+fn set_override_stat_symlink(
+    path: &Path,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+    rdev: u32,
+) -> ImageResult<()> {
+    let bytes = override_stat_bytes(uid, gid, mode, rdev);
+
+    // Use lsetxattr on symlinks.
+    use std::{ffi::CString, os::unix::ffi::OsStrExt};
+    let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|e| ImageError::Extraction {
+        digest: String::new(),
+        message: format!("invalid path for xattr: {e}"),
+        source: None,
+    })?;
+    let c_name = CString::new(OVERRIDE_XATTR_KEY).unwrap();
+
+    // macOS: setxattr with XATTR_NOFOLLOW option
+    let ret = unsafe {
+        libc::setxattr(
+            c_path.as_ptr(),
+            c_name.as_ptr(),
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+            0, // position
+            libc::XATTR_NOFOLLOW,
+        )
+    };
+    if ret != 0 {
+        let e = std::io::Error::last_os_error();
+        return Err(ImageError::Extraction {
+            digest: String::new(),
+            message: format!("failed to set xattr on symlink {}: {e}", path.display()),
+            source: Some(Box::new(e)),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_override_stat_symlink(
+    _path: &Path,
+    _uid: u32,
+    _gid: u32,
+    _mode: u32,
+    _rdev: u32,
+) -> ImageResult<()> {
+    // On Linux, symlinks are stored as regular files with S_IFLNK in the xattr.
+    // set_override_stat() is called on the regular file, not the symlink.
+    Ok(())
+}
+
+/// Construct a device number from major and minor (glibc-compatible encoding).
+fn makedev(major: u32, minor: u32) -> u32 {
+    ((major & 0xFFF) << 8) | (minor & 0xFF) | ((minor & 0xFFFFF00) << 12)
+}
+
+fn extraction_err(
+    tar_path: &Path,
+    e: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+) -> ImageError {
+    let source = e.into();
+    ImageError::Extraction {
+        digest: tar_path.display().to_string(),
+        message: source.to_string(),
+        source: Some(source),
+    }
+}
+
+/// Ensure the deepest existing ancestor of `path` still resolves under `dest`.
+fn ensure_host_path_contained(dest: &Path, path: &Path, tar_path: &Path) -> ImageResult<()> {
+    let root = std::fs::canonicalize(dest).map_err(|e| ImageError::Extraction {
+        digest: tar_path.display().to_string(),
+        message: format!(
+            "failed to canonicalize extraction root {}: {e}",
+            dest.display()
+        ),
+        source: Some(Box::new(e)),
+    })?;
+
+    let mut ancestor = path;
+    while !ancestor.exists() {
+        ancestor = ancestor.parent().ok_or_else(|| ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!("invalid extraction path: {}", path.display()),
+            source: None,
+        })?;
+    }
+
+    let canonical_ancestor =
+        std::fs::canonicalize(ancestor).map_err(|e| ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!("failed to canonicalize {}: {e}", ancestor.display()),
+            source: Some(Box::new(e)),
+        })?;
+
+    if !canonical_ancestor.starts_with(&root) {
+        return Err(ImageError::Extraction {
+            digest: tar_path.display().to_string(),
+            message: format!(
+                "tar entry escapes extraction root via symlinked ancestor: {}",
+                path.display()
+            ),
+            source: None,
+        });
+    }
+
+    Ok(())
+}
+
+/// Detect the compression format for a layer blob.
+fn detect_layer_compression(
+    tar_path: &Path,
+    media_type: Option<&str>,
+) -> ImageResult<LayerCompression> {
+    if let Some(media_type) = media_type {
+        if media_type.contains("zstd") {
+            return Ok(LayerCompression::Zstd);
+        }
+        if media_type.contains("gzip") {
+            return Ok(LayerCompression::Gzip);
+        }
+        if media_type.contains(".tar") {
+            return Ok(LayerCompression::Plain);
+        }
+    }
+
+    let mut file = std::fs::File::open(tar_path).map_err(|e| ImageError::Extraction {
+        digest: tar_path.display().to_string(),
+        message: format!("failed to open tarball for compression detection: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+    let mut header = [0u8; 4];
+    let read = file.read(&mut header).map_err(|e| ImageError::Extraction {
+        digest: tar_path.display().to_string(),
+        message: format!("failed to read tarball header: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+
+    if read >= 2 && header[..2] == [0x1F, 0x8B] {
+        return Ok(LayerCompression::Gzip);
+    }
+    if read == 4 && header == [0x28, 0xB5, 0x2F, 0xFD] {
+        return Ok(LayerCompression::Zstd);
+    }
+
+    Ok(LayerCompression::Plain)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    use super::{LayerCompression, detect_layer_compression, validate_entry_path};
+
+    #[test]
+    fn test_detect_layer_compression_from_media_type() {
+        assert_eq!(
+            detect_layer_compression(
+                Path::new("/nonexistent"),
+                Some("application/vnd.oci.image.layer.v1.tar+gzip")
+            )
+            .unwrap(),
+            LayerCompression::Gzip,
+        );
+        assert_eq!(
+            detect_layer_compression(
+                Path::new("/nonexistent"),
+                Some("application/vnd.oci.image.layer.v1.tar+zstd")
+            )
+            .unwrap(),
+            LayerCompression::Zstd,
+        );
+        assert_eq!(
+            detect_layer_compression(
+                Path::new("/nonexistent"),
+                Some("application/vnd.oci.image.layer.v1.tar")
+            )
+            .unwrap(),
+            LayerCompression::Plain,
+        );
+    }
+
+    #[test]
+    fn test_validate_entry_path_rejects_symlink_escape() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("root");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("escape")).unwrap();
+
+        let err = validate_entry_path(&root, Path::new("escape/file.txt"), Path::new("layer.tar"))
+            .unwrap_err();
+        assert!(err.to_string().contains("escapes extraction root"));
+    }
+}

--- a/crates/image/lib/layer/index.rs
+++ b/crates/image/lib/layer/index.rs
@@ -1,0 +1,168 @@
+//! Sidecar index generation for extracted layers.
+//!
+//! Walks the extracted layer tree and generates a binary sidecar index
+//! using [`IndexBuilder`](microsandbox_utils::index::IndexBuilder).
+
+use std::path::Path;
+
+use microsandbox_utils::index::IndexBuilder;
+
+use super::{OVERRIDE_XATTR_KEY, S_IFLNK, S_IFMT};
+use crate::error::{ImageError, ImageResult};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Whiteout file prefix.
+const WHITEOUT_PREFIX: &str = ".wh.";
+
+/// Opaque whiteout marker.
+const OPAQUE_WHITEOUT: &str = ".wh..wh..opq";
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build a binary sidecar index for an extracted layer directory.
+///
+/// The index is written to `index_path` and can be mmap'd by OverlayFs
+/// for O(log n) lookups.
+pub(crate) async fn build_sidecar_index(
+    extracted_dir: &Path,
+    index_path: &Path,
+) -> ImageResult<()> {
+    let extracted = extracted_dir.to_path_buf();
+    let output = index_path.to_path_buf();
+
+    // Run in a blocking thread since it does filesystem walking.
+    tokio::task::spawn_blocking(move || build_index_sync(&extracted, &output))
+        .await
+        .map_err(|e| {
+            ImageError::IndexBuild(
+                extracted_dir.display().to_string(),
+                std::io::Error::other(format!("task join error: {e}")),
+            )
+        })?
+}
+
+fn build_index_sync(extracted_dir: &Path, index_path: &Path) -> ImageResult<()> {
+    let builder = IndexBuilder::new();
+
+    // Walk the extracted tree.
+    let builder = walk_dir(extracted_dir, extracted_dir, builder)?;
+
+    let index_data = builder.build();
+    std::fs::write(index_path, &index_data)
+        .map_err(|e| ImageError::IndexBuild(extracted_dir.display().to_string(), e))?;
+
+    Ok(())
+}
+
+fn walk_dir(root: &Path, dir: &Path, mut builder: IndexBuilder) -> ImageResult<IndexBuilder> {
+    let rel_path = dir.strip_prefix(root).unwrap_or(Path::new(""));
+
+    let rel_str = if rel_path == Path::new("") {
+        "".to_string()
+    } else {
+        format!("{}", rel_path.display())
+    };
+
+    // Check if directory is opaque.
+    let opaque = dir.join(OPAQUE_WHITEOUT).exists();
+    if opaque {
+        builder = builder.opaque_dir(&rel_str);
+    } else {
+        builder = builder.dir(&rel_str);
+    }
+
+    // Read directory entries.
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(dir = %dir.display(), error = %e, "failed to read dir for index");
+            return Ok(builder);
+        }
+    };
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(dir = %dir.display(), error = %e, "failed to read dir entry for index");
+                continue;
+            }
+        };
+
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Skip .complete marker.
+        if name_str == ".complete" {
+            continue;
+        }
+
+        // Skip opaque whiteout marker (already handled as dir flag).
+        if name_str == OPAQUE_WHITEOUT {
+            continue;
+        }
+
+        let entry_path = entry.path();
+
+        // Handle whiteout files.
+        if let Some(target_name) = name_str.strip_prefix(WHITEOUT_PREFIX) {
+            if !target_name.is_empty() {
+                builder = builder.whiteout(&rel_str, target_name);
+            }
+            continue;
+        }
+
+        // Read metadata.
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(path = %entry_path.display(), error = %e, "failed to read metadata for index");
+                continue;
+            }
+        };
+
+        // Read override stat xattr for mode.
+        let (_uid, _gid, mode) = read_override_stat(&entry_path);
+
+        if metadata.is_dir() {
+            // Register as subdirectory entry (permissions only, S_IFDIR added automatically).
+            builder = builder.subdir(&rel_str, &name_str, mode & 0o7777);
+
+            // Recurse into subdirectory.
+            builder = walk_dir(root, &entry_path, builder)?;
+        } else if (mode & S_IFMT) == S_IFLNK {
+            // Symlink.
+            builder = builder.symlink(&rel_str, &name_str);
+        } else {
+            // Regular file, device node, FIFO, etc. (permissions only, S_IFREG added automatically).
+            builder = builder.file(&rel_str, &name_str, mode & 0o7777);
+        }
+    }
+
+    Ok(builder)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Read the override stat xattr and return (uid, gid, mode).
+/// Returns default values if xattr is missing or invalid.
+fn read_override_stat(path: &Path) -> (u32, u32, u32) {
+    let data = match xattr::get(path, OVERRIDE_XATTR_KEY) {
+        Ok(Some(d)) if d.len() >= 20 => d,
+        _ => return (0, 0, 0),
+    };
+
+    // Parse the 20-byte binary format.
+    let uid = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+    let gid = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+    let mode = u32::from_le_bytes([data[12], data[13], data[14], data[15]]);
+
+    (uid, gid, mode)
+}

--- a/crates/image/lib/layer/mod.rs
+++ b/crates/image/lib/layer/mod.rs
@@ -1,0 +1,540 @@
+//! Layer download, extraction, and management.
+
+pub(crate) mod extraction;
+pub(crate) mod index;
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, Read, Write},
+    os::fd::AsRawFd,
+    path::{Path, PathBuf},
+};
+
+use oci_client::client::{BlobResponse, SizedStream};
+use sha2::{Digest as Sha2Digest, Sha256};
+
+use crate::{
+    digest::Digest,
+    error::{ImageError, ImageResult},
+    store::{self, GlobalCache},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Xattr key for stat virtualization.
+pub(crate) const OVERRIDE_XATTR_KEY: &str = "user.containers.override_stat";
+
+/// File type mask.
+pub(crate) const S_IFMT: u32 = libc::S_IFMT as u32;
+
+/// Symlink file type bits.
+pub(crate) const S_IFLNK: u32 = libc::S_IFLNK as u32;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A single OCI layer handle with download/extraction state.
+pub(crate) struct Layer {
+    /// Compressed layer digest (from manifest).
+    pub digest: Digest,
+    /// Cached paths derived from the global cache.
+    tar_path: PathBuf,
+    extracted_dir: PathBuf,
+    extracting_dir: PathBuf,
+    index_path: PathBuf,
+    lock_path: PathBuf,
+    download_lock_path: PathBuf,
+    part_path: PathBuf,
+}
+
+enum DownloadStart {
+    Fresh,
+    Resume(u64),
+    Complete,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Layer {
+    /// Create a new layer handle.
+    pub fn new(digest: Digest, cache: &GlobalCache) -> Self {
+        Self {
+            tar_path: cache.tar_path(&digest),
+            extracted_dir: cache.extracted_dir(&digest),
+            extracting_dir: cache.extracting_dir(&digest),
+            index_path: cache.index_path(&digest),
+            lock_path: cache.lock_path(&digest),
+            download_lock_path: cache.download_lock_path(&digest),
+            part_path: cache.part_path(&digest),
+            digest,
+        }
+    }
+
+    /// Path to the extracted layer directory.
+    pub fn extracted_dir(&self) -> PathBuf {
+        self.extracted_dir.clone()
+    }
+
+    /// Check if this layer is already fully extracted.
+    pub fn is_extracted(&self) -> bool {
+        self.extracted_dir.join(store::COMPLETE_MARKER).exists()
+    }
+
+    /// Download the layer blob to the cache.
+    ///
+    /// Uses cross-process `flock()` to prevent races. Supports resumption
+    /// via partial `.part` files.
+    pub async fn download(
+        &self,
+        client: &oci_client::Client,
+        image_ref: &oci_client::Reference,
+        expected_size: Option<u64>,
+        force: bool,
+        progress: Option<&crate::progress::PullProgressSender>,
+        layer_index: usize,
+    ) -> ImageResult<()> {
+        let tar_path = &self.tar_path;
+        let part_path = &self.part_path;
+
+        // Acquire cross-process download lock.
+        let lock_file = open_lock_file(&self.download_lock_path)?;
+        flock_exclusive(&lock_file)?;
+        let _guard = scopeguard::guard(lock_file, |f| {
+            let _ = flock_unlock(&f);
+        });
+
+        if force {
+            remove_file_if_exists(tar_path)?;
+            remove_file_if_exists(part_path)?;
+        }
+
+        // Re-check after lock — another process may have completed the download.
+        if tar_path.exists() {
+            if let Some(expected) = expected_size {
+                if let Ok(meta) = std::fs::metadata(tar_path)
+                    && meta.len() == expected
+                {
+                    return Ok(());
+                }
+            } else if let Ok(meta) = std::fs::metadata(tar_path)
+                && meta.len() > 0
+            {
+                return Ok(());
+            }
+        }
+
+        // Stream the blob to a .part file.
+        let digest_display = self.digest.to_string();
+        let digest_str: std::sync::Arc<str> = digest_display.as_str().into();
+        let expected_hex = self.digest.hex();
+
+        let download_start = determine_download_start(part_path, expected_size, expected_hex)?;
+        if matches!(download_start, DownloadStart::Complete) {
+            std::fs::rename(part_path, tar_path).map_err(|e| ImageError::Cache {
+                path: tar_path.clone(),
+                source: e,
+            })?;
+
+            if let Some(p) = progress {
+                p.send(crate::progress::PullProgress::LayerDownloadComplete {
+                    layer_index,
+                    digest: digest_str,
+                    downloaded_bytes: expected_size.unwrap_or(0),
+                });
+            }
+
+            return Ok(());
+        }
+
+        let (mut stream, mut file, mut downloaded): (SizedStream, File, u64) = match download_start
+        {
+            DownloadStart::Fresh => {
+                let stream = client
+                    .pull_blob_stream(image_ref, digest_display.as_str())
+                    .await?;
+                let file = OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(part_path)
+                    .map_err(|e| ImageError::Cache {
+                        path: part_path.clone(),
+                        source: e,
+                    })?;
+                (stream, file, 0)
+            }
+            DownloadStart::Resume(offset) => {
+                let blob = client
+                    .pull_blob_stream_partial(image_ref, digest_display.as_str(), offset, None)
+                    .await?;
+
+                match blob {
+                    BlobResponse::Partial(stream) => {
+                        let file = OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(part_path)
+                            .map_err(|e| ImageError::Cache {
+                                path: part_path.clone(),
+                                source: e,
+                            })?;
+                        (stream, file, offset)
+                    }
+                    BlobResponse::Full(stream) => {
+                        let file = OpenOptions::new()
+                            .create(true)
+                            .truncate(true)
+                            .write(true)
+                            .open(part_path)
+                            .map_err(|e| ImageError::Cache {
+                                path: part_path.clone(),
+                                source: e,
+                            })?;
+                        (stream, file, 0)
+                    }
+                }
+            }
+            DownloadStart::Complete => unreachable!(),
+        };
+
+        use futures::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            file.write_all(&chunk).map_err(|e| ImageError::Cache {
+                path: part_path.clone(),
+                source: e,
+            })?;
+            downloaded += chunk.len() as u64;
+
+            if let Some(p) = progress {
+                p.send(crate::progress::PullProgress::LayerDownloadProgress {
+                    layer_index,
+                    digest: digest_str.clone(),
+                    downloaded_bytes: downloaded,
+                    total_bytes: expected_size,
+                });
+            }
+        }
+        file.flush().map_err(|e| ImageError::Cache {
+            path: part_path.clone(),
+            source: e,
+        })?;
+        drop(file);
+
+        // Verify hash.
+        let actual_hash = compute_sha256_file(part_path)?;
+        if actual_hash != expected_hex {
+            let _ = std::fs::remove_file(part_path);
+            return Err(ImageError::DigestMismatch {
+                digest: digest_display,
+                expected: expected_hex.to_string(),
+                actual: actual_hash,
+            });
+        }
+
+        // Atomic rename .part -> final.
+        std::fs::rename(part_path, tar_path).map_err(|e| ImageError::Cache {
+            path: tar_path.clone(),
+            source: e,
+        })?;
+
+        if let Some(p) = progress {
+            p.send(crate::progress::PullProgress::LayerDownloadComplete {
+                layer_index,
+                digest: digest_str,
+                downloaded_bytes: downloaded,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Extract this layer (decompress + untar).
+    ///
+    /// Uses cross-process `flock()` to prevent concurrent extraction.
+    pub async fn extract(
+        &self,
+        parent_extracted_dirs: &[PathBuf],
+        progress: Option<&crate::progress::PullProgressSender>,
+        layer_index: usize,
+        media_type: Option<&str>,
+        diff_id: &str,
+    ) -> ImageResult<()> {
+        // Cross-process lock.
+        let lock_file = open_lock_file(&self.lock_path)?;
+        flock_exclusive(&lock_file)?;
+        let _flock_guard = scopeguard::guard(lock_file, |f| {
+            let _ = flock_unlock(&f);
+        });
+
+        // Re-check after lock.
+        if self.is_extracted() {
+            return Ok(());
+        }
+
+        let diff_id_arc: std::sync::Arc<str> = diff_id.into();
+
+        if let Some(p) = progress {
+            p.send(crate::progress::PullProgress::LayerExtractStarted {
+                layer_index,
+                diff_id: diff_id_arc.clone(),
+            });
+        }
+
+        let extracting_dir = &self.extracting_dir;
+        let extracted_dir = &self.extracted_dir;
+
+        // Clean up any previous incomplete extraction.
+        let _ = std::fs::remove_dir_all(extracting_dir);
+        std::fs::create_dir_all(extracting_dir).map_err(|e| ImageError::Cache {
+            path: extracting_dir.clone(),
+            source: e,
+        })?;
+
+        // Run the extraction pipeline.
+        match extraction::extract_layer(
+            &self.tar_path,
+            extracting_dir,
+            parent_extracted_dirs,
+            media_type,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(extracting_dir);
+                return Err(e);
+            }
+        }
+
+        // Write .complete marker.
+        let marker_path = extracting_dir.join(store::COMPLETE_MARKER);
+        std::fs::write(&marker_path, b"").map_err(|e| ImageError::Cache {
+            path: marker_path,
+            source: e,
+        })?;
+
+        // Atomic rename.
+        // Remove target if it exists (incomplete from a crash).
+        let _ = std::fs::remove_dir_all(extracted_dir);
+        std::fs::rename(extracting_dir, extracted_dir).map_err(|e| ImageError::Cache {
+            path: extracted_dir.clone(),
+            source: e,
+        })?;
+
+        if let Some(p) = progress {
+            p.send(crate::progress::PullProgress::LayerExtractComplete {
+                layer_index,
+                diff_id: diff_id_arc,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Generate the binary sidecar index for this layer's extracted tree.
+    pub async fn build_index(&self) -> ImageResult<()> {
+        index::build_sidecar_index(&self.extracted_dir, &self.index_path).await
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Open or create a lock file.
+fn open_lock_file(path: &Path) -> ImageResult<File> {
+    OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(path)
+        .map_err(|e| ImageError::Cache {
+            path: path.to_path_buf(),
+            source: e,
+        })
+}
+
+/// Acquire an exclusive `flock()`.
+fn flock_exclusive(file: &File) -> ImageResult<()> {
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if ret != 0 {
+        return Err(ImageError::Io(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Release a `flock()`.
+fn flock_unlock(file: &File) -> ImageResult<()> {
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if ret != 0 {
+        return Err(ImageError::Io(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Compute the SHA-256 hex digest of a file.
+fn compute_sha256_file(path: &Path) -> ImageResult<String> {
+    let mut file = File::open(path).map_err(|e| ImageError::Cache {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).map_err(|e| ImageError::Cache {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn remove_file_if_exists(path: &Path) -> ImageResult<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(ImageError::Cache {
+            path: path.to_path_buf(),
+            source: err,
+        }),
+    }
+}
+
+fn determine_download_start(
+    part_path: &Path,
+    expected_size: Option<u64>,
+    expected_hex: &str,
+) -> ImageResult<DownloadStart> {
+    let part_size = match std::fs::metadata(part_path) {
+        Ok(meta) => meta.len(),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(DownloadStart::Fresh),
+        Err(err) => {
+            return Err(ImageError::Cache {
+                path: part_path.to_path_buf(),
+                source: err,
+            });
+        }
+    };
+
+    if part_size == 0 {
+        return Ok(DownloadStart::Fresh);
+    }
+
+    if let Some(expected) = expected_size {
+        if part_size > expected {
+            let _ = std::fs::remove_file(part_path);
+            return Ok(DownloadStart::Fresh);
+        }
+
+        if part_size == expected {
+            let actual_hash = compute_sha256_file(part_path)?;
+            if actual_hash == expected_hex {
+                return Ok(DownloadStart::Complete);
+            }
+
+            let _ = std::fs::remove_file(part_path);
+            return Ok(DownloadStart::Fresh);
+        }
+    }
+
+    Ok(DownloadStart::Resume(part_size))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{DownloadStart, determine_download_start, remove_file_if_exists};
+
+    #[test]
+    fn test_determine_download_start_returns_fresh_when_part_missing() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("layer.part");
+
+        let start = determine_download_start(&path, Some(10), "deadbeef").unwrap();
+
+        assert!(matches!(start, DownloadStart::Fresh));
+    }
+
+    #[test]
+    fn test_determine_download_start_resumes_partial_file() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("layer.part");
+        std::fs::write(&path, b"hello").unwrap();
+
+        let start = determine_download_start(&path, Some(10), "deadbeef").unwrap();
+
+        assert!(matches!(start, DownloadStart::Resume(5)));
+    }
+
+    #[test]
+    fn test_determine_download_start_resets_oversized_part_file() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("layer.part");
+        std::fs::write(&path, b"hello world").unwrap();
+
+        let start = determine_download_start(&path, Some(5), "deadbeef").unwrap();
+
+        assert!(matches!(start, DownloadStart::Fresh));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_determine_download_start_marks_complete_when_hash_matches() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("layer.part");
+        std::fs::write(&path, b"hello").unwrap();
+        let digest = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+        let start = determine_download_start(&path, Some(5), digest).unwrap();
+
+        assert!(matches!(start, DownloadStart::Complete));
+    }
+
+    #[test]
+    fn test_determine_download_start_restarts_when_full_part_hash_mismatches() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("layer.part");
+        std::fs::write(&path, b"hello").unwrap();
+
+        let start = determine_download_start(&path, Some(5), "deadbeef").unwrap();
+
+        assert!(matches!(start, DownloadStart::Fresh));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_remove_file_if_exists_deletes_existing_file() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("layer.tar.gz");
+        std::fs::write(&path, b"cached").unwrap();
+
+        remove_file_if_exists(&path).unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_remove_file_if_exists_ignores_missing_file() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("missing.tar.gz");
+
+        remove_file_if_exists(&path).unwrap();
+
+        assert!(!path.exists());
+    }
+}

--- a/crates/image/lib/lib.rs
+++ b/crates/image/lib/lib.rs
@@ -1,1 +1,34 @@
+//! OCI image pulling, layer extraction, and caching for microsandbox.
+//!
+//! This crate implements the OCI image lifecycle:
+//! - Registry communication (pull, auth, platform resolution)
+//! - Layer caching with content-addressable dedup
+//! - Layer extraction (async tar pipeline, stat virtualization, whiteouts)
+//! - Binary sidecar index generation for OverlayFs acceleration
 
+mod auth;
+mod config;
+mod digest;
+mod error;
+pub(crate) mod layer;
+mod manifest;
+mod platform;
+mod progress;
+mod pull;
+mod registry;
+mod store;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use auth::RegistryAuth;
+pub use config::ImageConfig;
+pub use digest::Digest;
+pub use error::{ImageError, ImageResult};
+pub use oci_client::Reference;
+pub use platform::Platform;
+pub use progress::{PullProgress, PullProgressHandle};
+pub use pull::{PullOptions, PullPolicy, PullResult};
+pub use registry::Registry;
+pub use store::GlobalCache;

--- a/crates/image/lib/manifest.rs
+++ b/crates/image/lib/manifest.rs
@@ -1,0 +1,52 @@
+//! OCI manifest and image index parsing.
+
+use oci_spec::image::{ImageIndex, ImageManifest};
+
+use crate::error::ImageError;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Parsed OCI manifest — either a single-platform manifest or a multi-platform index.
+pub(crate) enum OciManifest {
+    /// Single-platform image manifest.
+    Image(Box<ImageManifest>),
+    /// Multi-platform index (fat manifest).
+    ///
+    /// The inner `ImageIndex` is currently unused because `resolve_platform_manifest`
+    /// re-parses from raw bytes. TODO: pass this through to avoid re-deserialization.
+    Index(#[allow(dead_code)] Box<ImageIndex>),
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl OciManifest {
+    /// Parse from raw JSON bytes + media type.
+    pub fn parse(bytes: &[u8], media_type: &str) -> Result<Self, ImageError> {
+        match media_type {
+            "application/vnd.oci.image.manifest.v1+json"
+            | "application/vnd.docker.distribution.manifest.v2+json" => {
+                let manifest: ImageManifest = serde_json::from_slice(bytes)
+                    .map_err(|e| ImageError::ManifestParse(format!("image manifest: {e}")))?;
+                Ok(Self::Image(Box::new(manifest)))
+            }
+            "application/vnd.oci.image.index.v1+json"
+            | "application/vnd.docker.distribution.manifest.list.v2+json" => {
+                let index: ImageIndex = serde_json::from_slice(bytes)
+                    .map_err(|e| ImageError::ManifestParse(format!("image index: {e}")))?;
+                Ok(Self::Index(Box::new(index)))
+            }
+            other => Err(ImageError::ManifestParse(format!(
+                "unsupported manifest media type: {other}"
+            ))),
+        }
+    }
+
+    /// True if this is a multi-platform index.
+    pub fn is_index(&self) -> bool {
+        matches!(self, Self::Index(_))
+    }
+}

--- a/crates/image/lib/platform.rs
+++ b/crates/image/lib/platform.rs
@@ -1,0 +1,91 @@
+//! Target platform for OCI image resolution.
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Target platform for OCI image resolution.
+///
+/// Used to select the correct manifest from a multi-platform OCI index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Platform {
+    /// Operating system (always `linux` for microsandbox).
+    pub os: String,
+    /// CPU architecture (e.g., `amd64`, `arm64`).
+    pub arch: String,
+    /// Optional architecture variant (e.g., `v7` for armv7).
+    pub variant: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Platform {
+    /// Create a new platform.
+    pub fn new(os: impl Into<String>, arch: impl Into<String>) -> Self {
+        Self {
+            os: os.into(),
+            arch: arch.into(),
+            variant: None,
+        }
+    }
+
+    /// Create a new platform with variant.
+    pub fn with_variant(
+        os: impl Into<String>,
+        arch: impl Into<String>,
+        variant: impl Into<String>,
+    ) -> Self {
+        Self {
+            os: os.into(),
+            arch: arch.into(),
+            variant: Some(variant.into()),
+        }
+    }
+
+    /// Returns the platform for the current host, with OS forced to `linux`.
+    ///
+    /// Architecture detected via `std::env::consts::ARCH`:
+    /// `x86_64` -> `amd64`, `aarch64` -> `arm64`.
+    pub fn host_linux() -> Self {
+        let arch = match std::env::consts::ARCH {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            other => other,
+        };
+        Self::new("linux", arch)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for Platform {
+    fn default() -> Self {
+        Self::host_linux()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_host_linux() {
+        let p = Platform::host_linux();
+        assert_eq!(p.os, "linux");
+        assert!(p.arch == "amd64" || p.arch == "arm64" || !p.arch.is_empty());
+    }
+
+    #[test]
+    fn test_default_is_host_linux() {
+        let p = Platform::default();
+        assert_eq!(p.os, "linux");
+    }
+}

--- a/crates/image/lib/progress.rs
+++ b/crates/image/lib/progress.rs
@@ -1,0 +1,140 @@
+//! Pull progress reporting.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Default channel capacity.
+const DEFAULT_PROGRESS_CHANNEL_CAPACITY: usize = 256;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Progress events emitted during image pull and layer extraction.
+#[derive(Debug, Clone)]
+pub enum PullProgress {
+    /// Resolving the image reference.
+    Resolving {
+        /// The image reference being resolved.
+        reference: Arc<str>,
+    },
+
+    /// Manifest parsed. Layer count and total sizes now known.
+    Resolved {
+        /// The image reference.
+        reference: Arc<str>,
+        /// Resolved manifest digest.
+        manifest_digest: Arc<str>,
+        /// Number of layers.
+        layer_count: usize,
+        /// Sum of compressed layer sizes. `None` if manifest omits sizes.
+        total_download_bytes: Option<u64>,
+    },
+
+    /// Byte-level download progress for a single layer.
+    LayerDownloadProgress {
+        /// Layer index (0-based).
+        layer_index: usize,
+        /// Layer digest.
+        digest: Arc<str>,
+        /// Bytes downloaded so far.
+        downloaded_bytes: u64,
+        /// Total bytes (if known).
+        total_bytes: Option<u64>,
+    },
+
+    /// A single layer download completed and verified.
+    LayerDownloadComplete {
+        /// Layer index.
+        layer_index: usize,
+        /// Layer digest.
+        digest: Arc<str>,
+        /// Total downloaded bytes.
+        downloaded_bytes: u64,
+    },
+
+    /// Layer extraction started.
+    LayerExtractStarted {
+        /// Layer index.
+        layer_index: usize,
+        /// Layer diff ID.
+        diff_id: Arc<str>,
+    },
+
+    /// Layer extraction completed.
+    LayerExtractComplete {
+        /// Layer index.
+        layer_index: usize,
+        /// Layer diff ID.
+        diff_id: Arc<str>,
+    },
+
+    /// Sidecar index generation started for a layer.
+    LayerIndexStarted {
+        /// Layer index.
+        layer_index: usize,
+    },
+
+    /// Sidecar index generation completed for a layer.
+    LayerIndexComplete {
+        /// Layer index.
+        layer_index: usize,
+    },
+
+    /// Entire image pull completed.
+    Complete {
+        /// The image reference.
+        reference: Arc<str>,
+        /// Number of layers.
+        layer_count: usize,
+    },
+}
+
+/// Receiver for progress events.
+pub struct PullProgressHandle {
+    rx: mpsc::Receiver<PullProgress>,
+}
+
+/// Emits progress events. Uses `try_send` — never blocks downloads.
+#[derive(Clone)]
+pub(crate) struct PullProgressSender {
+    tx: mpsc::Sender<PullProgress>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PullProgressHandle {
+    /// Receive the next event. Returns `None` when the pull completes.
+    pub async fn recv(&mut self) -> Option<PullProgress> {
+        self.rx.recv().await
+    }
+
+    /// Convert into the underlying receiver for use with `tokio::select!`.
+    pub fn into_receiver(self) -> mpsc::Receiver<PullProgress> {
+        self.rx
+    }
+}
+
+impl PullProgressSender {
+    /// Emit a progress event. Silently discards if receiver is full or dropped.
+    pub(crate) fn send(&self, event: PullProgress) {
+        let _ = self.tx.try_send(event);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Create a progress channel pair.
+pub(crate) fn progress_channel() -> (PullProgressHandle, PullProgressSender) {
+    let (tx, rx) = mpsc::channel(DEFAULT_PROGRESS_CHANNEL_CAPACITY);
+    (PullProgressHandle { rx }, PullProgressSender { tx })
+}

--- a/crates/image/lib/pull.rs
+++ b/crates/image/lib/pull.rs
@@ -1,0 +1,66 @@
+//! Pull options, policy, and result types.
+
+use std::path::PathBuf;
+
+use crate::{config::ImageConfig, digest::Digest};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Controls when the registry is contacted for manifest freshness.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PullPolicy {
+    /// Use cached layers if complete, pull otherwise.
+    #[default]
+    IfMissing,
+
+    /// Always fetch manifest from registry, even if cached.
+    /// Reuses cached layers whose digests still match.
+    Always,
+
+    /// Never contact registry. Error if image not fully cached locally.
+    Never,
+}
+
+/// Options for [`Registry::pull()`](crate::Registry::pull).
+#[derive(Debug, Clone)]
+pub struct PullOptions {
+    /// Controls when the registry is contacted.
+    pub pull_policy: PullPolicy,
+
+    /// Re-download and re-extract even if all layers are already cached.
+    pub force: bool,
+
+    /// Generate binary sidecar indexes after extraction.
+    pub build_index: bool,
+}
+
+/// Result of a successful image pull.
+pub struct PullResult {
+    /// Extracted layer directories in bottom-to-top order.
+    pub layers: Vec<PathBuf>,
+
+    /// Parsed OCI image configuration.
+    pub config: ImageConfig,
+
+    /// Content-addressable digest of the resolved manifest.
+    pub manifest_digest: Digest,
+
+    /// True if all layers were already cached and no downloads occurred.
+    pub cached: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for PullOptions {
+    fn default() -> Self {
+        Self {
+            pull_policy: PullPolicy::default(),
+            force: false,
+            build_index: true,
+        }
+    }
+}

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -1,0 +1,951 @@
+//! OCI registry client.
+//!
+//! Wraps `oci-client` with platform resolution, caching, and progress reporting.
+
+use std::{path::PathBuf, sync::Arc};
+
+use oci_client::{Client, client::ClientConfig, manifest::ImageIndexEntry};
+use tokio::task::JoinHandle;
+
+use crate::{
+    auth::RegistryAuth,
+    config::ImageConfig,
+    digest::Digest,
+    error::{ImageError, ImageResult},
+    layer::Layer,
+    manifest::OciManifest,
+    platform::Platform,
+    progress::{self, PullProgress, PullProgressHandle, PullProgressSender},
+    pull::{PullOptions, PullPolicy, PullResult},
+    store::{CachedImageMetadata, CachedLayerMetadata, GlobalCache},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// OCI registry client with platform resolution, caching, and progress reporting.
+pub struct Registry {
+    client: Client,
+    auth: oci_client::secrets::RegistryAuth,
+    platform: Platform,
+    cache: GlobalCache,
+}
+
+/// Resolved manifest layer descriptor used during download/extraction.
+#[derive(Debug, Clone)]
+struct LayerDescriptor {
+    digest: Digest,
+    media_type: Option<String>,
+    size: Option<u64>,
+}
+
+struct CachedPullInfo {
+    result: PullResult,
+    metadata: CachedImageMetadata,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Registry {
+    /// Create a registry client with anonymous authentication.
+    pub fn new(platform: Platform, cache: GlobalCache) -> ImageResult<Self> {
+        let client = build_client(&platform);
+
+        Ok(Self {
+            client,
+            auth: oci_client::secrets::RegistryAuth::Anonymous,
+            platform,
+            cache,
+        })
+    }
+
+    /// Create a registry client with explicit authentication.
+    pub fn with_auth(
+        platform: Platform,
+        cache: GlobalCache,
+        auth: RegistryAuth,
+    ) -> ImageResult<Self> {
+        let client = build_client(&platform);
+
+        Ok(Self {
+            client,
+            auth: (&auth).into(),
+            platform,
+            cache,
+        })
+    }
+
+    /// Pull an image. Downloads layers concurrently, extracts sequentially.
+    pub async fn pull(
+        &self,
+        reference: &oci_client::Reference,
+        options: &PullOptions,
+    ) -> ImageResult<PullResult> {
+        self.pull_inner(reference, options, None).await
+    }
+
+    /// Pull with progress reporting.
+    pub fn pull_with_progress(
+        &self,
+        reference: &oci_client::Reference,
+        options: &PullOptions,
+    ) -> (PullProgressHandle, JoinHandle<ImageResult<PullResult>>)
+    where
+        Self: Send + Sync + 'static,
+    {
+        // We can't move self into the task, so we need to do this differently.
+        // Instead, we'll return the handle and the caller must drive the pull separately.
+        let (handle, sender) = progress::progress_channel();
+
+        // We need to clone the necessary state.
+        let reference = reference.clone();
+        let options = options.clone();
+        let client = self.client.clone();
+        let auth = self.auth.clone();
+        let platform = self.platform.clone();
+
+        // Create a new GlobalCache from the same directory.
+        let layers_dir = self.cache.layers_dir().to_path_buf();
+        let cache_parent = layers_dir.parent().unwrap_or(&layers_dir).to_path_buf();
+
+        let task = tokio::spawn(async move {
+            let cache = GlobalCache::new(&cache_parent)?;
+            let registry = Self {
+                client,
+                auth,
+                platform,
+                cache,
+            };
+            registry
+                .pull_inner(&reference, &options, Some(sender))
+                .await
+        });
+
+        (handle, task)
+    }
+
+    /// Core pull implementation.
+    async fn pull_inner(
+        &self,
+        reference: &oci_client::Reference,
+        options: &PullOptions,
+        progress: Option<PullProgressSender>,
+    ) -> ImageResult<PullResult> {
+        let ref_str: Arc<str> = reference.to_string().into();
+        let oci_ref = reference;
+
+        // Step 1: Early cache check using persisted image metadata.
+        if let Some(cached) = resolve_cached_pull_result(&self.cache, reference, options)? {
+            if let Some(ref p) = progress {
+                p.send(PullProgress::Resolving {
+                    reference: ref_str.clone(),
+                });
+                p.send(PullProgress::Resolved {
+                    reference: ref_str.clone(),
+                    manifest_digest: cached.metadata.manifest_digest.clone().into(),
+                    layer_count: cached.metadata.layers.len(),
+                    total_download_bytes: cached
+                        .metadata
+                        .layers
+                        .iter()
+                        .filter_map(|layer| layer.size_bytes)
+                        .reduce(|a, b| a + b),
+                });
+                p.send(PullProgress::Complete {
+                    reference: ref_str,
+                    layer_count: cached.metadata.layers.len(),
+                });
+            }
+
+            return Ok(cached.result);
+        }
+
+        if options.pull_policy == PullPolicy::Never {
+            return Err(ImageError::NotCached {
+                reference: reference.to_string(),
+            });
+        }
+
+        // Step 2: Resolve manifest.
+        if let Some(ref p) = progress {
+            p.send(PullProgress::Resolving {
+                reference: ref_str.clone(),
+            });
+        }
+
+        let (manifest_bytes, manifest_digest, config_bytes) =
+            self.fetch_manifest_and_config(oci_ref).await?;
+
+        let manifest_digest: Digest = manifest_digest.parse()?;
+
+        // Determine media type from manifest bytes. For multi-platform images,
+        // this also fetches the platform-specific config bytes.
+        let (manifest, config_bytes) = self
+            .parse_and_resolve_manifest(&manifest_bytes, config_bytes, oci_ref)
+            .await?;
+
+        // Step 3: Parse config.
+        let (image_config, diff_ids) = ImageConfig::parse(&config_bytes)?;
+
+        // Step 4: Get layer descriptors.
+        let layer_descriptors = self.extract_layer_digests(&manifest)?;
+
+        let layer_count = layer_descriptors.len();
+        let total_bytes: Option<u64> = {
+            let sum: u64 = layer_descriptors
+                .iter()
+                .filter_map(|layer| layer.size)
+                .sum();
+            if sum > 0 { Some(sum) } else { None }
+        };
+
+        if let Some(ref p) = progress {
+            p.send(PullProgress::Resolved {
+                reference: ref_str.clone(),
+                manifest_digest: manifest_digest.to_string().into(),
+                layer_count,
+                total_download_bytes: total_bytes,
+            });
+        }
+
+        // Step 5: Download layers concurrently.
+        let download_futures: Vec<_> = layer_descriptors
+            .iter()
+            .enumerate()
+            .map(|(i, layer_desc)| {
+                let layer = Layer::new(layer_desc.digest.clone(), &self.cache);
+                let client = self.client.clone();
+                let oci_ref = oci_ref.clone();
+                let size = layer_desc.size;
+                let progress = progress.clone();
+
+                async move {
+                    layer
+                        .download(&client, &oci_ref, size, options.force, progress.as_ref(), i)
+                        .await
+                }
+            })
+            .collect();
+
+        futures::future::try_join_all(download_futures).await?;
+
+        // Step 6: Extract layers sequentially (bottom-to-top).
+        let mut extracted_dirs: Vec<PathBuf> = Vec::with_capacity(layer_count);
+
+        for (i, layer_desc) in layer_descriptors.iter().enumerate() {
+            let layer = Layer::new(layer_desc.digest.clone(), &self.cache);
+
+            let diff_id = diff_ids.get(i).map(String::as_str).unwrap_or("");
+
+            if !layer.is_extracted() || options.force {
+                layer
+                    .extract(
+                        &extracted_dirs,
+                        progress.as_ref(),
+                        i,
+                        layer_desc.media_type.as_deref(),
+                        diff_id,
+                    )
+                    .await?;
+
+                // Build sidecar index if requested.
+                if options.build_index {
+                    if let Some(ref p) = progress {
+                        p.send(PullProgress::LayerIndexStarted { layer_index: i });
+                    }
+                    layer.build_index().await?;
+                    if let Some(ref p) = progress {
+                        p.send(PullProgress::LayerIndexComplete { layer_index: i });
+                    }
+                }
+            }
+
+            extracted_dirs.push(layer.extracted_dir());
+        }
+
+        // Step 7: Return result.
+        let layers: Vec<PathBuf> = layer_descriptors
+            .iter()
+            .map(|ld| self.cache.extracted_dir(&ld.digest))
+            .collect();
+        let cached_image = CachedImageMetadata {
+            manifest_digest: manifest_digest.to_string(),
+            config: image_config.clone(),
+            layers: layer_descriptors
+                .iter()
+                .enumerate()
+                .map(|(i, layer)| CachedLayerMetadata {
+                    digest: layer.digest.to_string(),
+                    media_type: layer.media_type.clone(),
+                    size_bytes: layer.size,
+                    diff_id: diff_ids.get(i).cloned().unwrap_or_default(),
+                })
+                .collect(),
+        };
+        self.cache.write_image_metadata(reference, &cached_image)?;
+
+        if let Some(ref p) = progress {
+            p.send(PullProgress::Complete {
+                reference: ref_str,
+                layer_count,
+            });
+        }
+
+        Ok(PullResult {
+            layers,
+            config: image_config,
+            manifest_digest,
+            cached: false,
+        })
+    }
+
+    /// Fetch manifest and config from the registry.
+    async fn fetch_manifest_and_config(
+        &self,
+        reference: &oci_client::Reference,
+    ) -> ImageResult<(Vec<u8>, String, Vec<u8>)> {
+        let (manifest, manifest_digest, config) = self
+            .client
+            .pull_manifest_and_config(reference, &self.auth)
+            .await?;
+
+        let manifest_bytes = serde_json::to_vec(&manifest)
+            .map_err(|e| ImageError::ManifestParse(format!("failed to serialize manifest: {e}")))?;
+
+        Ok((manifest_bytes, manifest_digest, config.into_bytes()))
+    }
+
+    /// Parse manifest, resolving multi-platform index if needed.
+    ///
+    /// Returns the manifest and the correct config bytes. For single-platform
+    /// manifests, the config bytes are passed through unchanged. For multi-platform
+    /// indexes, the platform-specific config bytes are fetched and returned.
+    async fn parse_and_resolve_manifest(
+        &self,
+        manifest_bytes: &[u8],
+        config_bytes: Vec<u8>,
+        reference: &oci_client::Reference,
+    ) -> ImageResult<(OciManifest, Vec<u8>)> {
+        // Try to detect media type from the JSON.
+        let media_type = detect_manifest_media_type(manifest_bytes);
+
+        let manifest = OciManifest::parse(manifest_bytes, &media_type)?;
+
+        if manifest.is_index() {
+            // Resolve platform-specific manifest and fetch its config.
+            self.resolve_platform_manifest(manifest_bytes, reference)
+                .await
+        } else {
+            Ok((manifest, config_bytes))
+        }
+    }
+
+    /// Resolve a platform-specific manifest from an OCI index.
+    ///
+    /// Returns the resolved manifest and its platform-specific config bytes.
+    async fn resolve_platform_manifest(
+        &self,
+        index_bytes: &[u8],
+        reference: &oci_client::Reference,
+    ) -> ImageResult<(OciManifest, Vec<u8>)> {
+        let index: oci_spec::image::ImageIndex = serde_json::from_slice(index_bytes)
+            .map_err(|e| ImageError::ManifestParse(format!("failed to parse index: {e}")))?;
+
+        let manifests = index.manifests();
+
+        // Find matching platform.
+        let mut best_match: Option<&oci_spec::image::Descriptor> = None;
+        let mut exact_variant = false;
+
+        for entry in manifests {
+            // Skip attestation manifests.
+            if entry.media_type().to_string().contains("attestation") {
+                continue;
+            }
+
+            let platform = match entry.platform().as_ref() {
+                Some(p) => p,
+                None => continue,
+            };
+
+            // OS must match.
+            if platform.os() != &oci_spec::image::Os::Other(self.platform.os.clone())
+                && format!("{}", platform.os()) != self.platform.os
+            {
+                continue;
+            }
+
+            // Architecture must match.
+            if platform.architecture() != &oci_spec::image::Arch::Other(self.platform.arch.clone())
+                && format!("{}", platform.architecture()) != self.platform.arch
+            {
+                continue;
+            }
+
+            // Check variant.
+            if let Some(ref target_variant) = self.platform.variant {
+                if let Some(entry_variant) = platform.variant().as_ref()
+                    && entry_variant == target_variant
+                {
+                    best_match = Some(entry);
+                    exact_variant = true;
+                    continue;
+                }
+                if !exact_variant {
+                    best_match = Some(entry);
+                }
+            } else {
+                best_match = Some(entry);
+            }
+        }
+
+        let entry = best_match.ok_or_else(|| ImageError::PlatformNotFound {
+            reference: reference.to_string(),
+            os: self.platform.os.clone(),
+            arch: self.platform.arch.clone(),
+        })?;
+
+        let digest = entry.digest();
+
+        // Fetch the platform-specific manifest and config.
+        let platform_ref = format!(
+            "{}/{}@{}",
+            reference.registry(),
+            reference.repository(),
+            digest
+        );
+        let platform_ref: oci_client::Reference = platform_ref.parse().map_err(|e| {
+            ImageError::ManifestParse(format!("failed to parse platform reference: {e}"))
+        })?;
+
+        let (manifest_bytes, _digest, config_bytes) =
+            self.fetch_manifest_and_config(&platform_ref).await?;
+
+        let media_type = detect_manifest_media_type(&manifest_bytes);
+        let manifest = OciManifest::parse(&manifest_bytes, &media_type)?;
+        Ok((manifest, config_bytes))
+    }
+
+    /// Extract layer digests and sizes from a parsed manifest.
+    fn extract_layer_digests(&self, manifest: &OciManifest) -> ImageResult<Vec<LayerDescriptor>> {
+        match manifest {
+            OciManifest::Image(m) => {
+                let layers: Vec<LayerDescriptor> = m
+                    .layers()
+                    .iter()
+                    .map(|desc| {
+                        let digest: Digest = desc.digest().to_string().parse().map_err(|_| {
+                            ImageError::ManifestParse(format!(
+                                "invalid layer digest: {}",
+                                desc.digest()
+                            ))
+                        })?;
+                        let size = if desc.size() > 0 {
+                            Some(desc.size())
+                        } else {
+                            None
+                        };
+                        Ok(LayerDescriptor {
+                            digest,
+                            media_type: Some(desc.media_type().to_string()),
+                            size,
+                        })
+                    })
+                    .collect::<ImageResult<Vec<_>>>()?;
+                Ok(layers)
+            }
+            OciManifest::Index(_) => Err(ImageError::ManifestParse(
+                "cannot extract layers from an index — resolve platform first".to_string(),
+            )),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Detect the media type of a manifest from its JSON content.
+fn detect_manifest_media_type(bytes: &[u8]) -> String {
+    // Try to parse the mediaType field from JSON.
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        if let Some(mt) = v.get("mediaType").and_then(|v| v.as_str()) {
+            return mt.to_string();
+        }
+
+        // Heuristic: if it has "manifests" array, it's an index.
+        if v.get("manifests").is_some() {
+            return "application/vnd.oci.image.index.v1+json".to_string();
+        }
+
+        // If it has "layers" array, it's an image manifest.
+        if v.get("layers").is_some() {
+            return "application/vnd.oci.image.manifest.v1+json".to_string();
+        }
+    }
+
+    // Default to OCI image manifest.
+    "application/vnd.oci.image.manifest.v1+json".to_string()
+}
+
+/// Build an OCI client that resolves multi-platform manifests for the requested target.
+fn build_client(platform: &Platform) -> Client {
+    let platform = platform.clone();
+    Client::new(ClientConfig {
+        protocol: oci_client::client::ClientProtocol::Https,
+        platform_resolver: Some(Box::new(move |manifests| {
+            resolve_platform_digest(manifests, &platform)
+        })),
+        ..Default::default()
+    })
+}
+
+/// Resolve the best matching platform-specific manifest digest.
+fn resolve_platform_digest(manifests: &[ImageIndexEntry], target: &Platform) -> Option<String> {
+    let mut arch_only_match: Option<String> = None;
+
+    for entry in manifests {
+        if entry.media_type.contains("attestation") {
+            continue;
+        }
+
+        let Some(platform) = entry.platform.as_ref() else {
+            continue;
+        };
+        if platform.os != target.os || platform.architecture != target.arch {
+            continue;
+        }
+
+        match target.variant.as_deref() {
+            Some(target_variant) if platform.variant.as_deref() == Some(target_variant) => {
+                return Some(entry.digest.clone());
+            }
+            Some(_) => {
+                if arch_only_match.is_none() {
+                    arch_only_match = Some(entry.digest.clone());
+                }
+            }
+            None => return Some(entry.digest.clone()),
+        }
+    }
+
+    arch_only_match
+}
+
+/// Build a pull result from cached image metadata.
+fn cached_pull_result(
+    cache: &GlobalCache,
+    metadata: &CachedImageMetadata,
+) -> ImageResult<PullResult> {
+    let manifest_digest: Digest = metadata.manifest_digest.parse()?;
+    let layer_digests = metadata
+        .layers
+        .iter()
+        .map(|layer| layer.digest.parse())
+        .collect::<ImageResult<Vec<Digest>>>()?;
+
+    Ok(PullResult {
+        layers: layer_digests
+            .iter()
+            .map(|digest| cache.extracted_dir(digest))
+            .collect(),
+        config: metadata.config.clone(),
+        manifest_digest,
+        cached: true,
+    })
+}
+
+fn resolve_cached_pull_result(
+    cache: &GlobalCache,
+    reference: &oci_client::Reference,
+    options: &PullOptions,
+) -> ImageResult<Option<CachedPullInfo>> {
+    if options.force || options.pull_policy == PullPolicy::Always {
+        return Ok(None);
+    }
+
+    let Some(metadata) = cache.read_image_metadata(reference)? else {
+        return Ok(None);
+    };
+
+    let cached_digests = match metadata
+        .layers
+        .iter()
+        .map(|layer| layer.digest.parse())
+        .collect::<ImageResult<Vec<Digest>>>()
+    {
+        Ok(digests) => digests,
+        Err(_) => return Ok(None),
+    };
+
+    if !cache.all_layers_extracted(&cached_digests) {
+        return Ok(None);
+    }
+
+    let result = match cached_pull_result(cache, &metadata) {
+        Ok(result) => result,
+        Err(_) => return Ok(None),
+    };
+
+    Ok(Some(CachedPullInfo { result, metadata }))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use oci_client::manifest::{ImageIndexEntry, Platform as OciPlatform};
+
+    use super::{Platform, resolve_cached_pull_result, resolve_platform_digest};
+    use crate::{
+        config::ImageConfig,
+        error::ImageError,
+        pull::{PullOptions, PullPolicy},
+        store::{COMPLETE_MARKER, CachedImageMetadata, CachedLayerMetadata, GlobalCache},
+    };
+
+    #[test]
+    fn test_platform_resolver_prefers_exact_variant() {
+        let manifests = vec![
+            ImageIndexEntry {
+                media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+                digest: "sha256:arch-only".into(),
+                size: 1,
+                platform: Some(OciPlatform {
+                    architecture: "arm".into(),
+                    os: "linux".into(),
+                    os_version: None,
+                    os_features: None,
+                    variant: None,
+                    features: None,
+                }),
+                annotations: None,
+            },
+            ImageIndexEntry {
+                media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+                digest: "sha256:exact".into(),
+                size: 1,
+                platform: Some(OciPlatform {
+                    architecture: "arm".into(),
+                    os: "linux".into(),
+                    os_version: None,
+                    os_features: None,
+                    variant: Some("v7".into()),
+                    features: None,
+                }),
+                annotations: None,
+            },
+        ];
+
+        let digest =
+            resolve_platform_digest(&manifests, &Platform::with_variant("linux", "arm", "v7"));
+        assert_eq!(digest.as_deref(), Some("sha256:exact"));
+    }
+
+    #[test]
+    fn test_resolve_cached_pull_result_if_missing_uses_complete_cache() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/alpine:latest".parse().unwrap();
+        let metadata = write_cached_image_fixture(&cache, &reference, &[true, true]);
+
+        let cached = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::IfMissing,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap()
+        .expect("expected cached pull result");
+
+        assert!(cached.result.cached);
+        assert_eq!(cached.result.layers.len(), 2);
+        assert_eq!(
+            cached.result.manifest_digest.to_string(),
+            metadata.manifest_digest
+        );
+        assert_eq!(cached.result.config.env, metadata.config.env);
+        assert_eq!(
+            cached.result.layers[0],
+            cache.extracted_dir(&parse_digest(&metadata.layers[0].digest))
+        );
+        assert_eq!(
+            cached.result.layers[1],
+            cache.extracted_dir(&parse_digest(&metadata.layers[1].digest))
+        );
+    }
+
+    #[test]
+    fn test_resolve_cached_pull_result_never_uses_complete_cache() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/busybox:latest".parse().unwrap();
+        write_cached_image_fixture(&cache, &reference, &[true]);
+
+        let cached = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::Never,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap();
+
+        assert!(cached.is_some());
+        assert!(cached.unwrap().result.cached);
+    }
+
+    #[tokio::test]
+    async fn test_pull_never_returns_not_cached_when_any_layer_is_missing() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/debian:stable".parse().unwrap();
+        write_cached_image_fixture(&cache, &reference, &[true, false]);
+
+        let cached = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::Never,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap();
+        assert!(cached.is_none());
+
+        let registry = super::Registry::new(Platform::default(), cache).unwrap();
+        let err = registry
+            .pull(
+                &reference,
+                &PullOptions {
+                    pull_policy: PullPolicy::Never,
+                    force: false,
+                    build_index: true,
+                },
+            )
+            .await;
+
+        assert!(matches!(err, Err(ImageError::NotCached { .. })));
+    }
+
+    #[test]
+    fn test_resolve_cached_pull_result_ignores_corrupt_metadata_file() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/ubuntu:latest".parse().unwrap();
+        let metadata_path = image_metadata_path(temp.path(), &reference);
+        std::fs::write(&metadata_path, b"{ definitely not json").unwrap();
+
+        let cached = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::IfMissing,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap();
+
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_resolve_cached_pull_result_skips_cache_for_force_and_always() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/fedora:latest".parse().unwrap();
+        write_cached_image_fixture(&cache, &reference, &[true]);
+
+        let forced = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::IfMissing,
+                force: true,
+                build_index: true,
+            },
+        )
+        .unwrap();
+        assert!(forced.is_none());
+
+        let always = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::Always,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap();
+        assert!(always.is_none());
+    }
+
+    #[test]
+    fn test_resolve_cached_pull_result_ignores_invalid_digest_metadata() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/redis:latest".parse().unwrap();
+        let mut metadata = write_cached_image_fixture(&cache, &reference, &[true]);
+        metadata.layers[0].digest = "not-a-digest".into();
+        cache.write_image_metadata(&reference, &metadata).unwrap();
+
+        let cached = resolve_cached_pull_result(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::IfMissing,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap();
+
+        assert!(cached.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_pull_never_treats_invalid_digest_metadata_as_not_cached() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/httpd:latest".parse().unwrap();
+        let mut metadata = write_cached_image_fixture(&cache, &reference, &[true]);
+        metadata.layers[0].digest = "not-a-digest".into();
+        cache.write_image_metadata(&reference, &metadata).unwrap();
+
+        let registry = super::Registry::new(Platform::default(), cache).unwrap();
+        let result = registry
+            .pull(
+                &reference,
+                &PullOptions {
+                    pull_policy: PullPolicy::Never,
+                    force: false,
+                    build_index: true,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(ImageError::NotCached { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_pull_with_progress_cached_if_missing_emits_only_summary_events() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/nginx:latest".parse().unwrap();
+        write_cached_image_fixture(&cache, &reference, &[true, true]);
+        let registry = super::Registry::new(Platform::default(), cache).unwrap();
+
+        let (mut handle, task) = registry.pull_with_progress(
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::IfMissing,
+                force: false,
+                build_index: true,
+            },
+        );
+
+        let result = task.await.unwrap().unwrap();
+        let mut events = Vec::new();
+        while let Some(event) = handle.recv().await {
+            events.push(event);
+        }
+
+        assert!(result.cached);
+        assert_eq!(events.len(), 3);
+        assert!(matches!(
+            &events[0],
+            crate::progress::PullProgress::Resolving { reference: event_ref }
+                if event_ref.as_ref() == reference.to_string()
+        ));
+        assert!(matches!(
+            &events[1],
+            crate::progress::PullProgress::Resolved {
+                reference: event_ref,
+                layer_count: 2,
+                ..
+            } if event_ref.as_ref() == reference.to_string()
+        ));
+        assert!(matches!(
+            &events[2],
+            crate::progress::PullProgress::Complete {
+                reference: event_ref,
+                layer_count: 2,
+            } if event_ref.as_ref() == reference.to_string()
+        ));
+    }
+
+    fn write_cached_image_fixture(
+        cache: &GlobalCache,
+        reference: &oci_client::Reference,
+        extracted_layers: &[bool],
+    ) -> CachedImageMetadata {
+        let metadata = CachedImageMetadata {
+            manifest_digest:
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_string(),
+            config: ImageConfig {
+                env: vec!["PATH=/usr/bin".into()],
+                ..Default::default()
+            },
+            layers: extracted_layers
+                .iter()
+                .enumerate()
+                .map(|(index, _)| CachedLayerMetadata {
+                    digest: layer_digest(index),
+                    media_type: Some("application/vnd.oci.image.layer.v1.tar+gzip".into()),
+                    size_bytes: Some((index as u64 + 1) * 100),
+                    diff_id: format!("sha256:{:064x}", index as u64 + 1000),
+                })
+                .collect(),
+        };
+
+        cache.write_image_metadata(reference, &metadata).unwrap();
+
+        for (index, extracted) in extracted_layers.iter().copied().enumerate() {
+            let digest = parse_digest(&layer_digest(index));
+            let extracted_dir = cache.extracted_dir(&digest);
+            std::fs::create_dir_all(&extracted_dir).unwrap();
+            if extracted {
+                std::fs::write(extracted_dir.join(COMPLETE_MARKER), b"").unwrap();
+            }
+        }
+
+        metadata
+    }
+
+    fn layer_digest(index: usize) -> String {
+        format!("sha256:{:064x}", index as u64 + 1)
+    }
+
+    fn parse_digest(digest: &str) -> crate::digest::Digest {
+        digest.parse().unwrap()
+    }
+
+    fn image_metadata_path(
+        cache_root: &std::path::Path,
+        reference: &oci_client::Reference,
+    ) -> std::path::PathBuf {
+        use sha2::{Digest as Sha2Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        hasher.update(reference.to_string().as_bytes());
+        cache_root
+            .join("images")
+            .join(format!("{}.json", hex::encode(hasher.finalize())))
+    }
+}

--- a/crates/image/lib/store.rs
+++ b/crates/image/lib/store.rs
@@ -1,0 +1,208 @@
+//! Global on-disk image and layer cache.
+
+use std::path::{Path, PathBuf};
+
+use oci_client::Reference;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as Sha2Digest, Sha256};
+
+use crate::{
+    config::ImageConfig,
+    digest::Digest,
+    error::{ImageError, ImageResult},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Subdirectory under the cache root for layer storage.
+const LAYERS_DIR: &str = "layers";
+
+/// Subdirectory under the cache root for image metadata.
+const IMAGES_DIR: &str = "images";
+
+/// Marker file written as the last step of extraction.
+pub(crate) const COMPLETE_MARKER: &str = ".complete";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// On-disk global cache for OCI layers.
+///
+/// Layout (all flat in `cache/layers/`, content-addressable by digest):
+/// ```text
+/// ~/.microsandbox/cache/layers/<digest_safe>.tar.gz            # compressed downloads
+/// ~/.microsandbox/cache/layers/<digest_safe>.extracted/        # extracted layer trees
+/// ~/.microsandbox/cache/layers/<digest_safe>.index             # binary sidecar indexes
+/// ~/.microsandbox/cache/layers/<digest_safe>.lock              # extraction flock files
+/// ~/.microsandbox/cache/layers/<digest_safe>.download.lock     # download flock files
+/// ```
+pub struct GlobalCache {
+    /// Root of the layer cache directory (`~/.microsandbox/cache/layers/`).
+    layers_dir: PathBuf,
+
+    /// Root of the image metadata directory (`~/.microsandbox/cache/images/`).
+    images_dir: PathBuf,
+}
+
+/// Cached metadata for a pulled image reference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CachedImageMetadata {
+    /// Content-addressable digest of the resolved manifest.
+    pub manifest_digest: String,
+    /// Parsed OCI image configuration.
+    pub config: ImageConfig,
+    /// Layer metadata in bottom-to-top order.
+    pub layers: Vec<CachedLayerMetadata>,
+}
+
+/// Cached metadata for a single layer descriptor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CachedLayerMetadata {
+    /// Compressed layer digest from the manifest.
+    pub digest: String,
+    /// OCI media type of the layer blob.
+    pub media_type: Option<String>,
+    /// Compressed blob size in bytes.
+    pub size_bytes: Option<u64>,
+    /// Uncompressed diff ID from the image config.
+    pub diff_id: String,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl GlobalCache {
+    /// Create a new GlobalCache using the provided cache directory.
+    ///
+    /// Creates `<cache_dir>/layers/` if it doesn't exist.
+    pub fn new(cache_dir: &Path) -> ImageResult<Self> {
+        let layers_dir = cache_dir.join(LAYERS_DIR);
+        let images_dir = cache_dir.join(IMAGES_DIR);
+        std::fs::create_dir_all(&layers_dir).map_err(|e| ImageError::Cache {
+            path: layers_dir.clone(),
+            source: e,
+        })?;
+        std::fs::create_dir_all(&images_dir).map_err(|e| ImageError::Cache {
+            path: images_dir.clone(),
+            source: e,
+        })?;
+        Ok(Self {
+            layers_dir,
+            images_dir,
+        })
+    }
+
+    /// Root layer cache directory.
+    pub fn layers_dir(&self) -> &Path {
+        &self.layers_dir
+    }
+
+    /// Path to the compressed tarball for a layer.
+    pub fn tar_path(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.tar.gz", digest.to_path_safe()))
+    }
+
+    /// Path to the partial download file for a layer.
+    pub fn part_path(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.tar.gz.part", digest.to_path_safe()))
+    }
+
+    /// Path to the extracted layer directory.
+    pub fn extracted_dir(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.extracted", digest.to_path_safe()))
+    }
+
+    /// Path to the in-progress extraction temp directory.
+    pub fn extracting_dir(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.extracting", digest.to_path_safe()))
+    }
+
+    /// Path to the binary sidecar index for a layer.
+    pub fn index_path(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.index", digest.to_path_safe()))
+    }
+
+    /// Path to the extraction lock file for a layer.
+    pub fn lock_path(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.lock", digest.to_path_safe()))
+    }
+
+    /// Path to the download lock file for a layer.
+    pub fn download_lock_path(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.download.lock", digest.to_path_safe()))
+    }
+
+    /// Check if a layer is fully extracted (`.complete` marker present).
+    pub fn is_extracted(&self, digest: &Digest) -> bool {
+        self.extracted_dir(digest).join(COMPLETE_MARKER).exists()
+    }
+
+    /// Check if all given layer digests are fully extracted.
+    pub fn all_layers_extracted(&self, digests: &[Digest]) -> bool {
+        digests.iter().all(|d| self.is_extracted(d))
+    }
+
+    /// Read cached metadata for an image reference.
+    pub(crate) fn read_image_metadata(
+        &self,
+        reference: &Reference,
+    ) -> ImageResult<Option<CachedImageMetadata>> {
+        let path = self.image_metadata_path(reference);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let data = std::fs::read_to_string(&path).map_err(|e| ImageError::Cache {
+            path: path.clone(),
+            source: e,
+        })?;
+
+        match serde_json::from_str::<CachedImageMetadata>(&data) {
+            Ok(metadata) => Ok(Some(metadata)),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "corrupt image metadata cache, ignoring");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Write cached metadata for an image reference.
+    pub(crate) fn write_image_metadata(
+        &self,
+        reference: &Reference,
+        metadata: &CachedImageMetadata,
+    ) -> ImageResult<()> {
+        let path = self.image_metadata_path(reference);
+        let temp_path = path.with_extension("json.part");
+        let payload = serde_json::to_vec(metadata).map_err(|e| {
+            ImageError::ConfigParse(format!("failed to serialize cached image metadata: {e}"))
+        })?;
+
+        std::fs::write(&temp_path, payload).map_err(|e| ImageError::Cache {
+            path: temp_path.clone(),
+            source: e,
+        })?;
+        std::fs::rename(&temp_path, &path).map_err(|e| ImageError::Cache { path, source: e })?;
+
+        Ok(())
+    }
+
+    /// Path to the cached metadata file for an image reference.
+    fn image_metadata_path(&self, reference: &Reference) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(reference.to_string().as_bytes());
+        let key = hex::encode(hasher.finalize());
+        self.images_dir.join(format!("{key}.json"))
+    }
+}

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -27,6 +27,7 @@ futures.workspace = true
 libc.workspace = true
 microsandbox-db = { path = "../db" }
 microsandbox-filesystem = { path = "../filesystem" }
+microsandbox-image = { path = "../image" }
 microsandbox-migration = { path = "../migration" }
 microsandbox-protocol = { path = "../protocol" }
 microsandbox-runtime = { path = "../runtime" }

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -4,10 +4,12 @@
 //! All fields have sensible defaults — a missing config file is equivalent to `{}`.
 
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::OnceLock,
 };
 
+use microsandbox_image::RegistryAuth;
 use microsandbox_runtime::logging::LogLevel;
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +54,9 @@ pub struct GlobalConfig {
 
     /// Default values for sandbox configuration.
     pub sandbox_defaults: SandboxDefaults,
+
+    /// Registry authentication configuration.
+    pub registries: RegistriesConfig,
 }
 
 /// Database configuration.
@@ -111,6 +116,39 @@ pub struct SandboxDefaults {
     pub workdir: Option<String>,
 }
 
+/// Registry authentication configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RegistriesConfig {
+    /// Per-registry authentication entries, keyed by registry hostname.
+    ///
+    /// Example:
+    /// ```json
+    /// {
+    ///   "registries": {
+    ///     "auth": {
+    ///       "ghcr.io": { "username": "user", "password_env": "GHCR_TOKEN" },
+    ///       "docker.io": { "username": "user", "secret_name": "dockerhub" }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    pub auth: HashMap<String, RegistryAuthEntry>,
+}
+
+/// A single registry authentication entry from global config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryAuthEntry {
+    /// Registry username.
+    pub username: String,
+
+    /// Environment variable containing the password/token.
+    pub password_env: Option<String>,
+
+    /// Secret name — password is read from `{home}/secrets/registries/<secret_name>`.
+    pub secret_name: Option<String>,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -153,6 +191,56 @@ impl GlobalConfig {
             .cache
             .clone()
             .unwrap_or_else(|| self.home().join(microsandbox_utils::CACHE_SUBDIR))
+    }
+
+    /// Resolve the `secrets` directory.
+    pub fn secrets_dir(&self) -> PathBuf {
+        self.paths
+            .secrets
+            .clone()
+            .unwrap_or_else(|| self.home().join(microsandbox_utils::SECRETS_SUBDIR))
+    }
+
+    /// Resolve registry authentication for a given hostname.
+    ///
+    /// Looks up `registries.auth` in global config, resolving credentials from
+    /// either `password_env` (environment variable) or `secret_name` (file-backed
+    /// secret in `{home}/secrets/registries/<name>`).
+    ///
+    /// Returns `Anonymous` if no entry matches.
+    pub fn resolve_registry_auth(&self, hostname: &str) -> MicrosandboxResult<RegistryAuth> {
+        let entry = match self.registries.auth.get(hostname) {
+            Some(entry) => entry,
+            None => return Ok(RegistryAuth::Anonymous),
+        };
+
+        let password = if let Some(ref env_var) = entry.password_env {
+            std::env::var(env_var).map_err(|_| {
+                crate::MicrosandboxError::InvalidConfig(format!(
+                    "registry auth for {hostname}: environment variable `{env_var}` is not set"
+                ))
+            })?
+        } else if let Some(ref secret_name) = entry.secret_name {
+            let secret_path = self.secrets_dir().join("registries").join(secret_name);
+            std::fs::read_to_string(&secret_path)
+                .map_err(|e| {
+                    crate::MicrosandboxError::InvalidConfig(format!(
+                        "registry auth for {hostname}: failed to read secret `{}`: {e}",
+                        secret_path.display()
+                    ))
+                })?
+                .trim()
+                .to_string()
+        } else {
+            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                "registry auth for {hostname}: entry has neither `password_env` nor `secret_name`"
+            )));
+        };
+
+        Ok(RegistryAuth::Basic {
+            username: entry.username.clone(),
+            password,
+        })
     }
 }
 

--- a/crates/microsandbox/lib/db/mod.rs
+++ b/crates/microsandbox/lib/db/mod.rs
@@ -175,6 +175,7 @@ mod tests {
             "microvm",
             "msbnet",
             "sandbox",
+            "sandbox_image",
             "sandbox_metric",
             "snapshot",
             "supervisor",

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -78,6 +78,10 @@ pub enum MicrosandboxError {
     #[error("volume already exists: {0}")]
     VolumeAlreadyExists(String),
 
+    /// An OCI image operation failed.
+    #[error("image error: {0}")]
+    Image(#[from] microsandbox_image::ImageError),
+
     /// A custom error message.
     #[error("{0}")]
     Custom(String),

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -20,4 +20,5 @@ pub mod size;
 pub mod volume;
 
 pub use error::*;
+pub use microsandbox_image::RegistryAuth;
 pub use microsandbox_runtime::logging::LogLevel;

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -63,6 +63,9 @@ pub async fn spawn_supervisor(
     let log_dir = sandbox_dir.join("logs");
     let runtime_dir = sandbox_dir.join("runtime");
     let scripts_dir = runtime_dir.join("scripts");
+    let empty_rootfs_dir = sandbox_dir.join("rootfs-base");
+    let rw_dir = sandbox_dir.join("rw");
+    let staging_dir = sandbox_dir.join("staging");
     let db_dir = global.home().join(microsandbox_utils::DB_SUBDIR);
     let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
 
@@ -70,6 +73,9 @@ pub async fn spawn_supervisor(
     tokio::try_join!(
         tokio::fs::create_dir_all(&log_dir),
         tokio::fs::create_dir_all(&scripts_dir),
+        tokio::fs::create_dir_all(&empty_rootfs_dir),
+        tokio::fs::create_dir_all(&rw_dir),
+        tokio::fs::create_dir_all(&staging_dir),
     )?;
 
     // Write scripts to the runtime scripts directory.
@@ -90,6 +96,9 @@ pub async fn spawn_supervisor(
         &db_path,
         &log_dir,
         &runtime_dir,
+        &empty_rootfs_dir,
+        &rw_dir,
+        &staging_dir,
         guest_raw_fd,
         &libkrunfw_path,
     ));
@@ -231,12 +240,16 @@ fn exit_action_str(action: &microsandbox_runtime::policy::ExitAction) -> &'stati
 }
 
 /// Build the `msb supervisor` CLI args for a sandbox.
+#[allow(clippy::too_many_arguments)]
 fn supervisor_cli_args(
     config: &SandboxConfig,
     sandbox_id: i32,
     db_path: &Path,
     log_dir: &Path,
     runtime_dir: &Path,
+    empty_rootfs_dir: &Path,
+    rw_dir: &Path,
+    staging_dir: &Path,
     agent_fd: RawFd,
     libkrunfw_path: &Path,
 ) -> Vec<OsString> {
@@ -294,11 +307,28 @@ fn supervisor_cli_args(
 
     match &config.image {
         RootfsSource::Bind(path) => {
-            args.push(OsString::from("--rootfs-layer"));
+            args.push(OsString::from("--rootfs-path"));
             args.push(path.as_os_str().to_os_string());
         }
-        RootfsSource::Oci(reference) => {
-            unimplemented!("OCI image references are not yet supported: {reference}");
+        RootfsSource::Oci(_) => {
+            args.push(OsString::from("--rootfs-upper"));
+            args.push(rw_dir.as_os_str().to_os_string());
+            args.push(OsString::from("--rootfs-staging"));
+            args.push(staging_dir.as_os_str().to_os_string());
+
+            // Scratch-style OCI images can legitimately have zero filesystem layers.
+            let synthetic_empty_lower;
+            let lowers: &[std::path::PathBuf] = if config.resolved_rootfs_layers.is_empty() {
+                synthetic_empty_lower = vec![empty_rootfs_dir.to_path_buf()];
+                &synthetic_empty_lower
+            } else {
+                &config.resolved_rootfs_layers
+            };
+
+            for layer_dir in lowers {
+                args.push(OsString::from("--rootfs-lower"));
+                args.push(layer_dir.as_os_str().to_os_string());
+            }
         }
     }
 
@@ -363,7 +393,10 @@ mod tests {
     use std::path::Path;
 
     use super::supervisor_cli_args;
-    use crate::{LogLevel, sandbox::SandboxBuilder};
+    use crate::{
+        LogLevel,
+        sandbox::{RootfsSource, SandboxBuilder},
+    };
 
     #[test]
     fn test_supervisor_cli_args_include_selected_log_level() {
@@ -379,6 +412,9 @@ mod tests {
             Path::new("/tmp/msb.db"),
             Path::new("/tmp/logs"),
             Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
             9,
             Path::new("/tmp/libkrunfw.dylib"),
         );
@@ -399,6 +435,9 @@ mod tests {
             Path::new("/tmp/msb.db"),
             Path::new("/tmp/logs"),
             Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
             9,
             Path::new("/tmp/libkrunfw.dylib"),
         );
@@ -409,5 +448,134 @@ mod tests {
                 Some("--error" | "--warn" | "--info" | "--debug" | "--trace")
             )
         }));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_use_passthrough_for_bind_rootfs() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .build()
+            .unwrap();
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(rendered.contains(&"--rootfs-path".to_string()));
+        assert!(rendered.contains(&"/tmp/rootfs".to_string()));
+        assert!(!rendered.contains(&"--rootfs-lower".to_string()));
+        assert!(!rendered.contains(&"--rootfs-upper".to_string()));
+        assert!(!rendered.contains(&"--rootfs-staging".to_string()));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_use_overlay_for_oci_rootfs() {
+        let mut config = SandboxBuilder::new("test")
+            .image("alpine:latest")
+            .build()
+            .unwrap();
+        assert!(matches!(config.image, RootfsSource::Oci(_)));
+        config.resolved_rootfs_layers = vec!["/tmp/layer0".into(), "/tmp/layer1".into()];
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(rendered.contains(&"--rootfs-lower".to_string()));
+        assert!(rendered.contains(&"/tmp/layer0".to_string()));
+        assert!(rendered.contains(&"/tmp/layer1".to_string()));
+        assert!(rendered.contains(&"--rootfs-upper".to_string()));
+        assert!(rendered.contains(&"/tmp/rw".to_string()));
+        assert!(rendered.contains(&"--rootfs-staging".to_string()));
+        assert!(rendered.contains(&"/tmp/staging".to_string()));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_use_overlay_for_single_oci_lower_without_index_args() {
+        let mut config = SandboxBuilder::new("test")
+            .image("alpine:latest")
+            .build()
+            .unwrap();
+        assert!(matches!(config.image, RootfsSource::Oci(_)));
+        config.resolved_rootfs_layers = vec!["/tmp/layer0".into()];
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(!rendered.contains(&"--rootfs-path".to_string()));
+        assert!(rendered.contains(&"--rootfs-lower".to_string()));
+        assert!(rendered.contains(&"/tmp/layer0".to_string()));
+        assert!(rendered.contains(&"--rootfs-upper".to_string()));
+        assert!(rendered.contains(&"--rootfs-staging".to_string()));
+        assert!(!rendered.iter().any(|arg| arg.ends_with(".index")));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_use_synthetic_lower_for_zero_layer_oci_rootfs() {
+        let config = SandboxBuilder::new("test")
+            .image("scratch:latest")
+            .build()
+            .unwrap();
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(!rendered.contains(&"--rootfs-path".to_string()));
+        assert!(rendered.contains(&"--rootfs-lower".to_string()));
+        assert!(rendered.contains(&"/tmp/rootfs-base".to_string()));
     }
 }

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -2,6 +2,8 @@
 
 use microsandbox_runtime::policy::ShutdownMode;
 
+use microsandbox_image::RegistryAuth;
+
 use super::{
     config::SandboxConfig,
     types::{ImageSource, MountBuilder, RootfsSource},
@@ -106,6 +108,18 @@ impl SandboxBuilder {
     /// Set the default shell.
     pub fn shell(mut self, shell: impl Into<String>) -> Self {
         self.config.shell = Some(shell.into());
+        self
+    }
+
+    /// Set registry authentication for private OCI registries.
+    pub fn registry_auth(mut self, auth: RegistryAuth) -> Self {
+        self.config.registry_auth = Some(auth);
+        self
+    }
+
+    /// Replace an existing stopped sandbox with the same name during create.
+    pub fn force(mut self) -> Self {
+        self.config.replace_existing = true;
         self
     }
 
@@ -281,5 +295,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.log_level, None);
+    }
+
+    #[test]
+    fn test_builder_force_sets_replace_existing() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine:3.23")
+            .force()
+            .build()
+            .unwrap();
+
+        assert!(config.replace_existing);
     }
 }

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -1,12 +1,14 @@
 //! Sandbox configuration.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use microsandbox_runtime::{
     logging::LogLevel,
     policy::{ChildPolicies, SupervisorPolicy},
 };
 use serde::{Deserialize, Serialize};
+
+use microsandbox_image::RegistryAuth;
 
 use super::types::{NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig, VolumeMount};
 
@@ -104,6 +106,28 @@ pub struct SandboxConfig {
     /// Per-child process policies.
     #[serde(default)]
     pub child_policies: ChildPolicies,
+
+    /// Registry authentication for private OCI registries.
+    ///
+    /// Redacted (set to `None`) before serialization to database — credentials
+    /// are only needed during the pull.
+    #[serde(default, skip_serializing)]
+    pub registry_auth: Option<RegistryAuth>,
+
+    /// Replace an existing stopped sandbox with the same name during create.
+    ///
+    /// This is an operation flag, not persisted sandbox state.
+    #[serde(skip)]
+    pub replace_existing: bool,
+
+    /// Resolved rootfs lower layer paths (populated at create time for OCI images).
+    ///
+    /// Sidecar indexes are discovered by naming convention in the runtime as
+    /// `<lower>.index`, so only the lower directory path is carried here.
+    /// Persisted so existing sandboxes can reuse the pinned lower stack
+    /// without re-resolving a mutable OCI reference.
+    #[serde(default)]
+    pub(crate) resolved_rootfs_layers: Vec<PathBuf>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -130,6 +154,47 @@ impl Default for SandboxConfig {
             ssh: SshConfig::default(),
             supervisor_policy: SupervisorPolicy::default(),
             child_policies: ChildPolicies::default(),
+            registry_auth: None,
+            replace_existing: false,
+            resolved_rootfs_layers: Vec::new(),
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use microsandbox_image::RegistryAuth;
+
+    use super::SandboxConfig;
+
+    #[test]
+    fn test_sandbox_config_serializes_pinned_rootfs_layers_but_redacts_registry_auth() {
+        let mut config = SandboxConfig {
+            name: "persisted".into(),
+            ..Default::default()
+        };
+        config.registry_auth = Some(RegistryAuth::Basic {
+            username: "alice".into(),
+            password: "secret".into(),
+        });
+        config.replace_existing = true;
+        config.resolved_rootfs_layers = vec!["/tmp/layer0".into(), "/tmp/layer1".into()];
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("registry_auth"));
+        assert!(!json.contains("replace_existing"));
+        assert!(json.contains("resolved_rootfs_layers"));
+
+        let decoded: SandboxConfig = serde_json::from_str(&json).unwrap();
+        assert!(decoded.registry_auth.is_none());
+        assert!(!decoded.replace_existing);
+        assert_eq!(
+            decoded.resolved_rootfs_layers,
+            config.resolved_rootfs_layers
+        );
     }
 }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -12,7 +12,7 @@ pub mod exec;
 pub mod fs;
 mod types;
 
-use std::{process::ExitStatus, sync::Arc};
+use std::{path::Path, process::ExitStatus, sync::Arc};
 
 use bytes::Bytes;
 use microsandbox_protocol::{
@@ -20,7 +20,8 @@ use microsandbox_protocol::{
     message::{Message, MessageType},
 };
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder, Set, TransactionTrait,
     sea_query::{Expr, OnConflict},
 };
 use tokio::sync::{Mutex, mpsc};
@@ -28,7 +29,10 @@ use tokio::sync::{Mutex, mpsc};
 use crate::{
     MicrosandboxResult,
     agent::AgentBridge,
-    db::entity::{sandbox as sandbox_entity, sandbox::SandboxStatus},
+    db::entity::{
+        image as image_entity, sandbox as sandbox_entity, sandbox::SandboxStatus,
+        sandbox_image as sandbox_image_entity,
+    },
     runtime::{SupervisorHandle, spawn_supervisor},
 };
 
@@ -83,7 +87,10 @@ impl Sandbox {
     ///
     /// Boots the VM with agentd ready to accept commands. Does not run
     /// any user workload — use `exec()`, `shell()`, etc. afterward.
-    pub async fn create(config: SandboxConfig) -> MicrosandboxResult<Self> {
+    pub async fn create(mut config: SandboxConfig) -> MicrosandboxResult<Self> {
+        let mut pinned_manifest_digest: Option<String> = None;
+        let mut pinned_reference: Option<String> = None;
+
         // Backend mounts hold closures and cannot cross process boundaries.
         // They will be supported when in-process VM mode is available.
         let backend_count = config.mounts.iter().filter(|m| m.is_backend()).count();
@@ -97,20 +104,82 @@ impl Sandbox {
 
         validate_rootfs_source(&config.image)?;
 
-        // Initialize the database.
+        // Initialize the database before any expensive image pull so we can
+        // fail fast on conflicting persisted sandbox state.
         let db =
             crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let sandbox_dir = crate::config::config().sandboxes_dir().join(&config.name);
+        prepare_create_target(db, &config, &sandbox_dir).await?;
 
-        // Upsert the sandbox record and keep its stable database ID.
-        let sandbox_id = upsert_sandbox_record(db, &config).await?;
+        // Resolve OCI images before spawning the supervisor.
+        if let RootfsSource::Oci(ref reference) = config.image {
+            let pull_result = pull_oci_image(reference, config.registry_auth.take()).await?;
+
+            // Store resolved layer paths for spawn_supervisor.
+            config.resolved_rootfs_layers = pull_result.layers;
+            pinned_manifest_digest = Some(pull_result.manifest_digest.to_string());
+            pinned_reference = Some(reference.clone());
+        }
+
+        // Insert the sandbox record and keep its stable database ID.
+        let sandbox_id = insert_sandbox_record(db, &config).await?;
 
         // Spawn supervisor + create bridge. On failure, mark the sandbox
         // as stopped so it doesn't appear as a phantom "Running" entry.
-        match Self::create_inner(config, sandbox_id).await {
-            Ok(sandbox) => Ok(sandbox),
+        let sandbox = match Self::create_inner(config, sandbox_id).await {
+            Ok(sandbox) => sandbox,
             Err(e) => {
                 let _ = update_sandbox_status(db, sandbox_id, SandboxStatus::Stopped).await;
-                Err(e)
+                return Err(e);
+            }
+        };
+
+        if let (Some(reference), Some(manifest_digest)) = (
+            pinned_reference.as_deref(),
+            pinned_manifest_digest.as_deref(),
+        ) && let Err(err) =
+            persist_oci_manifest_pin(db, sandbox_id, reference, manifest_digest).await
+        {
+            let _ = sandbox.stop().await;
+            let _ = update_sandbox_status(db, sandbox_id, SandboxStatus::Stopped).await;
+            return Err(err);
+        }
+
+        Ok(sandbox)
+    }
+
+    /// Start an existing stopped sandbox from persisted state.
+    ///
+    /// Reuses the serialized sandbox config and pinned rootfs state without
+    /// re-resolving the original OCI reference.
+    pub async fn start(name: &str) -> MicrosandboxResult<Self> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let model = load_sandbox_record(db, name).await?;
+
+        if model.status == SandboxStatus::Running || model.status == SandboxStatus::Draining {
+            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                "cannot start sandbox '{name}': already running"
+            )));
+        }
+
+        if model.status != SandboxStatus::Stopped {
+            return Err(crate::MicrosandboxError::Custom(format!(
+                "cannot start sandbox '{name}': status is {:?} (expected Stopped)",
+                model.status
+            )));
+        }
+
+        let config: SandboxConfig = serde_json::from_str(&model.config)?;
+        validate_rootfs_source(&config.image)?;
+        validate_start_state(&config, &crate::config::config().sandboxes_dir().join(name))?;
+        update_sandbox_status(db, model.id, SandboxStatus::Running).await?;
+
+        match Self::create_inner(config, model.id).await {
+            Ok(sandbox) => Ok(sandbox),
+            Err(err) => {
+                let _ = update_sandbox_status(db, model.id, SandboxStatus::Stopped).await;
+                Err(err)
             }
         }
     }
@@ -168,6 +237,8 @@ impl Sandbox {
                 "cannot remove sandbox '{name}': still running"
             )));
         }
+
+        remove_dir_if_exists(&crate::config::config().sandboxes_dir().join(name))?;
 
         let db =
             crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
@@ -388,18 +459,6 @@ impl Sandbox {
         }
         let script_path = format!("/.msb/scripts/{name}");
         self.shell_stream(&format!("sh {script_path}"), opts).await
-    }
-
-    /// Start the sandbox by running the `"start"` script.
-    ///
-    /// Returns error if no `"start"` script is defined.
-    pub async fn start(&self) -> MicrosandboxResult<ExecOutput> {
-        self.run("start", ()).await
-    }
-
-    /// Start the sandbox with streaming I/O.
-    pub async fn start_stream(&self) -> MicrosandboxResult<ExecHandle> {
-        self.run_stream("start", ()).await
     }
 }
 
@@ -664,6 +723,34 @@ async fn update_sandbox_status(
     Ok(())
 }
 
+/// Pull an OCI image and return the pull result.
+///
+/// Auth resolution:
+/// 1. Explicit `RegistryAuth` from `SandboxBuilder::registry_auth()` (if provided)
+/// 2. Global config `registries.auth` matched by registry hostname
+/// 3. Anonymous fallback
+async fn pull_oci_image(
+    reference: &str,
+    explicit_auth: Option<microsandbox_image::RegistryAuth>,
+) -> MicrosandboxResult<microsandbox_image::PullResult> {
+    let global = crate::config::config();
+    let cache = microsandbox_image::GlobalCache::new(&global.cache_dir())?;
+    let platform = microsandbox_image::Platform::host_linux();
+    let image_ref: microsandbox_image::Reference = reference.parse().map_err(|e| {
+        crate::MicrosandboxError::InvalidConfig(format!("invalid image reference: {e}"))
+    })?;
+
+    let auth = match explicit_auth {
+        Some(auth) => auth,
+        None => global.resolve_registry_auth(image_ref.registry())?,
+    };
+
+    let registry = microsandbox_image::Registry::with_auth(platform, cache, auth)?;
+    let options = microsandbox_image::PullOptions::default();
+    let result = registry.pull(&image_ref, &options).await?;
+    Ok(result)
+}
+
 /// Validate rootfs configuration that depends on host filesystem state.
 fn validate_rootfs_source(rootfs: &RootfsSource) -> MicrosandboxResult<()> {
     match rootfs {
@@ -688,8 +775,93 @@ fn validate_rootfs_source(rootfs: &RootfsSource) -> MicrosandboxResult<()> {
     Ok(())
 }
 
-/// Insert or update the sandbox record in the database and return its ID.
-async fn upsert_sandbox_record(
+fn remove_dir_if_exists(path: &Path) -> MicrosandboxResult<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Load a sandbox row by name.
+async fn load_sandbox_record(
+    db: &sea_orm::DatabaseConnection,
+    name: &str,
+) -> MicrosandboxResult<sandbox_entity::Model> {
+    sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Name.eq(name))
+        .one(db)
+        .await?
+        .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))
+}
+
+async fn prepare_create_target(
+    db: &sea_orm::DatabaseConnection,
+    config: &SandboxConfig,
+    sandbox_dir: &Path,
+) -> MicrosandboxResult<()> {
+    let existing = sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Name.eq(&config.name))
+        .one(db)
+        .await?;
+
+    let dir_exists = sandbox_dir.exists();
+
+    if !config.replace_existing {
+        if existing.is_some() || dir_exists {
+            return Err(crate::MicrosandboxError::Custom(format!(
+                "sandbox '{}' already exists; remove it, start the stopped sandbox, or recreate with .force()",
+                config.name
+            )));
+        }
+
+        return Ok(());
+    }
+
+    if let Some(model) = existing {
+        if matches!(
+            model.status,
+            SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
+        ) {
+            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                "cannot replace sandbox '{}': existing sandbox is still active",
+                config.name
+            )));
+        }
+
+        model.into_active_model().delete(db).await?;
+    }
+
+    remove_dir_if_exists(sandbox_dir)?;
+    Ok(())
+}
+
+fn validate_start_state(config: &SandboxConfig, sandbox_dir: &Path) -> MicrosandboxResult<()> {
+    if !sandbox_dir.exists() {
+        return Err(crate::MicrosandboxError::Custom(format!(
+            "sandbox state missing for '{}': {}",
+            config.name,
+            sandbox_dir.display()
+        )));
+    }
+
+    if let RootfsSource::Oci(_) = &config.image {
+        for lower in &config.resolved_rootfs_layers {
+            if !lower.is_dir() {
+                return Err(crate::MicrosandboxError::Custom(format!(
+                    "sandbox '{}' cannot start: pinned OCI lower is missing: {}",
+                    config.name,
+                    lower.display()
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Insert the sandbox record in the database and return its ID.
+async fn insert_sandbox_record(
     db: &sea_orm::DatabaseConnection,
     config: &SandboxConfig,
 ) -> MicrosandboxResult<i32> {
@@ -705,29 +877,85 @@ async fn upsert_sandbox_record(
         ..Default::default()
     };
 
-    sandbox_entity::Entity::insert(model)
-        .on_conflict(
-            OnConflict::column(sandbox_entity::Column::Name)
-                .update_columns([
-                    sandbox_entity::Column::Status,
-                    sandbox_entity::Column::Config,
-                    sandbox_entity::Column::UpdatedAt,
-                ])
-                .to_owned(),
-        )
+    let result = sandbox_entity::Entity::insert(model).exec(db).await?;
+    Ok(result.last_insert_id)
+}
+
+async fn persist_oci_manifest_pin(
+    db: &sea_orm::DatabaseConnection,
+    sandbox_id: i32,
+    reference: &str,
+    manifest_digest: &str,
+) -> MicrosandboxResult<()> {
+    let reference = reference.to_string();
+    let manifest_digest = manifest_digest.to_string();
+
+    db.transaction::<_, (), crate::MicrosandboxError>(|txn| {
+        Box::pin(async move {
+            replace_oci_manifest_pin(txn, sandbox_id, &reference, &manifest_digest).await
+        })
+    })
+    .await
+    .map_err(|err| match err {
+        sea_orm::TransactionError::Connection(db_err) => db_err.into(),
+        sea_orm::TransactionError::Transaction(err) => err,
+    })
+}
+
+async fn replace_oci_manifest_pin<C: ConnectionTrait>(
+    db: &C,
+    sandbox_id: i32,
+    reference: &str,
+    manifest_digest: &str,
+) -> MicrosandboxResult<()> {
+    let image_id = upsert_image_record(db, reference).await?;
+    let now = chrono::Utc::now().naive_utc();
+
+    sandbox_image_entity::Entity::delete_many()
+        .filter(sandbox_image_entity::Column::SandboxId.eq(sandbox_id))
         .exec(db)
         .await?;
 
-    sandbox_entity::Entity::find()
-        .filter(sandbox_entity::Column::Name.eq(&config.name))
+    sandbox_image_entity::Entity::insert(sandbox_image_entity::ActiveModel {
+        sandbox_id: Set(sandbox_id),
+        image_id: Set(image_id),
+        manifest_digest: Set(manifest_digest.to_string()),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    })
+    .exec(db)
+    .await?;
+
+    Ok(())
+}
+
+async fn upsert_image_record<C: ConnectionTrait>(
+    db: &C,
+    reference: &str,
+) -> MicrosandboxResult<i32> {
+    let now = chrono::Utc::now().naive_utc();
+
+    image_entity::Entity::insert(image_entity::ActiveModel {
+        reference: Set(reference.to_string()),
+        last_used_at: Set(Some(now)),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    })
+    .on_conflict(
+        OnConflict::column(image_entity::Column::Reference)
+            .update_columns([image_entity::Column::LastUsedAt])
+            .to_owned(),
+    )
+    .exec(db)
+    .await?;
+
+    image_entity::Entity::find()
+        .filter(image_entity::Column::Reference.eq(reference))
         .one(db)
         .await?
         .map(|model| model.id)
         .ok_or_else(|| {
-            crate::MicrosandboxError::Custom(format!(
-                "sandbox '{}' missing after upsert",
-                config.name
-            ))
+            crate::MicrosandboxError::Custom(format!("image '{}' missing after upsert", reference))
         })
 }
 
@@ -743,7 +971,15 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::{RootfsSource, validate_rootfs_source};
+    use microsandbox_db::entity::{image as image_entity, sandbox_image as sandbox_image_entity};
+    use microsandbox_migration::{Migrator, MigratorTrait};
+    use sea_orm::{ConnectOptions, Database, EntityTrait};
+    use tempfile::tempdir;
+
+    use super::{
+        RootfsSource, SandboxConfig, insert_sandbox_record, persist_oci_manifest_pin,
+        prepare_create_target, remove_dir_if_exists, validate_rootfs_source,
+    };
 
     fn unique_temp_path(suffix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -791,5 +1027,299 @@ mod tests {
         validate_rootfs_source(&RootfsSource::Bind(path.clone())).unwrap();
 
         fs::remove_dir(path).unwrap();
+    }
+
+    #[test]
+    fn test_remove_dir_if_exists_removes_existing_sandbox_tree() {
+        let temp = tempdir().unwrap();
+        let sandbox_dir = temp.path().join("sandbox");
+        fs::create_dir_all(sandbox_dir.join("runtime/scripts")).unwrap();
+        fs::write(sandbox_dir.join("runtime/scripts/start.sh"), b"echo hi").unwrap();
+        fs::create_dir_all(sandbox_dir.join("rw")).unwrap();
+
+        remove_dir_if_exists(&sandbox_dir).unwrap();
+
+        assert!(!sandbox_dir.exists());
+    }
+
+    #[test]
+    fn test_remove_dir_if_exists_ignores_missing_directory() {
+        let temp = tempdir().unwrap();
+        let sandbox_dir = temp.path().join("missing");
+
+        remove_dir_if_exists(&sandbox_dir).unwrap();
+
+        assert!(!sandbox_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn test_persist_oci_manifest_pin_upserts_image_and_manifest_digest() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(ConnectOptions::new(&db_url))
+            .await
+            .unwrap();
+        Migrator::up(&conn, None).await.unwrap();
+
+        let mut config = SandboxConfig {
+            name: "pinned".into(),
+            image: RootfsSource::Oci("docker.io/library/alpine:latest".into()),
+            ..Default::default()
+        };
+        config.resolved_rootfs_layers = vec!["/tmp/layer0".into()];
+        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+
+        persist_oci_manifest_pin(
+            &conn,
+            sandbox_id,
+            "docker.io/library/alpine:latest",
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .await
+        .unwrap();
+
+        persist_oci_manifest_pin(
+            &conn,
+            sandbox_id,
+            "docker.io/library/alpine:latest",
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .await
+        .unwrap();
+
+        let images = image_entity::Entity::find().all(&conn).await.unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].reference, "docker.io/library/alpine:latest");
+
+        let pins = sandbox_image_entity::Entity::find()
+            .all(&conn)
+            .await
+            .unwrap();
+        assert_eq!(pins.len(), 1);
+        assert_eq!(pins[0].sandbox_id, sandbox_id);
+        assert_eq!(pins[0].image_id, images[0].id);
+        assert_eq!(
+            pins[0].manifest_digest,
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_persist_oci_manifest_pin_replaces_stale_pin_for_different_reference() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(ConnectOptions::new(&db_url))
+            .await
+            .unwrap();
+        Migrator::up(&conn, None).await.unwrap();
+
+        let mut config = SandboxConfig {
+            name: "recreated".into(),
+            image: RootfsSource::Oci("docker.io/library/alpine:latest".into()),
+            ..Default::default()
+        };
+        config.resolved_rootfs_layers = vec!["/tmp/layer0".into()];
+        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+
+        persist_oci_manifest_pin(
+            &conn,
+            sandbox_id,
+            "docker.io/library/alpine:latest",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .await
+        .unwrap();
+
+        persist_oci_manifest_pin(
+            &conn,
+            sandbox_id,
+            "docker.io/library/busybox:latest",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+        .await
+        .unwrap();
+
+        let images = image_entity::Entity::find().all(&conn).await.unwrap();
+        assert_eq!(images.len(), 2);
+
+        let pins = sandbox_image_entity::Entity::find()
+            .all(&conn)
+            .await
+            .unwrap();
+        assert_eq!(pins.len(), 1);
+
+        let busybox_id = images
+            .iter()
+            .find(|image| image.reference == "docker.io/library/busybox:latest")
+            .unwrap()
+            .id;
+        assert_eq!(pins[0].sandbox_id, sandbox_id);
+        assert_eq!(pins[0].image_id, busybox_id);
+        assert_eq!(
+            pins[0].manifest_digest,
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_sandbox_record_persists_resolved_rootfs_layers_in_config_json() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(ConnectOptions::new(&db_url))
+            .await
+            .unwrap();
+        Migrator::up(&conn, None).await.unwrap();
+
+        let mut config = SandboxConfig {
+            name: "persisted-lowers".into(),
+            image: RootfsSource::Oci("docker.io/library/alpine:latest".into()),
+            ..Default::default()
+        };
+        config.resolved_rootfs_layers = vec!["/tmp/layer0".into(), "/tmp/layer1".into()];
+
+        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        let row = super::sandbox_entity::Entity::find_by_id(sandbox_id)
+            .one(&conn)
+            .await
+            .unwrap()
+            .unwrap();
+        let decoded: SandboxConfig = serde_json::from_str(&row.config).unwrap();
+
+        assert_eq!(
+            decoded.resolved_rootfs_layers,
+            config.resolved_rootfs_layers
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_create_target_rejects_existing_state_without_force() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(ConnectOptions::new(&db_url))
+            .await
+            .unwrap();
+        Migrator::up(&conn, None).await.unwrap();
+
+        let sandbox_dir = temp.path().join("sandboxes").join("existing");
+        fs::create_dir_all(&sandbox_dir).unwrap();
+
+        let config = SandboxConfig {
+            name: "existing".into(),
+            ..Default::default()
+        };
+
+        let err = prepare_create_target(&conn, &config, &sandbox_dir)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_create_target_force_replaces_stopped_sandbox_state() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(ConnectOptions::new(&db_url))
+            .await
+            .unwrap();
+        Migrator::up(&conn, None).await.unwrap();
+
+        let sandbox_dir = temp.path().join("sandboxes").join("replaceable");
+        fs::create_dir_all(sandbox_dir.join("rw")).unwrap();
+        let config = SandboxConfig {
+            name: "replaceable".into(),
+            ..Default::default()
+        };
+        let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
+        super::update_sandbox_status(&conn, sandbox_id, super::SandboxStatus::Stopped)
+            .await
+            .unwrap();
+
+        let mut forced = SandboxConfig {
+            name: "replaceable".into(),
+            ..Default::default()
+        };
+        forced.replace_existing = true;
+
+        prepare_create_target(&conn, &forced, &sandbox_dir)
+            .await
+            .unwrap();
+
+        assert!(!sandbox_dir.exists());
+        assert!(
+            super::sandbox_entity::Entity::find_by_id(sandbox_id)
+                .one(&conn)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_create_target_force_rejects_running_sandbox() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let conn = Database::connect(ConnectOptions::new(&db_url))
+            .await
+            .unwrap();
+        Migrator::up(&conn, None).await.unwrap();
+
+        let sandbox_dir = temp.path().join("sandboxes").join("running");
+        fs::create_dir_all(&sandbox_dir).unwrap();
+        let config = SandboxConfig {
+            name: "running".into(),
+            ..Default::default()
+        };
+        insert_sandbox_record(&conn, &config).await.unwrap();
+
+        let mut forced = SandboxConfig {
+            name: "running".into(),
+            ..Default::default()
+        };
+        forced.replace_existing = true;
+
+        let err = prepare_create_target(&conn, &forced, &sandbox_dir)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::MicrosandboxError::SandboxStillRunning(_)
+        ));
+        assert!(sandbox_dir.exists());
+    }
+
+    #[test]
+    fn test_validate_start_state_requires_existing_sandbox_dir() {
+        let temp = tempdir().unwrap();
+        let sandbox_dir = temp.path().join("missing");
+        let config = SandboxConfig {
+            name: "missing".into(),
+            ..Default::default()
+        };
+
+        let err = super::validate_start_state(&config, &sandbox_dir).unwrap_err();
+        assert!(err.to_string().contains("sandbox state missing"));
+    }
+
+    #[test]
+    fn test_validate_start_state_requires_persisted_oci_lowers() {
+        let temp = tempdir().unwrap();
+        let sandbox_dir = temp.path().join("persisted");
+        fs::create_dir_all(&sandbox_dir).unwrap();
+
+        let mut config = SandboxConfig {
+            name: "persisted".into(),
+            image: RootfsSource::Oci("docker.io/library/alpine:latest".into()),
+            ..Default::default()
+        };
+        config.resolved_rootfs_layers = vec![temp.path().join("missing-lower")];
+
+        let err = super::validate_start_state(&config, &sandbox_dir).unwrap_err();
+        assert!(err.to_string().contains("pinned OCI lower is missing"));
     }
 }

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -3,6 +3,7 @@
 mod m20260305_000001_create_image_tables;
 mod m20260305_000002_create_sandbox_tables;
 mod m20260305_000003_create_storage_tables;
+mod m20260305_000004_create_sandbox_images_table;
 
 use sea_orm_migration::prelude::*;
 
@@ -30,6 +31,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260305_000001_create_image_tables::Migration),
             Box::new(m20260305_000002_create_sandbox_tables::Migration),
             Box::new(m20260305_000003_create_storage_tables::Migration),
+            Box::new(m20260305_000004_create_sandbox_images_table::Migration),
         ]
     }
 }

--- a/crates/migration/lib/m20260305_000004_create_sandbox_images_table.rs
+++ b/crates/migration/lib/m20260305_000004_create_sandbox_images_table.rs
@@ -1,0 +1,109 @@
+//! Migration: Create sandbox_images join table for manifest pinning and safe image GC.
+
+use sea_orm_migration::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Types: Identifiers
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Iden)]
+enum SandboxImage {
+    Table,
+    Id,
+    SandboxId,
+    ImageId,
+    ManifestDigest,
+    CreatedAt,
+}
+
+/// Reference to existing tables for foreign keys.
+#[derive(Iden)]
+enum Sandbox {
+    Table,
+    Id,
+}
+
+#[derive(Iden)]
+enum Image {
+    Table,
+    Id,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260305_000004_create_sandbox_images_table"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(SandboxImage::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(SandboxImage::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(SandboxImage::SandboxId).integer().not_null())
+                    .col(ColumnDef::new(SandboxImage::ImageId).integer().not_null())
+                    .col(
+                        ColumnDef::new(SandboxImage::ManifestDigest)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SandboxImage::CreatedAt).date_time())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(SandboxImage::Table, SandboxImage::SandboxId)
+                            .to(Sandbox::Table, Sandbox::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(SandboxImage::Table, SandboxImage::ImageId)
+                            .to(Image::Table, Image::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Unique index: a sandbox can only reference each image once.
+        manager
+            .create_index(
+                sea_orm_migration::prelude::Index::create()
+                    .name("idx_sandbox_images_unique")
+                    .table(SandboxImage::Table)
+                    .col(SandboxImage::SandboxId)
+                    .col(SandboxImage::ImageId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(SandboxImage::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,3 +27,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/runtime/lib/supervisor.rs
+++ b/crates/runtime/lib/supervisor.rs
@@ -396,7 +396,11 @@ fn spawn_vm_process(
     let agent_fd = config.agent_fd;
     unsafe {
         cmd.pre_exec(move || {
-            if libc::fcntl(agent_fd, libc::F_SETFD, 0) == -1 {
+            let flags = libc::fcntl(agent_fd, libc::F_GETFD);
+            if flags == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::fcntl(agent_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
                 return Err(std::io::Error::last_os_error());
             }
             Ok(())
@@ -424,9 +428,22 @@ fn microvm_cli_args(config: &SupervisorConfig) -> Vec<OsString> {
     args.push(OsString::from("--memory-mib"));
     args.push(OsString::from(config.vm_config.memory_mib.to_string()));
 
-    for layer in &config.vm_config.rootfs_layers {
-        args.push(OsString::from("--rootfs-layer"));
-        args.push(layer.clone().into_os_string());
+    if let Some(ref rootfs_path) = config.vm_config.rootfs_path {
+        args.push(OsString::from("--rootfs-path"));
+        args.push(rootfs_path.clone().into_os_string());
+    }
+
+    for lower in &config.vm_config.rootfs_lowers {
+        args.push(OsString::from("--rootfs-lower"));
+        args.push(lower.clone().into_os_string());
+    }
+    if let Some(ref upper_dir) = config.vm_config.rootfs_upper {
+        args.push(OsString::from("--rootfs-upper"));
+        args.push(upper_dir.clone().into_os_string());
+    }
+    if let Some(ref staging_dir) = config.vm_config.rootfs_staging {
+        args.push(OsString::from("--rootfs-staging"));
+        args.push(staging_dir.clone().into_os_string());
     }
 
     for mount in &config.vm_config.mounts {
@@ -758,7 +775,10 @@ mod tests {
                 libkrunfw_path: PathBuf::from("/tmp/libkrunfw.dylib"),
                 vcpus: 1,
                 memory_mib: 512,
-                rootfs_layers: vec![PathBuf::from("/tmp/rootfs")],
+                rootfs_path: Some(PathBuf::from("/tmp/rootfs")),
+                rootfs_lowers: Vec::new(),
+                rootfs_upper: None,
+                rootfs_staging: None,
                 mounts: vec!["data:/tmp/data".into()],
                 backends: Vec::new(),
                 init_path: None,
@@ -799,5 +819,27 @@ mod tests {
         assert!(!rendered.iter().any(|arg| arg == "--info"));
         assert!(!rendered.iter().any(|arg| arg == "--debug"));
         assert!(!rendered.iter().any(|arg| arg == "--trace"));
+    }
+
+    #[test]
+    fn test_microvm_cli_args_include_overlay_rootfs_paths() {
+        let mut config = test_supervisor_config(None);
+        config.vm_config.rootfs_path = None;
+        config.vm_config.rootfs_lowers = vec![PathBuf::from("/tmp/layer0")];
+        config.vm_config.rootfs_upper = Some(PathBuf::from("/tmp/rw"));
+        config.vm_config.rootfs_staging = Some(PathBuf::from("/tmp/staging"));
+
+        let args = microvm_cli_args(&config);
+        let rendered = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(rendered.contains(&"--rootfs-lower".to_string()));
+        assert!(rendered.contains(&"/tmp/layer0".to_string()));
+        assert!(rendered.contains(&"--rootfs-upper".to_string()));
+        assert!(rendered.contains(&"/tmp/rw".to_string()));
+        assert!(rendered.contains(&"--rootfs-staging".to_string()));
+        assert!(rendered.contains(&"/tmp/staging".to_string()));
     }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -9,7 +9,7 @@ use std::{
     path::PathBuf,
 };
 
-use microsandbox_filesystem::{DynFileSystem, PassthroughConfig, PassthroughFs};
+use microsandbox_filesystem::{DynFileSystem, OverlayFs, PassthroughConfig, PassthroughFs};
 use msb_krun::{NetBackend, VmBuilder};
 
 //--------------------------------------------------------------------------------------------------
@@ -27,8 +27,17 @@ pub struct VmConfig {
     /// Memory in MiB.
     pub memory_mib: u32,
 
-    /// Root filesystem layer paths (single = passthrough, multiple = overlay).
-    pub rootfs_layers: Vec<PathBuf>,
+    /// Root filesystem path for direct passthrough mounts.
+    pub rootfs_path: Option<PathBuf>,
+
+    /// Root filesystem lower layer paths in bottom-to-top order.
+    pub rootfs_lowers: Vec<PathBuf>,
+
+    /// Writable upper layer directory for OverlayFs rootfs.
+    pub rootfs_upper: Option<PathBuf>,
+
+    /// Private staging directory for OverlayFs atomic operations.
+    pub rootfs_staging: Option<PathBuf>,
 
     /// Additional mounts as `tag:host_path` pairs.
     pub mounts: Vec<String>,
@@ -71,7 +80,10 @@ impl std::fmt::Debug for VmConfig {
             .field("libkrunfw_path", &self.libkrunfw_path)
             .field("vcpus", &self.vcpus)
             .field("memory_mib", &self.memory_mib)
-            .field("rootfs_layers", &self.rootfs_layers)
+            .field("rootfs_path", &self.rootfs_path)
+            .field("rootfs_lowers", &self.rootfs_lowers)
+            .field("rootfs_upper", &self.rootfs_upper)
+            .field("rootfs_staging", &self.rootfs_staging)
             .field("mounts", &self.mounts)
             .field("backends", &format!("[{} backend(s)]", self.backends.len()))
             .field("init_path", &self.init_path)
@@ -120,16 +132,36 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
             }
         });
 
-    // Root filesystem — single layer uses passthrough via virtio-fs with stat virtualization.
-    // TODO: Multiple layers should use OverlayFs via `fs.custom(Box::new(overlay))`
-    // from the microsandbox-filesystem crate (DynFileSystem backend with COW and whiteouts).
-    if let Some(first_layer) = config.rootfs_layers.first() {
+    // Root filesystem — either direct passthrough or OverlayFs, never both.
+    if let Some(rootfs_path) = config.rootfs_path.as_ref() {
+        if !config.rootfs_lowers.is_empty()
+            || config.rootfs_upper.is_some()
+            || config.rootfs_staging.is_some()
+        {
+            return Err(msb_krun::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "rootfs_path cannot be combined with overlay rootfs fields",
+            )));
+        }
+
         let cfg = PassthroughConfig {
-            root_dir: first_layer.clone(),
+            root_dir: rootfs_path.clone(),
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg)?;
         builder = builder.fs(move |fs| fs.tag("/dev/root").custom(Box::new(backend)));
+    } else if !config.rootfs_lowers.is_empty() {
+        let overlay = build_overlay_rootfs(
+            &config.rootfs_lowers,
+            config.rootfs_upper.as_deref(),
+            config.rootfs_staging.as_deref(),
+        )?;
+        builder = builder.fs(move |fs| fs.tag("/dev/root").custom(Box::new(overlay)));
+    } else if config.rootfs_upper.is_some() || config.rootfs_staging.is_some() {
+        return Err(msb_krun::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "overlay rootfs requires at least one lower layer",
+        )));
     }
 
     // Additional mounts (tag:host_path format).
@@ -196,4 +228,195 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
     }
 
     builder.build()?.enter()
+}
+
+/// Build an OverlayFs backend from rootfs lower layers.
+///
+/// Layers are ordered bottom-to-top: the first entry is the lowest (base) layer.
+fn build_overlay_rootfs(
+    layers: &[PathBuf],
+    upper_dir: Option<&std::path::Path>,
+    staging_dir: Option<&std::path::Path>,
+) -> msb_krun::Result<OverlayFs> {
+    debug_assert!(
+        !layers.is_empty(),
+        "overlay rootfs requires at least one lower layer"
+    );
+
+    let upper_dir = upper_dir.ok_or_else(|| {
+        msb_krun::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "overlay rootfs requires a writable upper directory",
+        ))
+    })?;
+    let staging_dir = staging_dir.ok_or_else(|| {
+        msb_krun::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "overlay rootfs requires a staging directory",
+        ))
+    })?;
+
+    let mut overlay_builder = OverlayFs::builder();
+
+    for layer in layers {
+        // Check if a sidecar index exists for this layer.
+        let index_path = layer.with_extension("index");
+        if index_path.exists() {
+            overlay_builder = overlay_builder.layer_with_index(layer, &index_path);
+        } else {
+            overlay_builder = overlay_builder.layer(layer);
+        }
+    }
+
+    overlay_builder = overlay_builder.writable(upper_dir).staging(staging_dir);
+
+    overlay_builder.build().map_err(msb_krun::Error::Io)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use microsandbox_utils::index::IndexBuilder;
+    use tempfile::tempdir;
+
+    use super::{VmConfig, build_and_enter, build_overlay_rootfs};
+
+    #[test]
+    fn test_build_and_enter_rejects_rootfs_path_combined_with_overlay_fields() {
+        let err = build_and_enter(VmConfig {
+            libkrunfw_path: PathBuf::from("/tmp/libkrunfw"),
+            vcpus: 1,
+            memory_mib: 512,
+            rootfs_path: Some(PathBuf::from("/tmp/rootfs")),
+            rootfs_lowers: vec![PathBuf::from("/tmp/layer0")],
+            rootfs_upper: Some(PathBuf::from("/tmp/rw")),
+            rootfs_staging: Some(PathBuf::from("/tmp/staging")),
+            mounts: Vec::new(),
+            backends: Vec::new(),
+            init_path: None,
+            env: Vec::new(),
+            workdir: None,
+            exec_path: None,
+            exec_args: Vec::new(),
+            net_fd: None,
+            agent_fd: None,
+        })
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("rootfs_path cannot be combined with overlay rootfs fields")
+        );
+    }
+
+    #[test]
+    fn test_build_and_enter_rejects_overlay_dirs_without_lowers() {
+        let err = build_and_enter(VmConfig {
+            libkrunfw_path: PathBuf::from("/tmp/libkrunfw"),
+            vcpus: 1,
+            memory_mib: 512,
+            rootfs_path: None,
+            rootfs_lowers: Vec::new(),
+            rootfs_upper: Some(PathBuf::from("/tmp/rw")),
+            rootfs_staging: Some(PathBuf::from("/tmp/staging")),
+            mounts: Vec::new(),
+            backends: Vec::new(),
+            init_path: None,
+            env: Vec::new(),
+            workdir: None,
+            exec_path: None,
+            exec_args: Vec::new(),
+            net_fd: None,
+            agent_fd: None,
+        })
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("overlay rootfs requires at least one lower layer")
+        );
+    }
+
+    #[test]
+    fn test_build_overlay_rootfs_requires_upper() {
+        let temp = tempdir().unwrap();
+        let lower = create_dir(temp.path(), "lower.extracted");
+        let staging = create_dir(temp.path(), "staging");
+
+        let err = match build_overlay_rootfs(&[lower], None, Some(&staging)) {
+            Ok(_) => panic!("expected missing upper dir to be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("overlay rootfs requires a writable upper directory")
+        );
+    }
+
+    #[test]
+    fn test_build_overlay_rootfs_requires_staging() {
+        let temp = tempdir().unwrap();
+        let lower = create_dir(temp.path(), "lower.extracted");
+        let upper = create_dir(temp.path(), "rw");
+
+        let err = match build_overlay_rootfs(&[lower], Some(&upper), None) {
+            Ok(_) => panic!("expected missing staging dir to be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("overlay rootfs requires a staging directory")
+        );
+    }
+
+    #[test]
+    fn test_build_overlay_rootfs_accepts_single_lower_without_index() {
+        let temp = tempdir().unwrap();
+        let lower = create_dir(temp.path(), "lower.extracted");
+        let upper = create_dir(temp.path(), "rw");
+        let staging = create_dir(temp.path(), "staging");
+
+        assert!(build_overlay_rootfs(&[lower], Some(&upper), Some(&staging)).is_ok());
+    }
+
+    #[test]
+    fn test_build_overlay_rootfs_accepts_single_lower_with_conventional_index() {
+        let temp = tempdir().unwrap();
+        let lower = create_dir(temp.path(), "lower.extracted");
+        let upper = create_dir(temp.path(), "rw");
+        let staging = create_dir(temp.path(), "staging");
+        let index_path = lower.with_extension("index");
+        let index = IndexBuilder::new()
+            .dir("")
+            .file("", "hello.txt", 0o644)
+            .build();
+        std::fs::write(&index_path, index).unwrap();
+
+        assert!(build_overlay_rootfs(&[lower], Some(&upper), Some(&staging)).is_ok());
+    }
+
+    #[test]
+    fn test_build_overlay_rootfs_falls_back_when_conventional_index_is_corrupt() {
+        let temp = tempdir().unwrap();
+        let lower = create_dir(temp.path(), "lower.extracted");
+        let upper = create_dir(temp.path(), "rw");
+        let staging = create_dir(temp.path(), "staging");
+        let index_path = lower.with_extension("index");
+        std::fs::write(&index_path, b"definitely not a valid index").unwrap();
+
+        assert!(build_overlay_rootfs(&[lower], Some(&upper), Some(&staging)).is_ok());
+    }
+
+    fn create_dir(root: &Path, name: &str) -> PathBuf {
+        let path = root.join(name);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
 }


### PR DESCRIPTION
## Summary

- Add the `microsandbox-image` crate implementing the full OCI image pull lifecycle: registry communication, manifest/platform resolution, content-addressable layer caching, async tar extraction with whiteout handling, and sidecar index generation for OverlayFs acceleration
- Wire OCI image pulling into the sandbox create/start/remove lifecycle so that `Sandbox::create()` transparently pulls images before spawning the supervisor
- Replace the single `rootfs_layers` vec in VmConfig with explicit passthrough (`rootfs_path`) and overlay (`rootfs_lowers` / `rootfs_upper` / `rootfs_staging`) fields, enabling proper OverlayFs-backed rootfs from pulled image layers
- Add registry authentication support via global config (`registries.auth`) with environment variable and file-backed secret credential resolution

## Changes

### New crate: `microsandbox-image` (13 new files, ~3,200 lines)
- `auth.rs` - `RegistryAuth` enum (Anonymous, Basic) with oci-client conversion
- `config.rs` - OCI image config parser (env, cmd, entrypoint, workdir, user, labels)
- `digest.rs` - Content-addressable digest type with algorithm/hex parsing
- `error.rs` - `ImageError` / `ImageResult` error types
- `manifest.rs` - OCI manifest and image index parsing with media type dispatch
- `platform.rs` - Platform matching (os, arch, variant) for multi-arch images
- `progress.rs` - Pull progress tracking with `PullProgressHandle`
- `pull.rs` - `PullOptions` and `PullResult` types with pull policy
- `registry.rs` - Full registry client: token auth, manifest fetch, platform resolution, blob streaming, layer orchestration (~950 lines)
- `store.rs` - `GlobalCache` for content-addressable blob and layer dedup
- `layer/mod.rs` - Layer download, decompression, and caching pipeline
- `layer/extraction.rs` - Async tar extraction with OCI whiteout handling and stat virtualization
- `layer/index.rs` - Binary sidecar index generation for OverlayFs acceleration

### Sandbox lifecycle changes (`crates/microsandbox`)
- `sandbox/mod.rs` - `Sandbox::create()` pulls OCI images before supervisor spawn; new `Sandbox::start()` for restarting stopped sandboxes; `Sandbox::remove()` cleans up sandbox directory; manifest digest pinning in DB
- `sandbox/config.rs` - `SandboxConfig` gains `resolved_rootfs_layers`, `registry_auth`, serialization support
- `sandbox/builder.rs` - `SandboxBuilder::registry_auth()` setter
- `config/mod.rs` - `GlobalConfig` adds `RegistriesConfig` with per-hostname auth entries; `resolve_registry_auth()` method with env-var and secret-file resolution
- `runtime/spawn.rs` - Creates overlay directories (rootfs-base, rw, staging); passes `--rootfs-lower/--rootfs-upper/--rootfs-staging` CLI args for OCI images
- `error.rs` - New `SandboxStillRunning` error variant
- `lib.rs` - Re-export `microsandbox_image` and `size` module

### Runtime / VM changes (`crates/runtime`)
- `vm.rs` - `VmConfig` replaces `rootfs_layers: Vec<PathBuf>` with `rootfs_path`, `rootfs_lowers`, `rootfs_upper`, `rootfs_staging`; new `build_overlay_rootfs()` constructs `OverlayFs` from layers with sidecar index support; validation tests
- `supervisor.rs` - CLI arg generation updated for new rootfs fields; `pre_exec` properly clears `FD_CLOEXEC` via `F_GETFD`/`F_SETFD`; overlay rootfs test

### CLI changes (`crates/cli`)
- `microvm_cmd.rs` - Replace `--rootfs-layer` with `--rootfs-path`, `--rootfs-lower`, `--rootfs-upper`, `--rootfs-staging`
- `supervisor_cmd.rs` - Same CLI arg changes for supervisor subcommand

### Database changes
- New `sandbox_image` entity and `sandbox_images` migration table for pinning manifest digests per sandbox
- `crates/db/lib/entity/mod.rs` - Register new entity module

## Test Plan

- Run `cargo check --workspace` to verify compilation across all crates
- Run `cargo test -p microsandbox-runtime` to verify VM config validation tests (overlay + passthrough mutual exclusion, missing lower layers, sidecar index detection)
- Run `cargo test -p microsandbox` to verify supervisor CLI arg generation tests with new rootfs fields
- Run `cargo clippy --workspace` to verify no lint warnings
- Manual integration test: create a sandbox with an OCI image reference and verify layers are pulled, cached, and mounted via OverlayFs