### PR TITLE
feat(sandbox): add disk image rootfs support (qcow2, raw, vmdk)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03891ebc2f62bf58f7627ea5caf7d71c7a9486ab51a5079dbe18705aafabbfa2"
+checksum = "05cf928e5eee0283f5e41fe49dc040b1d15e67c829128ea3d870f1ab03eafd51"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5526c95301fbff464a271d80c3e68ffdda0543c1a9a334731e38de9034641b2b"
+checksum = "d8539fa4ad87eb9ba9698b2040b70d673fbadea4bdcf70e97f7f42a4b44f4d4d"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2102,15 +2102,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661a455f6a52567d447b0eafe56d926f53f87e592c1e78178a178fb3c342f7a4"
+checksum = "0f6f42fbd5c75f4dc3de4c0725bdd150fabfc11118cf01e539a5ae4f29a4d76c"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aaeda4fce3795390610de7df73c02d4a389fc8f402487ed1de9b1b5d9ebb4b"
+checksum = "13f59b88fc46690b413b55db3d6c7f1bfc31ee5190f5a56222e0877753e98f20"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -2119,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448723903cf94b929bbcdec529b1dc0a1de0ed812efeb8a1524d50d0440ee71e"
+checksum = "f9a4d976af9809ef83e15e5145c2876cd1b855763e4800f643f1c31cfd69bd14"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -2147,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b1ce5bf7776773fed6a78d7aecc789f96a975cad37400615d28a1308689ca"
+checksum = "8d2f8b8cc85742698dc430f1787cff6824a5d7dd1db8a2327403db6d631f66ad"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5ae836b8a2327078a6b902c75b96d1ef85bec94f24bd5dabc50d3ca767b2ed"
+checksum = "54cdb45537ba5f3c04d32b59b6935c7cce08e53d8cda44f319bb796b1d7465b3"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -2169,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180b96e962b122b841f5479df8591f814da512bf638448256d6837b94ccb25c6"
+checksum = "b10c517e067576e43979d122a57e63dcf6770a0565bb7199ad2893c38ef193a8"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -2179,18 +2179,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017d30f52205a049602ed42f8668f0c2b00f681ca1a7294beff51dcee69c86d9"
+checksum = "d7aa527f08bc50d2f4bc977088239ac2e8231118cbe2171170bd1b4883652294"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64353c1e846e4dce67fa1dd84f947cb79528d9b141a45223cdcc7f18001f263a"
+checksum = "24b63adfdcfd9135ac775ae69ab89042774cde40652c43e7779b1db65f746328"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4011f7168a4af998929340cae8a119743fab754a35a2ba6a5c3951939e0d23"
+checksum = "a4d5680cb7e5af8cd1dfb74afa26cad714523760c02b3e87f2385a23fe55ac9a"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -19,6 +19,14 @@ struct TmpfsSpec<'a> {
     noexec: bool,
 }
 
+/// Parsed block-device root specification.
+#[derive(Debug)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+struct BlockRootSpec<'a> {
+    device: &'a str,
+    fstype: Option<&'a str>,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -31,6 +39,7 @@ struct TmpfsSpec<'a> {
 pub fn init() -> AgentdResult<()> {
     linux::mount_filesystems()?;
     linux::mount_runtime()?;
+    linux::mount_block_root()?;
     linux::apply_tmpfs_mounts()?;
     linux::create_run_dir()?;
     Ok(())
@@ -83,6 +92,32 @@ fn parse_tmpfs_entry(entry: &str) -> AgentdResult<TmpfsSpec<'_>> {
     })
 }
 
+/// Parses a block-device root specification: `device[,fstype=TYPE]`
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_block_root(val: &str) -> AgentdResult<BlockRootSpec<'_>> {
+    let mut parts = val.split(',');
+    let device = parts.next().unwrap();
+    if device.is_empty() {
+        return Err(AgentdError::Init("MSB_BLOCK_ROOT has empty device path".into()));
+    }
+
+    let mut fstype = None;
+    for opt in parts {
+        if let Some(val) = opt.strip_prefix("fstype=") {
+            if val.is_empty() {
+                return Err(AgentdError::Init("MSB_BLOCK_ROOT has empty fstype value".into()));
+            }
+            fstype = Some(val);
+        } else {
+            return Err(AgentdError::Init(format!(
+                "unknown MSB_BLOCK_ROOT option: {opt}"
+            )));
+        }
+    }
+
+    Ok(BlockRootSpec { device, fstype })
+}
+
 //--------------------------------------------------------------------------------------------------
 // Modules
 //--------------------------------------------------------------------------------------------------
@@ -94,11 +129,11 @@ mod linux {
 
     use nix::mount::{MsFlags, mount};
     use nix::sys::stat::Mode;
-    use nix::unistd::mkdir;
+    use nix::unistd::{chdir, chroot, mkdir};
 
     use crate::error::{AgentdError, AgentdResult};
 
-    use super::TmpfsSpec;
+    use super::{BlockRootSpec, TmpfsSpec};
 
     /// Mounts essential Linux filesystems.
     pub fn mount_filesystems() -> AgentdResult<()> {
@@ -188,6 +223,112 @@ mod linux {
             None::<&str>,
         )?;
         Ok(())
+    }
+
+    /// Mounts a block device as the new root filesystem, if `MSB_BLOCK_ROOT` is set.
+    ///
+    /// Steps: mount block device at `/newroot`, bind-mount `/.msb` into it,
+    /// pivot via `MS_MOVE` + `chroot`, then re-mount essential filesystems.
+    pub fn mount_block_root() -> AgentdResult<()> {
+        let val = match std::env::var(microsandbox_protocol::ENV_BLOCK_ROOT) {
+            Ok(v) if !v.is_empty() => v,
+            _ => return Ok(()),
+        };
+
+        let spec = super::parse_block_root(&val)?;
+
+        // Create the temporary mount point.
+        mkdir_ignore_exists("/newroot")?;
+
+        // Mount the block device.
+        if let Some(fstype) = spec.fstype {
+            mount(
+                Some(spec.device),
+                "/newroot",
+                Some(fstype),
+                MsFlags::empty(),
+                None::<&str>,
+            )
+            .map_err(|e| {
+                AgentdError::Init(format!(
+                    "failed to mount {} at /newroot as {fstype}: {e}",
+                    spec.device
+                ))
+            })?;
+        } else {
+            try_mount(spec.device, "/newroot")?;
+        }
+
+        // Bind-mount the runtime filesystem into the new root.
+        let msb_target = "/newroot/.msb";
+        mkdir_ignore_exists(msb_target)?;
+        mount(
+            Some(microsandbox_protocol::RUNTIME_MOUNT_POINT),
+            msb_target,
+            None::<&str>,
+            MsFlags::MS_BIND,
+            None::<&str>,
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to bind-mount /.msb into /newroot: {e}")))?;
+
+        // Pivot: move the new root on top of /.
+        chdir("/newroot")
+            .map_err(|e| AgentdError::Init(format!("failed to chdir /newroot: {e}")))?;
+
+        mount(
+            Some("."),
+            "/",
+            None::<&str>,
+            MsFlags::MS_MOVE,
+            None::<&str>,
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to MS_MOVE /newroot to /: {e}")))?;
+
+        chroot(".")
+            .map_err(|e| AgentdError::Init(format!("failed to chroot: {e}")))?;
+
+        chdir("/")
+            .map_err(|e| AgentdError::Init(format!("failed to chdir / after chroot: {e}")))?;
+
+        // Re-mount essential filesystems in the new root.
+        mount_filesystems()?;
+
+        Ok(())
+    }
+
+    /// Tries every filesystem type listed in `/proc/filesystems` until one succeeds.
+    fn try_mount(device: &str, target: &str) -> AgentdResult<()> {
+        let content = std::fs::read_to_string("/proc/filesystems").map_err(|e| {
+            AgentdError::Init(format!("failed to read /proc/filesystems: {e}"))
+        })?;
+
+        for line in content.lines() {
+            // Skip virtual filesystems marked with "nodev".
+            if line.starts_with("nodev") {
+                continue;
+            }
+
+            let fstype = line.trim();
+            if fstype.is_empty() {
+                continue;
+            }
+
+            if mount(
+                Some(device),
+                target,
+                Some(fstype),
+                MsFlags::empty(),
+                None::<&str>,
+            )
+            .is_ok()
+            {
+                return Ok(());
+            }
+        }
+
+        Err(AgentdError::Init(format!(
+            "failed to mount {device} at {target}: no supported filesystem found"
+        )))
     }
 
     /// Reads `MSB_TMPFS` env var and mounts each tmpfs entry.
@@ -359,5 +500,37 @@ mod tests {
     fn test_parse_empty_path_errors() {
         let err = parse_tmpfs_entry(",size=256").unwrap_err();
         assert!(err.to_string().contains("empty path"));
+    }
+
+    #[test]
+    fn test_parse_block_root_device_only() {
+        let spec = parse_block_root("/dev/vda").unwrap();
+        assert_eq!(spec.device, "/dev/vda");
+        assert_eq!(spec.fstype, None);
+    }
+
+    #[test]
+    fn test_parse_block_root_with_fstype() {
+        let spec = parse_block_root("/dev/vda,fstype=ext4").unwrap();
+        assert_eq!(spec.device, "/dev/vda");
+        assert_eq!(spec.fstype, Some("ext4"));
+    }
+
+    #[test]
+    fn test_parse_block_root_empty_device_errors() {
+        let err = parse_block_root(",fstype=ext4").unwrap_err();
+        assert!(err.to_string().contains("empty device path"));
+    }
+
+    #[test]
+    fn test_parse_block_root_unknown_option_errors() {
+        let err = parse_block_root("/dev/vda,bogus=42").unwrap_err();
+        assert!(err.to_string().contains("unknown MSB_BLOCK_ROOT option"));
+    }
+
+    #[test]
+    fn test_parse_block_root_empty_fstype_errors() {
+        let err = parse_block_root("/dev/vda,fstype=").unwrap_err();
+        assert!(err.to_string().contains("empty fstype"));
     }
 }

--- a/crates/cli/lib/microvm_cmd.rs
+++ b/crates/cli/lib/microvm_cmd.rs
@@ -43,7 +43,19 @@ pub struct MicrovmArgs {
     #[arg(long)]
     pub rootfs_staging: Option<PathBuf>,
 
-    /// Additional mounts as `tag:host_path` (repeatable).
+    /// Disk image file path for virtio-blk rootfs.
+    #[arg(long)]
+    pub rootfs_disk: Option<PathBuf>,
+
+    /// Disk image format (qcow2, raw, vmdk).
+    #[arg(long)]
+    pub rootfs_disk_format: Option<String>,
+
+    /// Mount disk image as read-only.
+    #[arg(long)]
+    pub rootfs_disk_readonly: bool,
+
+    /// Additional mounts as `tag:host_path[:ro]` (repeatable).
     #[arg(long)]
     pub mount: Vec<String>,
 
@@ -92,6 +104,9 @@ pub fn run(args: MicrovmArgs) -> RuntimeResult<()> {
         rootfs_lowers: args.rootfs_lower,
         rootfs_upper: args.rootfs_upper,
         rootfs_staging: args.rootfs_staging,
+        rootfs_disk: args.rootfs_disk,
+        rootfs_disk_format: args.rootfs_disk_format,
+        rootfs_disk_readonly: args.rootfs_disk_readonly,
         mounts: args.mount,
         backends: vec![],
         init_path: args.init_path,

--- a/crates/cli/lib/supervisor_cmd.rs
+++ b/crates/cli/lib/supervisor_cmd.rs
@@ -116,6 +116,18 @@ pub struct SupervisorArgs {
     #[arg(long)]
     pub rootfs_staging: Option<PathBuf>,
 
+    /// Disk image file path for virtio-blk rootfs.
+    #[arg(long)]
+    pub rootfs_disk: Option<PathBuf>,
+
+    /// Disk image format (qcow2, raw, vmdk).
+    #[arg(long)]
+    pub rootfs_disk_format: Option<String>,
+
+    /// Mount disk image as read-only.
+    #[arg(long)]
+    pub rootfs_disk_readonly: bool,
+
     /// Additional mounts as `tag:host_path` (repeatable).
     #[arg(long)]
     pub mount: Vec<String>,
@@ -173,6 +185,9 @@ pub async fn run(args: SupervisorArgs, log_level: Option<LogLevel>) -> RuntimeRe
         rootfs_lowers: args.rootfs_lower,
         rootfs_upper: args.rootfs_upper,
         rootfs_staging: args.rootfs_staging,
+        rootfs_disk: args.rootfs_disk,
+        rootfs_disk_format: args.rootfs_disk_format,
+        rootfs_disk_readonly: args.rootfs_disk_readonly,
         mounts: args.mount,
         backends: vec![],
         init_path: args.init_path,

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 [dependencies]
 libc.workspace = true
 microsandbox-utils = { path = "../utils" }
-msb_krun = "0.1.2"
+msb_krun = "0.1.3"
 scopeguard.workspace = true
 tempfile.workspace = true
 tracing.workspace = true

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -346,6 +346,27 @@ fn supervisor_cli_args(
                 args.push(layer_dir.as_os_str().to_os_string());
             }
         }
+        RootfsSource::DiskImage {
+            path,
+            format,
+            fstype,
+        } => {
+            args.push(OsString::from("--rootfs-disk"));
+            args.push(path.as_os_str().to_os_string());
+            args.push(OsString::from("--rootfs-disk-format"));
+            args.push(OsString::from(format.as_str()));
+
+            // Build MSB_BLOCK_ROOT env var value.
+            let mut block_root_val = String::from("/dev/vda");
+            if let Some(ft) = fstype {
+                block_root_val.push_str(&format!(",fstype={ft}"));
+            }
+            args.push(OsString::from("--env"));
+            args.push(OsString::from(format!(
+                "{}={block_root_val}",
+                microsandbox_protocol::ENV_BLOCK_ROOT
+            )));
+        }
     }
 
     // Process mounts: emit --mount args for virtiofs mounts, collect tmpfs specs.
@@ -655,5 +676,83 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(!rendered.iter().any(|a| a.starts_with("MSB_TMPFS=")));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_disk_image_with_fstype() {
+        let config = SandboxBuilder::new("test")
+            .image(|i: crate::sandbox::ImageBuilder| i.disk("/tmp/ubuntu.qcow2").fstype("ext4"))
+            .build()
+            .unwrap();
+
+        assert!(matches!(config.image, RootfsSource::DiskImage { .. }));
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(rendered.contains(&"--rootfs-disk".to_string()));
+        assert!(rendered.contains(&"/tmp/ubuntu.qcow2".to_string()));
+        assert!(rendered.contains(&"--rootfs-disk-format".to_string()));
+        assert!(rendered.contains(&"qcow2".to_string()));
+        assert!(rendered.contains(&"MSB_BLOCK_ROOT=/dev/vda,fstype=ext4".to_string()));
+
+        // Should not contain bind or overlay args.
+        assert!(!rendered.contains(&"--rootfs-path".to_string()));
+        assert!(!rendered.contains(&"--rootfs-lower".to_string()));
+        assert!(!rendered.contains(&"--rootfs-upper".to_string()));
+        assert!(!rendered.contains(&"--rootfs-staging".to_string()));
+    }
+
+    #[test]
+    fn test_supervisor_cli_args_disk_image_without_fstype() {
+        let config = SandboxBuilder::new("test")
+            .image(|i: crate::sandbox::ImageBuilder| i.disk("/tmp/alpine.raw"))
+            .build()
+            .unwrap();
+
+        assert!(matches!(config.image, RootfsSource::DiskImage { .. }));
+
+        let args = supervisor_cli_args(
+            &config,
+            42,
+            Path::new("/tmp/msb.db"),
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/rootfs-base"),
+            Path::new("/tmp/rw"),
+            Path::new("/tmp/staging"),
+            9,
+            Path::new("/tmp/libkrunfw.dylib"),
+        );
+
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(rendered.contains(&"--rootfs-disk".to_string()));
+        assert!(rendered.contains(&"/tmp/alpine.raw".to_string()));
+        assert!(rendered.contains(&"--rootfs-disk-format".to_string()));
+        assert!(rendered.contains(&"raw".to_string()));
+        assert!(rendered.contains(&"MSB_BLOCK_ROOT=/dev/vda".to_string()));
+
+        // Should not contain bind or overlay args.
+        assert!(!rendered.contains(&"--rootfs-path".to_string()));
+        assert!(!rendered.contains(&"--rootfs-lower".to_string()));
     }
 }

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -6,7 +6,7 @@ use microsandbox_image::RegistryAuth;
 
 use super::{
     config::SandboxConfig,
-    types::{ImageSource, MountBuilder, RootfsSource},
+    types::{IntoImage, MountBuilder, RootfsSource},
 };
 use crate::{LogLevel, MicrosandboxResult, size::Mebibytes};
 
@@ -38,23 +38,22 @@ impl SandboxBuilder {
 
     /// Set the root filesystem image source.
     ///
-    /// Accepts a string or path:
+    /// Accepts a string, path, or closure:
     /// - **`&str` / `String`**: Paths starting with `/`, `./`, or `../` are treated as local
-    ///   bind mounts. Everything else is treated as an OCI image reference.
-    /// - **`PathBuf`**: Always treated as a local bind mount.
+    ///   paths. Everything else is treated as an OCI image reference. Disk image extensions
+    ///   (`.qcow2`, `.raw`, `.vmdk`) resolve to virtio-blk block device rootfs.
+    /// - **`PathBuf`**: Always treated as a local path.
+    /// - **Closure**: `|i| i.disk("./image.qcow2").fstype("ext4")` for explicit disk image
+    ///   configuration.
     ///
     /// ```ignore
-    /// .image("python:3.12")           // OCI image
-    /// .image("./rootfs")              // local directory (bind mount)
-    /// .image("/abs/path/to/rootfs")   // local directory (bind mount)
-    /// .image(PathBuf::from("./rootfs")) // local directory (bind mount)
+    /// .image("python:3.12")                                // OCI image
+    /// .image("./rootfs")                                   // local directory (bind mount)
+    /// .image("./ubuntu.qcow2")                             // disk image (auto-detect fs)
+    /// .image(|i| i.disk("./ubuntu.qcow2").fstype("ext4"))  // disk image (explicit fs)
     /// ```
-    ///
-    /// Disk image formats (`.qcow2`, `.raw`, `.vmdk`) are not yet supported and
-    /// will produce a build error.
-    pub fn image(mut self, image: impl Into<ImageSource>) -> Self {
-        let source: ImageSource = image.into();
-        match source.into_rootfs_source() {
+    pub fn image(mut self, image: impl IntoImage) -> Self {
+        match image.into_rootfs_source() {
             Ok(rootfs) => self.config.image = rootfs,
             Err(e) => {
                 if self.build_error.is_none() {
@@ -243,6 +242,11 @@ impl SandboxBuilder {
             RootfsSource::Oci(s) if s.is_empty() => {
                 return Err(crate::MicrosandboxError::InvalidConfig(
                     "image source is required".into(),
+                ));
+            }
+            RootfsSource::DiskImage { .. } if !self.config.patches.is_empty() => {
+                return Err(crate::MicrosandboxError::InvalidConfig(
+                    "patches are not compatible with disk image rootfs".into(),
                 ));
             }
             _ => {}

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -52,8 +52,8 @@ pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, Sandbo
 pub use microsandbox_filesystem::AccessMode;
 pub use microsandbox_runtime::logging::LogLevel;
 pub use types::{
-    ImageSource, MountBuilder, NetworkConfig, Patch, RootfsSource, SecretsConfig, SshConfig,
-    VolumeMount,
+    DiskImageFormat, ImageBuilder, ImageSource, IntoImage, MountBuilder, NetworkConfig, Patch,
+    RootfsSource, SecretsConfig, SshConfig, VolumeMount,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -770,6 +770,21 @@ fn validate_rootfs_source(rootfs: &RootfsSource) -> MicrosandboxResult<()> {
             }
         }
         RootfsSource::Oci(_) => {}
+        RootfsSource::DiskImage { path, .. } => {
+            if !path.exists() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "disk image does not exist: {}",
+                    path.display()
+                )));
+            }
+
+            if !path.is_file() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "disk image is not a regular file: {}",
+                    path.display()
+                )));
+            }
+        }
     }
 
     Ok(())

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -15,6 +15,17 @@ use crate::size::Mebibytes;
 // Types
 //--------------------------------------------------------------------------------------------------
 
+/// Disk image format for virtio-blk rootfs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiskImageFormat {
+    /// QEMU Copy-on-Write v2.
+    Qcow2,
+    /// Raw disk image.
+    Raw,
+    /// VMware Disk (FLAT/ZERO only, no delta links).
+    Vmdk,
+}
+
 /// Root filesystem source for a sandbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RootfsSource {
@@ -23,6 +34,16 @@ pub enum RootfsSource {
 
     /// Use an OCI image reference (e.g. `python:3.12`).
     Oci(String),
+
+    /// Use a disk image file as the root filesystem via virtio-blk.
+    DiskImage {
+        /// Path to the disk image file on the host.
+        path: PathBuf,
+        /// Disk image format.
+        format: DiskImageFormat,
+        /// Inner filesystem type (optional; auto-detected if absent).
+        fstype: Option<String>,
+    },
 }
 
 /// Intermediate type for parsing user input into a [`RootfsSource`].
@@ -30,12 +51,12 @@ pub enum RootfsSource {
 /// Accepts `&str`, `String`, or `PathBuf` and resolves to the correct
 /// [`RootfsSource`] variant:
 ///
-/// - **`PathBuf`** → always [`RootfsSource::Bind`].
+/// - **`PathBuf`** → always local (bind mount or disk image based on extension).
 /// - **`&str` / `String`** → local path if prefixed with `/`, `./`, or `../`;
 ///   otherwise [`RootfsSource::Oci`].
 ///
-/// Disk image formats (`.qcow2`, `.raw`, `.vmdk`) are detected but not yet
-/// supported and will return an error from [`into_rootfs_source`](Self::into_rootfs_source).
+/// Disk image extensions (`.qcow2`, `.raw`, `.vmdk`) resolve to
+/// [`RootfsSource::DiskImage`].
 pub enum ImageSource {
     /// A string that needs to be resolved.
     Text(String),
@@ -44,8 +65,26 @@ pub enum ImageSource {
     Path(PathBuf),
 }
 
-/// Extensions that indicate unsupported disk image formats.
-const UNSUPPORTED_DISK_IMAGE_EXTENSIONS: &[&str] = &["qcow2", "raw", "vmdk"];
+/// Builder for configuring a disk image rootfs.
+///
+/// Used with the closure form of [`SandboxBuilder::image`]:
+///
+/// ```ignore
+/// .image(|i| i.disk("./ubuntu.qcow2").fstype("ext4"))
+/// ```
+pub struct ImageBuilder {
+    source: Option<RootfsSource>,
+    error: Option<crate::MicrosandboxError>,
+}
+
+/// Trait for types that can be passed to [`SandboxBuilder::image`].
+///
+/// Implemented for:
+/// - `&str`, `String`, `PathBuf` — resolved via [`ImageSource`].
+/// - `FnOnce(ImageBuilder) -> ImageBuilder` — closure-based disk image configuration.
+pub trait IntoImage {
+    fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource>;
+}
 
 /// A volume mount specification for a sandbox.
 pub enum VolumeMount {
@@ -356,18 +395,12 @@ impl VolumeMount {
 
 impl ImageSource {
     /// Resolve into a [`RootfsSource`].
-    ///
-    /// Returns an error for unsupported disk image formats (`.qcow2`, `.raw`, `.vmdk`).
     pub fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
         match self {
-            Self::Path(path) => {
-                Self::check_unsupported_extension(path.to_string_lossy().as_ref())?;
-                Ok(RootfsSource::Bind(path))
-            }
+            Self::Path(path) => Self::resolve_path(path),
             Self::Text(s) => {
                 if s.starts_with('/') || s.starts_with("./") || s.starts_with("../") {
-                    Self::check_unsupported_extension(&s)?;
-                    Ok(RootfsSource::Bind(PathBuf::from(s)))
+                    Self::resolve_path(PathBuf::from(s))
                 } else {
                     Ok(RootfsSource::Oci(s))
                 }
@@ -375,24 +408,187 @@ impl ImageSource {
         }
     }
 
-    /// Return an error if the path has an unsupported disk image extension.
-    fn check_unsupported_extension(path: &str) -> crate::MicrosandboxResult<()> {
-        if let Some(ext) = std::path::Path::new(path)
-            .extension()
-            .and_then(|e| e.to_str())
-            && UNSUPPORTED_DISK_IMAGE_EXTENSIONS.contains(&ext)
-        {
-            return Err(crate::MicrosandboxError::InvalidConfig(format!(
-                "disk image format '.{ext}' is not yet supported: {path}"
-            )));
+    /// Resolve a local path into either a bind mount or a disk image source.
+    fn resolve_path(path: PathBuf) -> crate::MicrosandboxResult<RootfsSource> {
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if let Some(format) = DiskImageFormat::from_extension(ext) {
+            Ok(RootfsSource::DiskImage {
+                path,
+                format,
+                fstype: None,
+            })
+        } else {
+            Ok(RootfsSource::Bind(path))
         }
-        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: DiskImageFormat
+//--------------------------------------------------------------------------------------------------
+
+impl DiskImageFormat {
+    /// Returns the format as a CLI-safe lowercase string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Qcow2 => "qcow2",
+            Self::Raw => "raw",
+            Self::Vmdk => "vmdk",
+        }
+    }
+
+    /// Parse a disk image format from a file extension.
+    ///
+    /// Returns `None` if the extension is not a recognized disk image format.
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext {
+            "qcow2" => Some(Self::Qcow2),
+            "raw" => Some(Self::Raw),
+            "vmdk" => Some(Self::Vmdk),
+            _ => None,
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: ImageBuilder
+//--------------------------------------------------------------------------------------------------
+
+impl ImageBuilder {
+    /// Create a new image builder.
+    pub fn new() -> Self {
+        Self {
+            source: None,
+            error: None,
+        }
+    }
+
+    /// Use a disk image file as the root filesystem.
+    ///
+    /// The format is derived from the file extension:
+    /// `.qcow2`, `.raw`, `.vmdk`.
+    ///
+    /// ```ignore
+    /// .image(|i| i.disk("./ubuntu.qcow2"))
+    /// .image(|i| i.disk("./alpine.raw").fstype("ext4"))
+    /// ```
+    pub fn disk(mut self, path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let format = match DiskImageFormat::from_extension(ext) {
+            Some(f) => f,
+            None => {
+                self.error = Some(crate::MicrosandboxError::InvalidConfig(format!(
+                    "unrecognized disk image extension: {ext:?} (expected .qcow2, .raw, or .vmdk)"
+                )));
+                return self;
+            }
+        };
+        self.source = Some(RootfsSource::DiskImage {
+            path,
+            format,
+            fstype: None,
+        });
+        self
+    }
+
+    /// Set the inner filesystem type for a disk image.
+    ///
+    /// If omitted, agentd auto-detects the filesystem by probing
+    /// `/proc/filesystems`.
+    ///
+    /// ```ignore
+    /// .image(|i| i.disk("./ubuntu.raw").fstype("ext4"))
+    /// ```
+    pub fn fstype(mut self, fstype: impl Into<String>) -> Self {
+        let fstype = fstype.into();
+        if fstype.contains(',') || fstype.contains('=') {
+            self.error = Some(crate::MicrosandboxError::InvalidConfig(format!(
+                "fstype must not contain ',' or '=': {fstype}"
+            )));
+            return self;
+        }
+        match &mut self.source {
+            Some(RootfsSource::DiskImage { fstype: ft, .. }) => {
+                *ft = Some(fstype);
+            }
+            _ => {
+                if self.error.is_none() {
+                    self.error = Some(crate::MicrosandboxError::InvalidConfig(
+                        "fstype() requires disk() to be called first".into(),
+                    ));
+                }
+            }
+        }
+        self
+    }
+
+    /// Consume the builder and return the resolved [`RootfsSource`].
+    pub(crate) fn build(self) -> crate::MicrosandboxResult<RootfsSource> {
+        if let Some(e) = self.error {
+            return Err(e);
+        }
+        self.source.ok_or_else(|| {
+            crate::MicrosandboxError::InvalidConfig(
+                "ImageBuilder: no image source set (call .disk())".into(),
+            )
+        })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations: IntoImage
+//--------------------------------------------------------------------------------------------------
+
+impl IntoImage for &str {
+    fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
+        ImageSource::from(self).into_rootfs_source()
+    }
+}
+
+impl IntoImage for String {
+    fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
+        ImageSource::from(self).into_rootfs_source()
+    }
+}
+
+impl IntoImage for PathBuf {
+    fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
+        ImageSource::from(self).into_rootfs_source()
+    }
+}
+
+impl<F> IntoImage for F
+where
+    F: FnOnce(ImageBuilder) -> ImageBuilder,
+{
+    fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
+        self(ImageBuilder::new()).build()
     }
 }
 
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
+
+impl std::fmt::Display for DiskImageFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for DiskImageFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "qcow2" => Ok(Self::Qcow2),
+            "raw" => Ok(Self::Raw),
+            "vmdk" => Ok(Self::Vmdk),
+            _ => Err(format!("unknown disk image format: {s}")),
+        }
+    }
+}
 
 impl Default for RootfsSource {
     fn default() -> Self {
@@ -551,5 +747,138 @@ impl std::fmt::Debug for VolumeMount {
                 .field("backend", &"<dyn DynFileSystem>")
                 .finish(),
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_disk_image_format_from_extension() {
+        assert_eq!(
+            DiskImageFormat::from_extension("qcow2"),
+            Some(DiskImageFormat::Qcow2)
+        );
+        assert_eq!(
+            DiskImageFormat::from_extension("raw"),
+            Some(DiskImageFormat::Raw)
+        );
+        assert_eq!(
+            DiskImageFormat::from_extension("vmdk"),
+            Some(DiskImageFormat::Vmdk)
+        );
+        assert_eq!(DiskImageFormat::from_extension("ext4"), None);
+        assert_eq!(DiskImageFormat::from_extension(""), None);
+    }
+
+    #[test]
+    fn test_disk_image_format_display_roundtrip() {
+        for fmt in [
+            DiskImageFormat::Qcow2,
+            DiskImageFormat::Raw,
+            DiskImageFormat::Vmdk,
+        ] {
+            let s = fmt.to_string();
+            let parsed: DiskImageFormat = s.parse().unwrap();
+            assert_eq!(parsed, fmt);
+        }
+    }
+
+    #[test]
+    fn test_disk_image_format_from_str_unknown() {
+        assert!("ext4".parse::<DiskImageFormat>().is_err());
+    }
+
+    #[test]
+    fn test_image_source_resolves_qcow2() {
+        let source = ImageSource::from("./disk.qcow2");
+        let rootfs = source.into_rootfs_source().unwrap();
+        match rootfs {
+            RootfsSource::DiskImage { format, .. } => assert_eq!(format, DiskImageFormat::Qcow2),
+            _ => panic!("expected DiskImage"),
+        }
+    }
+
+    #[test]
+    fn test_image_source_resolves_raw() {
+        let source = ImageSource::from("/images/test.raw");
+        let rootfs = source.into_rootfs_source().unwrap();
+        match rootfs {
+            RootfsSource::DiskImage { format, .. } => assert_eq!(format, DiskImageFormat::Raw),
+            _ => panic!("expected DiskImage"),
+        }
+    }
+
+    #[test]
+    fn test_image_source_resolves_directory_as_bind() {
+        let source = ImageSource::from("./rootfs");
+        let rootfs = source.into_rootfs_source().unwrap();
+        assert!(matches!(rootfs, RootfsSource::Bind(_)));
+    }
+
+    #[test]
+    fn test_image_source_resolves_oci_reference() {
+        let source = ImageSource::from("python:3.12");
+        let rootfs = source.into_rootfs_source().unwrap();
+        assert!(matches!(rootfs, RootfsSource::Oci(_)));
+    }
+
+    #[test]
+    fn test_image_builder_disk_with_fstype() {
+        let rootfs = (|i: ImageBuilder| i.disk("./test.qcow2").fstype("ext4"))
+            .into_rootfs_source()
+            .unwrap();
+        match rootfs {
+            RootfsSource::DiskImage { format, fstype, .. } => {
+                assert_eq!(format, DiskImageFormat::Qcow2);
+                assert_eq!(fstype.as_deref(), Some("ext4"));
+            }
+            _ => panic!("expected DiskImage"),
+        }
+    }
+
+    #[test]
+    fn test_image_builder_disk_without_fstype() {
+        let rootfs = (|i: ImageBuilder| i.disk("./test.raw"))
+            .into_rootfs_source()
+            .unwrap();
+        match rootfs {
+            RootfsSource::DiskImage { format, fstype, .. } => {
+                assert_eq!(format, DiskImageFormat::Raw);
+                assert_eq!(fstype, None);
+            }
+            _ => panic!("expected DiskImage"),
+        }
+    }
+
+    #[test]
+    fn test_image_builder_bad_extension_errors() {
+        let result = (|i: ImageBuilder| i.disk("./test.txt")).into_rootfs_source();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_image_builder_fstype_without_disk_errors() {
+        let result = (|i: ImageBuilder| i.fstype("ext4")).into_rootfs_source();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_image_builder_fstype_rejects_comma() {
+        let result =
+            (|i: ImageBuilder| i.disk("./test.qcow2").fstype("ext4,size=100")).into_rootfs_source();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_image_builder_fstype_rejects_equals() {
+        let result =
+            (|i: ImageBuilder| i.disk("./test.qcow2").fstype("key=value")).into_rootfs_source();
+        assert!(result.is_err());
     }
 }

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -41,6 +41,13 @@ pub const RUNTIME_MOUNT_POINT: &str = "/.msb";
 /// - `MSB_TMPFS=/tmp,size=256,noexec` — with noexec flag
 pub const ENV_TMPFS: &str = "MSB_TMPFS";
 
+/// Environment variable specifying the block device for rootfs switch.
+///
+/// Format: `device[,key=value,...]`
+/// - `device` — block device path (required, always first element)
+/// - `fstype=TYPE` — filesystem type (optional; auto-detected if absent)
+pub const ENV_BLOCK_ROOT: &str = "MSB_BLOCK_ROOT";
+
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,14 +19,12 @@ microsandbox-db = { path = "../db" }
 microsandbox-filesystem = { path = "../filesystem" }
 microsandbox-protocol = { path = "../protocol" }
 microsandbox-utils = { path = "../utils" }
-msb_krun = { version = "0.1.2", features = ["net"] }
+msb_krun = { version = "0.1.3", features = ["blk", "net"] }
 nix = { workspace = true, features = ["process", "signal"] }
 sea-orm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/runtime/lib/supervisor.rs
+++ b/crates/runtime/lib/supervisor.rs
@@ -446,6 +446,18 @@ fn microvm_cli_args(config: &SupervisorConfig) -> Vec<OsString> {
         args.push(staging_dir.clone().into_os_string());
     }
 
+    if let Some(ref disk_path) = config.vm_config.rootfs_disk {
+        args.push(OsString::from("--rootfs-disk"));
+        args.push(disk_path.clone().into_os_string());
+    }
+    if let Some(ref disk_format) = config.vm_config.rootfs_disk_format {
+        args.push(OsString::from("--rootfs-disk-format"));
+        args.push(OsString::from(disk_format));
+    }
+    if config.vm_config.rootfs_disk_readonly {
+        args.push(OsString::from("--rootfs-disk-readonly"));
+    }
+
     for mount in &config.vm_config.mounts {
         args.push(OsString::from("--mount"));
         args.push(OsString::from(mount));
@@ -779,6 +791,9 @@ mod tests {
                 rootfs_lowers: Vec::new(),
                 rootfs_upper: None,
                 rootfs_staging: None,
+                rootfs_disk: None,
+                rootfs_disk_format: None,
+                rootfs_disk_readonly: false,
                 mounts: vec!["data:/tmp/data".into()],
                 backends: Vec::new(),
                 init_path: None,

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -39,7 +39,16 @@ pub struct VmConfig {
     /// Private staging directory for OverlayFs atomic operations.
     pub rootfs_staging: Option<PathBuf>,
 
-    /// Additional mounts as `tag:host_path` pairs.
+    /// Disk image path for virtio-blk rootfs.
+    pub rootfs_disk: Option<PathBuf>,
+
+    /// Disk image format string ("qcow2", "raw", "vmdk").
+    pub rootfs_disk_format: Option<String>,
+
+    /// Whether the disk image is read-only.
+    pub rootfs_disk_readonly: bool,
+
+    /// Additional mounts as `tag:host_path[:ro]` strings.
     pub mounts: Vec<String>,
 
     /// Pre-built filesystem backends as `(tag, backend)` pairs.
@@ -84,6 +93,9 @@ impl std::fmt::Debug for VmConfig {
             .field("rootfs_lowers", &self.rootfs_lowers)
             .field("rootfs_upper", &self.rootfs_upper)
             .field("rootfs_staging", &self.rootfs_staging)
+            .field("rootfs_disk", &self.rootfs_disk)
+            .field("rootfs_disk_format", &self.rootfs_disk_format)
+            .field("rootfs_disk_readonly", &self.rootfs_disk_readonly)
             .field("mounts", &self.mounts)
             .field("backends", &format!("[{} backend(s)]", self.backends.len()))
             .field("init_path", &self.init_path)
@@ -162,11 +174,46 @@ fn build_and_enter(config: VmConfig) -> msb_krun::Result<std::convert::Infallibl
             std::io::ErrorKind::InvalidInput,
             "overlay rootfs requires at least one lower layer",
         )));
+    } else if let Some(ref disk_path) = config.rootfs_disk {
+        // Empty trampoline: PassthroughFs injects /init.krun (agentd) automatically.
+        let empty_trampoline = tempfile::tempdir().map_err(msb_krun::Error::Io)?;
+        let cfg = PassthroughConfig {
+            root_dir: empty_trampoline.path().to_path_buf(),
+            ..Default::default()
+        };
+        let backend = PassthroughFs::new(cfg)?;
+        builder = builder.fs(move |fs| fs.tag("/dev/root").custom(Box::new(backend)));
+
+        // Attach disk image as virtio-blk device.
+        let format_str = config.rootfs_disk_format.as_deref().unwrap_or("raw");
+        let format: msb_krun::DiskImageFormat = match format_str {
+            "qcow2" => msb_krun::DiskImageFormat::Qcow2,
+            "raw" => msb_krun::DiskImageFormat::Raw,
+            "vmdk" => msb_krun::DiskImageFormat::Vmdk,
+            other => {
+                return Err(msb_krun::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("unknown disk image format: {other}"),
+                )));
+            }
+        };
+        let disk_path = disk_path.clone();
+        let readonly = config.rootfs_disk_readonly;
+        builder = builder.disk(move |d| d.path(&disk_path).format(format).read_only(readonly));
+
+        // Keep the trampoline directory alive until VM exits.
+        // enter() never returns, so we prevent cleanup on drop.
+        let _ = empty_trampoline.keep();
     }
 
-    // Additional mounts (tag:host_path format).
+    // Additional mounts (tag:host_path[:ro] format).
     for mount_spec in &config.mounts {
-        if let Some((tag, path)) = mount_spec.split_once(':') {
+        let (spec, _readonly) = match mount_spec.strip_suffix(":ro") {
+            Some(s) => (s, true),
+            None => (mount_spec.as_str(), false),
+        };
+
+        if let Some((tag, path)) = spec.split_once(':') {
             let tag = tag.to_string();
             let cfg = PassthroughConfig {
                 root_dir: PathBuf::from(path),
@@ -296,6 +343,9 @@ mod tests {
             rootfs_lowers: vec![PathBuf::from("/tmp/layer0")],
             rootfs_upper: Some(PathBuf::from("/tmp/rw")),
             rootfs_staging: Some(PathBuf::from("/tmp/staging")),
+            rootfs_disk: None,
+            rootfs_disk_format: None,
+            rootfs_disk_readonly: false,
             mounts: Vec::new(),
             backends: Vec::new(),
             init_path: None,
@@ -324,6 +374,9 @@ mod tests {
             rootfs_lowers: Vec::new(),
             rootfs_upper: Some(PathBuf::from("/tmp/rw")),
             rootfs_staging: Some(PathBuf::from("/tmp/staging")),
+            rootfs_disk: None,
+            rootfs_disk_format: None,
+            rootfs_disk_readonly: false,
             mounts: Vec::new(),
             backends: Vec::new(),
             init_path: None,


### PR DESCRIPTION
## Summary

- Add support for qcow2, raw, and vmdk disk images as sandbox root filesystems via virtio-blk
- The kernel boots from a virtiofs trampoline, and agentd switches root to the block device during init using mount(MS_MOVE) + chroot
- Introduces closure-based `.image(|i| i.disk("./x.qcow2").fstype("ext4"))` API alongside the existing string shorthand
- Also fixes a pre-existing bug where readonly mount specs corrupted the host path

## Changes

### Protocol (`crates/protocol/lib/lib.rs`)
- Add `ENV_BLOCK_ROOT` constant for `MSB_BLOCK_ROOT` env var

### Sandbox types (`crates/microsandbox/lib/sandbox/types.rs`)
- Add `DiskImageFormat` enum (Qcow2, Raw, Vmdk) with `from_extension`, `Display`, `FromStr`
- Add `RootfsSource::DiskImage { path, format, fstype }` variant
- Add `ImageBuilder` struct with `.disk()` and `.fstype()` methods
- Add `IntoImage` trait so `.image()` accepts both strings and closures
- Replace `check_unsupported_extension()` with proper extension-based resolution
- Add fstype validation (reject `,` and `=` characters)

### Sandbox builder (`crates/microsandbox/lib/sandbox/builder.rs`)
- Refactor `.image()` to accept `impl IntoImage` instead of `impl Into<ImageSource>`
- Remove `.disk_fstype()` in favor of closure-based `ImageBuilder`
- Add patch validation for disk image rootfs

### Sandbox creation (`crates/microsandbox/lib/sandbox/mod.rs`)
- Add `DiskImage` validation in `validate_rootfs_source()` (file exists, is regular file)
- Export `DiskImageFormat`, `ImageBuilder`, `IntoImage`

### Spawn args (`crates/microsandbox/lib/runtime/spawn.rs`)
- Add `DiskImage` branch to `supervisor_cli_args()` emitting `--rootfs-disk`, `--rootfs-disk-format`, and `MSB_BLOCK_ROOT` env var

### Runtime (`crates/runtime/lib/vm.rs`)
- Add `rootfs_disk`, `rootfs_disk_format`, `rootfs_disk_readonly` to `VmConfig`
- Add disk image branch in `build_and_enter()`: empty virtiofs trampoline + virtio-blk device
- Fix `:ro` mount spec parsing (strip suffix before split)

### Runtime supervisor (`crates/runtime/lib/supervisor.rs`)
- Pass `--rootfs-disk*` args through `microvm_cli_args()`

### CLI (`crates/cli/lib/supervisor_cmd.rs`, `microvm_cmd.rs`)
- Add `--rootfs-disk`, `--rootfs-disk-format`, `--rootfs-disk-readonly` CLI args to both subcommands

### Agentd (`crates/agentd/lib/init.rs`)
- Add `mount_block_root()` to init sequence (after mount_runtime, before tmpfs)
- Implement root switch: mount block device, bind-mount /.msb, chdir, MS_MOVE, chroot, re-mount filesystems
- Add `try_mount()` for auto-detecting filesystem type from /proc/filesystems
- Add `parse_block_root()` parser with validation

### Dependencies
- Bump msb_krun from 0.1.2 to 0.1.3 (blk feature with DiskImageFormat)
- Add `tempfile` as runtime dependency (trampoline directory)

## Test Plan

- [x] `cargo test -p msb_krun --features blk` -- 20 tests pass (libkrun repo)
- [x] `cargo test --lib` in crates/agentd -- 14 tests pass (5 new: parse_block_root variants)
- [x] `cargo check` on workspace -- compiles clean (after `just build-agentd`)
- [ ] `just build-agentd` -- rebuild agentd binary (required before full workspace build)
- [ ] End-to-end test with a qcow2 disk image once agentd is rebuilt
- [ ] Verify libkrunfw kernel has CONFIG_VIRTIO_BLK=y (confirmed in config files)