### PR TITLE
perf(image): parallelize layer extraction pipeline (#412)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3928,6 +3929,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"

--- a/crates/filesystem/README.md
+++ b/crates/filesystem/README.md
@@ -1,51 +1,18 @@
 # microsandbox-filesystem
 
-Filesystem backends for [microsandbox](https://github.com/zerocore-ai/microsandbox) virtual machines. This crate gives each sandbox a complete, Linux-compatible filesystem by combining five pluggable backends that all implement the same `DynFileSystem` trait.
+Filesystem backends for [microsandbox](https://github.com/zerocore-ai/microsandbox) virtual machines. This crate provides five pluggable backends that give each sandbox a complete, Linux-compatible filesystem — from bind-mounting a host directory to stacking OCI image layers with copy-on-write.
 
-## Backends at a Glance
+- **No root required** — runs unprivileged; guest-visible ownership and permissions are virtualized without touching the host filesystem
+- **Runs on macOS too** — the guest sees a full Linux filesystem even when the host is macOS
+- **Zero-copy I/O** — file reads and writes flow directly between host and guest with no intermediate allocation
+- **Real OCI layer semantics** — OverlayFs handles whiteouts, opaque directories, and atomic copy-up correctly
+- **Composable** — all five backends implement `DynFileSystem` and can be nested freely
 
-| Backend | What it does | Typical use |
-|---|---|---|
-| **PassthroughFs** | Exposes a single host directory to the guest | Bind-mounting a project folder into the VM |
-| **OverlayFs** | Stacks read-only image layers with a writable upper layer (copy-on-write) | OCI/container images like `python:3.12` |
-| **MemFs** | A pure in-memory filesystem with no host I/O | Scratch space, `/tmp`, ephemeral workloads |
-| **DualFs** | Composes two backends with a pluggable dispatch policy | Combining an image (OverlayFs) with a volume (PassthroughFs) under one mount |
-| **ProxyFs** | Wraps any backend with access-control, read, and write hooks | Enforcing permissions, logging, or transforming file data on the fly |
-
-Every backend implements the `DynFileSystem` trait, so they are fully interchangeable and composable.
-
-## How the Pieces Fit Together
-
-```
-Guest VM
-  |
-  | (FUSE / virtio-fs)
-  v
-DynFileSystem
-  |
-  +-- PassthroughFs        single host directory
-  +-- OverlayFs            layered image with COW
-  +-- MemFs                in-memory scratch space
-  +-- DualFs               combines two backends
-  |     +-- backend_a      (e.g. OverlayFs)
-  |     +-- backend_b      (e.g. PassthroughFs)
-  |
-  +-- ProxyFs              wraps any backend
-        +-- inner          (e.g. PassthroughFs)
-```
-
-You can nest these freely. For example, a `ProxyFs` can wrap a `DualFs` that combines an `OverlayFs` with a `MemFs`.
-
-## Backend Details
+## Backends
 
 ### PassthroughFs
 
-Maps a single host directory into the guest. The guest sees standard Linux ownership, permissions, and file types even when the host runs macOS or uses a different filesystem.
-
-- **Stat virtualization** stores uid, gid, mode, and rdev in an extended attribute (`user.containers.override_stat`) so the host file's real metadata stays untouched.
-- **Special files** (block devices, char devices, sockets, FIFOs) are stored as regular files on the host with their type bits recorded in the xattr.
-- **Symlinks on Linux** are file-backed (the file content is the symlink target) to avoid permission issues with real symlinks on unprivileged hosts.
-- **Path confinement** uses `openat2(RESOLVE_BENEATH)` on Linux and `O_NOFOLLOW_ANY` on macOS to prevent the guest from escaping the root directory.
+Exposes a single host directory to the guest VM. The guest sees standard Linux ownership, permissions, and file types even when the host runs macOS.
 
 ```rust
 let fs = PassthroughFs::builder()
@@ -53,53 +20,39 @@ let fs = PassthroughFs::builder()
     .build()?;
 ```
 
+Metadata like uid, gid, and mode are stored in an extended attribute on the host, so the actual host file permissions stay untouched. Special files (devices, sockets, FIFOs) are stored as regular files with their type bits in the xattr. Path confinement prevents the guest from escaping the root directory.
+
 ### OverlayFs
 
-Implements a union filesystem with N read-only lower layers and one writable upper layer, similar to Linux kernel overlayfs but in userspace.
-
-- **Copy-on-write**: when the guest modifies a file from a lower layer, the file is copied to the upper layer first. The lower layers are never modified.
-- **Whiteouts**: deleting a lower-layer file creates a `.wh.<name>` marker in the upper layer so the file appears gone.
-- **Opaque directories**: when a lower-layer directory is replaced, a `.wh..wh..opq` marker hides all its former children.
-- **Atomic copy-up**: files are staged in a work directory and atomically renamed into the upper layer.
+Stacks N read-only layers with one writable upper layer — like Linux kernel overlayfs, but in userspace. This is how OCI container images work.
 
 ```rust
 let fs = OverlayFs::builder()
-    .layer("/layer0")       // bottom layer
-    .layer("/layer1")       // stacked on top
-    .writable("/upper")     // writable layer
-    .staging("/staging")     // staging area (must be on same filesystem as upper)
+    .layer("/layer0")       // bottom layer (e.g. base OS)
+    .layer("/layer1")       // stacked on top (e.g. pip install)
+    .writable("/upper")     // sandbox-local writable layer
+    .staging("/staging")    // must be on same filesystem as upper
     .build()?;
 ```
 
+When the guest modifies a file from a lower layer, it's copied to the upper layer first (copy-on-write). Deleting a lower-layer file creates a whiteout marker so it appears gone. The lower layers are never modified.
+
 ### MemFs
 
-A pure in-memory filesystem. Files, directories, symlinks, and metadata all live in Rust data structures with no host I/O.
-
-- Optional **capacity limits** on total data size and inode count.
-- Aggressive caching by default since the process memory is the sole owner of the data.
-- Great for ephemeral workloads where persistence is not needed.
+A pure in-memory filesystem — no host I/O at all. Good for scratch space and ephemeral workloads.
 
 ```rust
+use microsandbox_filesystem::SizeExt;
+
 let fs = MemFs::builder()
-    .capacity(64 * 1024 * 1024)   // 64 MiB limit
+    .capacity(64.mib())
     .max_inodes(10_000)
     .build()?;
 ```
 
 ### DualFs
 
-Combines two backends (`backend_a` and `backend_b`) under a single filesystem with a pluggable dispatch policy that decides which backend handles each operation.
-
-Built-in policies:
-
-| Policy | Behavior |
-|---|---|
-| `ReadBackendBWriteBackendA` | Reads come from B, writes go to A (default) |
-| `BackendAOnly` | Everything goes to A, B is ignored |
-| `BackendAFallbackToBackendBRead` | Reads try A first, fall back to B |
-| `MergeReadsBackendAPrecedence` | Directories are merged from both, A wins on conflicts |
-
-When a write targets a file that lives on the other backend, DualFs **materializes** (copies) it to the target backend automatically.
+Combines two backends under a single mount point with a dispatch policy that routes each operation to the right backend.
 
 ```rust
 let fs = DualFs::builder()
@@ -109,61 +62,71 @@ let fs = DualFs::builder()
     .build()?;
 ```
 
+Built-in policies:
+
+| Policy | Behavior |
+|---|---|
+| `ReadBackendBWriteBackendA` | Reads from B, writes to A (default) |
+| `BackendAOnly` | Everything goes to A |
+| `BackendAFallbackToBackendBRead` | Reads try A first, fall back to B |
+| `MergeReadsBackendAPrecedence` | Merge directory listings, A wins on conflicts |
+
+When a write targets a file that lives on the other backend, DualFs copies it over automatically.
+
 ### ProxyFs
 
-A transparent decorator that wraps any `DynFileSystem` and lets you attach hooks:
-
-- **on_access**: called before `open`, `create`, and `opendir`. Return an error to deny access.
-- **on_read**: called after the inner backend reads data. Use it to transform or inspect file contents.
-- **on_write**: called before the inner backend writes data. Use it to transform or validate writes.
-
-ProxyFs tracks inode-to-path mappings internally so hooks receive human-readable paths instead of raw inode numbers.
+Wraps any backend with hooks for access control, read interception, and write validation.
 
 ```rust
 let fs = ProxyFs::builder(Box::new(passthrough_fs))
-    .on_access(my_access_hook)
-    .on_read(my_read_hook)
+    .on_access(my_access_hook)   // called before open/create — return error to deny
+    .on_read(my_read_hook)       // called after reads — transform/inspect data
+    .on_write(my_write_hook)     // called before writes — transform/validate data
     .build()?;
 ```
 
-## Shared Infrastructure
+Hooks receive human-readable paths (not raw inode numbers). Zero overhead when no hooks are set.
 
-A few pieces are shared across backends:
+## Composability
 
-- **MultikeyBTreeMap**: a dual-key ordered map used for inode tables, allowing lookup by either FUSE inode or host identity.
-- **Stat virtualization**: the xattr-based scheme for storing Linux file metadata on any host filesystem.
-- **Name validation**: rejects empty names, `..`, paths with `/` or `\`, null bytes, and `.wh.*` prefixes (reserved for whiteouts).
-- **Platform abstraction**: translates between Linux and macOS error codes, xattr APIs, and path resolution strategies.
-- **init.krun**: a virtual file (inode 2) containing the embedded `agentd` binary. It appears at the root of every backend and cannot be deleted or overwritten.
+Backends can be nested freely since they all implement `DynFileSystem`. For example, a `ProxyFs` can wrap a `DualFs` that combines an `OverlayFs` with a `MemFs`:
 
-## Security
+```rust
+let overlay = OverlayFs::builder()
+    .layer("/layer0")
+    .layer("/layer1")
+    .writable("/upper")
+    .staging("/staging")
+    .build()?;
 
-The filesystem layer is a trust boundary. The guest VM is untrusted, and all guest-provided names, paths, offsets, and xattr values are treated as potentially malicious.
+let mem = MemFs::builder()
+    .capacity(64.mib())
+    .build()?;
 
-Key protections:
+let dual = DualFs::builder()
+    .backend_a(overlay)
+    .backend_b(mem)
+    .policy(ReadBackendBWriteBackendA)
+    .build()?;
 
-- **Path confinement**: all file access uses fd-relative opens with `RESOLVE_BENEATH` (Linux) or `O_NOFOLLOW_ANY` (macOS). The guest cannot escape the designated root directory.
-- **Xattr protection**: the `user.containers.override_stat` attribute is invisible to the guest. It is filtered from `listxattr` and blocked on `getxattr`, `setxattr`, and `removexattr`.
-- **Whiteout injection prevention**: `validate_name()` rejects any name starting with `.wh.`, so the guest cannot forge whiteout markers.
-- **Inode safety**: inode numbers are monotonically increasing and never reused, preventing stale-inode attacks.
-- **No symlink following**: guest-controlled path components are opened with `O_NOFOLLOW` to prevent symlink-based escapes.
-- **File descriptor hygiene**: all fds are opened with `O_CLOEXEC` and explicitly closed on release.
-
-## Crate Structure
-
-```
-crates/filesystem/
-  lib/
-    lib.rs                   # public API and re-exports
-    agentd.rs                # embedded agentd binary
-    backends/
-      mod.rs
-      shared/                # inode tables, stat override, validation, platform
-      passthroughfs/         # single-directory passthrough
-      overlayfs/             # multi-layer copy-on-write
-      memfs/                 # pure in-memory
-      dualfs/                # two-backend composition
-      proxy/                 # decorator with hooks
+let fs = ProxyFs::builder(Box::new(dual))
+    .on_access(my_access_hook)
+    .build()?;
 ```
 
-Each backend follows the same internal layout: `mod.rs`, `builder.rs`, `types.rs`, `inode.rs`, `file_ops.rs`, `dir_ops.rs`, `metadata.rs`, `create_ops.rs`, `remove_ops.rs`, `xattr_ops.rs`, `special.rs`, and a `tests/` directory.
+## Cache Policies
+
+All backends support configurable kernel caching:
+
+| Policy | Behavior |
+|---|---|
+| `Never` | No caching — every read hits the backend (DIRECT_IO) |
+| `Auto` | Kernel decides (default for PassthroughFs, OverlayFs, DualFs) |
+| `Always` | Aggressive caching (default for MemFs, since memory is authoritative) |
+
+```rust
+let fs = PassthroughFs::builder()
+    .root_dir("/path/to/dir")
+    .cache_policy(CachePolicy::Always)
+    .build()?;
+```

--- a/crates/filesystem/lib/backends/dualfs/builder.rs
+++ b/crates/filesystem/lib/backends/dualfs/builder.rs
@@ -8,6 +8,8 @@ use super::{
     policy::DualDispatchPolicy,
     types::{CachePolicy, DualFsConfig, DualState},
 };
+use microsandbox_utils::size::Bytes;
+
 use crate::{DynFileSystem, backends::shared::init_binary};
 
 use std::{io, time::Duration};
@@ -99,8 +101,15 @@ impl DualFsBuilder {
     }
 
     /// Set the materialization chunk size.
-    pub fn copy_chunk_size(mut self, s: usize) -> Self {
-        self.copy_chunk_size = s;
+    ///
+    /// Accepts bare `u64` (interpreted as bytes) or a [`SizeExt`](microsandbox_utils::size::SizeExt) helper:
+    ///
+    /// ```ignore
+    /// .copy_chunk_size(1.mib())   // 1 MiB chunks
+    /// .copy_chunk_size(4096)      // 4096-byte chunks
+    /// ```
+    pub fn copy_chunk_size(mut self, size: impl Into<Bytes>) -> Self {
+        self.copy_chunk_size = size.into().as_u64() as usize;
         self
     }
 

--- a/crates/filesystem/lib/backends/memfs/builder.rs
+++ b/crates/filesystem/lib/backends/memfs/builder.rs
@@ -1,8 +1,10 @@
 //! Builder API for constructing a MemFs instance.
 //!
 //! ```ignore
+//! use microsandbox_filesystem::SizeExt;
+//!
 //! MemFs::builder()
-//!     .capacity(1024 * 1024 * 64)
+//!     .capacity(64.mib())
 //!     .max_inodes(10_000)
 //!     .build()?
 //! ```
@@ -17,6 +19,8 @@ use std::{
     },
     time::Duration,
 };
+
+use microsandbox_utils::size::Bytes;
 
 use super::{
     MemFs, inode,
@@ -55,9 +59,17 @@ impl MemFsBuilder {
         }
     }
 
-    /// Set the maximum capacity in bytes for file data.
-    pub fn capacity(mut self, bytes: u64) -> Self {
-        self.capacity = Some(bytes);
+    /// Set the maximum capacity for file data.
+    ///
+    /// Accepts bare `u64` (interpreted as bytes) or a [`SizeExt`](microsandbox_utils::size::SizeExt) helper:
+    ///
+    /// ```ignore
+    /// .capacity(64.mib())   // 64 MiB
+    /// .capacity(1.gib())    // 1 GiB
+    /// .capacity(4096)       // 4096 bytes
+    /// ```
+    pub fn capacity(mut self, size: impl Into<Bytes>) -> Self {
+        self.capacity = Some(size.into().as_u64());
         self
     }
 

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -24,6 +24,7 @@ pub use backends::{
     passthroughfs::{CachePolicy, PassthroughConfig, PassthroughFs, PassthroughFsBuilder},
     proxy::{AccessMode, ProxyFs, ProxyFsBuilder},
 };
+pub use microsandbox_utils::size::{ByteSize, Bytes, Mebibytes, SizeExt};
 pub use msb_krun::backends::fs::{
     Context, DirEntry, DynFileSystem, Entry, Extensions, FsOptions, GetxattrReply, ListxattrReply,
     OpenOptions, RemovemappingOne, SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -30,4 +30,5 @@ tracing.workspace = true
 xattr.workspace = true
 
 [dev-dependencies]
+tar.workspace = true
 tempfile.workspace = true

--- a/crates/image/README.md
+++ b/crates/image/README.md
@@ -1,0 +1,108 @@
+# microsandbox-image
+
+Pull OCI container images, extract their layers, and cache everything locally. This crate handles the full image lifecycle for [microsandbox](https://github.com/zerocore-ai/microsandbox) — from resolving a multi-platform manifest to producing ready-to-mount layer directories.
+
+- **Multi-platform resolution** — automatically picks the right manifest for your OS and architecture
+- **Parallel downloads** — all layers download and extract concurrently with SHA256 verification
+- **Content-addressable caching** — duplicate layers across images are stored once, with cross-process safety via `flock()`
+- **Progress streaming** — real-time events for download, extraction, and indexing stages
+- **Sidecar indexes** — builds binary indexes per layer for fast OverlayFs lookups at runtime
+
+## Quick Start
+
+```rust
+use microsandbox_image::{GlobalCache, Platform, PullOptions, Registry};
+
+let cache = GlobalCache::new("/path/to/cache")?;
+let platform = Platform::host_linux();
+let registry = Registry::new(platform, cache)?;
+
+let reference = "docker.io/library/alpine:latest".parse()?;
+let result = registry.pull(&reference, &PullOptions::default()).await?;
+
+// Extracted layer directories, bottom-to-top
+for layer_path in &result.layers {
+    println!("{}", layer_path.display());
+}
+
+// Parsed image config (env, cmd, entrypoint, user, etc.)
+println!("entrypoint: {:?}", result.config.entrypoint);
+println!("env: {:?}", result.config.env);
+```
+
+## Authentication
+
+```rust
+use microsandbox_image::RegistryAuth;
+
+// Public registries — no credentials needed
+let registry = Registry::new(platform, cache)?;
+
+// Private registries
+let auth = RegistryAuth::Basic {
+    username: "user".into(),
+    password: "token".into(),
+};
+let registry = Registry::with_auth(platform, cache, auth)?;
+```
+
+## Pull Policies
+
+Control when the crate contacts the registry vs. uses the local cache.
+
+```rust
+use microsandbox_image::{PullOptions, PullPolicy};
+
+// Use cache if available, download otherwise (default)
+let opts = PullOptions { pull_policy: PullPolicy::IfMissing, ..Default::default() };
+
+// Always fetch a fresh manifest, but reuse cached layers by digest
+let opts = PullOptions { pull_policy: PullPolicy::Always, ..Default::default() };
+
+// Cache-only — error if the image isn't already cached
+let opts = PullOptions { pull_policy: PullPolicy::Never, ..Default::default() };
+```
+
+## Progress Reporting
+
+Stream progress events while the download runs in the background.
+
+```rust
+let (mut progress, task) = registry.pull_with_progress(&reference, &PullOptions::default());
+
+tokio::spawn(async move {
+    while let Some(event) = progress.recv().await {
+        match event {
+            PullProgress::Resolved { layer_count, .. } => {
+                println!("Pulling {layer_count} layers");
+            }
+            PullProgress::LayerDownloadProgress { downloaded_bytes, total_bytes, .. } => {
+                println!("Downloaded {downloaded_bytes}/{total_bytes:?} bytes");
+            }
+            PullProgress::Complete { .. } => {
+                println!("Done!");
+            }
+            _ => {}
+        }
+    }
+});
+
+let result = task.await??;
+```
+
+## Multi-Platform Images
+
+Fat manifests (OCI Image Index) are automatically resolved to your target platform. `Platform::host_linux()` detects the current architecture by default.
+
+```rust
+use microsandbox_image::Platform;
+
+// Auto-detect (e.g. linux/amd64 or linux/arm64)
+let platform = Platform::host_linux();
+
+// Explicit platform
+let platform = Platform::new("linux", "arm64");
+
+// With variant (e.g. armv7)
+let platform = Platform::with_variant("linux", "arm", "v7");
+```

--- a/crates/image/lib/layer/extraction.rs
+++ b/crates/image/lib/layer/extraction.rs
@@ -5,6 +5,7 @@
 //! platform-aware symlinks, special file handling, and whiteout markers.
 
 use std::{
+    collections::BTreeSet,
     io::Read,
     path::{Component, Path, PathBuf},
 };
@@ -47,6 +48,17 @@ const S_IFIFO: u32 = libc::S_IFIFO as u32;
 // Types
 //--------------------------------------------------------------------------------------------------
 
+/// Result of layer extraction.
+pub(crate) struct ExtractionResult {
+    /// Relative paths of directories created implicitly (not from tar entries).
+    ///
+    /// These directories were created by `ensure_parent_dir` because a tar entry
+    /// referenced a path whose parent didn't exist in this layer. Their xattrs
+    /// have default values (uid=0, gid=0, mode=S_IFDIR|0o755) and may need
+    /// correction from lower layers in a post-extraction fixup pass.
+    pub implicit_dirs: Vec<PathBuf>,
+}
+
 /// Deferred hardlink to create in the second pass.
 struct DeferredHardlink {
     path: PathBuf,
@@ -73,9 +85,8 @@ enum LayerCompression {
 pub(crate) async fn extract_layer(
     tar_path: &Path,
     dest: &Path,
-    parent_layers: &[PathBuf],
     media_type: Option<&str>,
-) -> ImageResult<()> {
+) -> ImageResult<ExtractionResult> {
     use tar::Archive;
 
     let compression = detect_layer_compression(tar_path, media_type)?;
@@ -95,6 +106,7 @@ pub(crate) async fn extract_layer(
     let mut archive = Archive::new(archive_reader);
 
     let mut deferred_hardlinks: Vec<DeferredHardlink> = Vec::new();
+    let mut implicit_dirs: BTreeSet<PathBuf> = BTreeSet::new();
     let mut total_size: u64 = 0;
     let mut entry_count: u64 = 0;
 
@@ -165,6 +177,7 @@ pub(crate) async fn extract_layer(
             // Set stat xattr.
             let mode = S_IFDIR | (tar_mode & 0o7777);
             set_override_stat(&full_path, uid, gid, mode, 0)?;
+            clear_implicit_entry(&full_path, dest, &mut implicit_dirs);
         } else if entry_type == tar::EntryType::Symlink {
             let link_target = entry
                 .link_name()
@@ -173,16 +186,13 @@ pub(crate) async fn extract_layer(
                 .unwrap_or_default();
 
             // Ensure parent directory exists.
-            ensure_parent_dir(&full_path, dest, parent_layers)?;
+            ensure_parent_dir(&full_path, dest, &mut implicit_dirs)?;
 
             let mode = S_IFLNK | 0o777;
 
             if cfg!(target_os = "linux") {
                 // Linux: store as regular file with content = target path.
                 // (xattrs can't be set on symlinks on most Linux filesystems.)
-                if let Some(parent) = full_path.parent() {
-                    std::fs::create_dir_all(parent).map_err(|e| extraction_err(tar_path, e))?;
-                }
                 // Remove any existing entry (could be a directory from a lower layer).
                 let _ = std::fs::remove_dir_all(&full_path);
                 let _ = std::fs::remove_file(&full_path);
@@ -190,16 +200,16 @@ pub(crate) async fn extract_layer(
                     .map_err(|e| extraction_err(tar_path, e))?;
                 set_host_permissions(&full_path, 0o600)?;
                 set_override_stat(&full_path, uid, gid, mode, 0)?;
+                clear_implicit_entry(&full_path, dest, &mut implicit_dirs);
             } else {
                 // macOS: real symlink with XATTR_NOFOLLOW.
-                if let Some(parent) = full_path.parent() {
-                    std::fs::create_dir_all(parent).map_err(|e| extraction_err(tar_path, e))?;
-                }
-                // Remove any existing file at the target.
+                // Remove any existing entry (could be a directory from a lower layer).
+                let _ = std::fs::remove_dir_all(&full_path);
                 let _ = std::fs::remove_file(&full_path);
                 std::os::unix::fs::symlink(&link_target, &full_path)
                     .map_err(|e| extraction_err(tar_path, e))?;
                 set_override_stat_symlink(&full_path, uid, gid, mode, 0)?;
+                clear_implicit_entry(&full_path, dest, &mut implicit_dirs);
             }
         } else if entry_type == tar::EntryType::Regular || entry_type == tar::EntryType::Continuous
         {
@@ -220,7 +230,7 @@ pub(crate) async fn extract_layer(
                 });
             }
 
-            ensure_parent_dir(&full_path, dest, parent_layers)?;
+            ensure_parent_dir(&full_path, dest, &mut implicit_dirs)?;
 
             let mut file = tokio::fs::File::create(&full_path)
                 .await
@@ -233,9 +243,10 @@ pub(crate) async fn extract_layer(
             set_host_permissions(&full_path, 0o600)?;
             let mode = S_IFREG | (tar_mode & 0o7777);
             set_override_stat(&full_path, uid, gid, mode, 0)?;
+            clear_implicit_entry(&full_path, dest, &mut implicit_dirs);
         } else if entry_type == tar::EntryType::Block || entry_type == tar::EntryType::Char {
             // Block/char device: store as empty regular file with device info in xattr.
-            ensure_parent_dir(&full_path, dest, parent_layers)?;
+            ensure_parent_dir(&full_path, dest, &mut implicit_dirs)?;
             std::fs::write(&full_path, b"").map_err(|e| extraction_err(tar_path, e))?;
             set_host_permissions(&full_path, 0o600)?;
 
@@ -249,13 +260,15 @@ pub(crate) async fn extract_layer(
             };
             let mode = type_bits | (tar_mode & 0o7777);
             set_override_stat(&full_path, uid, gid, mode, rdev)?;
+            clear_implicit_entry(&full_path, dest, &mut implicit_dirs);
         } else if entry_type == tar::EntryType::Fifo {
             // FIFO: store as empty regular file.
-            ensure_parent_dir(&full_path, dest, parent_layers)?;
+            ensure_parent_dir(&full_path, dest, &mut implicit_dirs)?;
             std::fs::write(&full_path, b"").map_err(|e| extraction_err(tar_path, e))?;
             set_host_permissions(&full_path, 0o600)?;
             let mode = S_IFIFO | (tar_mode & 0o7777);
             set_override_stat(&full_path, uid, gid, mode, 0)?;
+            clear_implicit_entry(&full_path, dest, &mut implicit_dirs);
         }
         // Skip other types (GNUSparse, XHeader, etc.)
     }
@@ -270,7 +283,7 @@ pub(crate) async fn extract_layer(
             );
             continue;
         }
-        ensure_parent_dir(&hl.path, dest, parent_layers)?;
+        ensure_parent_dir(&hl.path, dest, &mut implicit_dirs)?;
         let _ = std::fs::remove_file(&hl.path);
         std::fs::hard_link(&hl.target, &hl.path).map_err(|e| ImageError::Extraction {
             digest: tar_path.display().to_string(),
@@ -281,9 +294,12 @@ pub(crate) async fn extract_layer(
             ),
             source: Some(Box::new(e)),
         })?;
+        clear_implicit_entry(&hl.path, dest, &mut implicit_dirs);
     }
 
-    Ok(())
+    Ok(ExtractionResult {
+        implicit_dirs: implicit_dirs.into_iter().collect(),
+    })
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -334,8 +350,17 @@ fn validate_entry_path(dest: &Path, entry_path: &Path, tar_path: &Path) -> Image
     Ok(full_path)
 }
 
-/// Ensure parent directories exist, searching parent layers if needed.
-fn ensure_parent_dir(path: &Path, dest: &Path, parent_layers: &[PathBuf]) -> ImageResult<()> {
+/// Ensure parent directories exist, tracking implicitly-created ones for post-fixup.
+///
+/// Directories created here (not from tar entries) get a default xattr
+/// (`uid=0, gid=0, mode=S_IFDIR|0o755`). Their relative paths are appended
+/// to `implicit_dirs` so a post-extraction fixup pass can copy the correct
+/// xattr from the lower layer that originally defined the directory.
+fn ensure_parent_dir(
+    path: &Path,
+    dest: &Path,
+    implicit_dirs: &mut BTreeSet<PathBuf>,
+) -> ImageResult<()> {
     if let Some(parent) = path.parent() {
         if parent.exists() {
             return Ok(());
@@ -353,32 +378,33 @@ fn ensure_parent_dir(path: &Path, dest: &Path, parent_layers: &[PathBuf]) -> Ima
             }
         }
 
-        // Create missing directories, copying xattrs from parent layers if found.
+        // Create missing directories with default xattrs (top-down after reverse).
         for dir in missing.into_iter().rev() {
-            std::fs::create_dir_all(&dir).map_err(|e| ImageError::Extraction {
+            std::fs::create_dir(&dir).map_err(|e| ImageError::Extraction {
                 digest: String::new(),
                 message: format!("failed to create dir {}: {e}", dir.display()),
                 source: Some(Box::new(e)),
             })?;
 
-            // Try to copy xattrs from a parent layer.
-            if let Ok(rel) = dir.strip_prefix(dest) {
-                for parent_dir in parent_layers.iter().rev() {
-                    let parent_path = parent_dir.join(rel);
-                    if parent_path.exists() {
-                        // Copy the override stat xattr.
-                        if let Ok(Some(data)) = xattr::get(&parent_path, OVERRIDE_XATTR_KEY) {
-                            let _ = xattr::set(&dir, OVERRIDE_XATTR_KEY, &data);
-                        }
-                        break;
-                    }
-                }
-            }
-
             set_host_permissions(&dir, 0o700)?;
+
+            // Default xattr — may be corrected in the fixup pass.
+            let mode = S_IFDIR | 0o755;
+            set_override_stat(&dir, 0, 0, mode, 0)?;
+
+            // Track for post-fixup.
+            if let Ok(rel) = dir.strip_prefix(dest) {
+                implicit_dirs.insert(rel.to_path_buf());
+            }
         }
     }
     Ok(())
+}
+
+fn clear_implicit_entry(path: &Path, dest: &Path, implicit_dirs: &mut BTreeSet<PathBuf>) {
+    if let Ok(rel) = path.strip_prefix(dest) {
+        implicit_dirs.remove(rel);
+    }
 }
 
 /// Set host file permissions (minimum readable/writable by owner).
@@ -488,6 +514,47 @@ fn extraction_err(
     }
 }
 
+/// Fix xattrs on implicitly-created directories by copying from lower layers.
+///
+/// After parallel extraction, directories that were created by `ensure_parent_dir`
+/// (not from tar entries) have default xattrs. This pass searches lower layers
+/// bottom-to-top and copies the correct xattr from the first layer that defines
+/// the directory.
+///
+/// This is typically a no-op — most OCI layers include explicit directory entries
+/// for all paths they touch.
+pub(crate) fn fixup_implicit_dirs(
+    layer_dir: &Path,
+    implicit_dirs: &[PathBuf],
+    lower_layers: &[PathBuf],
+) -> ImageResult<()> {
+    for rel_dir in implicit_dirs {
+        let target = layer_dir.join(rel_dir);
+        if !target.exists() {
+            continue;
+        }
+
+        // Search lower layers top-to-bottom (most recent first).
+        for lower in lower_layers.iter().rev() {
+            let source = lower.join(rel_dir);
+            if source.exists() {
+                if let Ok(Some(data)) = xattr::get(&source, OVERRIDE_XATTR_KEY)
+                    && let Err(e) = xattr::set(&target, OVERRIDE_XATTR_KEY, &data)
+                {
+                    tracing::warn!(
+                        target = %target.display(),
+                        source = %source.display(),
+                        error = %e,
+                        "failed to copy override_stat xattr during fixup"
+                    );
+                }
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Ensure the deepest existing ancestor of `path` still resolves under `dest`.
 fn ensure_host_path_contained(dest: &Path, path: &Path, tar_path: &Path) -> ImageResult<()> {
     let root = std::fs::canonicalize(dest).map_err(|e| ImageError::Extraction {
@@ -578,7 +645,10 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{LayerCompression, detect_layer_compression, validate_entry_path};
+    use super::{
+        LayerCompression, OVERRIDE_XATTR_KEY, detect_layer_compression, extract_layer,
+        validate_entry_path,
+    };
 
     #[test]
     fn test_detect_layer_compression_from_media_type() {
@@ -620,5 +690,78 @@ mod tests {
         let err = validate_entry_path(&root, Path::new("escape/file.txt"), Path::new("layer.tar"))
             .unwrap_err();
         assert!(err.to_string().contains("escapes extraction root"));
+    }
+
+    #[test]
+    fn test_extract_layer_clears_explicit_dirs_from_fixup_set() {
+        let temp = tempdir().unwrap();
+        let tar_path = temp.path().join("layer.tar");
+        let dest = temp.path().join("dest");
+        std::fs::create_dir(&dest).unwrap();
+
+        let tar_file = std::fs::File::create(&tar_path).unwrap();
+        let mut builder = tar::Builder::new(tar_file);
+
+        let file_contents = b"tool";
+        let mut file_header = tar::Header::new_gnu();
+        file_header.set_size(file_contents.len() as u64);
+        file_header.set_mode(0o644);
+        file_header.set_uid(0);
+        file_header.set_gid(0);
+        file_header.set_cksum();
+        builder
+            .append_data(&mut file_header, "usr/local/bin/tool", &file_contents[..])
+            .unwrap();
+
+        let mut dir_header = tar::Header::new_gnu();
+        dir_header.set_entry_type(tar::EntryType::Directory);
+        dir_header.set_size(0);
+        dir_header.set_mode(0o700);
+        dir_header.set_uid(42);
+        dir_header.set_gid(7);
+        dir_header.set_cksum();
+        builder
+            .append_data(&mut dir_header, "usr/local", std::io::empty())
+            .unwrap();
+        builder.finish().unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = runtime
+            .block_on(extract_layer(
+                &tar_path,
+                &dest,
+                Some("application/vnd.oci.image.layer.v1.tar"),
+            ))
+            .unwrap();
+
+        assert!(
+            !result
+                .implicit_dirs
+                .contains(&Path::new("usr/local").to_path_buf())
+        );
+        assert!(
+            result
+                .implicit_dirs
+                .contains(&Path::new("usr").to_path_buf())
+        );
+        assert!(
+            result
+                .implicit_dirs
+                .contains(&Path::new("usr/local/bin").to_path_buf())
+        );
+
+        let xattr = xattr::get(dest.join("usr/local"), OVERRIDE_XATTR_KEY)
+            .unwrap()
+            .unwrap();
+        assert_eq!(xattr.len(), 20);
+        assert_eq!(u32::from_le_bytes(xattr[4..8].try_into().unwrap()), 42);
+        assert_eq!(u32::from_le_bytes(xattr[8..12].try_into().unwrap()), 7);
+        assert_eq!(
+            u32::from_le_bytes(xattr[12..16].try_into().unwrap()) & 0o7777,
+            0o700
+        );
     }
 }

--- a/crates/image/lib/layer/mod.rs
+++ b/crates/image/lib/layer/mod.rs
@@ -45,6 +45,7 @@ pub(crate) struct Layer {
     extracted_dir: PathBuf,
     extracting_dir: PathBuf,
     index_path: PathBuf,
+    implicit_dirs_path: PathBuf,
     lock_path: PathBuf,
     download_lock_path: PathBuf,
     part_path: PathBuf,
@@ -68,6 +69,7 @@ impl Layer {
             extracted_dir: cache.extracted_dir(&digest),
             extracting_dir: cache.extracting_dir(&digest),
             index_path: cache.index_path(&digest),
+            implicit_dirs_path: cache.implicit_dirs_path(&digest),
             lock_path: cache.lock_path(&digest),
             download_lock_path: cache.download_lock_path(&digest),
             part_path: cache.part_path(&digest),
@@ -257,14 +259,16 @@ impl Layer {
     /// Extract this layer (decompress + untar).
     ///
     /// Uses cross-process `flock()` to prevent concurrent extraction.
+    /// Returns an `ExtractionResult` containing the list of implicitly-created
+    /// directories that may need xattr fixup from lower layers.
     pub async fn extract(
         &self,
-        parent_extracted_dirs: &[PathBuf],
         progress: Option<&crate::progress::PullProgressSender>,
         layer_index: usize,
         media_type: Option<&str>,
         diff_id: &str,
-    ) -> ImageResult<()> {
+        force: bool,
+    ) -> ImageResult<extraction::ExtractionResult> {
         // Cross-process lock.
         let lock_file = open_lock_file(&self.lock_path)?;
         flock_exclusive(&lock_file)?;
@@ -273,8 +277,10 @@ impl Layer {
         });
 
         // Re-check after lock.
-        if self.is_extracted() {
-            return Ok(());
+        if self.is_extracted() && !force {
+            return Ok(extraction::ExtractionResult {
+                implicit_dirs: read_pending_implicit_dirs(&self.implicit_dirs_path)?,
+            });
         }
 
         let diff_id_arc: std::sync::Arc<str> = diff_id.into();
@@ -289,28 +295,30 @@ impl Layer {
         let extracting_dir = &self.extracting_dir;
         let extracted_dir = &self.extracted_dir;
 
+        if force {
+            let _ = std::fs::remove_dir_all(extracted_dir);
+            remove_file_if_exists(&self.implicit_dirs_path)?;
+        }
+
         // Clean up any previous incomplete extraction.
         let _ = std::fs::remove_dir_all(extracting_dir);
+        remove_file_if_exists(&self.implicit_dirs_path)?;
         std::fs::create_dir_all(extracting_dir).map_err(|e| ImageError::Cache {
             path: extracting_dir.clone(),
             source: e,
         })?;
 
         // Run the extraction pipeline.
-        match extraction::extract_layer(
-            &self.tar_path,
-            extracting_dir,
-            parent_extracted_dirs,
-            media_type,
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(e) => {
-                let _ = std::fs::remove_dir_all(extracting_dir);
-                return Err(e);
-            }
-        }
+        let result =
+            match extraction::extract_layer(&self.tar_path, extracting_dir, media_type).await {
+                Ok(result) => result,
+                Err(e) => {
+                    let _ = std::fs::remove_dir_all(extracting_dir);
+                    return Err(e);
+                }
+            };
+
+        write_pending_implicit_dirs(&self.implicit_dirs_path, &result.implicit_dirs)?;
 
         // Write .complete marker.
         let marker_path = extracting_dir.join(store::COMPLETE_MARKER);
@@ -334,12 +342,23 @@ impl Layer {
             });
         }
 
-        Ok(())
+        Ok(result)
     }
 
     /// Generate the binary sidecar index for this layer's extracted tree.
     pub async fn build_index(&self) -> ImageResult<()> {
         index::build_sidecar_index(&self.extracted_dir, &self.index_path).await
+    }
+
+    /// Load any pending implicit directories that still need fixup.
+    pub fn pending_implicit_dirs(&self) -> ImageResult<Vec<PathBuf>> {
+        read_pending_implicit_dirs(&self.implicit_dirs_path)
+    }
+
+    /// Clear the pending implicit directory marker after fixup completes.
+    pub fn clear_pending_implicit_dirs(&self) -> ImageResult<()> {
+        remove_file_if_exists(&self.implicit_dirs_path)?;
+        Ok(())
     }
 }
 
@@ -450,15 +469,101 @@ fn determine_download_start(
     Ok(DownloadStart::Resume(part_size))
 }
 
+fn write_pending_implicit_dirs(path: &Path, implicit_dirs: &[PathBuf]) -> ImageResult<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    if implicit_dirs.is_empty() {
+        remove_file_if_exists(path)?;
+        return Ok(());
+    }
+
+    let mut data = Vec::new();
+    for entry in implicit_dirs {
+        let bytes = entry.as_os_str().as_bytes();
+        let len = u32::try_from(bytes.len()).map_err(|_| ImageError::Cache {
+            path: path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("implicit dir path too long: {}", entry.display()),
+            ),
+        })?;
+        data.extend_from_slice(&len.to_le_bytes());
+        data.extend_from_slice(bytes);
+    }
+
+    std::fs::write(path, data).map_err(|e| ImageError::Cache {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+fn read_pending_implicit_dirs(path: &Path) -> ImageResult<Vec<PathBuf>> {
+    use std::os::unix::ffi::OsStringExt;
+
+    let data = match std::fs::read(path) {
+        Ok(data) => data,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(ImageError::Cache {
+                path: path.to_path_buf(),
+                source: err,
+            });
+        }
+    };
+
+    let mut offset = 0usize;
+    let mut paths = Vec::new();
+    while offset < data.len() {
+        let len_end = offset + 4;
+        if len_end > data.len() {
+            return Err(ImageError::Cache {
+                path: path.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "truncated implicit dirs sidecar",
+                ),
+            });
+        }
+        let len = u32::from_le_bytes(data[offset..len_end].try_into().unwrap()) as usize;
+        offset = len_end;
+        let path_end = offset + len;
+        if path_end > data.len() {
+            return Err(ImageError::Cache {
+                path: path.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid implicit dirs sidecar entry length",
+                ),
+            });
+        }
+        paths.push(PathBuf::from(std::ffi::OsString::from_vec(
+            data[offset..path_end].to_vec(),
+        )));
+        offset = path_end;
+    }
+
+    Ok(paths)
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt, path::PathBuf};
+
     use tempfile::tempdir;
 
-    use super::{DownloadStart, determine_download_start, remove_file_if_exists};
+    use crate::{
+        digest::Digest,
+        store::{COMPLETE_MARKER, GlobalCache},
+    };
+
+    use super::{
+        DownloadStart, Layer, determine_download_start, read_pending_implicit_dirs,
+        remove_file_if_exists, write_pending_implicit_dirs,
+    };
 
     #[test]
     fn test_determine_download_start_returns_fresh_when_part_missing() {
@@ -536,5 +641,79 @@ mod tests {
         remove_file_if_exists(&path).unwrap();
 
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_extract_reads_pending_implicit_dirs_from_existing_layer() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let digest: Digest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+                .parse()
+                .unwrap();
+        let layer = Layer::new(digest.clone(), &cache);
+
+        let extracted_dir = cache.extracted_dir(&digest);
+        let implicit_dirs_path = cache.implicit_dirs_path(&digest);
+        std::fs::create_dir_all(&extracted_dir).unwrap();
+        std::fs::write(extracted_dir.join(COMPLETE_MARKER), b"").unwrap();
+        write_pending_implicit_dirs(
+            &implicit_dirs_path,
+            &[PathBuf::from("usr"), PathBuf::from("usr/local/bin")],
+        )
+        .unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = runtime
+            .block_on(layer.extract(
+                None,
+                0,
+                Some("application/vnd.oci.image.layer.v1.tar"),
+                "sha256:deadbeef",
+                false,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            result.implicit_dirs,
+            vec![PathBuf::from("usr"), PathBuf::from("usr/local/bin")]
+        );
+    }
+
+    #[test]
+    fn test_clear_pending_implicit_dirs_removes_marker() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let digest: Digest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+                .parse()
+                .unwrap();
+        let layer = Layer::new(digest.clone(), &cache);
+
+        let extracted_dir = cache.extracted_dir(&digest);
+        let implicit_dirs_path = cache.implicit_dirs_path(&digest);
+        std::fs::create_dir_all(&extracted_dir).unwrap();
+        write_pending_implicit_dirs(&implicit_dirs_path, &[PathBuf::from("usr")]).unwrap();
+
+        layer.clear_pending_implicit_dirs().unwrap();
+
+        assert!(!implicit_dirs_path.exists());
+    }
+
+    #[test]
+    fn test_pending_implicit_dirs_round_trip_raw_bytes() {
+        let temp = tempdir().unwrap();
+        let sidecar_path = temp.path().join("layer.implicit_dirs");
+        let raw_path = PathBuf::from(OsString::from_vec(vec![
+            b'u', b's', b'r', b'/', b'b', b'i', b'n', b'/', 0xff, b'\n', b'x',
+        ]));
+
+        write_pending_implicit_dirs(&sidecar_path, std::slice::from_ref(&raw_path)).unwrap();
+        let round_tripped = read_pending_implicit_dirs(&sidecar_path).unwrap();
+
+        assert_eq!(round_tripped, vec![raw_path]);
     }
 }

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -45,6 +45,17 @@ struct CachedPullInfo {
     metadata: CachedImageMetadata,
 }
 
+struct LayerPipelineSuccess {
+    layer_index: usize,
+    layer: Layer,
+    extracted_dir: PathBuf,
+    implicit_dirs: Vec<PathBuf>,
+}
+
+struct LayerPipelineFailure {
+    error: ImageError,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -78,7 +89,7 @@ impl Registry {
         })
     }
 
-    /// Pull an image. Downloads layers concurrently, extracts sequentially.
+    /// Pull an image. Downloads, extracts, and indexes layers concurrently.
     pub async fn pull(
         &self,
         reference: &oci_client::Reference,
@@ -211,8 +222,13 @@ impl Registry {
             });
         }
 
-        // Step 5: Download layers concurrently.
-        let download_futures: Vec<_> = layer_descriptors
+        // Step 5+6: Download, extract, and index ALL layers in parallel.
+        //
+        // Each layer's pipeline (download → extract → index) runs independently.
+        // Extraction no longer depends on other layers being extracted first.
+        // A fast post-fixup pass corrects xattrs on any implicitly-created
+        // directories that need metadata from lower layers.
+        let layer_futures: Vec<_> = layer_descriptors
             .iter()
             .enumerate()
             .map(|(i, layer_desc)| {
@@ -220,57 +236,109 @@ impl Registry {
                 let client = self.client.clone();
                 let oci_ref = oci_ref.clone();
                 let size = layer_desc.size;
+                let force = options.force;
+                let build_index = options.build_index;
                 let progress = progress.clone();
+                let media_type = layer_desc.media_type.clone();
+                let diff_id = diff_ids.get(i).cloned().unwrap_or_default();
 
                 async move {
-                    layer
-                        .download(&client, &oci_ref, size, options.force, progress.as_ref(), i)
+                    // Download.
+                    if let Err(error) = layer
+                        .download(&client, &oci_ref, size, force, progress.as_ref(), i)
                         .await
+                    {
+                        return Err(LayerPipelineFailure { error });
+                    }
+
+                    // Extract (no parent layer dependency — parallel safe).
+                    let result = if !layer.is_extracted() || force {
+                        let result = match layer
+                            .extract(progress.as_ref(), i, media_type.as_deref(), &diff_id, force)
+                            .await
+                        {
+                            Ok(result) => result,
+                            Err(error) => return Err(LayerPipelineFailure { error }),
+                        };
+
+                        // Index.
+                        if build_index {
+                            if let Some(ref p) = progress {
+                                p.send(PullProgress::LayerIndexStarted { layer_index: i });
+                            }
+                            if let Err(error) = layer.build_index().await {
+                                return Err(LayerPipelineFailure { error });
+                            }
+                            if let Some(ref p) = progress {
+                                p.send(PullProgress::LayerIndexComplete { layer_index: i });
+                            }
+                        }
+
+                        result
+                    } else {
+                        crate::layer::extraction::ExtractionResult {
+                            implicit_dirs: match layer.pending_implicit_dirs() {
+                                Ok(implicit_dirs) => implicit_dirs,
+                                Err(error) => return Err(LayerPipelineFailure { error }),
+                            },
+                        }
+                    };
+
+                    Ok::<_, LayerPipelineFailure>(LayerPipelineSuccess {
+                        layer_index: i,
+                        extracted_dir: layer.extracted_dir(),
+                        implicit_dirs: result.implicit_dirs,
+                        layer,
+                    })
                 }
             })
             .collect();
 
-        futures::future::try_join_all(download_futures).await?;
+        let outcomes = futures::future::join_all(layer_futures).await;
+        let mut results: Vec<LayerPipelineSuccess> = Vec::with_capacity(layer_count);
+        let mut first_error: Option<ImageError> = None;
 
-        // Step 6: Extract layers sequentially (bottom-to-top).
-        let mut extracted_dirs: Vec<PathBuf> = Vec::with_capacity(layer_count);
-
-        for (i, layer_desc) in layer_descriptors.iter().enumerate() {
-            let layer = Layer::new(layer_desc.digest.clone(), &self.cache);
-
-            let diff_id = diff_ids.get(i).map(String::as_str).unwrap_or("");
-
-            if !layer.is_extracted() || options.force {
-                layer
-                    .extract(
-                        &extracted_dirs,
-                        progress.as_ref(),
-                        i,
-                        layer_desc.media_type.as_deref(),
-                        diff_id,
-                    )
-                    .await?;
-
-                // Build sidecar index if requested.
-                if options.build_index {
-                    if let Some(ref p) = progress {
-                        p.send(PullProgress::LayerIndexStarted { layer_index: i });
-                    }
-                    layer.build_index().await?;
-                    if let Some(ref p) = progress {
-                        p.send(PullProgress::LayerIndexComplete { layer_index: i });
+        for outcome in outcomes {
+            match outcome {
+                Ok(result) => results.push(result),
+                Err(failure) => {
+                    if first_error.is_none() {
+                        first_error = Some(failure.error);
                     }
                 }
             }
+        }
 
-            extracted_dirs.push(layer.extracted_dir());
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+
+        // Sort results by layer index (futures may complete out of order).
+        results.sort_by_key(|result| result.layer_index);
+
+        // Step 6b: Sequential fixup pass for implicitly-created directories.
+        //
+        // Most layers are self-contained (their tars include all parent directory
+        // entries), so this is typically a no-op. For the rare case where a layer
+        // references a path whose parent was defined by a lower layer, we copy
+        // the correct override_stat xattr from that lower layer.
+        let extracted_dirs: Vec<PathBuf> = results
+            .iter()
+            .map(|result| result.extracted_dir.clone())
+            .collect();
+        for result in &results {
+            if !result.implicit_dirs.is_empty() && result.layer_index > 0 {
+                crate::layer::extraction::fixup_implicit_dirs(
+                    &extracted_dirs[result.layer_index],
+                    &result.implicit_dirs,
+                    &extracted_dirs[..result.layer_index],
+                )?;
+            }
+            result.layer.clear_pending_implicit_dirs()?;
         }
 
         // Step 7: Return result.
-        let layers: Vec<PathBuf> = layer_descriptors
-            .iter()
-            .map(|ld| self.cache.extracted_dir(&ld.digest))
-            .collect();
+        let layers = extracted_dirs;
         let cached_image = CachedImageMetadata {
             manifest_digest: manifest_digest.to_string(),
             config: image_config.clone(),

--- a/crates/image/lib/store.rs
+++ b/crates/image/lib/store.rs
@@ -36,6 +36,7 @@ pub(crate) const COMPLETE_MARKER: &str = ".complete";
 /// ~/.microsandbox/cache/layers/<digest_safe>.tar.gz            # compressed downloads
 /// ~/.microsandbox/cache/layers/<digest_safe>.extracted/        # extracted layer trees
 /// ~/.microsandbox/cache/layers/<digest_safe>.index             # binary sidecar indexes
+/// ~/.microsandbox/cache/layers/<digest_safe>.implicit_dirs     # pending implicit-dir fixups
 /// ~/.microsandbox/cache/layers/<digest_safe>.lock              # extraction flock files
 /// ~/.microsandbox/cache/layers/<digest_safe>.download.lock     # download flock files
 /// ```
@@ -129,6 +130,12 @@ impl GlobalCache {
     pub fn index_path(&self, digest: &Digest) -> PathBuf {
         self.layers_dir
             .join(format!("{}.index", digest.to_path_safe()))
+    }
+
+    /// Path to the pending implicit-dir fixup sidecar for a layer.
+    pub fn implicit_dirs_path(&self, digest: &Digest) -> PathBuf {
+        self.layers_dir
+            .join(format!("{}.implicit_dirs", digest.to_path_safe()))
     }
 
     /// Path to the extraction lock file for a layer.

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -16,9 +16,9 @@ pub(crate) mod db;
 pub mod runtime;
 pub mod sandbox;
 pub mod setup;
-pub mod size;
 pub mod volume;
 
 pub use error::*;
 pub use microsandbox_image::RegistryAuth;
 pub use microsandbox_runtime::logging::LogLevel;
+pub use microsandbox_utils::size;

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -1,6 +1,7 @@
 //! Shared constants and utilities for the microsandbox project.
 
 pub mod index;
+pub mod size;
 
 //--------------------------------------------------------------------------------------------------
 // Constants: Directory Layout

--- a/crates/utils/lib/size.rs
+++ b/crates/utils/lib/size.rs
@@ -1,11 +1,11 @@
 //! Byte-size types and conversion helpers.
 //!
 //! Provides [`ByteSize`], [`Bytes`], and [`Mebibytes`] for type-safe size
-//! specification across the SDK.  The [`SizeExt`] trait adds `.bytes()`,
+//! specification across the project. The [`SizeExt`] trait adds `.bytes()`,
 //! `.kib()`, `.mib()`, and `.gib()` helpers to integer literals.
 //!
 //! ```ignore
-//! use microsandbox::size::{SizeExt, Mebibytes};
+//! use microsandbox_utils::size::{SizeExt, Mebibytes};
 //!
 //! // All equivalent — 512 MiB:
 //! let a: Mebibytes = 512.into();    // bare integer

--- a/plan.md
+++ b/plan.md
@@ -1,377 +1,304 @@
-# libkrunfw Build Plan
+# Proposal: Parallel Layer Processing Pipeline
 
-## Overview
+## Problem
 
-libkrunfw bundles the Linux kernel as a native shared library (`.so` on Linux, `.dylib` on macOS) that is loaded at runtime via `dlopen`. It is a runtime dependency of `msb_krun`, not a Rust crate dependency.
-
-This plan covers:
-
-1. Vendoring libkrunfw as a git submodule
-2. Building the library from source via a justfile
-3. Optional prebuilt binary download via a `build.rs` feature flag
-
-### Why Vendor libkrunfw?
-
-- **Self-contained SDK** — users shouldn't need to system-install libkrunfw
-- **Version pinning** — prevents ABI mismatches between msb_krun and the kernel library
-- **Custom patches** — upstream libkrunfw carries patches we depend on (clean PID 1 exit, vsock dgram, Apple TSO); forking gives us control
-- **Reproducible builds** — build from a pinned commit, not whatever's in `/usr/local/lib`
-
----
-
-## 1. Git Submodule Setup
-
-### Fork
-
-Fork `containers/libkrunfw` to `zerocore-ai/libkrunfw`. This gives us:
-
-- Release tagging for prebuilt binaries (e.g., `v4.10.0`)
-- Ability to carry custom patches if upstream diverges
-- Mirrors the `zerocore-ai/libkrun` pattern
-
-### Submodule
-
-```bash
-cd microsandbox
-git submodule add https://github.com/zerocore-ai/libkrunfw.git lib/libkrunfw
-git submodule update --init
-```
-
-#### Repository Structure
+The current pull pipeline processes layers in three strictly sequential phases:
 
 ```
-microsandbox/
-├── lib/
-│   └── libkrunfw/              # Git submodule (zerocore-ai/libkrunfw)
-│       ├── Makefile
-│       ├── bin2cbundle.py
-│       ├── build_on_krunvm.sh  # (unused — replaced by justfile Docker build)
-│       ├── config-libkrunfw_aarch64
-│       ├── config-libkrunfw_x86_64
-│       ├── patches/
-│       └── ...
-├── microsandbox/
-│   ├── Cargo.toml
-│   ├── build.rs                # NEW: optional prebuilt download
-│   ├── bin/
-│   └── lib/
-├── justfile                    # NEW: build recipes
-└── Cargo.toml
+1. Download ALL layers ──(barrier)──→ 2. Extract+Index each layer one-by-one ──→ 3. Return
 ```
 
----
+This means:
+- Extraction of layer 0 waits for ALL downloads (including a 500MB layer 4)
+- Each layer's extraction blocks the next, even though most layers are self-contained
+- Each layer's indexing blocks the next extraction, even though indexing only reads
+- Total wall time = max(all downloads) + sum(all extractions) + sum(all indexes)
 
-## 2. Build Process
+## Current Code Structure
 
-### How libkrunfw is Built
-
-The build has two stages:
-
-1. **Compile the Linux kernel** — requires a Linux environment (can't build Linux kernel on macOS natively)
-2. **Generate the shared library** — convert kernel binary to C source via `bin2cbundle.py`, then compile to `.so`/`.dylib`
-
-#### Stage 1: Kernel Compilation
-
-1. Download kernel tarball (`linux-6.12.34` from `cdn.kernel.org`)
-2. Apply patches from `patches/` (21 patches: vsock dgram, TSO, TSI, etc.)
-3. Copy arch-specific kernel config (`config-libkrunfw_{arch}`)
-4. Run `make olddefconfig && make`
-5. Output: `vmlinux` (x86_64) or `Image` (aarch64)
-
-#### Stage 2: Shared Library
-
-1. Run `bin2cbundle.py` to convert kernel binary → `kernel.c` (C array with page-aligned kernel bytes + accessor functions)
-2. Compile: `cc -fPIC -DABI_VERSION=4 -shared -o libkrunfw.{so,dylib} kernel.c`
-3. Strip (Linux only)
-
-### Platform-Specific Build
-
-#### Linux (Native)
-
-Both stages run natively. Straightforward.
-
-Dependencies: `gcc`, `make`, `python3`, `python3-pyelftools`, `bc`, `flex`, `bison`, `libelf-dev`, `libssl-dev`, `dwarves`, `curl`
-
-#### macOS (Docker)
-
-Stage 1 runs inside a Docker container (Fedora-based, matching upstream's builder choice). Stage 2 runs on the macOS host.
-
-Flow:
-
-```
-┌─────────────────────────────────────────────────────┐
-│  Docker (Fedora)                                    │
-│  1. Install kernel build deps (dnf builddep kernel) │
-│  2. Download + patch + compile kernel               │
-│  3. Run bin2cbundle.py → kernel.c                   │
-│  (bind-mounted lib/libkrunfw/ ↔ /work)              │
-└─────────────────────────────────────────────────────┘
-                        │
-                   kernel.c (on host via bind mount)
-                        │
-                        ▼
-┌─────────────────────────────────────────────────────┐
-│  macOS Host                                         │
-│  cc -fPIC -shared -o libkrunfw.4.dylib kernel.c     │
-└─────────────────────────────────────────────────────┘
-```
-
-This replaces the existing `build_on_krunvm.sh` with Docker. The plan is to eventually replace Docker with microsandbox itself (dogfooding).
-
----
-
-## 3. Justfile
-
-The justfile lives at the microsandbox project root.
-
-### Recipes
-
-```just
-# ── libkrunfw ─────────────────────────────────────────────────────────────────
-
-# Build libkrunfw for the current platform
-build-libkrunfw:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    OS="$(uname -s)"
-    if [ "$OS" = "Linux" ]; then
-        just _build-libkrunfw-linux
-    elif [ "$OS" = "Darwin" ]; then
-        just _build-libkrunfw-macos
-    else
-        echo "Unsupported OS: $OS"
-        exit 1
-    fi
-
-# Clean libkrunfw build artifacts
-clean-libkrunfw:
-    cd lib/libkrunfw && make clean
-
-# ── Internal recipes ──────────────────────────────────────────────────────────
-
-# Linux: build kernel + shared library natively
-_build-libkrunfw-linux:
-    cd lib/libkrunfw && make -j"$(nproc)"
-
-# macOS: build kernel in Docker, compile dylib on host
-_build-libkrunfw-macos:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    LIBKRUNFW_DIR="$(pwd)/lib/libkrunfw"
-    ARCH="$(uname -m)"
-
-    # Stage 1: Compile kernel inside Docker (Fedora)
-    docker run --rm \
-        -v "$LIBKRUNFW_DIR:/work" \
-        -w /work \
-        fedora:latest \
-        bash -c "
-            dnf install -y 'dnf-command(builddep)' python3-pyelftools curl && \
-            dnf builddep -y kernel && \
-            make -j\$(nproc)
-        "
-
-    # Stage 2: Compile dylib on macOS host
-    # kernel.c was generated inside Docker via bind mount
-    ABI_VERSION=4
-    cc -fPIC -DABI_VERSION=$ABI_VERSION -shared \
-        -o "$LIBKRUNFW_DIR/libkrunfw.$ABI_VERSION.dylib" \
-        "$LIBKRUNFW_DIR/kernel.c"
-
-    echo "Built: lib/libkrunfw/libkrunfw.$ABI_VERSION.dylib"
-
-# Install libkrunfw to a target directory (for use by msb_krun at runtime)
-install-libkrunfw target_dir="target/lib":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    mkdir -p "{{ target_dir }}"
-    OS="$(uname -s)"
-    ABI_VERSION=4
-    if [ "$OS" = "Linux" ]; then
-        FULL_VERSION="4.10.0"
-        cp "lib/libkrunfw/libkrunfw.so.$FULL_VERSION" "{{ target_dir }}/"
-        cd "{{ target_dir }}"
-        ln -sf "libkrunfw.so.$FULL_VERSION" "libkrunfw.so.$ABI_VERSION"
-        ln -sf "libkrunfw.so.$ABI_VERSION" "libkrunfw.so"
-    elif [ "$OS" = "Darwin" ]; then
-        cp "lib/libkrunfw/libkrunfw.$ABI_VERSION.dylib" "{{ target_dir }}/"
-        cd "{{ target_dir }}"
-        ln -sf "libkrunfw.$ABI_VERSION.dylib" "libkrunfw.dylib"
-    fi
-    echo "Installed libkrunfw to {{ target_dir }}/"
-```
-
-### Key Design Decisions
-
-1. **Fedora base image** — matches upstream's builder convention; `dnf builddep kernel` pulls all kernel build deps in one command
-2. **Single Docker run** — no persistent container; `--rm` ensures clean state
-3. **Bind mount** — `lib/libkrunfw/` is mounted at `/work` so `kernel.c` appears on host after the Docker run
-4. **ABI_VERSION variable** — currently `4`, centralized for easy bumping
-5. **install recipe** — copies the built library to a location where msb_krun can find it at runtime (e.g., `target/lib/`), with proper symlinks
-
----
-
-## 4. Prebuilt Download (Feature Flag)
-
-### Feature Flag
-
-The `microsandbox` crate gets a `prebuilt-libkrunfw` feature flag. When enabled, `build.rs` downloads the prebuilt library from `zerocore-ai/libkrunfw` GitHub releases.
-
-```toml
-# microsandbox/Cargo.toml
-[features]
-prebuilt-libkrunfw = []
-
-[build-dependencies]
-reqwest = { version = "0.13", features = ["blocking"], optional = true }
-
-[features]
-prebuilt-libkrunfw = ["dep:reqwest"]
-```
-
-### build.rs
+### Orchestration (`registry.rs:215-267`)
 
 ```rust
-fn main() {
-    #[cfg(feature = "prebuilt-libkrunfw")]
-    download_libkrunfw();
-}
+// Step 5: Download all layers concurrently (barrier at end)
+let download_futures = layer_descriptors.iter().enumerate().map(|(i, desc)| {
+    async move { layer.download(...).await }
+});
+futures::future::try_join_all(download_futures).await?;   // ← BARRIER
 
-#[cfg(feature = "prebuilt-libkrunfw")]
-fn download_libkrunfw() {
-    use std::path::PathBuf;
-
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let lib_dir = out_dir.join("lib");
-    std::fs::create_dir_all(&lib_dir).unwrap();
-
-    let version = "4.10.0";
-    let abi_version = "4";
-
-    let (filename, url) = if cfg!(target_os = "macos") {
-        let name = format!("libkrunfw.{abi_version}.dylib");
-        let url = format!(
-            "https://github.com/zerocore-ai/libkrunfw/releases/download/v{version}/{name}"
-        );
-        (name, url)
-    } else {
-        let name = format!("libkrunfw.so.{version}");
-        let url = format!(
-            "https://github.com/zerocore-ai/libkrunfw/releases/download/v{version}/{name}"
-        );
-        (name, url)
-    };
-
-    let dest = lib_dir.join(&filename);
-
-    if !dest.exists() {
-        let bytes = reqwest::blocking::get(&url)
-            .unwrap_or_else(|e| panic!("Failed to download libkrunfw from {url}: {e}"))
-            .bytes()
-            .unwrap();
-        std::fs::write(&dest, &bytes).unwrap();
-    }
-
-    // Tell downstream code where to find the library
-    println!("cargo:rustc-env=LIBKRUNFW_PATH={}", dest.display());
-    println!("cargo:rerun-if-changed=build.rs");
+// Step 6: Extract layers one-by-one, sequentially
+let mut extracted_dirs: Vec<PathBuf> = Vec::new();
+for (i, desc) in layer_descriptors.iter().enumerate() {
+    layer.extract(&extracted_dirs, ...).await?;            // ← SEQUENTIAL
+    layer.build_index().await?;                            // ← BLOCKS NEXT
+    extracted_dirs.push(layer.extracted_dir());
 }
 ```
 
-### How msb_krun Finds libkrunfw
+### Extraction (`extraction.rs:73-287`)
 
-The `KernelBuilder::krunfw_path()` API in msb_krun allows specifying an explicit path:
+`extract_layer()` takes `parent_layers: &[PathBuf]` — a list of already-extracted lower layer directories. This is used by `ensure_parent_dir()` (line 338) when a tar entry references a path whose parent directory doesn't exist in the current layer. In that case, it:
+
+1. Creates the missing directory via `create_dir_all`
+2. Searches `parent_layers` (bottom-to-top) for the same directory
+3. Copies the `override_stat` xattr from the parent layer's version of that directory
+
+This creates a **data dependency**: layer N's extraction needs layers 0..N-1 fully extracted.
+
+### Why This Dependency Matters
+
+Our OverlayFs implementation searches layers **top-down and stops at the first match** for any path lookup (`inode.rs:591-632`). When `getattr` is called on a directory, the metadata comes from the **topmost layer that contains it**, read via the on-disk `override_stat` xattr.
+
+This means if layer 2 implicitly creates `usr/local/` with a default/wrong xattr, and layer 0 has `usr/local/` with the correct xattr, the guest sees layer 2's wrong metadata — layer 0 is never consulted.
+
+**However**: in the vast majority of OCI images, every layer's tar includes explicit directory entries for all paths it touches. The `ensure_parent_dir` fallback to parent layers is a **rare edge case** — it handles the degenerate scenario where a tar contains `usr/local/bin/python` without a preceding `usr/local/` directory entry.
+
+## Proposed Solution: Parallel Extract + Post-Fixup
+
+Extract all layers in parallel with no parent layer dependencies. Then run a fast sequential fixup pass to correct any implicitly-created directories.
+
+### Architecture
+
+```
+Phase 1: FULLY PARALLEL (download → extract → index, per layer)
+┌─ download[0] → extract[0] → index[0] ─┐
+│  download[1] → extract[1] → index[1]  │ all concurrent
+│  download[2] → extract[2] → index[2]  │
+└─ download[3] → extract[3] → index[3] ─┘
+                      │
+                 join_all
+                      │
+Phase 2: FAST SEQUENTIAL FIXUP (xattr correction, rare)
+for layer in 1..N (bottom-to-top):
+    for each implicitly-created dir (tracked during phase 1):
+        copy correct xattr from the lowest layer that defines it
+```
+
+### Wall Time Comparison (5-layer image)
+
+Assumptions: download=2s/layer, extraction=1s/layer, indexing=0.3s/layer
+
+| Approach | Wall Time | Speedup |
+|----------|-----------|---------|
+| Current (all sequential) | 2.0 + 5.0 + 1.5 = **8.5s** | — |
+| Parallel extract + fixup | max(2+1+0.3) + ~0 = **3.3s** | **61%** |
+
+## Detailed Design
+
+### Step 1: Modify `extract_layer` to Track Implicit Directories
+
+Currently `ensure_parent_dir` creates missing directories and copies xattrs inline. Change it to:
+
+1. **Remove the `parent_layers` parameter** from `extract_layer()`
+2. **`ensure_parent_dir` still creates missing directories** with a default xattr (`uid=0, gid=0, mode=S_IFDIR|0o755, rdev=0`)
+3. **Track which directories were implicitly created** (not from a tar directory entry) by accumulating their relative paths into a `Vec<PathBuf>` returned alongside the extraction result
+
+**Changes to `extraction.rs`:**
 
 ```rust
-// When prebuilt-libkrunfw is enabled, use the downloaded path
-let krunfw_path = env!("LIBKRUNFW_PATH");
+/// Result of layer extraction, including directories that need post-fixup.
+pub(crate) struct ExtractionResult {
+    /// Relative paths of directories created implicitly (not from tar entries).
+    /// These need xattr fixup from lower layers in a post-processing pass.
+    pub implicit_dirs: Vec<PathBuf>,
+}
 
-VmBuilder::new()
-    .kernel(|k| k.krunfw_path(krunfw_path))
+pub(crate) async fn extract_layer(
+    tar_path: &Path,
+    dest: &Path,
+    media_type: Option<&str>,
+    // parent_layers parameter REMOVED
+) -> ImageResult<ExtractionResult> {
+    let mut implicit_dirs: Vec<PathBuf> = Vec::new();
     // ...
+    // Pass implicit_dirs to ensure_parent_dir:
+    ensure_parent_dir(&full_path, dest, &mut implicit_dirs)?;
+    // ...
+    Ok(ExtractionResult { implicit_dirs })
+}
 ```
 
-When the feature is NOT enabled, the user is expected to either:
-- Build via `just build-libkrunfw && just install-libkrunfw`
-- Have libkrunfw installed system-wide (fallback to OS dynamic linker search)
+**Changes to `ensure_parent_dir`:**
 
----
+```rust
+fn ensure_parent_dir(
+    path: &Path,
+    dest: &Path,
+    implicit_dirs: &mut Vec<PathBuf>,  // replaces parent_layers
+) -> ImageResult<()> {
+    // ... (same walk-up-missing-ancestors logic) ...
 
-## 5. GitHub Releases (zerocore-ai/libkrunfw)
+    for dir in missing.into_iter().rev() {
+        std::fs::create_dir_all(&dir)?;
+        set_host_permissions(&dir, 0o700)?;
 
-### Release Artifacts
+        // Default xattr — may be corrected in fixup pass.
+        let mode = S_IFDIR | 0o755;
+        set_override_stat(&dir, 0, 0, mode, 0)?;
 
-Each release (e.g., `v4.10.0`) publishes:
-
-| Artifact | Platform | Architecture |
-|----------|----------|-------------|
-| `libkrunfw.4.dylib` | macOS | aarch64 (Apple Silicon) |
-| `libkrunfw.so.4.10.0` | Linux | x86_64 |
-| `libkrunfw.so.4.10.0` | Linux | aarch64 |
-
-### Release Process
-
-1. Build on each target platform (CI or manual)
-2. Tag the fork: `git tag v4.10.0 && git push --tags`
-3. Create GitHub release with the built artifacts
-4. Update `ABI_VERSION`/`FULL_VERSION` in the justfile and `build.rs` when bumping
-
-### Versioning
-
-- **ABI version** (`4`) — bumped when the `krunfw_get_kernel()` / `krunfw_get_version()` interface changes (rare)
-- **Full version** (`4.10.0`) — bumped when kernel version, patches, or config changes
-- msb_krun checks `krunfw_get_version()` at runtime to verify ABI compatibility
-
----
-
-## 6. Developer Workflow
-
-### First-Time Setup
-
-```bash
-# Clone with submodules
-git clone --recurse-submodules https://github.com/zerocore-ai/microsandbox.git
-
-# Or if already cloned
-git submodule update --init
-
-# Build libkrunfw
-just build-libkrunfw
-just install-libkrunfw
-
-# Build microsandbox
-cargo build
+        // Track for post-fixup.
+        if let Ok(rel) = dir.strip_prefix(dest) {
+            implicit_dirs.push(rel.to_path_buf());
+        }
+    }
+    Ok(())
+}
 ```
 
-### Quick Start (Prebuilt)
+### Step 2: Add Fixup Function
 
-```bash
-# Skip building libkrunfw from source
-cargo build --features prebuilt-libkrunfw
+New function in `extraction.rs` (or `layer/mod.rs`):
+
+```rust
+/// Fix xattrs on implicitly-created directories by copying from lower layers.
+///
+/// After parallel extraction, directories that were created implicitly
+/// (not from tar entries) may have default xattrs. This pass searches
+/// lower layers bottom-to-top and copies the correct xattr.
+pub(crate) fn fixup_implicit_dirs(
+    layer_dir: &Path,
+    implicit_dirs: &[PathBuf],
+    lower_layers: &[PathBuf],  // layers below this one, bottom-to-top
+) -> ImageResult<()> {
+    for rel_dir in implicit_dirs {
+        let target = layer_dir.join(rel_dir);
+        if !target.exists() {
+            continue;
+        }
+
+        // Search lower layers top-to-bottom (most recent first) for this dir.
+        for lower in lower_layers.iter().rev() {
+            let source = lower.join(rel_dir);
+            if source.exists() {
+                if let Ok(Some(data)) = xattr::get(&source, OVERRIDE_XATTR_KEY) {
+                    let _ = xattr::set(&target, OVERRIDE_XATTR_KEY, &data);
+                }
+                break;
+            }
+        }
+    }
+    Ok(())
+}
 ```
 
-### Updating libkrunfw
+### Step 3: Restructure `pull_inner` Orchestration
 
-```bash
-cd lib/libkrunfw
-git fetch origin
-git checkout v4.11.0  # or whatever new version
-cd ../..
-git add lib/libkrunfw
-git commit -S -m "chore: update libkrunfw to v4.11.0"
-just build-libkrunfw
+Replace the current sequential download-barrier→extract loop with fully parallel pipelines:
+
+```rust
+// Step 5+6: Download, extract, and index ALL layers in parallel.
+let layer_futures: Vec<_> = layer_descriptors
+    .iter()
+    .enumerate()
+    .map(|(i, layer_desc)| {
+        let layer = Layer::new(layer_desc.digest.clone(), &self.cache);
+        let client = self.client.clone();
+        let oci_ref = oci_ref.clone();
+        let progress = progress.clone();
+        let media_type = layer_desc.media_type.clone();
+        let diff_id = diff_ids.get(i).cloned().unwrap_or_default();
+        let build_index = options.build_index;
+        let force = options.force;
+        let size = layer_desc.size;
+
+        async move {
+            // Download
+            layer.download(&client, &oci_ref, size, force, progress.as_ref(), i).await?;
+
+            // Extract (no parent_layers — parallel safe)
+            let result = layer.extract(progress.as_ref(), i, media_type.as_deref(), &diff_id).await?;
+
+            // Index
+            if build_index {
+                if let Some(ref p) = progress {
+                    p.send(PullProgress::LayerIndexStarted { layer_index: i });
+                }
+                layer.build_index().await?;
+                if let Some(ref p) = progress {
+                    p.send(PullProgress::LayerIndexComplete { layer_index: i });
+                }
+            }
+
+            Ok::<_, ImageError>((i, layer.extracted_dir(), result.implicit_dirs))
+        }
+    })
+    .collect();
+
+let results = futures::future::try_join_all(layer_futures).await?;
+
+// Collect results in layer order.
+let mut layer_results: Vec<(PathBuf, Vec<PathBuf>)> = vec![(PathBuf::new(), Vec::new()); layer_count];
+for (i, extracted_dir, implicit_dirs) in results {
+    layer_results[i] = (extracted_dir, implicit_dirs);
+}
+
+// Step 6b: Sequential fixup pass (fast — only implicit dirs).
+let extracted_dirs: Vec<PathBuf> = layer_results.iter().map(|(dir, _)| dir.clone()).collect();
+for i in 1..layer_count {
+    let (ref layer_dir, ref implicit_dirs) = layer_results[i];
+    if !implicit_dirs.is_empty() {
+        extraction::fixup_implicit_dirs(layer_dir, implicit_dirs, &extracted_dirs[..i])?;
+    }
+}
 ```
 
----
+### Step 4: Update `Layer::extract` Signature
 
-## Summary
+Remove `parent_extracted_dirs` parameter, return `ExtractionResult`:
 
-| Component | Approach |
-|-----------|----------|
-| **Source** | Git submodule at `lib/libkrunfw/` (fork: `zerocore-ai/libkrunfw`) |
-| **Linux build** | Native via justfile (`make -j$(nproc)`) |
-| **macOS build** | Docker (Fedora) for kernel + native `cc` for dylib |
-| **Prebuilt download** | `prebuilt-libkrunfw` feature flag, `build.rs` downloads from GitHub releases |
-| **Runtime loading** | `msb_krun` loads via `dlopen`; path set via `KernelBuilder::krunfw_path()` |
-| **Future** | Replace Docker with microsandbox for macOS builds (dogfooding) |
+```rust
+// Before:
+pub async fn extract(
+    &self,
+    parent_extracted_dirs: &[PathBuf],
+    progress: Option<&PullProgressSender>,
+    layer_index: usize,
+    media_type: Option<&str>,
+    diff_id: &str,
+) -> ImageResult<()>
+
+// After:
+pub async fn extract(
+    &self,
+    progress: Option<&PullProgressSender>,
+    layer_index: usize,
+    media_type: Option<&str>,
+    diff_id: &str,
+) -> ImageResult<ExtractionResult>
+```
+
+### Step 5: Re-indexing After Fixup
+
+**Not needed.** The sidecar index records `d_type` (file type) from `entry_rec.mode >> 12`, which is `S_IFDIR >> 12 = 4` (`DT_DIR`) regardless of permission bits. The fixup only changes permission bits and uid/gid in the xattr — the index's `d_type` field remains correct.
+
+The OverlayFs never reads uid/gid/mode from the index for `getattr` — it always reads the real on-disk xattr. So re-indexing would be wasted work.
+
+### Why This Is Safe
+
+| Concern | Analysis |
+|---------|----------|
+| **Directory metadata correctness** | Fixup pass copies correct xattr from lower layers after all layers are extracted. Same data as current sequential approach. |
+| **Rare edge case** | Most OCI layers include explicit directory entries. `implicit_dirs` will typically be empty. Fixup pass is a no-op. |
+| **Index correctness** | Index only uses `d_type` (file type bits), not permission bits. `S_IFDIR` is always correct for directories. No re-index needed. |
+| **Cross-process safety** | Per-layer `flock()` still prevents two processes from extracting the same digest concurrently. Parallel extraction is within a single process across different digests. |
+| **Whiteout handling** | Whiteouts are per-layer markers. Each layer's whiteouts are extracted independently — no cross-layer dependency during extraction. OverlayFs interprets them at runtime. |
+| **Hardlink handling** | Hardlinks are resolved within the same layer (pass 2 of extraction). No cross-layer dependency. |
+
+### Error Handling
+
+If any layer's download/extract/index fails, `try_join_all` propagates the first error. Already-extracted layers remain in cache (valid, with `.complete` marker). The fixup pass is skipped on error.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `crates/image/lib/layer/extraction.rs` | Add `ExtractionResult` type. Remove `parent_layers` from `extract_layer`. Change `ensure_parent_dir` to track implicit dirs. Add `fixup_implicit_dirs`. |
+| `crates/image/lib/layer/mod.rs` | Update `Layer::extract` signature (remove `parent_extracted_dirs`, return `ExtractionResult`). |
+| `crates/image/lib/registry.rs` | Rewrite `pull_inner` steps 5-6: parallel `try_join_all` for download+extract+index, then sequential fixup. |
+
+## Verification
+
+1. `cargo test` — all existing tests pass
+2. Add unit test for `fixup_implicit_dirs` with a multi-layer temp directory setup
+3. Add test that extracts a layer with a missing parent dir and verifies the default xattr is set
+4. Add test that fixup correctly copies xattr from a lower layer
+5. Manual test: `docker pull python:3.12` equivalent — verify guest sees correct directory permissions


### PR DESCRIPTION
## Summary

- Parallelize the OCI layer processing pipeline so all layers download, extract, and index concurrently instead of sequentially
- Previously extraction was serial because `ensure_parent_dir` searched already-extracted lower layers for directory xattrs; this dependency is removed by deferring xattr fixup to a post-pass
- Wall time for multi-layer images drops from `max(downloads) + sum(extractions) + sum(indexes)` to approximately `max(download + extract + index per layer) + trivial fixup`
- Implicit directory metadata is persisted as a sidecar file so cached layers retain pending fixups across process restarts

## Changes

### Parallel extraction pipeline (`crates/image/`)
- `extraction.rs`: Add `ExtractionResult` type with `implicit_dirs` field. Rewrite `ensure_parent_dir` to create directories with default xattrs and track them in a `BTreeSet` instead of searching parent layers. Add `clear_implicit_entry` to remove dirs that get explicit tar entries later. Add `fixup_implicit_dirs` post-pass function
- `layer/mod.rs`: Update `Layer::extract` to remove `parent_extracted_dirs` parameter, return `ExtractionResult`, accept `force` flag. Add `implicit_dirs_path` field and `pending_implicit_dirs`/`clear_pending_implicit_dirs` methods. Add `write_pending_implicit_dirs`/`read_pending_implicit_dirs` helpers with length-prefixed binary sidecar format. Add tests for sidecar round-trip, cached layer implicit dir reads, and cleanup
- `registry.rs`: Rewrite `pull_inner` steps 5-6 from sequential download-barrier + serial extraction to fully parallel per-layer pipelines via `futures::future::join_all`. Add `LayerPipelineSuccess`/`LayerPipelineFailure` types. Add sequential fixup pass after parallel phase. Sort results by layer index since futures complete out of order
- `store.rs`: Add `implicit_dirs_path` method to `GlobalCache`
- `Cargo.toml`: Add `tar` dev-dependency for extraction tests

### SizeExt module relocation
- Move `SizeExt`/`Mebibytes`/`Bytes` from `microsandbox/lib/size.rs` to `microsandbox-utils/lib/size.rs` so it can be used by the filesystem crate
- Update re-export in `microsandbox/lib/lib.rs`

### Filesystem crate improvements
- `memfs/builder.rs`: Accept `impl Into<Bytes>` for `capacity()` and `max_inodes()` so callers can use `64.mib()` syntax
- `dualfs/builder.rs`: Accept `impl Into<Bytes>` for `materialization_threshold()`
- `lib.rs`: Re-export `SizeExt` from `microsandbox_utils`
- `README.md`: Rewrite for conciseness

### Documentation
- Add `crates/image/README.md` documenting the image crate architecture
- Update `plan.md` with parallel extraction proposal and analysis

## Test Plan

- Run `cargo build` to verify compilation with zero warnings
- Run `cargo test` to verify all tests pass (900+ tests across workspace)
- New tests in `layer/mod.rs`: `test_extract_reads_pending_implicit_dirs_from_existing_layer`, `test_clear_pending_implicit_dirs_removes_marker`, `test_pending_implicit_dirs_round_trip_raw_bytes`
- New test in `extraction.rs`: `test_extract_layer_clears_explicit_dirs_from_fixup_set` verifies that directories appearing as explicit tar entries are removed from the implicit dirs set
- Verify no clippy warnings: `cargo clippy --workspace`