### PR TITLE
feat(overlay): add read-only mode with optional upper layer

### DIFF
--- a/crates/filesystem/lib/backends/overlayfs/builder.rs
+++ b/crates/filesystem/lib/backends/overlayfs/builder.rs
@@ -1,11 +1,19 @@
 //! Builder API for constructing an OverlayFs instance.
 //!
 //! ```ignore
+//! // Read-write mode:
 //! OverlayFs::builder()
 //!     .layer(lower0)
 //!     .layer(lower1)
 //!     .writable(upper)
 //!     .staging(staging)
+//!     .build()?
+//!
+//! // Read-only mode:
+//! OverlayFs::builder()
+//!     .layer(lower0)
+//!     .layer(lower1)
+//!     .read_only()
 //!     .build()?
 //! ```
 
@@ -39,6 +47,7 @@ pub struct OverlayFsBuilder {
     lower_indexes: Vec<Option<PathBuf>>,
     upper_dir: Option<PathBuf>,
     staging_dir: Option<PathBuf>,
+    read_only: bool,
     strict: bool,
     entry_timeout: Duration,
     attr_timeout: Duration,
@@ -58,6 +67,7 @@ impl OverlayFsBuilder {
             lower_indexes: Vec::new(),
             upper_dir: None,
             staging_dir: None,
+            read_only: false,
             strict: true,
             entry_timeout: Duration::from_secs(5),
             attr_timeout: Duration::from_secs(5),
@@ -109,6 +119,15 @@ impl OverlayFsBuilder {
         self
     }
 
+    /// Enable read-only mode (no writable upper layer).
+    ///
+    /// Mutually exclusive with `.writable()` and `.staging()`.
+    /// All mutation operations will return EROFS.
+    pub fn read_only(mut self) -> Self {
+        self.read_only = true;
+        self
+    }
+
     /// Enable or disable strict mode.
     pub fn strict(mut self, enabled: bool) -> Self {
         self.strict = enabled;
@@ -141,13 +160,6 @@ impl OverlayFsBuilder {
 
     /// Build the OverlayFs instance.
     pub fn build(self) -> io::Result<OverlayFs> {
-        let upper_dir = self.upper_dir.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "upper directory not set")
-        })?;
-        let staging_dir = self.staging_dir.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "staging directory not set")
-        })?;
-
         if self.lowers.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -195,8 +207,97 @@ impl OverlayFsBuilder {
             });
         }
 
+        if self.read_only {
+            return self.build_read_only(
+                lowers,
+                #[cfg(target_os = "linux")]
+                proc_self_fd_main,
+            );
+        }
+
+        self.build_read_write(
+            lowers,
+            #[cfg(target_os = "linux")]
+            proc_self_fd_main,
+            #[cfg(target_os = "linux")]
+            has_openat2,
+        )
+    }
+
+    /// Build a read-only OverlayFs (no upper layer, no staging directory).
+    fn build_read_only(
+        self,
+        lowers: Vec<Layer>,
+        #[cfg(target_os = "linux")] proc_self_fd_main: File,
+    ) -> io::Result<OverlayFs> {
+        // Validate: writable/staging/writeback must not be set in read-only mode.
+        if self.writeback {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "writeback must not be set in read-only mode",
+            ));
+        }
+        if self.upper_dir.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "upper directory must not be set in read-only mode",
+            ));
+        }
+        if self.staging_dir.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "staging directory must not be set in read-only mode",
+            ));
+        }
+
+        let init_file = init_binary::create_init_file()?;
+
+        let cfg = OverlayConfig {
+            entry_timeout: self.entry_timeout,
+            attr_timeout: self.attr_timeout,
+            cache_policy: self.cache_policy,
+            writeback: false, // Force-disable in read-only mode.
+            read_only: true,
+        };
+
+        Ok(OverlayFs {
+            lowers,
+            upper: None,
+            staging_fd: None,
+            nodes: RwLock::new(BTreeMap::new()),
+            dentries: RwLock::new(BTreeMap::new()),
+            upper_alt_keys: RwLock::new(BTreeMap::new()),
+            lower_origin_keys: RwLock::new(BTreeMap::new()),
+            origin_index: RwLock::new(BTreeMap::new()),
+            next_inode: AtomicU64::new(3), // 1=root, 2=init
+            file_handles: RwLock::new(BTreeMap::new()),
+            dir_handles: RwLock::new(BTreeMap::new()),
+            next_handle: AtomicU64::new(1), // 0=init handle
+            writeback: AtomicBool::new(false),
+            init_file,
+            names: NameTable::new(),
+            #[cfg(target_os = "linux")]
+            proc_self_fd: proc_self_fd_main,
+            cfg,
+        })
+    }
+
+    /// Build a read-write OverlayFs with upper layer and staging directory.
+    fn build_read_write(
+        self,
+        lowers: Vec<Layer>,
+        #[cfg(target_os = "linux")] proc_self_fd_main: File,
+        #[cfg(target_os = "linux")] has_openat2: bool,
+    ) -> io::Result<OverlayFs> {
+        let upper_dir = self.upper_dir.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "upper directory not set")
+        })?;
+        let staging_dir = self.staging_dir.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "staging directory not set")
+        })?;
+
         // Open upper layer.
-        let upper_index = self.lowers.len();
+        let upper_index = lowers.len();
         let upper_root_fd = open_dir(&upper_dir)?;
 
         // Probe xattr support on upper if strict mode.
@@ -243,7 +344,6 @@ impl OverlayFsBuilder {
         // Clean leftover temp files in staging_dir.
         clean_staging_dir(&staging_fd)?;
 
-        // Create init binary file.
         let init_file = init_binary::create_init_file()?;
 
         let cfg = OverlayConfig {
@@ -251,12 +351,13 @@ impl OverlayFsBuilder {
             attr_timeout: self.attr_timeout,
             cache_policy: self.cache_policy,
             writeback: self.writeback,
+            read_only: false,
         };
 
         Ok(OverlayFs {
             lowers,
-            upper,
-            staging_fd,
+            upper: Some(upper),
+            staging_fd: Some(staging_fd),
             nodes: RwLock::new(BTreeMap::new()),
             dentries: RwLock::new(BTreeMap::new()),
             upper_alt_keys: RwLock::new(BTreeMap::new()),
@@ -269,6 +370,8 @@ impl OverlayFsBuilder {
             writeback: AtomicBool::new(false),
             init_file,
             names: NameTable::new(),
+            #[cfg(target_os = "linux")]
+            proc_self_fd: proc_self_fd_main,
             cfg,
         })
     }

--- a/crates/filesystem/lib/backends/overlayfs/copy_up.rs
+++ b/crates/filesystem/lib/backends/overlayfs/copy_up.rs
@@ -126,10 +126,10 @@ pub(crate) fn open_upper_parent_fd(fs: &OverlayFs, parent_ino: u64) -> io::Resul
 
     let state = parent_node.state.read().unwrap();
     match &*state {
-        NodeState::Root { upper_fd } => inode::dup_fd_raw(upper_fd.as_raw_fd()),
+        NodeState::Root { root_fd } => inode::dup_fd_raw(root_fd.as_raw_fd()),
         #[cfg(target_os = "linux")]
         NodeState::Upper { file, .. } => inode::reopen_fd_linux(
-            &fs.upper.proc_self_fd,
+            &fs.proc_self_fd,
             file.as_raw_fd(),
             libc::O_RDONLY | libc::O_DIRECTORY,
         ),
@@ -195,6 +195,14 @@ fn copy_up_regular(
         libc::close(fd);
     });
 
+    // Scopeguard to unlink temp file on error. Defused after successful renameat.
+    let staging_fd = fs.staging_fd.as_ref().unwrap().as_raw_fd();
+    let mut unlink_guard = scopeguard::guard(Some(temp_name.clone()), |name| {
+        if let Some(name) = name {
+            unsafe { libc::unlinkat(staging_fd, name.as_ptr(), 0) };
+        }
+    });
+
     // Copy file data.
     let st = platform::fstat(lower_fd)?;
     let file_size = st.st_size as u64;
@@ -212,7 +220,7 @@ fn copy_up_regular(
     // Atomic rename from staging_dir to upper parent.
     let ret = unsafe {
         libc::renameat(
-            fs.staging_fd.as_raw_fd(),
+            staging_fd,
             temp_name.as_ptr(),
             upper_parent_fd,
             name.as_ptr(),
@@ -220,10 +228,11 @@ fn copy_up_regular(
     };
     if ret < 0 {
         let err = io::Error::last_os_error();
-        // Clean up temp file on failure.
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
         return Err(platform::linux_error(err));
     }
+
+    // Defuse the unlink guard — renameat succeeded.
+    *unlink_guard = None;
 
     // fsync the destination parent for durability.
     fsync_fd(upper_parent_fd)?;
@@ -340,22 +349,25 @@ fn copy_up_symlink(
             let _close_temp = scopeguard::guard(temp_fd, |fd| unsafe {
                 libc::close(fd);
             });
+            let staging_fd_raw = fs.staging_fd.as_ref().unwrap().as_raw_fd();
+            let mut unlink_guard = scopeguard::guard(Some(temp_name.clone()), |name| {
+                if let Some(name) = name {
+                    unsafe { libc::unlinkat(staging_fd_raw, name.as_ptr(), 0) };
+                }
+            });
 
             let written =
                 unsafe { libc::write(temp_fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
             if written < 0 || (written as usize) != buf.len() {
-                unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
                 return Err(platform::eio());
             }
 
             // Create stat override (real symlinks don't have overlay xattrs).
             let mode = libc::S_IFLNK as u32 | (st.st_mode as u32 & 0o7777);
-            if let Err(e) = stat_override::set_override(temp_fd, st.st_uid, st.st_gid, mode, 0) {
-                unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-                return Err(e);
-            }
+            stat_override::set_override(temp_fd, st.st_uid, st.st_gid, mode, 0)?;
 
             stage_and_install(fs, temp_fd, &temp_name, &st, upper_parent_fd, name)?;
+            *unlink_guard = None;
         } else {
             // File-backed symlink on lower: reopen for data copy.
             let lower_fd = inode::open_node_fd(fs, node.inode, libc::O_RDONLY)?;
@@ -367,23 +379,25 @@ fn copy_up_symlink(
             let _close_temp = scopeguard::guard(temp_fd, |fd| unsafe {
                 libc::close(fd);
             });
+            let staging_fd_raw = fs.staging_fd.as_ref().unwrap().as_raw_fd();
+            let mut unlink_guard = scopeguard::guard(Some(temp_name.clone()), |name| {
+                if let Some(name) = name {
+                    unsafe { libc::unlinkat(staging_fd_raw, name.as_ptr(), 0) };
+                }
+            });
 
             copy_file_data(lower_fd, temp_fd, st.st_size as u64)?;
             copy_xattrs(lower_fd, temp_fd)?;
 
             stage_and_install(fs, temp_fd, &temp_name, &st, upper_parent_fd, name)?;
+            *unlink_guard = None;
         }
     }
 
     #[cfg(target_os = "macos")]
     {
-        // Open lower fd for xattr copy.
-        let lower_fd = inode::open_node_fd(fs, node.inode, libc::O_RDONLY)?;
-        let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe {
-            libc::close(fd);
-        });
-
-        // Read link target on macOS.
+        // Read link target on macOS using /.vol path.
+        // Cannot use open_node_fd(O_RDONLY) because O_NOFOLLOW on a symlink returns ELOOP on macOS.
         let state = node.state.read().unwrap();
         let (node_dev, node_ino) = match &*state {
             NodeState::Lower { dev, ino, .. } | NodeState::Upper { dev, ino, .. } => (*dev, *ino),
@@ -392,6 +406,20 @@ fn copy_up_symlink(
         drop(state);
 
         let vol = inode::vol_path(node_dev, node_ino);
+
+        // Open the lower symlink with O_SYMLINK for xattr copy and fstat.
+        let lower_fd = unsafe {
+            libc::open(
+                vol.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+            )
+        };
+        if lower_fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        let _close_lower = scopeguard::guard(lower_fd, |fd| unsafe {
+            libc::close(fd);
+        });
         let mut buf = vec![0u8; libc::PATH_MAX as usize];
         let len = unsafe {
             libc::readlink(
@@ -408,67 +436,55 @@ fn copy_up_symlink(
         let target = unsafe { CStr::from_bytes_with_nul_unchecked(&buf) };
 
         // Stage: create symlink in staging_dir, not directly in upper.
+        let staging_fd_raw = fs.staging_fd.as_ref().unwrap().as_raw_fd();
         let temp_name = create_temp_symlink_name(fs);
-        let ret = unsafe {
-            libc::symlinkat(
-                target.as_ptr(),
-                fs.staging_fd.as_raw_fd(),
-                temp_name.as_ptr(),
-            )
-        };
+        let ret = unsafe { libc::symlinkat(target.as_ptr(), staging_fd_raw, temp_name.as_ptr()) };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
 
-        // Fstat lower before opening the staged symlink so a failure here
-        // does not leak sym_fd or the temp file.
+        // Scopeguard to unlink staged symlink on error. Defused after renameat.
+        let mut unlink_guard = scopeguard::guard(Some(temp_name.clone()), |name| {
+            if let Some(name) = name {
+                unsafe { libc::unlinkat(staging_fd_raw, name.as_ptr(), 0) };
+            }
+        });
+
         let lower_st = platform::fstat(lower_fd)?;
 
         // Copy xattrs via O_SYMLINK fd on the staged symlink.
         let sym_fd = unsafe {
             libc::openat(
-                fs.staging_fd.as_raw_fd(),
+                staging_fd_raw,
                 temp_name.as_ptr(),
                 libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
             )
         };
         if sym_fd < 0 {
-            let err = io::Error::last_os_error();
-            unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-            return Err(platform::linux_error(err));
+            return Err(platform::linux_error(io::Error::last_os_error()));
         }
+        let _close_sym = scopeguard::guard(sym_fd, |fd| unsafe {
+            libc::close(fd);
+        });
 
-        let xattr_result = copy_xattrs(lower_fd, sym_fd);
-        let ts_result = if xattr_result.is_ok() {
-            apply_timestamps(sym_fd, &lower_st)
-        } else {
-            Ok(())
-        };
-        unsafe { libc::close(sym_fd) };
-
-        if let Err(e) = xattr_result {
-            unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-            return Err(e);
-        }
-        if let Err(e) = ts_result {
-            unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-            return Err(e);
-        }
+        copy_xattrs(lower_fd, sym_fd)?;
+        apply_timestamps(sym_fd, &lower_st)?;
 
         // Atomically install into upper.
         let ret = unsafe {
             libc::renameat(
-                fs.staging_fd.as_raw_fd(),
+                staging_fd_raw,
                 temp_name.as_ptr(),
                 upper_parent_fd,
                 name.as_ptr(),
             )
         };
         if ret < 0 {
-            let err = io::Error::last_os_error();
-            unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-            return Err(platform::linux_error(err));
+            return Err(platform::linux_error(io::Error::last_os_error()));
         }
+
+        // Defuse — renameat succeeded.
+        *unlink_guard = None;
     }
 
     // fsync the destination parent for durability.
@@ -502,41 +518,41 @@ fn copy_up_special(
         libc::close(fd);
     });
 
+    // Scopeguard to unlink temp file on error. Defused after renameat succeeds.
+    let staging_fd_raw = fs.staging_fd.as_ref().unwrap().as_raw_fd();
+    let mut unlink_guard = scopeguard::guard(Some(temp_name.clone()), |name| {
+        if let Some(name) = name {
+            unsafe { libc::unlinkat(staging_fd_raw, name.as_ptr(), 0) };
+        }
+    });
+
     // Fstat lower before creating temp file so failure doesn't leak it.
     let st = platform::fstat(lower_fd)?;
 
     // Copy xattrs from lower (which includes override with type/rdev info).
-    if let Err(e) = copy_xattrs(lower_fd, temp_fd) {
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(e);
-    }
+    copy_xattrs(lower_fd, temp_fd)?;
 
     // Preserve source timestamps.
-    if let Err(e) = apply_timestamps(temp_fd, &st) {
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(e);
-    }
+    apply_timestamps(temp_fd, &st)?;
 
     // fsync temp file.
-    if let Err(e) = fsync_fd(temp_fd) {
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(e);
-    }
+    fsync_fd(temp_fd)?;
 
     // Atomic rename from staging_dir to upper parent.
     let ret = unsafe {
         libc::renameat(
-            fs.staging_fd.as_raw_fd(),
+            staging_fd_raw,
             temp_name.as_ptr(),
             upper_parent_fd,
             name.as_ptr(),
         )
     };
     if ret < 0 {
-        let err = io::Error::last_os_error();
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(platform::linux_error(err));
+        return Err(platform::linux_error(io::Error::last_os_error()));
     }
+
+    // Defuse — renameat succeeded.
+    *unlink_guard = None;
 
     // fsync the destination parent for durability.
     fsync_fd(upper_parent_fd)?;
@@ -553,8 +569,7 @@ fn copy_up_special(
 
 /// Apply timestamps, fsync, and atomically install a staged temp file into the upper layer.
 ///
-/// On failure, cleans up the temp file. Used by `copy_up_symlink` to deduplicate
-/// the identical staging tail shared between the real-symlink and file-backed branches.
+/// Callers must provide a scopeguard for temp file cleanup on error.
 #[cfg(target_os = "linux")]
 fn stage_and_install(
     fs: &OverlayFs,
@@ -564,27 +579,19 @@ fn stage_and_install(
     upper_parent_fd: RawFd,
     name: &CStr,
 ) -> io::Result<()> {
-    if let Err(e) = apply_timestamps(temp_fd, st) {
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(e);
-    }
-    if let Err(e) = fsync_fd(temp_fd) {
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(e);
-    }
+    apply_timestamps(temp_fd, st)?;
+    fsync_fd(temp_fd)?;
 
     let ret = unsafe {
         libc::renameat(
-            fs.staging_fd.as_raw_fd(),
+            fs.staging_fd.as_ref().unwrap().as_raw_fd(),
             temp_name.as_ptr(),
             upper_parent_fd,
             name.as_ptr(),
         )
     };
     if ret < 0 {
-        let err = io::Error::last_os_error();
-        unsafe { libc::unlinkat(fs.staging_fd.as_raw_fd(), temp_name.as_ptr(), 0) };
-        return Err(platform::linux_error(err));
+        return Err(platform::linux_error(io::Error::last_os_error()));
     }
 
     Ok(())
@@ -1213,7 +1220,7 @@ fn create_temp_file(fs: &OverlayFs) -> io::Result<(RawFd, std::ffi::CString)> {
 
     let fd = unsafe {
         libc::openat(
-            fs.staging_fd.as_raw_fd(),
+            fs.staging_fd.as_ref().unwrap().as_raw_fd(),
             name_cstr.as_ptr(),
             libc::O_CREAT | libc::O_EXCL | libc::O_RDWR | libc::O_CLOEXEC,
             (libc::S_IRUSR | libc::S_IWUSR) as libc::c_uint,

--- a/crates/filesystem/lib/backends/overlayfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/create_ops.rs
@@ -45,6 +45,9 @@ pub(crate) fn do_create(
     umask: u32,
     _extensions: Extensions,
 ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -131,6 +134,9 @@ pub(crate) fn do_mkdir(
     umask: u32,
     _extensions: Extensions,
 ) -> io::Result<Entry> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -186,6 +192,9 @@ pub(crate) fn do_mknod(
     umask: u32,
     _extensions: Extensions,
 ) -> io::Result<Entry> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -240,6 +249,9 @@ pub(crate) fn do_symlink(
     name: &CStr,
     _extensions: Extensions,
 ) -> io::Result<Entry> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -336,6 +348,9 @@ pub(crate) fn do_link(
     newparent: u64,
     newname: &CStr,
 ) -> io::Result<Entry> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(newname)?;
 
     if init_binary::is_init_name(newname.to_bytes()) {

--- a/crates/filesystem/lib/backends/overlayfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/dir_ops.rs
@@ -65,8 +65,7 @@ pub(crate) fn do_readdir(
     _size: u32,
     offset: u64,
 ) -> io::Result<Vec<DirEntry<'static>>> {
-    let dir_entries = serve_snapshot_entries(fs, ino, handle, offset, true)?;
-    Ok(dir_entries)
+    serve_snapshot_entries(fs, ino, handle, offset, true)
 }
 
 /// Read directory entries with attributes (readdirplus).
@@ -227,8 +226,12 @@ fn build_snapshot(fs: &OverlayFs, ino: u64) -> io::Result<DirSnapshot> {
     let mut entries: Vec<MergedDirEntry> = Vec::new();
     let mut is_opaque = node.opaque.load(Ordering::Acquire);
 
-    // Phase 1: Scan upper layer.
-    let upper_dir_fd = inode::get_upper_dir_fd(fs, &node);
+    // Phase 1: Scan upper layer (skipped in read-only mode).
+    let upper_dir_fd = if fs.upper.is_some() {
+        inode::get_upper_dir_fd(fs, &node)
+    } else {
+        None
+    };
     if let Some(upper_fd_node) = upper_dir_fd {
         let upper_fd = upper_fd_node.raw();
         let raw_entries = layer::read_dir_entries_raw(upper_fd)?;
@@ -386,8 +389,12 @@ pub(crate) fn is_merged_dir_empty(fs: &OverlayFs, ino: u64) -> io::Result<bool> 
     let mut seen: HashSet<Vec<u8>> = HashSet::new();
     let mut is_opaque = node.opaque.load(Ordering::Acquire);
 
-    // Phase 1: Scan upper layer.
-    let upper_dir_fd = inode::get_upper_dir_fd(fs, &node);
+    // Phase 1: Scan upper layer (skipped in read-only mode).
+    let upper_dir_fd = if fs.upper.is_some() {
+        inode::get_upper_dir_fd(fs, &node)
+    } else {
+        None
+    };
     if let Some(upper_fd_node) = upper_dir_fd {
         let upper_fd = upper_fd_node.raw();
         let raw_entries = layer::read_dir_entries_raw(upper_fd)?;

--- a/crates/filesystem/lib/backends/overlayfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/file_ops.rs
@@ -44,6 +44,10 @@ pub(crate) fn do_open(
         || access_mode == libc::O_RDWR
         || open_flags & libc::O_TRUNC != 0;
 
+    if fs.cfg.read_only && is_write {
+        return Err(platform::erofs());
+    }
+
     // Copy-up before write opens.
     if is_write {
         copy_up::ensure_upper(fs, ino)?;
@@ -120,6 +124,9 @@ pub(crate) fn do_write(
     offset: u64,
     kill_priv: bool,
 ) -> io::Result<usize> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     if ino == init_binary::INIT_INODE {
         return Err(platform::eacces());
     }

--- a/crates/filesystem/lib/backends/overlayfs/inode.rs
+++ b/crates/filesystem/lib/backends/overlayfs/inode.rs
@@ -126,7 +126,11 @@ pub(crate) fn translate_open_flags(linux_flags_val: i32) -> i32 {
 /// all directories and metadata-bearing entries (those with overlay_origin
 /// or overlay_redirect xattrs).
 pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
-    let upper_fd = fs.upper.root_fd.as_raw_fd();
+    let upper_fd = if let Some(ref upper) = fs.upper {
+        upper.root_fd.as_raw_fd()
+    } else {
+        fs.lowers.last().unwrap().root_fd.as_raw_fd()
+    };
     let st = platform::fstat(upper_fd)?;
 
     // Create root node with Root state.
@@ -146,9 +150,7 @@ pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
         inode: ROOT_INODE,
         kind: libc::S_IFDIR as u32,
         lookup_refs: std::sync::atomic::AtomicU64::new(2), // libfuse convention
-        state: RwLock::new(NodeState::Root {
-            upper_fd: root_file,
-        }),
+        state: RwLock::new(NodeState::Root { root_fd: root_file }),
         opaque: std::sync::atomic::AtomicBool::new(false),
         copy_up_lock: Mutex::new(()),
         origin: None,
@@ -165,34 +167,36 @@ pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
     }
 
     // Register upper alt key for root.
-    #[cfg(target_os = "linux")]
-    {
-        let mut stx: libc::statx = unsafe { std::mem::zeroed() };
-        let ret = unsafe {
-            libc::statx(
-                upper_fd,
-                c"".as_ptr(),
-                libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW | libc::AT_STATX_SYNC_AS_STAT,
-                libc::STATX_BASIC_STATS | libc::STATX_MNT_ID,
-                &mut stx,
-            )
-        };
-        if ret >= 0 {
-            let alt_key = InodeAltKey::new(
-                stx.stx_ino,
-                stx.stx_dev_major as u64 * 256 + stx.stx_dev_minor as u64,
-                stx.stx_mnt_id,
-            );
+    if fs.upper.is_some() {
+        #[cfg(target_os = "linux")]
+        {
+            let mut stx: libc::statx = unsafe { std::mem::zeroed() };
+            let ret = unsafe {
+                libc::statx(
+                    upper_fd,
+                    c"".as_ptr(),
+                    libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW | libc::AT_STATX_SYNC_AS_STAT,
+                    libc::STATX_BASIC_STATS | libc::STATX_MNT_ID,
+                    &mut stx,
+                )
+            };
+            if ret >= 0 {
+                let alt_key = InodeAltKey::new(
+                    stx.stx_ino,
+                    stx.stx_dev_major as u64 * 256 + stx.stx_dev_minor as u64,
+                    stx.stx_mnt_id,
+                );
+                let mut upper_alt = fs.upper_alt_keys.write().unwrap();
+                upper_alt.insert(alt_key, ROOT_INODE);
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let alt_key = InodeAltKey::new(st.st_ino as u64, st.st_dev as u64);
             let mut upper_alt = fs.upper_alt_keys.write().unwrap();
             upper_alt.insert(alt_key, ROOT_INODE);
         }
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        let alt_key = InodeAltKey::new(st.st_ino as u64, st.st_dev as u64);
-        let mut upper_alt = fs.upper_alt_keys.write().unwrap();
-        upper_alt.insert(alt_key, ROOT_INODE);
     }
 
     // Check if root is opaque.
@@ -201,7 +205,9 @@ pub(crate) fn register_root_inode(fs: &OverlayFs) -> io::Result<()> {
     }
 
     // BFS hydrate the upper layer to rebuild origin_index and redirect state.
-    bfs_hydrate_upper(fs)?;
+    if fs.upper.is_some() {
+        bfs_hydrate_upper(fs)?;
+    }
 
     Ok(())
 }
@@ -220,7 +226,7 @@ fn bfs_hydrate_upper(fs: &OverlayFs) -> io::Result<()> {
     use super::{origin, types::RedirectState};
     use std::collections::VecDeque;
 
-    let upper_fd = fs.upper.root_fd.as_raw_fd();
+    let upper_fd = fs.upper.as_ref().unwrap().root_fd.as_raw_fd();
     let root_dir_fd = dup_fd_raw(upper_fd)?;
 
     let mut queue: VecDeque<(RawFd, u64)> = VecDeque::new();
@@ -546,41 +552,46 @@ pub(crate) fn do_lookup(fs: &OverlayFs, parent: u64, name: &CStr) -> io::Result<
     };
 
     // Try upper layer first.
-    let upper_parent_fd = get_upper_dir_fd(fs, &parent_node);
+    if fs.upper.is_some() {
+        let upper_parent_fd = get_upper_dir_fd(fs, &parent_node);
 
-    if let Some(ref upper_fd_node) = upper_parent_fd {
-        let upper_fd = upper_fd_node.raw();
+        if let Some(ref upper_fd_node) = upper_parent_fd {
+            let upper_fd = upper_fd_node.raw();
 
-        // Check whiteout in upper.
-        if layer::check_whiteout(upper_fd, name.to_bytes())? {
-            return Err(platform::enoent());
-        }
-
-        // Check if entry exists in upper.
-        #[cfg(target_os = "linux")]
-        let upper_flags = libc::O_PATH | libc::O_NOFOLLOW;
-        #[cfg(target_os = "macos")]
-        let upper_flags = libc::O_RDONLY | libc::O_NOFOLLOW;
-
-        match layer::open_child_beneath(
-            upper_fd,
-            name,
-            upper_flags,
-            #[cfg(target_os = "linux")]
-            fs.upper.has_openat2,
-            #[cfg(target_os = "macos")]
-            false,
-        ) {
-            Ok(fd) => {
-                return resolve_upper(fs, parent, name, fd);
+            // Check whiteout in upper.
+            if layer::check_whiteout(upper_fd, name.to_bytes())? {
+                return Err(platform::enoent());
             }
-            Err(e) if platform::is_enoent(&e) => {}
-            Err(e) => return Err(e),
+
+            // Check if entry exists in upper.
+            #[cfg(target_os = "linux")]
+            let upper_flags = libc::O_PATH | libc::O_NOFOLLOW;
+            #[cfg(target_os = "macos")]
+            let upper_flags = libc::O_RDONLY | libc::O_NOFOLLOW;
+
+            match layer::open_child_beneath(
+                upper_fd,
+                name,
+                upper_flags,
+                #[cfg(target_os = "linux")]
+                fs.upper.as_ref().unwrap().has_openat2,
+                #[cfg(target_os = "macos")]
+                false,
+            ) {
+                Ok(fd) => {
+                    return resolve_upper(fs, parent, name, fd);
+                }
+                Err(e) if platform::is_enoent(&e) => {}
+                Err(e) => return Err(e),
+            }
         }
     }
 
-    // If parent is opaque, don't search lowers.
-    if parent_node.opaque.load(Ordering::Acquire) {
+    // If parent is opaque AND we already checked the upper, don't search lowers.
+    // In read-only mode (no upper), the opaque dir's entries live on a lower layer,
+    // so we must still search lowers — the per-layer opaque check inside the loop
+    // handles stopping at the correct layer.
+    if fs.upper.is_some() && parent_node.opaque.load(Ordering::Acquire) {
         return Err(platform::enoent());
     }
 
@@ -825,11 +836,26 @@ fn resolve_lower(
 ) -> io::Result<Entry> {
     // Open fd to get xattr override. On Linux, keep the fd for reuse as the
     // O_PATH pinning fd (avoids a redundant second open_lower_child_fd call).
-    let lower_fd = open_lower_child_fd(lower_layer, parent, name, fs)?;
+    //
+    // On macOS, symlinks cannot be opened with O_NOFOLLOW (returns ELOOP) and
+    // cannot carry user xattrs, so skip the fd-based override for symlinks.
+    #[cfg(target_os = "macos")]
+    let is_symlink = (st.st_mode as u32) & (libc::S_IFMT as u32) == (libc::S_IFLNK as u32);
+    #[cfg(target_os = "linux")]
+    let is_symlink = false; // Linux uses O_PATH which works on symlinks.
+
+    let (lower_fd, patched) = if is_symlink {
+        (-1, st)
+    } else {
+        let fd = open_lower_child_fd(lower_layer, parent, name, fs)?;
+        let p = stat_override::patched_stat(fd, st)?;
+        (fd, p)
+    };
     let _close = scopeguard::guard(lower_fd, |fd| unsafe {
-        libc::close(fd);
+        if fd >= 0 {
+            libc::close(fd);
+        }
     });
-    let patched = stat_override::patched_stat(lower_fd, st)?;
 
     // Construct origin ID for hardlink unification.
     let origin_id = LowerOriginId::new(lower_layer.index, st.st_ino);
@@ -837,7 +863,7 @@ fn resolve_lower(
 
     // Check if this origin was already copied up (cross-copy-up dedup).
     // If so, resolve to the existing upper node instead of creating a new Lower node.
-    {
+    if !fs.cfg.read_only {
         let origin_idx = fs.origin_index.read().unwrap();
         if let Some(&existing_ino) = origin_idx.get(&origin_id) {
             let nodes = fs.nodes.read().unwrap();
@@ -1044,16 +1070,20 @@ pub(crate) fn forget_one_locked(
 /// Must be called AFTER releasing nodes/dentries write locks to avoid
 /// lock ordering deadlocks.
 fn cleanup_dedup_maps(fs: &OverlayFs, inode: u64, origin: Option<LowerOriginId>) {
-    // Remove from upper_alt_keys (scan — alt_key not stored on node).
-    fs.upper_alt_keys
-        .write()
-        .unwrap()
-        .retain(|_, &mut v| v != inode);
+    // Always clean lower_origin_keys (populated for lower-layer hardlinks even in read-only mode).
+    // Only clean upper_alt_keys and origin_index in writable mode.
+    if !fs.cfg.read_only {
+        fs.upper_alt_keys
+            .write()
+            .unwrap()
+            .retain(|_, &mut v| v != inode);
+    }
 
-    // Remove from origin-based maps if the node had an origin.
     if let Some(origin_id) = origin {
         fs.lower_origin_keys.write().unwrap().remove(&origin_id);
-        fs.origin_index.write().unwrap().remove(&origin_id);
+        if !fs.cfg.read_only {
+            fs.origin_index.write().unwrap().remove(&origin_id);
+        }
     }
 }
 
@@ -1061,20 +1091,28 @@ fn cleanup_dedup_maps(fs: &OverlayFs, inode: u64, origin: Option<LowerOriginId>)
 ///
 /// Called from batch_forget after releasing nodes/dentries locks.
 pub(crate) fn cleanup_dedup_maps_batch(fs: &OverlayFs, removed: &[(u64, Option<LowerOriginId>)]) {
-    // Collect removed inodes for efficient set lookup.
-    let removed_set: HashSet<u64> = removed.iter().map(|(ino, _)| *ino).collect();
+    // Always clean lower_origin_keys (populated for lower-layer hardlinks even in read-only mode).
+    // Only clean upper_alt_keys and origin_index in writable mode.
+    if !fs.cfg.read_only {
+        let removed_set: HashSet<u64> = removed.iter().map(|(ino, _)| *ino).collect();
 
-    fs.upper_alt_keys
-        .write()
-        .unwrap()
-        .retain(|_, v| !removed_set.contains(v));
+        fs.upper_alt_keys
+            .write()
+            .unwrap()
+            .retain(|_, v| !removed_set.contains(v));
+
+        let mut origin_idx = fs.origin_index.write().unwrap();
+        for (_, origin) in removed {
+            if let Some(origin_id) = origin {
+                origin_idx.remove(origin_id);
+            }
+        }
+    }
 
     let mut origin_keys = fs.lower_origin_keys.write().unwrap();
-    let mut origin_idx = fs.origin_index.write().unwrap();
     for (_, origin) in removed {
         if let Some(origin_id) = origin {
             origin_keys.remove(origin_id);
-            origin_idx.remove(origin_id);
         }
     }
 }
@@ -1092,9 +1130,9 @@ pub(crate) fn stat_node(fs: &OverlayFs, inode: u64) -> io::Result<stat64> {
 
     let state = node.state.read().unwrap();
     match &*state {
-        NodeState::Root { upper_fd } => {
-            let st = platform::fstat(upper_fd.as_raw_fd())?;
-            stat_override::patched_stat(upper_fd.as_raw_fd(), st)
+        NodeState::Root { root_fd } => {
+            let st = platform::fstat(root_fd.as_raw_fd())?;
+            stat_override::patched_stat(root_fd.as_raw_fd(), st)
         }
         #[cfg(target_os = "linux")]
         NodeState::Lower { file, .. } | NodeState::Upper { file, .. } => {
@@ -1126,8 +1164,8 @@ pub(crate) fn open_node_fd(fs: &OverlayFs, inode: u64, flags: i32) -> io::Result
 
     let state = node.state.read().unwrap();
     match &*state {
-        NodeState::Root { upper_fd } => {
-            let fd = unsafe { libc::fcntl(upper_fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+        NodeState::Root { root_fd } => {
+            let fd = unsafe { libc::fcntl(root_fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
             if fd < 0 {
                 return Err(platform::linux_error(io::Error::last_os_error()));
             }
@@ -1135,13 +1173,25 @@ pub(crate) fn open_node_fd(fs: &OverlayFs, inode: u64, flags: i32) -> io::Result
         }
         #[cfg(target_os = "linux")]
         NodeState::Lower { file, .. } | NodeState::Upper { file, .. } => {
-            reopen_fd_linux(&fs.upper.proc_self_fd, file.as_raw_fd(), flags)
+            reopen_fd_linux(&fs.proc_self_fd, file.as_raw_fd(), flags)
         }
         #[cfg(target_os = "macos")]
         NodeState::Lower { ino, dev, .. } | NodeState::Upper { ino, dev, .. } => {
             let path = vol_path(*dev, *ino);
             let fd =
                 unsafe { libc::open(path.as_ptr(), flags | libc::O_CLOEXEC | libc::O_NOFOLLOW) };
+            if fd >= 0 {
+                return Ok(fd);
+            }
+            // Only fall back to O_SYMLINK for ELOOP (symlink with O_NOFOLLOW).
+            // Other errors (EACCES, ENOENT, etc.) should propagate immediately.
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() != Some(libc::ELOOP) {
+                return Err(platform::linux_error(err));
+            }
+            // O_SYMLINK opens the symlink itself (not its target) on macOS.
+            let fd =
+                unsafe { libc::open(path.as_ptr(), flags | libc::O_CLOEXEC | libc::O_SYMLINK) };
             if fd < 0 {
                 return Err(platform::linux_error(io::Error::last_os_error()));
             }
@@ -1180,15 +1230,15 @@ fn make_entry(
 pub(crate) fn get_upper_dir_fd(fs: &OverlayFs, parent_node: &OverlayNode) -> Option<NodeFd> {
     let state = parent_node.state.read().unwrap();
     match &*state {
-        NodeState::Root { upper_fd } => Some(NodeFd {
-            fd: upper_fd.as_raw_fd(),
+        NodeState::Root { root_fd } => Some(NodeFd {
+            fd: root_fd.as_raw_fd(),
             owned: false,
         }),
         NodeState::Upper { .. } => {
             #[cfg(target_os = "linux")]
             if let NodeState::Upper { file, .. } = &*state {
                 if let Ok(fd) = reopen_fd_linux(
-                    &fs.upper.proc_self_fd,
+                    &fs.proc_self_fd,
                     file.as_raw_fd(),
                     libc::O_RDONLY | libc::O_DIRECTORY,
                 ) {
@@ -1448,19 +1498,35 @@ fn open_lower_child_fd(
                 libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
             )
         };
-        if fd < 0 {
-            // Try as directory.
-            let fd = unsafe {
-                libc::openat(
-                    parent_fd_node.raw(),
-                    name.as_ptr(),
-                    libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
-                )
-            };
-            if fd < 0 {
-                return Err(platform::linux_error(io::Error::last_os_error()));
-            }
+        if fd >= 0 {
             return Ok(fd);
+        }
+        // Try as directory.
+        let fd = unsafe {
+            libc::openat(
+                parent_fd_node.raw(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+            )
+        };
+        if fd >= 0 {
+            return Ok(fd);
+        }
+        // Only fall back to O_SYMLINK for ELOOP (symlink with O_NOFOLLOW).
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ELOOP) {
+            return Err(platform::linux_error(err));
+        }
+        // O_SYMLINK opens the symlink itself (not its target) on macOS.
+        let fd = unsafe {
+            libc::openat(
+                parent_fd_node.raw(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+            )
+        };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
         }
         Ok(fd)
     }
@@ -1536,9 +1602,12 @@ pub(crate) fn vol_path(dev: u64, ino: u64) -> CString {
 }
 
 /// Open a /.vol path on macOS.
+///
+/// Tries O_RDONLY first, then O_DIRECTORY for directories. If ELOOP is returned
+/// (symlink with O_NOFOLLOW), falls back to O_SYMLINK which opens the symlink
+/// itself without following it.
 #[cfg(target_os = "macos")]
 fn open_macos_vol(path: &CStr) -> io::Result<RawFd> {
-    // Try O_RDONLY first, then O_RDONLY | O_DIRECTORY.
     let fd = unsafe {
         libc::open(
             path.as_ptr(),
@@ -1552,6 +1621,21 @@ fn open_macos_vol(path: &CStr) -> io::Result<RawFd> {
         libc::open(
             path.as_ptr(),
             libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+        )
+    };
+    if fd >= 0 {
+        return Ok(fd);
+    }
+    // Only fall back to O_SYMLINK for ELOOP (symlink with O_NOFOLLOW).
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() != Some(libc::ELOOP) {
+        return Err(platform::linux_error(err));
+    }
+    // O_SYMLINK opens the symlink itself (not its target) on macOS.
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
         )
     };
     if fd >= 0 {

--- a/crates/filesystem/lib/backends/overlayfs/metadata.rs
+++ b/crates/filesystem/lib/backends/overlayfs/metadata.rs
@@ -47,6 +47,9 @@ pub(crate) fn do_setattr(
     _handle: Option<u64>,
     valid: SetattrValid,
 ) -> io::Result<(stat64, Duration)> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     if ino == init_binary::INIT_INODE {
         return Err(platform::eacces());
     }
@@ -168,6 +171,10 @@ pub(crate) fn do_access(fs: &OverlayFs, ctx: Context, ino: u64, mask: u32) -> io
     // F_OK: just check existence.
     if mask == libc::F_OK as u32 {
         return Ok(());
+    }
+
+    if fs.cfg.read_only && mask & libc::W_OK as u32 != 0 {
+        return Err(platform::erofs());
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/filesystem/lib/backends/overlayfs/mod.rs
+++ b/crates/filesystem/lib/backends/overlayfs/mod.rs
@@ -58,11 +58,11 @@ pub struct OverlayFs {
     /// Read-only lower layers (bottom-to-top order, index 0 = bottommost).
     pub(crate) lowers: Vec<Layer>,
 
-    /// Writable upper layer.
-    pub(crate) upper: Layer,
+    /// Writable upper layer (`None` in read-only mode).
+    pub(crate) upper: Option<Layer>,
 
-    /// Staging directory fd (same filesystem as upper, for atomic copy-up).
-    pub(crate) staging_fd: File,
+    /// Staging directory fd (`None` in read-only mode).
+    pub(crate) staging_fd: Option<File>,
 
     /// Inode table: FUSE inode → OverlayNode.
     pub(crate) nodes: RwLock<BTreeMap<u64, Arc<OverlayNode>>>,
@@ -99,6 +99,10 @@ pub struct OverlayFs {
 
     /// Name interning table for path components.
     pub(crate) names: NameTable,
+
+    /// Linux: /proc/self/fd handle for secure inode reopening.
+    #[cfg(target_os = "linux")]
+    pub(crate) proc_self_fd: File,
 
     /// Configuration.
     pub(crate) cfg: OverlayConfig,
@@ -144,25 +148,28 @@ impl DynFileSystem for OverlayFs {
 
         let mut opts = FsOptions::empty();
 
-        let wanted = FsOptions::DONT_MASK
-            | FsOptions::BIG_WRITES
-            | FsOptions::ASYNC_READ
-            | FsOptions::PARALLEL_DIROPS
-            | FsOptions::MAX_PAGES
-            | FsOptions::HANDLE_KILLPRIV_V2;
-        opts |= capable & wanted;
+        // Read-relevant capabilities (always requested).
+        let read_wanted = FsOptions::ASYNC_READ | FsOptions::PARALLEL_DIROPS | FsOptions::MAX_PAGES;
+        opts |= capable & read_wanted;
 
         if capable.contains(FsOptions::DO_READDIRPLUS) {
             opts |= FsOptions::DO_READDIRPLUS | FsOptions::READDIRPLUS_AUTO;
         }
 
-        if self.cfg.writeback && capable.contains(FsOptions::WRITEBACK_CACHE) {
-            opts |= FsOptions::WRITEBACK_CACHE;
-            self.writeback.store(true, Ordering::Relaxed);
-        }
+        // Write-relevant capabilities (skipped in read-only mode).
+        if !self.cfg.read_only {
+            let write_wanted =
+                FsOptions::DONT_MASK | FsOptions::BIG_WRITES | FsOptions::HANDLE_KILLPRIV_V2;
+            opts |= capable & write_wanted;
 
-        // Clear umask so the client can set all mode bits.
-        unsafe { libc::umask(0o000) };
+            if self.cfg.writeback && capable.contains(FsOptions::WRITEBACK_CACHE) {
+                opts |= FsOptions::WRITEBACK_CACHE;
+                self.writeback.store(true, Ordering::Relaxed);
+            }
+
+            // Clear umask so the client can set all mode bits.
+            unsafe { libc::umask(0o000) };
+        }
 
         Ok(opts)
     }

--- a/crates/filesystem/lib/backends/overlayfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/remove_ops.rs
@@ -46,6 +46,9 @@ const KNOWN_RENAME_FLAGS: u32 = RENAME_NOREPLACE | RENAME_EXCHANGE;
 /// and is not a directory. Ensures the parent is on upper, unlinks the upper
 /// entry if present, and creates a whiteout if the name exists on lower layers.
 pub(crate) fn do_unlink(fs: &OverlayFs, _ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -100,6 +103,9 @@ pub(crate) fn do_unlink(fs: &OverlayFs, _ctx: Context, parent: u64, name: &CStr)
 /// is a directory, and is empty across all layers. Ensures the parent is on
 /// upper, removes the upper entry and creates a whiteout if needed.
 pub(crate) fn do_rmdir(fs: &OverlayFs, _ctx: Context, parent: u64, name: &CStr) -> io::Result<()> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(name)?;
 
     if init_binary::is_init_name(name.to_bytes()) {
@@ -168,6 +174,9 @@ pub(crate) fn do_rename(
     newname: &CStr,
     flags: u32,
 ) -> io::Result<()> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     name_validation::validate_overlay_name(oldname)?;
     name_validation::validate_overlay_name(newname)?;
 

--- a/crates/filesystem/lib/backends/overlayfs/special.rs
+++ b/crates/filesystem/lib/backends/overlayfs/special.rs
@@ -15,7 +15,10 @@ use crate::{
 
 /// Get filesystem statistics from the upper layer.
 pub(crate) fn do_statfs(fs: &OverlayFs, _ctx: Context, _ino: u64) -> io::Result<statvfs64> {
-    let fd = fs.upper.root_fd.as_raw_fd();
+    let fd = match &fs.upper {
+        Some(upper) => upper.root_fd.as_raw_fd(),
+        None => fs.lowers.last().unwrap().root_fd.as_raw_fd(),
+    };
 
     #[cfg(target_os = "linux")]
     {
@@ -52,6 +55,10 @@ pub(crate) fn do_fsync(
 
     let handles = fs.file_handles.read().unwrap();
     let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+
+    if fs.cfg.read_only {
+        return Ok(());
+    }
     #[allow(clippy::readonly_write_lock)]
     let f = data.file.write().unwrap();
     let fd = f.as_raw_fd();
@@ -86,6 +93,10 @@ pub(crate) fn do_fsyncdir(
     _handle: u64,
 ) -> io::Result<()> {
     if ino == init_binary::INIT_INODE {
+        return Ok(());
+    }
+
+    if fs.cfg.read_only {
         return Ok(());
     }
 
@@ -153,6 +164,9 @@ pub(crate) fn do_fallocate(
     offset: u64,
     length: u64,
 ) -> io::Result<()> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     if ino == init_binary::INIT_INODE {
         return Err(platform::eacces());
     }
@@ -232,6 +246,9 @@ pub(crate) fn do_copyfilerange(
     len: u64,
     flags: u64,
 ) -> io::Result<usize> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     if inode_in == init_binary::INIT_INODE || inode_out == init_binary::INIT_INODE {
         return Err(platform::enosys());
     }

--- a/crates/filesystem/lib/backends/overlayfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/mod.rs
@@ -11,6 +11,7 @@ mod test_index;
 mod test_lookup;
 mod test_metadata;
 mod test_multi_layer;
+mod test_read_only;
 mod test_readdir;
 mod test_remove_ops;
 mod test_rename;
@@ -47,6 +48,7 @@ const LINUX_EACCES: i32 = 13;
 const LINUX_EEXIST: i32 = 17;
 const LINUX_EINVAL: i32 = 22;
 const LINUX_ENOTEMPTY: i32 = 39;
+const LINUX_EROFS: i32 = 30;
 const LINUX_ENODATA: i32 = 61;
 
 /// Root inode number (FUSE convention).
@@ -79,6 +81,83 @@ struct MockZeroCopyWriter {
 struct MockZeroCopyReader {
     data: Vec<u8>,
     pos: usize,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn root_ctx() -> Context {
+    Context {
+        uid: 0,
+        gid: 0,
+        pid: 1,
+    }
+}
+
+fn make_cstr(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+fn fs_lookup(fs: &OverlayFs, parent: u64, name: &str) -> io::Result<Entry> {
+    fs.lookup(root_ctx(), parent, &make_cstr(name))
+}
+
+fn fs_lookup_root(fs: &OverlayFs, name: &str) -> io::Result<Entry> {
+    fs_lookup(fs, ROOT_INODE, name)
+}
+
+fn fs_fuse_open(fs: &OverlayFs, inode: u64, flags: u32) -> io::Result<u64> {
+    let (handle, _opts) = fs.open(root_ctx(), inode, false, flags)?;
+    Ok(handle.unwrap())
+}
+
+fn fs_fuse_opendir(fs: &OverlayFs, inode: u64) -> io::Result<u64> {
+    let (handle, _opts) = fs.opendir(root_ctx(), inode, 0)?;
+    Ok(handle.unwrap())
+}
+
+fn fs_fuse_read(
+    fs: &OverlayFs,
+    inode: u64,
+    handle: u64,
+    size: u32,
+    offset: u64,
+) -> io::Result<Vec<u8>> {
+    let mut writer = MockZeroCopyWriter::new();
+    let n = fs.read(
+        root_ctx(),
+        inode,
+        handle,
+        &mut writer,
+        size,
+        offset,
+        None,
+        0,
+    )?;
+    let mut data = writer.into_data();
+    data.truncate(n);
+    Ok(data)
+}
+
+fn fs_readdir_names(fs: &OverlayFs, inode: u64) -> io::Result<Vec<Vec<u8>>> {
+    let handle = fs_fuse_opendir(fs, inode)?;
+    let entries = fs.readdir(root_ctx(), inode, handle, 65536, 0)?;
+    let names = entries.iter().map(|e| e.name.to_vec()).collect();
+    fs.releasedir(root_ctx(), inode, 0, handle)?;
+    Ok(names)
+}
+
+fn assert_errno<T>(result: io::Result<T>, expected_errno: i32) {
+    match result {
+        Ok(_) => panic!("expected errno {expected_errno}, got Ok"),
+        Err(err) => assert_eq!(
+            err.raw_os_error(),
+            Some(expected_errno),
+            "expected errno {expected_errno}, got {:?}",
+            err
+        ),
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -136,11 +215,7 @@ impl OverlayTestSandbox {
 
     /// Get a default Context (uid=0, gid=0 — root user).
     fn ctx(&self) -> Context {
-        Context {
-            uid: 0,
-            gid: 0,
-            pid: 1,
-        }
+        root_ctx()
     }
 
     /// Get a Context with specific uid/gid.
@@ -150,17 +225,17 @@ impl OverlayTestSandbox {
 
     /// Make a CString from a &str (panics on embedded nul).
     fn cstr(s: &str) -> CString {
-        CString::new(s).unwrap()
+        make_cstr(s)
     }
 
     /// Lookup a name in a parent directory.
     fn lookup(&self, parent: u64, name: &str) -> io::Result<Entry> {
-        self.fs.lookup(self.ctx(), parent, &Self::cstr(name))
+        fs_lookup(&self.fs, parent, name)
     }
 
     /// Lookup a name in the root directory.
     fn lookup_root(&self, name: &str) -> io::Result<Entry> {
-        self.lookup(ROOT_INODE, name)
+        fs_lookup_root(&self.fs, name)
     }
 
     /// Create a file via the FUSE create() operation. Returns (Entry, handle).
@@ -202,14 +277,12 @@ impl OverlayTestSandbox {
 
     /// Open a file by inode. Returns handle.
     fn fuse_open(&self, inode: u64, flags: u32) -> io::Result<u64> {
-        let (handle, _opts) = self.fs.open(self.ctx(), inode, false, flags)?;
-        Ok(handle.unwrap())
+        fs_fuse_open(&self.fs, inode, flags)
     }
 
     /// Open a directory by inode. Returns handle.
     fn fuse_opendir(&self, inode: u64) -> io::Result<u64> {
-        let (handle, _opts) = self.fs.opendir(self.ctx(), inode, 0)?;
-        Ok(handle.unwrap())
+        fs_fuse_opendir(&self.fs, inode)
     }
 
     /// Write data to a file handle via MockZeroCopyReader.
@@ -231,29 +304,12 @@ impl OverlayTestSandbox {
 
     /// Read data from a file handle via MockZeroCopyWriter.
     fn fuse_read(&self, inode: u64, handle: u64, size: u32, offset: u64) -> io::Result<Vec<u8>> {
-        let mut writer = MockZeroCopyWriter::new();
-        let n = self.fs.read(
-            self.ctx(),
-            inode,
-            handle,
-            &mut writer,
-            size,
-            offset,
-            None,
-            0,
-        )?;
-        let mut data = writer.into_data();
-        data.truncate(n);
-        Ok(data)
+        fs_fuse_read(&self.fs, inode, handle, size, offset)
     }
 
     /// Collect all entry names from readdir on the given inode.
     fn readdir_names(&self, inode: u64) -> io::Result<Vec<Vec<u8>>> {
-        let handle = self.fuse_opendir(inode)?;
-        let entries = self.fs.readdir(self.ctx(), inode, handle, 65536, 0)?;
-        let names = entries.iter().map(|e| e.name.to_vec()).collect();
-        self.fs.releasedir(self.ctx(), inode, 0, handle)?;
-        Ok(names)
+        fs_readdir_names(&self.fs, inode)
     }
 
     /// Check if a whiteout marker exists on the upper layer.
@@ -269,15 +325,82 @@ impl OverlayTestSandbox {
 
     /// Assert that an io::Result is an error with the expected Linux errno.
     fn assert_errno<T>(result: io::Result<T>, expected_errno: i32) {
-        match result {
-            Ok(_) => panic!("expected errno {expected_errno}, got Ok"),
-            Err(err) => assert_eq!(
-                err.raw_os_error(),
-                Some(expected_errno),
-                "expected errno {expected_errno}, got {:?}",
-                err
-            ),
+        assert_errno(result, expected_errno)
+    }
+}
+
+/// Test harness providing a read-only OverlayFs (no upper layer).
+struct ReadOnlyOverlayTestSandbox {
+    fs: OverlayFs,
+    _tmp: TempDir,
+}
+
+impl ReadOnlyOverlayTestSandbox {
+    /// Create a read-only sandbox with 1 lower layer. `f` populates before mount.
+    fn with_lower(f: impl FnOnce(&Path)) -> Self {
+        Self::with_layers(1, |lowers| {
+            f(&lowers[0]);
+        })
+    }
+
+    /// Create a read-only sandbox with N lower layers.
+    fn with_layers(n: usize, f: impl FnOnce(&[PathBuf])) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mut lower_roots = Vec::with_capacity(n);
+        for i in 0..n {
+            let lower = tmp.path().join(format!("lower_{i}"));
+            std::fs::create_dir(&lower).unwrap();
+            lower_roots.push(lower);
         }
+
+        f(&lower_roots);
+
+        let mut builder = OverlayFs::builder();
+        for lower in &lower_roots {
+            builder = builder.layer(lower);
+        }
+        let fs = builder.read_only().build().unwrap();
+
+        fs.init(FsOptions::empty()).unwrap();
+
+        Self { fs, _tmp: tmp }
+    }
+
+    fn ctx(&self) -> Context {
+        root_ctx()
+    }
+
+    fn cstr(s: &str) -> CString {
+        make_cstr(s)
+    }
+
+    fn lookup(&self, parent: u64, name: &str) -> io::Result<Entry> {
+        fs_lookup(&self.fs, parent, name)
+    }
+
+    fn lookup_root(&self, name: &str) -> io::Result<Entry> {
+        fs_lookup_root(&self.fs, name)
+    }
+
+    fn fuse_open(&self, inode: u64, flags: u32) -> io::Result<u64> {
+        fs_fuse_open(&self.fs, inode, flags)
+    }
+
+    fn fuse_opendir(&self, inode: u64) -> io::Result<u64> {
+        fs_fuse_opendir(&self.fs, inode)
+    }
+
+    fn fuse_read(&self, inode: u64, handle: u64, size: u32, offset: u64) -> io::Result<Vec<u8>> {
+        fs_fuse_read(&self.fs, inode, handle, size, offset)
+    }
+
+    fn readdir_names(&self, inode: u64) -> io::Result<Vec<Vec<u8>>> {
+        fs_readdir_names(&self.fs, inode)
+    }
+
+    fn assert_errno<T>(result: io::Result<T>, expected_errno: i32) {
+        assert_errno(result, expected_errno)
     }
 }
 

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_read_only.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_read_only.rs
@@ -1,0 +1,537 @@
+//! Tests for read-only overlay mode (no upper layer).
+
+use super::*;
+
+//--------------------------------------------------------------------------------------------------
+// Tests: Builder
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_builder_read_only_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lower = tmp.path().join("lower");
+    std::fs::create_dir(&lower).unwrap();
+
+    let fs = OverlayFs::builder()
+        .layer(&lower)
+        .read_only()
+        .build()
+        .unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+}
+
+#[test]
+fn test_builder_read_only_rejects_writable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lower = tmp.path().join("lower");
+    let upper = tmp.path().join("upper");
+    std::fs::create_dir(&lower).unwrap();
+    std::fs::create_dir(&upper).unwrap();
+
+    match OverlayFs::builder()
+        .layer(&lower)
+        .writable(&upper)
+        .read_only()
+        .build()
+    {
+        Ok(_) => panic!("expected read_only + writable to be rejected"),
+        Err(e) => assert!(e.to_string().contains("must not be set")),
+    }
+}
+
+#[test]
+fn test_builder_read_only_rejects_staging() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lower = tmp.path().join("lower");
+    let staging = tmp.path().join("staging");
+    std::fs::create_dir(&lower).unwrap();
+    std::fs::create_dir(&staging).unwrap();
+
+    match OverlayFs::builder()
+        .layer(&lower)
+        .staging(&staging)
+        .read_only()
+        .build()
+    {
+        Ok(_) => panic!("expected read_only + staging to be rejected"),
+        Err(e) => assert!(e.to_string().contains("must not be set")),
+    }
+}
+
+#[test]
+fn test_builder_read_only_requires_lower() {
+    match OverlayFs::builder().read_only().build() {
+        Ok(_) => panic!("expected missing lower layer to be rejected"),
+        Err(e) => assert!(e.to_string().contains("lower layer")),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: EROFS on mutation operations
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_erofs_create() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|_| {});
+    let result = sb.fs.create(
+        sb.ctx(),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("new_file"),
+        0o644,
+        false,
+        libc::O_RDWR as u32,
+        0,
+        Extensions::default(),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result.map(|_| ()), LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_mkdir() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|_| {});
+    let result = sb.fs.mkdir(
+        sb.ctx(),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("new_dir"),
+        0o755,
+        0,
+        Extensions::default(),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_mknod() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|_| {});
+    let result = sb.fs.mknod(
+        sb.ctx(),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("new_node"),
+        libc::S_IFREG as u32 | 0o644,
+        0,
+        0,
+        Extensions::default(),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_symlink() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|_| {});
+    let result = sb.fs.symlink(
+        sb.ctx(),
+        &ReadOnlyOverlayTestSandbox::cstr("/target"),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("new_link"),
+        Extensions::default(),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_unlink() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let result = sb.fs.unlink(
+        sb.ctx(),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("file"),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_rmdir() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::create_dir(lower.join("subdir")).unwrap();
+    });
+    let result = sb.fs.rmdir(
+        sb.ctx(),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("subdir"),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_rename() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("old"), b"data").unwrap();
+    });
+    let result = sb.fs.rename(
+        sb.ctx(),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("old"),
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("new"),
+        0,
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_setattr() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let result = sb.fs.setattr(
+        sb.ctx(),
+        entry.inode,
+        unsafe { std::mem::zeroed() },
+        None,
+        SetattrValid::MODE,
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_setxattr() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let result = sb.fs.setxattr(
+        sb.ctx(),
+        entry.inode,
+        &ReadOnlyOverlayTestSandbox::cstr("user.test"),
+        b"value",
+        0,
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_removexattr() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let result = sb.fs.removexattr(
+        sb.ctx(),
+        entry.inode,
+        &ReadOnlyOverlayTestSandbox::cstr("user.test"),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_write() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let result = sb.fs.write(
+        sb.ctx(),
+        entry.inode,
+        0,
+        &mut MockZeroCopyReader::new(b"new data".to_vec()),
+        8,
+        0,
+        None,
+        false,
+        false,
+        0,
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_link() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let result = sb.fs.link(
+        sb.ctx(),
+        entry.inode,
+        ROOT_INODE,
+        &ReadOnlyOverlayTestSandbox::cstr("hardlink"),
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+}
+
+#[test]
+fn test_erofs_fallocate() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
+    let result = sb.fs.fallocate(sb.ctx(), entry.inode, handle, 0, 0, 1024);
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+    sb.fs
+        .release(sb.ctx(), entry.inode, 0, handle, false, false, None)
+        .unwrap();
+}
+
+#[test]
+fn test_erofs_copyfilerange() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("src"), b"data").unwrap();
+        std::fs::write(lower.join("dst"), b"data").unwrap();
+    });
+    let src = sb.lookup_root("src").unwrap();
+    let dst = sb.lookup_root("dst").unwrap();
+    let src_handle = sb.fuse_open(src.inode, libc::O_RDONLY as u32).unwrap();
+    let dst_handle = sb.fuse_open(dst.inode, libc::O_RDONLY as u32).unwrap();
+    let result = sb.fs.copyfilerange(
+        sb.ctx(),
+        src.inode,
+        src_handle,
+        0,
+        dst.inode,
+        dst_handle,
+        0,
+        4,
+        0,
+    );
+    ReadOnlyOverlayTestSandbox::assert_errno(result, LINUX_EROFS);
+    sb.fs
+        .release(sb.ctx(), src.inode, 0, src_handle, false, false, None)
+        .unwrap();
+    sb.fs
+        .release(sb.ctx(), dst.inode, 0, dst_handle, false, false, None)
+        .unwrap();
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: Open flags enforcement
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_erofs_open_write_mode() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+
+    // O_WRONLY rejected.
+    ReadOnlyOverlayTestSandbox::assert_errno(
+        sb.fuse_open(entry.inode, libc::O_WRONLY as u32),
+        LINUX_EROFS,
+    );
+
+    // O_RDWR rejected.
+    ReadOnlyOverlayTestSandbox::assert_errno(
+        sb.fuse_open(entry.inode, libc::O_RDWR as u32),
+        LINUX_EROFS,
+    );
+}
+
+#[test]
+fn test_open_rdonly_works() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"hello").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+
+    // O_RDONLY succeeds.
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
+    sb.fs
+        .release(sb.ctx(), entry.inode, 0, handle, false, false, None)
+        .unwrap();
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: access(W_OK)
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_erofs_access_w_ok() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+
+    // W_OK returns EROFS.
+    ReadOnlyOverlayTestSandbox::assert_errno(
+        sb.fs.access(sb.ctx(), entry.inode, libc::W_OK as u32),
+        LINUX_EROFS,
+    );
+
+    // R_OK still works.
+    sb.fs
+        .access(sb.ctx(), entry.inode, libc::R_OK as u32)
+        .unwrap();
+
+    // F_OK still works.
+    sb.fs
+        .access(sb.ctx(), entry.inode, libc::F_OK as u32)
+        .unwrap();
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: Read operations work
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_read_only_lookup() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"hello").unwrap();
+        std::fs::create_dir(lower.join("subdir")).unwrap();
+    });
+
+    let file_entry = sb.lookup_root("file").unwrap();
+    assert_ne!(file_entry.inode, 0);
+
+    let dir_entry = sb.lookup_root("subdir").unwrap();
+    assert_ne!(dir_entry.inode, 0);
+
+    // Nonexistent returns ENOENT.
+    ReadOnlyOverlayTestSandbox::assert_errno(sb.lookup_root("missing"), LINUX_ENOENT);
+}
+
+#[test]
+fn test_read_only_getattr() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"hello world").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let (st, _timeout) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    assert_eq!(st.st_size, 11); // "hello world"
+}
+
+#[test]
+fn test_read_only_read_file() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"hello world").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
+    let data = sb.fuse_read(entry.inode, handle, 1024, 0).unwrap();
+    assert_eq!(data, b"hello world");
+    sb.fs
+        .release(sb.ctx(), entry.inode, 0, handle, false, false, None)
+        .unwrap();
+}
+
+#[test]
+fn test_read_only_readdir() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("a"), b"").unwrap();
+        std::fs::write(lower.join("b"), b"").unwrap();
+        std::fs::create_dir(lower.join("c")).unwrap();
+    });
+    let names = sb.readdir_names(ROOT_INODE).unwrap();
+    assert!(names.contains(&b"a".to_vec()));
+    assert!(names.contains(&b"b".to_vec()));
+    assert!(names.contains(&b"c".to_vec()));
+}
+
+#[test]
+fn test_read_only_statfs() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|_| {});
+    let st = sb.fs.statfs(sb.ctx(), ROOT_INODE).unwrap();
+    // Should return valid statfs from the lower layer.
+    assert!(st.f_bsize > 0);
+}
+
+#[test]
+fn test_read_only_readlink() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::os::unix::fs::symlink("/target/path", lower.join("link")).unwrap();
+    });
+    let entry = sb.lookup_root("link").unwrap();
+    let target = sb.fs.readlink(sb.ctx(), entry.inode).unwrap();
+    assert_eq!(target, b"/target/path");
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: Multi-layer whiteout correctness
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_read_only_whiteout_masks_lower() {
+    let sb = ReadOnlyOverlayTestSandbox::with_layers(2, |lowers| {
+        // Layer 0 (bottom): has "file"
+        std::fs::write(lowers[0].join("file"), b"base data").unwrap();
+        // Layer 1 (top): has whiteout for "file"
+        std::fs::write(lowers[1].join(".wh.file"), b"").unwrap();
+    });
+
+    // "file" should NOT be visible (masked by whiteout on top layer).
+    ReadOnlyOverlayTestSandbox::assert_errno(sb.lookup_root("file"), LINUX_ENOENT);
+}
+
+#[test]
+fn test_read_only_opaque_masks_all_below() {
+    let sb = ReadOnlyOverlayTestSandbox::with_layers(2, |lowers| {
+        // Layer 0 (bottom): has subdir with file
+        std::fs::create_dir(lowers[0].join("subdir")).unwrap();
+        std::fs::write(lowers[0].join("subdir").join("old_file"), b"data").unwrap();
+
+        // Layer 1 (top): has opaque subdir with different file
+        std::fs::create_dir(lowers[1].join("subdir")).unwrap();
+        std::fs::write(lowers[1].join("subdir").join(".wh..wh..opq"), b"").unwrap();
+        std::fs::write(lowers[1].join("subdir").join("new_file"), b"new").unwrap();
+    });
+
+    let subdir = sb.lookup_root("subdir").unwrap();
+
+    // new_file should be visible via lookup (it's on the opaque layer).
+    sb.lookup(subdir.inode, "new_file").unwrap();
+
+    // old_file should NOT be visible (opaque dir hides everything below).
+    ReadOnlyOverlayTestSandbox::assert_errno(sb.lookup(subdir.inode, "old_file"), LINUX_ENOENT);
+}
+
+#[test]
+fn test_read_only_multi_layer_merge() {
+    let sb = ReadOnlyOverlayTestSandbox::with_layers(3, |lowers| {
+        // Layer 0: base files.
+        std::fs::write(lowers[0].join("base"), b"base").unwrap();
+        std::fs::write(lowers[0].join("override_me"), b"v1").unwrap();
+
+        // Layer 1: overrides one file, adds another.
+        std::fs::write(lowers[1].join("override_me"), b"v2").unwrap();
+        std::fs::write(lowers[1].join("layer1_only"), b"l1").unwrap();
+
+        // Layer 2: adds a file, whiteouts base.
+        std::fs::write(lowers[2].join("layer2_only"), b"l2").unwrap();
+        std::fs::write(lowers[2].join(".wh.base"), b"").unwrap();
+    });
+
+    // "base" is whiteout'd by layer 2.
+    ReadOnlyOverlayTestSandbox::assert_errno(sb.lookup_root("base"), LINUX_ENOENT);
+
+    // "override_me" comes from layer 1 (higher wins).
+    let entry = sb.lookup_root("override_me").unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
+    let data = sb.fuse_read(entry.inode, handle, 1024, 0).unwrap();
+    assert_eq!(data, b"v2");
+    sb.fs
+        .release(sb.ctx(), entry.inode, 0, handle, false, false, None)
+        .unwrap();
+
+    // Both layer-specific files visible.
+    sb.lookup_root("layer1_only").unwrap();
+    sb.lookup_root("layer2_only").unwrap();
+
+    // Readdir shows correct set.
+    let names = sb.readdir_names(ROOT_INODE).unwrap();
+    assert!(!names.contains(&b"base".to_vec()));
+    assert!(names.contains(&b"override_me".to_vec()));
+    assert!(names.contains(&b"layer1_only".to_vec()));
+    assert!(names.contains(&b"layer2_only".to_vec()));
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: No-op sync operations
+//--------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_read_only_flush_noop() {
+    let sb = ReadOnlyOverlayTestSandbox::with_lower(|lower| {
+        std::fs::write(lower.join("file"), b"data").unwrap();
+    });
+    let entry = sb.lookup_root("file").unwrap();
+    let handle = sb.fuse_open(entry.inode, libc::O_RDONLY as u32).unwrap();
+
+    // flush should succeed (no-op).
+    sb.fs.flush(sb.ctx(), entry.inode, handle, 0).unwrap();
+    sb.fs
+        .release(sb.ctx(), entry.inode, 0, handle, false, false, None)
+        .unwrap();
+}

--- a/crates/filesystem/lib/backends/overlayfs/types.rs
+++ b/crates/filesystem/lib/backends/overlayfs/types.rs
@@ -39,6 +39,12 @@ pub struct OverlayConfig {
 
     /// Enable writeback caching (default: false).
     pub writeback: bool,
+
+    /// Read-only mode (default: false).
+    ///
+    /// When true, no writable upper layer exists. All mutation operations
+    /// return EROFS. Copy-up is disabled. The merged view is immutable.
+    pub read_only: bool,
 }
 
 /// Cache policy for FUSE open options.
@@ -94,8 +100,8 @@ pub(crate) struct OverlayNode {
 pub(crate) enum NodeState {
     /// The overlay root directory.
     Root {
-        /// Fd to the upper layer's root directory.
-        upper_fd: File,
+        /// Fd to the root directory (upper layer in rw mode, top lower in ro mode).
+        root_fd: File,
     },
 
     /// Entry lives on a read-only lower layer.

--- a/crates/filesystem/lib/backends/overlayfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/xattr_ops.rs
@@ -35,16 +35,8 @@ use super::{
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Check if an xattr name is an internal overlay key that should be hidden.
-fn is_internal_xattr(name: &CStr) -> bool {
-    name == stat_override::OVERRIDE_XATTR_KEY
-        || name == ORIGIN_XATTR_KEY
-        || name == REDIRECT_XATTR_KEY
-        || name == TOMBSTONES_XATTR_KEY
-}
-
-/// Check if a raw xattr name matches any internal key.
-fn is_internal_xattr_bytes(name: &[u8]) -> bool {
+/// Check if an xattr name matches any internal overlay key that should be hidden.
+fn is_internal_xattr(name: &[u8]) -> bool {
     name == stat_override::OVERRIDE_XATTR_KEY.to_bytes()
         || name == ORIGIN_XATTR_KEY.to_bytes()
         || name == REDIRECT_XATTR_KEY.to_bytes()
@@ -64,7 +56,7 @@ pub(crate) fn do_getxattr(
     }
 
     // Block reads of internal xattrs.
-    if is_internal_xattr(name) {
+    if is_internal_xattr(name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -209,28 +201,64 @@ pub(crate) fn do_listxattr(
         // Exhausted retries — the xattr list keeps changing.
         Err(platform::eio())
     } else {
-        let mut buf = vec![0u8; size as usize];
+        // Cannot pass the guest's `size` directly to the kernel because it was
+        // computed from the *filtered* byte count (internal xattrs removed).
+        // The raw kernel list is larger, so we must read the full list, filter,
+        // and then check whether the filtered result fits.
+        for _ in 0..3 {
+            #[cfg(target_os = "linux")]
+            let raw_size = unsafe {
+                libc::listxattr(
+                    path.as_ptr() as *const libc::c_char,
+                    std::ptr::null_mut(),
+                    0,
+                )
+            };
 
-        #[cfg(target_os = "linux")]
-        let ret = unsafe {
-            libc::listxattr(
-                path.as_ptr() as *const libc::c_char,
-                buf.as_mut_ptr() as *mut libc::c_char,
-                buf.len(),
-            )
-        };
+            #[cfg(target_os = "macos")]
+            let raw_size = unsafe { libc::flistxattr(fd, std::ptr::null_mut(), 0, 0) };
 
-        #[cfg(target_os = "macos")]
-        let ret =
-            unsafe { libc::flistxattr(fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len(), 0) };
+            if raw_size < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
 
-        if ret < 0 {
-            return Err(platform::linux_error(io::Error::last_os_error()));
+            if raw_size == 0 {
+                return Ok(ListxattrReply::Names(Vec::new()));
+            }
+
+            let mut buf = vec![0u8; raw_size as usize];
+
+            #[cfg(target_os = "linux")]
+            let ret = unsafe {
+                libc::listxattr(
+                    path.as_ptr() as *const libc::c_char,
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            };
+
+            #[cfg(target_os = "macos")]
+            let ret = unsafe {
+                libc::flistxattr(fd, buf.as_mut_ptr() as *mut libc::c_char, buf.len(), 0)
+            };
+
+            if ret < 0 {
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::ERANGE) {
+                    continue;
+                }
+                return Err(platform::linux_error(err));
+            }
+            buf.truncate(ret as usize);
+
+            let filtered = filter_internal_xattrs(&buf);
+            if filtered.len() > size as usize {
+                return Err(platform::erange());
+            }
+            return Ok(ListxattrReply::Names(filtered));
         }
-        buf.truncate(ret as usize);
 
-        let filtered = filter_internal_xattrs(&buf);
-        Ok(ListxattrReply::Names(filtered))
+        Err(platform::eio())
     }
 }
 
@@ -245,10 +273,13 @@ pub(crate) fn do_setxattr(
     value: &[u8],
     flags: u32,
 ) -> io::Result<()> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     if ino == init_binary::INIT_INODE {
         return Err(platform::eacces());
     }
-    if is_internal_xattr(name) {
+    if is_internal_xattr(name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -307,10 +338,13 @@ pub(crate) fn do_removexattr(
     ino: u64,
     name: &CStr,
 ) -> io::Result<()> {
+    if fs.cfg.read_only {
+        return Err(platform::erofs());
+    }
     if ino == init_binary::INIT_INODE {
         return Err(platform::eacces());
     }
-    if is_internal_xattr(name) {
+    if is_internal_xattr(name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -375,7 +409,7 @@ fn filter_internal_xattrs(names: &[u8]) -> Vec<u8> {
         if entry.is_empty() {
             continue;
         }
-        if !is_internal_xattr_bytes(entry) {
+        if !is_internal_xattr(entry) {
             result.extend_from_slice(entry);
             result.push(0);
         }

--- a/crates/filesystem/lib/backends/shared/platform.rs
+++ b/crates/filesystem/lib/backends/shared/platform.rs
@@ -56,6 +56,7 @@ const LINUX_EROFS: i32 = 30;
 const LINUX_EMLINK: i32 = 31;
 const LINUX_EPIPE: i32 = 32;
 const LINUX_EDOM: i32 = 33;
+const LINUX_ERANGE: i32 = 34;
 const LINUX_EDEADLK: i32 = 35;
 const LINUX_ENAMETOOLONG: i32 = 36;
 const LINUX_ENOLCK: i32 = 37;
@@ -321,7 +322,12 @@ pub(crate) fn enxio() -> io::Error {
 
 /// Create an `io::Error` with Linux `ERANGE`.
 pub(crate) fn erange() -> io::Error {
-    io::Error::from_raw_os_error(34) // LINUX_ERANGE
+    io::Error::from_raw_os_error(LINUX_ERANGE)
+}
+
+/// Create an `io::Error` with Linux `EROFS`.
+pub(crate) fn erofs() -> io::Error {
+    io::Error::from_raw_os_error(LINUX_EROFS)
 }
 
 /// Check if an error is ENOENT.

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -243,19 +243,6 @@ fn build_overlay_rootfs(
         "overlay rootfs requires at least one lower layer"
     );
 
-    let upper_dir = upper_dir.ok_or_else(|| {
-        msb_krun::Error::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "overlay rootfs requires a writable upper directory",
-        ))
-    })?;
-    let staging_dir = staging_dir.ok_or_else(|| {
-        msb_krun::Error::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "overlay rootfs requires a staging directory",
-        ))
-    })?;
-
     let mut overlay_builder = OverlayFs::builder();
 
     for layer in layers {
@@ -268,7 +255,20 @@ fn build_overlay_rootfs(
         }
     }
 
-    overlay_builder = overlay_builder.writable(upper_dir).staging(staging_dir);
+    match (upper_dir, staging_dir) {
+        (Some(upper), Some(staging)) => {
+            overlay_builder = overlay_builder.writable(upper).staging(staging);
+        }
+        (None, None) => {
+            overlay_builder = overlay_builder.read_only();
+        }
+        _ => {
+            return Err(msb_krun::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "overlay rootfs: upper_dir and staging_dir must both be set or both be omitted",
+            )));
+        }
+    }
 
     overlay_builder.build().map_err(msb_krun::Error::Io)
 }
@@ -343,37 +343,32 @@ mod tests {
     }
 
     #[test]
-    fn test_build_overlay_rootfs_requires_upper() {
+    fn test_build_overlay_rootfs_rejects_mismatched_upper_staging() {
         let temp = tempdir().unwrap();
         let lower = create_dir(temp.path(), "lower.extracted");
         let staging = create_dir(temp.path(), "staging");
 
-        let err = match build_overlay_rootfs(&[lower], None, Some(&staging)) {
-            Ok(_) => panic!("expected missing upper dir to be rejected"),
-            Err(err) => err,
-        };
+        // upper missing but staging present → error
+        match build_overlay_rootfs(&[lower.clone()], None, Some(&staging)) {
+            Ok(_) => panic!("expected mismatched upper/staging to be rejected"),
+            Err(err) => assert!(err.to_string().contains("both be set or both be omitted")),
+        }
 
-        assert!(
-            err.to_string()
-                .contains("overlay rootfs requires a writable upper directory")
-        );
+        // upper present but staging missing → error
+        let upper = create_dir(temp.path(), "rw");
+        match build_overlay_rootfs(&[lower], Some(&upper), None) {
+            Ok(_) => panic!("expected mismatched upper/staging to be rejected"),
+            Err(err) => assert!(err.to_string().contains("both be set or both be omitted")),
+        }
     }
 
     #[test]
-    fn test_build_overlay_rootfs_requires_staging() {
+    fn test_build_overlay_rootfs_read_only() {
         let temp = tempdir().unwrap();
         let lower = create_dir(temp.path(), "lower.extracted");
-        let upper = create_dir(temp.path(), "rw");
 
-        let err = match build_overlay_rootfs(&[lower], Some(&upper), None) {
-            Ok(_) => panic!("expected missing staging dir to be rejected"),
-            Err(err) => err,
-        };
-
-        assert!(
-            err.to_string()
-                .contains("overlay rootfs requires a staging directory")
-        );
+        // Both None → read-only mode (should succeed).
+        build_overlay_rootfs(&[lower], None, None).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add read-only mode to OverlayFs where the upper layer is optional and all mutation operations return EROFS, enabling immutable container rootfs with only lower layers
- Fix temp file leaks in all copy-up functions using defusable scopeguards instead of manual error-branch unlinks
- Fix macOS symlink handling across `open_node_fd`, `open_macos_vol`, and `open_lower_child_fd` by adding `O_SYMLINK` fallback gated on ELOOP (macOS returns ELOOP for `O_NOFOLLOW` on symlinks, unlike Linux `O_PATH|O_NOFOLLOW`)
- Fix `do_listxattr` ERANGE bug where the filtered xattr size was passed to the kernel instead of querying the raw size first

## Changes

**Builder and config (`builder.rs`, `types.rs`):**
- Add `.read_only()` builder method, mutually exclusive with `.writable()`, `.staging()`, and `.writeback()`
- `upper` and `staging_fd` become `Option<T>`, set to `None` in read-only mode
- Add `read_only: bool` to `OverlayConfig`
- Rename `NodeState::Root { upper_fd }` to `{ root_fd }` (uses top lower layer fd when no upper)
- Split `build()` into `build_read_only()` and `build_read_write()` paths

**EROFS guards (`create_ops.rs`, `file_ops.rs`, `metadata.rs`, `remove_ops.rs`, `special.rs`, `xattr_ops.rs`, `mod.rs`):**
- Add EROFS early return on all 14 mutation operations: create, mkdir, mknod, symlink, link, unlink, rmdir, rename, setattr, write, setxattr, removexattr, fallocate, copyfilerange
- Reject write-mode opens (O_WRONLY, O_RDWR, O_TRUNC) in `do_open`
- Return EROFS for `access(W_OK)`

**Read-only optimizations (`inode.rs`, `dir_ops.rs`):**
- Skip upper layer scan in `do_lookup`, `build_snapshot`, `is_merged_dir_empty`
- Skip `origin_index` check in `resolve_lower` (always empty in read-only)
- Skip `upper_alt_keys`/`origin_index` cleanup in `cleanup_dedup_maps` (empty maps)
- Always clean `lower_origin_keys` (needed for intra-layer hardlink dedup even in read-only)
- Skip BFS hydration and upper alt key registration at init
- Fix opaque directory handling: in read-only mode, still search lowers since opaque dir entries live on lower layers

**macOS symlink fixes (`inode.rs`, `copy_up.rs`):**
- `open_node_fd`: Add `O_SYMLINK` fallback when `O_NOFOLLOW` returns `ELOOP`
- `open_macos_vol`: Add `O_SYMLINK` as third fallback after `O_RDONLY` and `O_DIRECTORY`
- `open_lower_child_fd`: Add `O_SYMLINK` as third fallback
- All fallbacks are gated on `ELOOP` only -- other errors propagate immediately
- `resolve_lower`: Skip `open_lower_child_fd` for symlinks on macOS (symlinks cannot carry user xattrs)
- `copy_up_symlink` macOS branch: Use `O_SYMLINK` to open lower symlink fd

**Temp file leak fixes (`copy_up.rs`):**
- `copy_up_regular`: Add defusable `unlinkat` scopeguard after `create_temp_file`, defused after `renameat`
- `copy_up_symlink` (Linux real-symlink, file-backed, and macOS branches): Same scopeguard pattern
- `copy_up_special`: Replace manual `if let Err` unlink pattern with scopeguard
- `stage_and_install`: Simplified to use `?` since callers now own scopeguards

**Xattr fixes (`xattr_ops.rs`):**
- Fix `do_listxattr` ERANGE: `size != 0` branch now queries full raw kernel size, reads, filters, then checks against guest size
- Merge `is_internal_xattr` and `is_internal_xattr_bytes` into a single `is_internal_xattr(&[u8])` function

**Other fixes (`special.rs`, `file_ops.rs`, `platform.rs`, `dir_ops.rs`):**
- Remove `do_flush` read-only guard (flush is a read-safe fd health check via dup+close)
- Move `do_fsync`/`do_fsyncdir` read-only guards after handle validation (bogus handles now return EBADF)
- Add `LINUX_ERANGE` constant (was magic number 34)
- Simplify `do_readdir` return

**Tests (`tests/mod.rs`, `tests/test_read_only.rs`):**
- Add `test_read_only.rs` with 31 tests covering builder validation, EROFS guards on all mutation ops, open flags enforcement, access checks, read operations, multi-layer whiteout/opaque correctness, and readlink
- Extract shared test helpers (`root_ctx`, `make_cstr`, `fs_lookup`, `fs_fuse_open`, `fs_fuse_read`, `fs_readdir_names`, `assert_errno`) into free functions to deduplicate between `OverlayTestSandbox` and `ReadOnlyOverlayTestSandbox`

**Runtime (`vm.rs`):**
- Update `build_overlay_rootfs` to handle optional upper/staging via `match (upper_dir, staging_dir)`

## Test Plan

- Run overlay test suite: `cargo test -p microsandbox-filesystem -- overlayfs::tests`
  - All 226 tests pass (195 existing + 31 new read-only tests)
- Run full crate tests: `cargo test -p microsandbox-filesystem`
- Verify compilation: `cargo check -p microsandbox-filesystem`
- Verify clippy: `cargo clippy -p microsandbox-filesystem`
- Key test scenarios covered:
  - Builder rejects `read_only + writable`, `read_only + staging`, `read_only + writeback`
  - All 14 mutation ops return EROFS in read-only mode
  - Read operations (lookup, getattr, read, readdir, statfs, readlink) work in read-only mode
  - Multi-layer whiteout masking and opaque directory handling work correctly
  - EROFS tests use valid file handles to prove guard ordering