### PR TITLE
feat(cli): add user-facing CLI commands for sandbox lifecycle management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1023,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1810,6 +1828,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,8 +2175,16 @@ dependencies = [
 name = "microsandbox-cli"
 version = "0.2.6"
 dependencies = [
+ "anyhow",
+ "chrono",
  "clap",
+ "console",
+ "indicatif",
+ "microsandbox",
+ "microsandbox-image",
  "microsandbox-runtime",
+ "rand 0.9.2",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4722,10 +4761,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,8 +16,16 @@ name = "microsandbox_cli"
 path = "lib/lib.rs"
 
 [dependencies]
+anyhow.workspace = true
+chrono.workspace = true
 clap.workspace = true
+console.workspace = true
+indicatif.workspace = true
+microsandbox = { path = "../microsandbox" }
+microsandbox-image = { path = "../image" }
 microsandbox-runtime = { path = "../runtime" }
+rand.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -2,6 +2,9 @@
 
 use clap::{Parser, Subcommand};
 use microsandbox_cli::{
+    commands::{
+        attach, create, exec, inspect, list, ps, pull, remove, run, shell, start, stop,
+    },
     log_args::{self, LogArgs},
     microvm_cmd::{self, MicrovmArgs},
     supervisor_cmd::{self, SupervisorArgs},
@@ -26,10 +29,50 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Run the supervisor process.
+    #[command(hide = true)]
     Supervisor(SupervisorArgs),
 
     /// Run the microVM process.
+    #[command(hide = true)]
     Microvm(MicrovmArgs),
+
+    /// Create and start a new sandbox.
+    Run(run::RunArgs),
+
+    /// Create and boot a fresh sandbox (no workload).
+    Create(create::CreateArgs),
+
+    /// Start/resume an existing stopped sandbox.
+    Start(start::StartArgs),
+
+    /// Stop a running sandbox.
+    Stop(stop::StopArgs),
+
+    /// List all sandboxes.
+    #[command(visible_alias = "ls")]
+    List(list::ListArgs),
+
+    /// Show running sandboxes.
+    Ps(ps::PsArgs),
+
+    /// Remove a stopped sandbox.
+    #[command(visible_alias = "rm")]
+    Remove(remove::RemoveArgs),
+
+    /// Execute a command in a sandbox.
+    Exec(exec::ExecArgs),
+
+    /// Attach to a sandbox with interactive terminal.
+    Attach(attach::AttachArgs),
+
+    /// Interactive shell in a sandbox.
+    Shell(shell::ShellArgs),
+
+    /// Pull an image from a registry.
+    Pull(pull::PullArgs),
+
+    /// Show detailed sandbox information.
+    Inspect(inspect::InspectArgs),
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -51,13 +94,30 @@ async fn main() {
     let log_level = cli.logs.selected_level();
     log_args::init_tracing(log_level);
 
-    let result = match cli.command {
-        Commands::Supervisor(args) => supervisor_cmd::run(args, log_level).await,
-        Commands::Microvm(args) => microvm_cmd::run(args),
+    let result: Result<(), Box<dyn std::error::Error>> = match cli.command {
+        // Hidden internal commands.
+        Commands::Supervisor(args) => supervisor_cmd::run(args, log_level)
+            .await
+            .map_err(Into::into),
+        Commands::Microvm(args) => microvm_cmd::run(args).map_err(Into::into),
+
+        // User-facing commands.
+        Commands::Run(args) => run::run(args).await.map_err(Into::into),
+        Commands::Create(args) => create::run(args).await.map_err(Into::into),
+        Commands::Start(args) => start::run(args).await.map_err(Into::into),
+        Commands::Stop(args) => stop::run(args).await.map_err(Into::into),
+        Commands::List(args) => list::run(args).await.map_err(Into::into),
+        Commands::Ps(args) => ps::run(args).await.map_err(Into::into),
+        Commands::Remove(args) => remove::run(args).await.map_err(Into::into),
+        Commands::Exec(args) => exec::run(args).await.map_err(Into::into),
+        Commands::Attach(args) => attach::run(args).await.map_err(Into::into),
+        Commands::Shell(args) => shell::run(args).await.map_err(Into::into),
+        Commands::Pull(args) => pull::run(args).await.map_err(Into::into),
+        Commands::Inspect(args) => inspect::run(args).await.map_err(Into::into),
     };
 
     if let Err(e) = result {
-        eprintln!("error: {e}");
+        microsandbox_cli::ui::error(&e.to_string());
         std::process::exit(1);
     }
 }

--- a/crates/cli/lib/commands/attach.rs
+++ b/crates/cli/lib/commands/attach.rs
@@ -1,0 +1,98 @@
+//! `msb attach` command — attach to a sandbox with interactive terminal.
+
+use clap::Args;
+use microsandbox::sandbox::{AttachOptionsBuilder, Sandbox, SandboxStatus};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Attach to a running sandbox with an interactive terminal.
+#[derive(Debug, Args)]
+pub struct AttachArgs {
+    /// Name of the sandbox.
+    pub name: String,
+
+    /// Custom detach key sequence (e.g., "ctrl-p,ctrl-q").
+    #[arg(long)]
+    pub detach_keys: Option<String>,
+
+    /// Command to run interactively (after --).
+    #[arg(last = true)]
+    pub command: Vec<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb attach` command.
+pub async fn run(args: AttachArgs) -> anyhow::Result<()> {
+    let info = Sandbox::get(&args.name).await?;
+
+    let sandbox = match info.status {
+        SandboxStatus::Running | SandboxStatus::Draining => {
+            anyhow::bail!(
+                "sandbox '{}' is already running in another process; \
+                 cross-process attach is not yet supported",
+                args.name
+            );
+        }
+        SandboxStatus::Stopped | SandboxStatus::Crashed => {
+            let spinner = ui::Spinner::start("Starting", &args.name);
+            match Sandbox::start(&args.name).await {
+                Ok(s) => {
+                    spinner.finish_success("Started");
+                    s
+                }
+                Err(e) => {
+                    spinner.finish_error();
+                    return Err(e.into());
+                }
+            }
+        }
+        _ => {
+            anyhow::bail!(
+                "sandbox '{}' is in state {:?} and cannot be attached to",
+                args.name,
+                info.status
+            );
+        }
+    };
+
+    // Resolve the command to run (if any, from after --).
+    let detach_keys = args.detach_keys.clone();
+    let exit_code = if args.command.is_empty() {
+        sandbox.attach((), |a: AttachOptionsBuilder| {
+            let mut a = a;
+            if let Some(ref keys) = detach_keys {
+                a = a.detach_keys(keys);
+            }
+            a
+        }).await?
+    } else {
+        let cmd = args.command[0].clone();
+        let cmd_args: Vec<String> = args.command[1..].to_vec();
+        sandbox.attach(cmd, |a: AttachOptionsBuilder| {
+            let mut a = a;
+            if let Some(ref keys) = detach_keys {
+                a = a.detach_keys(keys);
+            }
+            if !cmd_args.is_empty() {
+                a = a.args(cmd_args);
+            }
+            a
+        }).await?
+    };
+
+    let _ = sandbox.stop().await;
+    let _ = sandbox.wait().await;
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/create.rs
+++ b/crates/cli/lib/commands/create.rs
@@ -1,0 +1,113 @@
+//! `msb create` command — create and boot a fresh sandbox.
+
+use clap::Args;
+use microsandbox::sandbox::Sandbox;
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Create and boot a fresh sandbox (no workload launch).
+#[derive(Debug, Args)]
+pub struct CreateArgs {
+    /// Image reference (OCI image, directory, or disk image).
+    pub image: String,
+
+    /// Sandbox name. Auto-generated if not provided.
+    #[arg(short, long)]
+    pub name: Option<String>,
+
+    /// Number of virtual CPUs.
+    #[arg(short = 'c', long)]
+    pub cpus: Option<u8>,
+
+    /// Memory limit (e.g., 512M, 1G).
+    #[arg(short, long)]
+    pub memory: Option<String>,
+
+    /// Volume mount (host:guest or name:guest). Can be repeated.
+    #[arg(short, long)]
+    pub volume: Vec<String>,
+
+    /// Working directory inside sandbox.
+    #[arg(short, long)]
+    pub workdir: Option<String>,
+
+    /// Default shell.
+    #[arg(long)]
+    pub shell: Option<String>,
+
+    /// Environment variable (KEY=value). Can be repeated.
+    #[arg(short, long)]
+    pub env: Vec<String>,
+
+    /// Replace existing stopped sandbox with same name.
+    #[arg(long)]
+    pub force: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb create` command.
+pub async fn run(args: CreateArgs) -> anyhow::Result<()> {
+    let name = args.name.unwrap_or_else(ui::generate_name);
+    let spinner = ui::Spinner::start("Creating", &name);
+
+    let mut builder = Sandbox::builder(&name).image(args.image.as_str());
+
+    if let Some(cpus) = args.cpus {
+        builder = builder.cpus(cpus);
+    }
+    if let Some(ref mem) = args.memory {
+        builder = builder.memory(ui::parse_memory(mem).map_err(anyhow::Error::msg)?);
+    }
+    if let Some(ref workdir) = args.workdir {
+        builder = builder.workdir(workdir);
+    }
+    if let Some(ref shell) = args.shell {
+        builder = builder.shell(shell);
+    }
+    if args.force {
+        builder = builder.force();
+    }
+    for env_str in &args.env {
+        let (k, v) = ui::parse_env(env_str).map_err(anyhow::Error::msg)?;
+        builder = builder.env(k, v);
+    }
+    for vol_str in &args.volume {
+        builder = apply_volume(builder, vol_str)?;
+    }
+
+    match builder.create().await {
+        Ok(_sandbox) => {
+            spinner.finish_success("Created");
+            // Sandbox stays running — supervisor continues as background process.
+        }
+        Err(e) => {
+            spinner.finish_error();
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse a volume spec and apply it to the builder.
+pub fn apply_volume(
+    builder: microsandbox::sandbox::SandboxBuilder,
+    spec: &str,
+) -> anyhow::Result<microsandbox::sandbox::SandboxBuilder> {
+    let (source, guest) = spec
+        .split_once(':')
+        .ok_or_else(|| anyhow::anyhow!("volume must be in format source:guest"))?;
+
+    if source.starts_with('/') || source.starts_with("./") || source.starts_with("../") {
+        Ok(builder.volume(guest, |m| m.bind(source)))
+    } else {
+        Ok(builder.volume(guest, |m| m.named(source)))
+    }
+}

--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -1,0 +1,137 @@
+//! `msb exec` command — execute a command in a sandbox.
+
+use std::io::Write;
+
+use clap::Args;
+use microsandbox::sandbox::{AttachOptionsBuilder, ExecOptionsBuilder, Sandbox, SandboxStatus};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Execute a command in a sandbox.
+#[derive(Debug, Args)]
+pub struct ExecArgs {
+    /// Name of the sandbox.
+    pub name: String,
+
+    /// Keep stdin open (interactive).
+    #[arg(short, long)]
+    pub interactive: bool,
+
+    /// Allocate a pseudo-TTY.
+    #[arg(short, long)]
+    pub tty: bool,
+
+    /// Environment variable (KEY=value). Can be repeated.
+    #[arg(short, long)]
+    pub env: Vec<String>,
+
+    /// Working directory inside sandbox.
+    #[arg(short, long)]
+    pub workdir: Option<String>,
+
+    /// Command to execute (after --).
+    #[arg(last = true, required = true)]
+    pub command: Vec<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb exec` command.
+pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
+    // Check sandbox status.
+    let info = Sandbox::get(&args.name).await?;
+
+    let sandbox = match info.status {
+        SandboxStatus::Running | SandboxStatus::Draining => {
+            anyhow::bail!(
+                "sandbox '{}' is already running in another process; \
+                 cross-process exec is not yet supported",
+                args.name
+            );
+        }
+        SandboxStatus::Stopped | SandboxStatus::Crashed => {
+            let spinner = ui::Spinner::start("Starting", &args.name);
+            match Sandbox::start(&args.name).await {
+                Ok(s) => {
+                    spinner.finish_success("Started");
+                    s
+                }
+                Err(e) => {
+                    spinner.finish_error();
+                    return Err(e.into());
+                }
+            }
+        }
+        _ => {
+            anyhow::bail!(
+                "sandbox '{}' is in state {:?} and cannot be started",
+                args.name,
+                info.status
+            );
+        }
+    };
+
+    let cmd = args.command[0].clone();
+    let cmd_args: Vec<String> = args.command[1..].to_vec();
+
+    // Build exec options.
+    let env_pairs: Vec<(String, String)> = args
+        .env
+        .iter()
+        .map(|s| ui::parse_env(s).map_err(anyhow::Error::msg))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let workdir = args.workdir.clone();
+    let tty = args.tty;
+
+    if args.interactive && args.tty {
+        // Interactive mode with TTY — use attach.
+        let exit_code = sandbox.attach(cmd, |a: AttachOptionsBuilder| {
+            let mut a = a.args(cmd_args);
+            for (k, v) in &env_pairs {
+                a = a.env(k, v);
+            }
+            if let Some(ref cwd) = workdir {
+                a = a.cwd(cwd);
+            }
+            a
+        }).await?;
+
+        let _ = sandbox.stop().await;
+        let _ = sandbox.wait().await;
+
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
+    } else {
+        // Non-interactive: exec and capture output.
+        let output = sandbox.exec(cmd, |e: ExecOptionsBuilder| {
+            let mut e = e.args(cmd_args).tty(tty);
+            for (k, v) in &env_pairs {
+                e = e.env(k, v);
+            }
+            if let Some(ref cwd) = workdir {
+                e = e.cwd(cwd);
+            }
+            e
+        }).await?;
+
+        std::io::stdout().write_all(&output.stdout)?;
+        std::io::stderr().write_all(&output.stderr)?;
+
+        let _ = sandbox.stop().await;
+        let _ = sandbox.wait().await;
+
+        if !output.status.success {
+            std::process::exit(output.status.code);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/inspect.rs
+++ b/crates/cli/lib/commands/inspect.rs
@@ -1,0 +1,118 @@
+//! `msb inspect` command — show detailed sandbox information.
+
+use clap::Args;
+use microsandbox::sandbox::{Sandbox, SandboxConfig, VolumeMount};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Show detailed sandbox information.
+#[derive(Debug, Args)]
+pub struct InspectArgs {
+    /// Name of the sandbox to inspect.
+    pub name: String,
+
+    /// Output format.
+    #[arg(long, value_name = "FORMAT")]
+    pub format: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb inspect` command.
+pub async fn run(args: InspectArgs) -> anyhow::Result<()> {
+    let info = Sandbox::get(&args.name).await?;
+
+    if args.format.as_deref() == Some("json") {
+        let config: serde_json::Value =
+            serde_json::from_str(&info.config).unwrap_or(serde_json::Value::Null);
+        let json = serde_json::json!({
+            "name": info.name,
+            "status": format!("{:?}", info.status),
+            "config": config,
+            "created_at": info.created_at.map(|dt| ui::format_datetime(&dt)),
+            "updated_at": info.updated_at.map(|dt| ui::format_datetime(&dt)),
+        });
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+
+    let status = format!("{:?}", info.status);
+
+    ui::detail_kv("Name", &info.name);
+    ui::detail_kv("Status", &ui::format_status(&status));
+
+    if let Some(ref dt) = info.created_at {
+        ui::detail_kv("Created", &ui::format_datetime(dt));
+    }
+    if let Some(ref dt) = info.updated_at {
+        ui::detail_kv("Updated", &ui::format_datetime(dt));
+    }
+
+    // Parse and display config details.
+    if let Ok(config) = serde_json::from_str::<SandboxConfig>(&info.config) {
+        let image = match &config.image {
+            microsandbox::sandbox::RootfsSource::Oci(s) => s.clone(),
+            microsandbox::sandbox::RootfsSource::Bind(p) => p.display().to_string(),
+            microsandbox::sandbox::RootfsSource::DiskImage { path, .. } => {
+                path.display().to_string()
+            }
+        };
+        ui::detail_kv("Image", &image);
+
+        ui::detail_header("Resources");
+        ui::detail_kv_indent("CPUs", &config.cpus.to_string());
+        ui::detail_kv_indent("Memory", &format!("{} MiB", config.memory_mib));
+
+        if let Some(ref workdir) = config.workdir {
+            ui::detail_kv("Workdir", workdir);
+        }
+        if let Some(ref shell) = config.shell {
+            ui::detail_kv("Shell", shell);
+        }
+
+        if !config.env.is_empty() {
+            ui::detail_header("Environment");
+            for (k, v) in &config.env {
+                println!("  {k}={v}");
+            }
+        }
+
+        if !config.mounts.is_empty() {
+            ui::detail_header("Mounts");
+            for mount in &config.mounts {
+                match mount {
+                    VolumeMount::Bind {
+                        host,
+                        guest,
+                        readonly,
+                    } => {
+                        let ro = if *readonly { " (ro)" } else { " (rw)" };
+                        println!("  {guest:<16}\u{2192} {}{ro}", host.display());
+                    }
+                    VolumeMount::Named {
+                        name,
+                        guest,
+                        readonly,
+                    } => {
+                        let ro = if *readonly { " (ro)" } else { " (rw)" };
+                        println!("  {guest:<16}\u{2192} volume:{name}{ro}");
+                    }
+                    VolumeMount::Tmpfs { guest, size_mib } => {
+                        let size = size_mib
+                            .map(|s| format!(" ({s} MiB)"))
+                            .unwrap_or_default();
+                        println!("  {guest:<16}\u{2192} tmpfs{size}");
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/list.rs
+++ b/crates/cli/lib/commands/list.rs
@@ -1,0 +1,123 @@
+//! `msb list` command — list all sandboxes.
+
+use clap::Args;
+use microsandbox::sandbox::{Sandbox, SandboxConfig, SandboxStatus};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// List all stored sandboxes.
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    /// Show only running sandboxes.
+    #[arg(long)]
+    pub running: bool,
+
+    /// Show only stopped sandboxes.
+    #[arg(long)]
+    pub stopped: bool,
+
+    /// Output format.
+    #[arg(long, value_name = "FORMAT")]
+    pub format: Option<String>,
+
+    /// Show only sandbox names.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb list` command.
+pub async fn run(args: ListArgs) -> anyhow::Result<()> {
+    let sandboxes = Sandbox::list().await?;
+
+    let filtered: Vec<_> = sandboxes
+        .into_iter()
+        .filter(|s| {
+            if args.running {
+                s.status == SandboxStatus::Running
+            } else if args.stopped {
+                s.status == SandboxStatus::Stopped
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if args.format.as_deref() == Some("json") {
+        print_json(&filtered)?;
+        return Ok(());
+    }
+
+    if args.quiet {
+        for s in &filtered {
+            println!("{}", s.name);
+        }
+        return Ok(());
+    }
+
+    if filtered.is_empty() {
+        eprintln!("No sandboxes found.");
+        return Ok(());
+    }
+
+    let mut table = ui::Table::new(&["Name", "Image", "Status", "Created"]);
+
+    for s in &filtered {
+        let image = extract_image(&s.config);
+        let status = format!("{:?}", s.status);
+        let created = s
+            .created_at
+            .as_ref()
+            .map(ui::format_datetime)
+            .unwrap_or_else(|| "-".to_string());
+
+        table.add_row(vec![
+            s.name.clone(),
+            image,
+            ui::format_status(&status),
+            created,
+        ]);
+    }
+
+    table.print();
+    Ok(())
+}
+
+/// Extract image name from config JSON.
+fn extract_image(config_json: &str) -> String {
+    serde_json::from_str::<SandboxConfig>(config_json)
+        .ok()
+        .map(|c| match c.image {
+            microsandbox::sandbox::RootfsSource::Oci(ref s) => s.clone(),
+            microsandbox::sandbox::RootfsSource::Bind(ref p) => p.display().to_string(),
+            microsandbox::sandbox::RootfsSource::DiskImage { ref path, .. } => {
+                path.display().to_string()
+            }
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn print_json(
+    sandboxes: &[microsandbox::sandbox::SandboxInfo],
+) -> anyhow::Result<()> {
+    let entries: Vec<serde_json::Value> = sandboxes
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "name": s.name,
+                "status": format!("{:?}", s.status),
+                "created_at": s.created_at.map(|dt| ui::format_datetime(&dt)),
+                "image": extract_image(&s.config),
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&entries)?);
+    Ok(())
+}

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -1,0 +1,18 @@
+//! CLI command implementations.
+
+//--------------------------------------------------------------------------------------------------
+// Exports
+//--------------------------------------------------------------------------------------------------
+
+pub mod attach;
+pub mod create;
+pub mod exec;
+pub mod inspect;
+pub mod list;
+pub mod ps;
+pub mod pull;
+pub mod remove;
+pub mod run;
+pub mod shell;
+pub mod start;
+pub mod stop;

--- a/crates/cli/lib/commands/ps.rs
+++ b/crates/cli/lib/commands/ps.rs
@@ -1,0 +1,81 @@
+//! `msb ps` command — show running sandboxes (quick view).
+
+use clap::Args;
+use microsandbox::sandbox::{Sandbox, SandboxConfig, SandboxStatus};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Show running sandboxes.
+#[derive(Debug, Args)]
+pub struct PsArgs {
+    /// Show all sandboxes (including stopped).
+    #[arg(short, long)]
+    pub all: bool,
+
+    /// Show only sandbox names.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb ps` command.
+pub async fn run(args: PsArgs) -> anyhow::Result<()> {
+    let sandboxes = Sandbox::list().await?;
+
+    let filtered: Vec<_> = if args.all {
+        sandboxes
+    } else {
+        sandboxes
+            .into_iter()
+            .filter(|s| s.status == SandboxStatus::Running || s.status == SandboxStatus::Draining)
+            .collect()
+    };
+
+    if args.quiet {
+        for s in &filtered {
+            println!("{}", s.name);
+        }
+        return Ok(());
+    }
+
+    if filtered.is_empty() {
+        if args.all {
+            eprintln!("No sandboxes found.");
+        } else {
+            eprintln!("No running sandboxes.");
+        }
+        return Ok(());
+    }
+
+    let mut table = ui::Table::new(&["Name", "Image", "Status"]);
+
+    for s in &filtered {
+        let image = extract_image(&s.config);
+        let status = format!("{:?}", s.status);
+        table.add_row(vec![s.name.clone(), image, ui::format_status(&status)]);
+    }
+
+    table.print();
+    Ok(())
+}
+
+/// Extract image name from config JSON.
+fn extract_image(config_json: &str) -> String {
+    serde_json::from_str::<SandboxConfig>(config_json)
+        .ok()
+        .map(|c| match c.image {
+            microsandbox::sandbox::RootfsSource::Oci(ref s) => s.clone(),
+            microsandbox::sandbox::RootfsSource::Bind(ref p) => p.display().to_string(),
+            microsandbox::sandbox::RootfsSource::DiskImage { ref path, .. } => {
+                path.display().to_string()
+            }
+        })
+        .unwrap_or_else(|| "-".to_string())
+}

--- a/crates/cli/lib/commands/pull.rs
+++ b/crates/cli/lib/commands/pull.rs
@@ -1,0 +1,56 @@
+//! `msb pull` command — pull an image from a registry.
+
+use clap::Args;
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Pull an image from a registry.
+#[derive(Debug, Args)]
+pub struct PullArgs {
+    /// Image reference (e.g., python:3.11, ubuntu:22.04).
+    pub reference: String,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb pull` command.
+pub async fn run(args: PullArgs) -> anyhow::Result<()> {
+    let spinner = ui::Spinner::start("Pulling", &args.reference);
+
+    let global = microsandbox::config::config();
+    let cache = microsandbox_image::GlobalCache::new(&global.cache_dir())?;
+    let platform = microsandbox_image::Platform::host_linux();
+    let image_ref: microsandbox_image::Reference = args
+        .reference
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid image reference: {e}"))?;
+
+    let auth = global.resolve_registry_auth(image_ref.registry())?;
+    let registry = microsandbox_image::Registry::with_auth(platform, cache, auth)?;
+
+    let options = microsandbox_image::PullOptions {
+        pull_policy: microsandbox_image::PullPolicy::Always,
+        ..Default::default()
+    };
+
+    match registry.pull(&image_ref, &options).await {
+        Ok(result) => {
+            spinner.finish_success("Pulled");
+            if result.cached {
+                eprintln!("   (already cached)");
+            }
+        }
+        Err(e) => {
+            spinner.finish_error();
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/remove.rs
+++ b/crates/cli/lib/commands/remove.rs
@@ -1,0 +1,52 @@
+//! `msb remove` command — remove a stopped sandbox.
+
+use clap::Args;
+use microsandbox::sandbox::Sandbox;
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Remove a stopped sandbox.
+#[derive(Debug, Args)]
+pub struct RemoveArgs {
+    /// Name(s) of the sandbox(es) to remove.
+    #[arg(required = true)]
+    pub names: Vec<String>,
+
+    /// Force removal (stop running sandbox first).
+    #[arg(long)]
+    pub force: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb remove` command.
+pub async fn run(args: RemoveArgs) -> anyhow::Result<()> {
+    for name in &args.names {
+        if args.force {
+            // Try to stop the sandbox first if it's running.
+            let _ = Sandbox::stop_by_name(name).await;
+            // Give the supervisor a moment to shut down.
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+
+        let spinner = ui::Spinner::start("Removing", name);
+
+        match Sandbox::remove(name).await {
+            Ok(()) => {
+                spinner.finish_success("Removed");
+            }
+            Err(e) => {
+                spinner.finish_error();
+                ui::error(&format!("{e}"));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -1,0 +1,155 @@
+//! `msb run` command — create and start a new sandbox.
+
+use std::io::Write;
+
+use clap::Args;
+use microsandbox::sandbox::{ExecOptionsBuilder, Sandbox};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Create and start a new sandbox.
+#[derive(Debug, Args)]
+pub struct RunArgs {
+    /// Image reference (OCI image, directory, or disk image).
+    pub image: String,
+
+    /// Sandbox name. Auto-generated if not provided.
+    #[arg(short, long)]
+    pub name: Option<String>,
+
+    /// Number of virtual CPUs.
+    #[arg(short = 'c', long)]
+    pub cpus: Option<u8>,
+
+    /// Memory limit (e.g., 512M, 1G).
+    #[arg(short, long)]
+    pub memory: Option<String>,
+
+    /// Volume mount (host:guest or name:guest). Can be repeated.
+    #[arg(short, long)]
+    pub volume: Vec<String>,
+
+    /// Working directory inside sandbox.
+    #[arg(short, long)]
+    pub workdir: Option<String>,
+
+    /// Default shell.
+    #[arg(long)]
+    pub shell: Option<String>,
+
+    /// Environment variable (KEY=value). Can be repeated.
+    #[arg(short, long)]
+    pub env: Vec<String>,
+
+    /// Replace existing stopped sandbox with same name.
+    #[arg(long)]
+    pub force: bool,
+
+    /// Run in background (detach).
+    #[arg(short, long)]
+    pub detach: bool,
+
+    /// Command to execute (after --).
+    #[arg(last = true)]
+    pub command: Vec<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb run` command.
+pub async fn run(args: RunArgs) -> anyhow::Result<()> {
+    let is_named = args.name.is_some();
+    let name = args.name.unwrap_or_else(ui::generate_name);
+
+    let spinner = ui::Spinner::start("Creating", &name);
+
+    let mut builder = Sandbox::builder(&name).image(args.image.as_str());
+
+    if let Some(cpus) = args.cpus {
+        builder = builder.cpus(cpus);
+    }
+    if let Some(ref mem) = args.memory {
+        builder = builder.memory(ui::parse_memory(mem).map_err(anyhow::Error::msg)?);
+    }
+    if let Some(ref workdir) = args.workdir {
+        builder = builder.workdir(workdir);
+    }
+    if let Some(ref shell) = args.shell {
+        builder = builder.shell(shell);
+    }
+    if args.force {
+        builder = builder.force();
+    }
+    for env_str in &args.env {
+        let (k, v) = ui::parse_env(env_str).map_err(anyhow::Error::msg)?;
+        builder = builder.env(k, v);
+    }
+    for vol_str in &args.volume {
+        builder = super::create::apply_volume(builder, vol_str)?;
+    }
+
+    let sandbox = match builder.create().await {
+        Ok(s) => {
+            spinner.finish_success("Created");
+            s
+        }
+        Err(e) => {
+            spinner.finish_error();
+            return Err(e.into());
+        }
+    };
+
+    // Detach mode: just print the name and exit.
+    if args.detach {
+        println!("{name}");
+        return Ok(());
+    }
+
+    if !args.command.is_empty() {
+        // Non-interactive: exec command and stream output.
+        let cmd = args.command[0].clone();
+        let cmd_args: Vec<String> = args.command[1..].to_vec();
+
+        let output = sandbox.exec(&cmd, |e: ExecOptionsBuilder| e.args(cmd_args)).await?;
+
+        std::io::stdout().write_all(&output.stdout)?;
+        std::io::stderr().write_all(&output.stderr)?;
+
+        // Stop and clean up.
+        let _ = sandbox.stop().await;
+        let _ = sandbox.wait().await;
+
+        // Remove unnamed (ephemeral) sandboxes.
+        if !is_named {
+            let _ = Sandbox::remove(&name).await;
+        }
+
+        if !output.status.success {
+            std::process::exit(output.status.code);
+        }
+    } else {
+        // Interactive: attach to sandbox shell.
+        let exit_code = sandbox.attach((), ()).await?;
+
+        // Stop and clean up.
+        let _ = sandbox.stop().await;
+        let _ = sandbox.wait().await;
+
+        // Remove unnamed (ephemeral) sandboxes.
+        if !is_named {
+            let _ = Sandbox::remove(&name).await;
+        }
+
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/shell.rs
+++ b/crates/cli/lib/commands/shell.rs
@@ -1,0 +1,75 @@
+//! `msb shell` command — interactive shell in a sandbox (alias for attach).
+
+use clap::Args;
+use microsandbox::sandbox::{Sandbox, SandboxStatus};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Interactive shell in a running sandbox.
+#[derive(Debug, Args)]
+pub struct ShellArgs {
+    /// Name of the sandbox.
+    pub name: String,
+
+    /// Shell to use (overrides sandbox default).
+    #[arg(long)]
+    pub shell: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb shell` command.
+pub async fn run(args: ShellArgs) -> anyhow::Result<()> {
+    let info = Sandbox::get(&args.name).await?;
+
+    let sandbox = match info.status {
+        SandboxStatus::Running | SandboxStatus::Draining => {
+            anyhow::bail!(
+                "sandbox '{}' is already running in another process; \
+                 cross-process attach is not yet supported",
+                args.name
+            );
+        }
+        SandboxStatus::Stopped | SandboxStatus::Crashed => {
+            let spinner = ui::Spinner::start("Starting", &args.name);
+            match Sandbox::start(&args.name).await {
+                Ok(s) => {
+                    spinner.finish_success("Started");
+                    s
+                }
+                Err(e) => {
+                    spinner.finish_error();
+                    return Err(e.into());
+                }
+            }
+        }
+        _ => {
+            anyhow::bail!(
+                "sandbox '{}' is in state {:?} and cannot be attached to",
+                args.name,
+                info.status
+            );
+        }
+    };
+
+    // Use the specified shell or default.
+    let exit_code = match args.shell {
+        Some(ref shell) => sandbox.attach(shell.as_str(), ()).await?,
+        None => sandbox.attach((), ()).await?,
+    };
+
+    let _ = sandbox.stop().await;
+    let _ = sandbox.wait().await;
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/start.rs
+++ b/crates/cli/lib/commands/start.rs
@@ -1,0 +1,39 @@
+//! `msb start` command — start/resume an existing stopped sandbox.
+
+use clap::Args;
+use microsandbox::sandbox::Sandbox;
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Start/resume an existing stopped sandbox.
+#[derive(Debug, Args)]
+pub struct StartArgs {
+    /// Name of the sandbox to start.
+    pub name: String,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb start` command.
+pub async fn run(args: StartArgs) -> anyhow::Result<()> {
+    let spinner = ui::Spinner::start("Starting", &args.name);
+
+    match Sandbox::start(&args.name).await {
+        Ok(_sandbox) => {
+            spinner.finish_success("Started");
+            // Sandbox stays running — supervisor continues as background process.
+        }
+        Err(e) => {
+            spinner.finish_error();
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/commands/stop.rs
+++ b/crates/cli/lib/commands/stop.rs
@@ -1,0 +1,48 @@
+//! `msb stop` command — stop a running sandbox.
+
+use clap::Args;
+use microsandbox::sandbox::Sandbox;
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Stop a running sandbox.
+#[derive(Debug, Args)]
+pub struct StopArgs {
+    /// Name of the sandbox to stop.
+    pub name: String,
+
+    /// Force kill (SIGKILL instead of graceful shutdown).
+    #[arg(long)]
+    pub force: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb stop` command.
+pub async fn run(args: StopArgs) -> anyhow::Result<()> {
+    let spinner = ui::Spinner::start("Stopping", &args.name);
+
+    let result = if args.force {
+        Sandbox::kill_by_name(&args.name).await
+    } else {
+        Sandbox::stop_by_name(&args.name).await
+    };
+
+    match result {
+        Ok(()) => {
+            spinner.finish_success("Stopped");
+        }
+        Err(e) => {
+            spinner.finish_error();
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/lib/lib.rs
+++ b/crates/cli/lib/lib.rs
@@ -8,7 +8,9 @@
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub mod commands;
 pub mod log_args;
 pub mod microvm_cmd;
 pub mod styles;
 pub mod supervisor_cmd;
+pub mod ui;

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -1,0 +1,268 @@
+//! CLI output styling and helpers.
+//!
+//! Implements the microsandbox output design system: spinners, tables,
+//! detail views, and styled messages. All ephemeral output goes to stderr;
+//! final data output goes to stdout.
+
+use std::io::IsTerminal;
+use std::time::{Duration, Instant};
+
+use console::style;
+use indicatif::{ProgressBar, ProgressStyle};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Ephemeral braille spinner for long-running operations.
+pub struct Spinner {
+    pb: Option<ProgressBar>,
+    start: Instant,
+    label: String,
+    target: String,
+}
+
+/// Minimal table renderer with column alignment.
+pub struct Table {
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Spinner {
+    /// Start a new spinner. Label is the action verb (e.g., "Creating"),
+    /// target is the object name (e.g., "mybox").
+    pub fn start(label: &str, target: &str) -> Self {
+        let is_tty = std::io::stderr().is_terminal();
+        let pb = if is_tty {
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "⠋"])
+                    .template(&format!("   {{spinner}} {:<12} {{msg}}", label))
+                    .unwrap(),
+            );
+            pb.set_message(target.to_string());
+            pb.enable_steady_tick(Duration::from_millis(80));
+            Some(pb)
+        } else {
+            None
+        };
+
+        Self {
+            pb,
+            start: Instant::now(),
+            label: label.to_string(),
+            target: target.to_string(),
+        }
+    }
+
+    /// Finish with success. Shows `✓ <past_tense> <target> (duration)`.
+    pub fn finish_success(self, past_tense: &str) {
+        let elapsed = self.start.elapsed();
+        let duration = if elapsed.as_millis() > 500 {
+            format!(" ({})", format_duration(elapsed))
+        } else {
+            String::new()
+        };
+
+        if let Some(pb) = self.pb {
+            pb.finish_and_clear();
+        }
+
+        eprintln!(
+            "   {} {:<12} {}{}",
+            style("✓").green(),
+            past_tense,
+            self.target,
+            style(duration).dim()
+        );
+    }
+
+    /// Finish with error. Shows `✗ <label> <target>`.
+    pub fn finish_error(self) {
+        if let Some(pb) = self.pb {
+            pb.finish_and_clear();
+        }
+        eprintln!(
+            "   {} {:<12} {}",
+            style("✗").red(),
+            self.label,
+            self.target
+        );
+    }
+}
+
+impl Table {
+    /// Create a new table with the given column headers.
+    pub fn new(headers: &[&str]) -> Self {
+        Self {
+            headers: headers.iter().map(|h| h.to_string()).collect(),
+            rows: Vec::new(),
+        }
+    }
+
+    /// Add a row to the table.
+    pub fn add_row(&mut self, row: Vec<String>) {
+        self.rows.push(row);
+    }
+
+    /// Print the table to stdout with column alignment.
+    pub fn print(&self) {
+        if self.rows.is_empty() {
+            return;
+        }
+
+        let col_count = self.headers.len();
+        let mut widths: Vec<usize> = self.headers.iter().map(|h| h.len()).collect();
+
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < col_count {
+                    widths[i] = widths[i].max(cell.len());
+                }
+            }
+        }
+
+        // Print headers
+        let header: String = self
+            .headers
+            .iter()
+            .enumerate()
+            .map(|(i, h)| {
+                if i < col_count - 1 {
+                    format!("{:<width$}    ", h.to_uppercase(), width = widths[i])
+                } else {
+                    h.to_uppercase()
+                }
+            })
+            .collect();
+        println!("{}", style(header).cyan().bold());
+
+        // Print rows
+        for row in &self.rows {
+            let line: String = row
+                .iter()
+                .enumerate()
+                .map(|(i, cell)| {
+                    if i < col_count - 1 {
+                        format!("{:<width$}    ", cell, width = widths[i])
+                    } else {
+                        cell.clone()
+                    }
+                })
+                .collect();
+            println!("{line}");
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Print a styled error message to stderr.
+pub fn error(msg: &str) {
+    eprintln!("{} {msg}", style("error:").red().bold());
+}
+
+/// Print an error message with context lines.
+pub fn error_context(msg: &str, context: &[&str]) {
+    eprintln!("{} {msg}", style("error:").red().bold());
+    for line in context {
+        eprintln!("  {} {}", style("→").dim(), style(line).dim());
+    }
+}
+
+/// Print a styled warning message to stderr.
+pub fn warn(msg: &str) {
+    eprintln!("{} {msg}", style("warn:").yellow().bold());
+}
+
+/// Print a one-shot success message to stderr.
+pub fn success(msg: &str) {
+    eprintln!("{} {msg}", style("✓").green());
+}
+
+/// Format a sandbox status with appropriate color.
+pub fn format_status(status: &str) -> String {
+    match status {
+        "Running" => format!("{}", style("running").green().bold()),
+        "Stopped" => format!("{}", style("stopped").dim()),
+        "Paused" => format!("{}", style("paused").yellow().bold()),
+        "Draining" => format!("{}", style("draining").yellow().bold()),
+        "Crashed" => format!("{}", style("crashed").red().bold()),
+        other => other.to_lowercase(),
+    }
+}
+
+/// Print a section header in detail views.
+pub fn detail_header(title: &str) {
+    println!();
+    println!("{}", style(title).bold());
+}
+
+/// Print a top-level key-value pair in detail views.
+pub fn detail_kv(key: &str, value: &str) {
+    println!("{:<16}{value}", style(format!("{key}:")).cyan());
+}
+
+/// Print an indented key-value pair in detail views.
+pub fn detail_kv_indent(key: &str, value: &str) {
+    println!("  {:<14}{value}", style(format!("{key}:")).cyan());
+}
+
+/// Parse a memory size string (e.g., "512M", "1G") into MiB.
+pub fn parse_memory(s: &str) -> Result<u32, String> {
+    let s = s.trim();
+    if let Some(num) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
+        num.parse::<u32>()
+            .map(|n| n * 1024)
+            .map_err(|e| format!("invalid memory size: {e}"))
+    } else if let Some(num) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
+        num.parse::<u32>()
+            .map_err(|e| format!("invalid memory size: {e}"))
+    } else {
+        s.parse::<u32>()
+            .map_err(|e| format!("invalid memory size (expected e.g. 512M, 1G): {e}"))
+    }
+}
+
+/// Parse an environment variable specification (KEY=value or KEY).
+pub fn parse_env(s: &str) -> Result<(String, String), String> {
+    if let Some(eq_pos) = s.find('=') {
+        Ok((s[..eq_pos].to_string(), s[eq_pos + 1..].to_string()))
+    } else {
+        match std::env::var(s) {
+            Ok(val) => Ok((s.to_string(), val)),
+            Err(_) => Err(format!("environment variable '{s}' not set")),
+        }
+    }
+}
+
+/// Generate a random sandbox name.
+pub fn generate_name() -> String {
+    use rand::Rng;
+    let id: u32 = rand::rng().random();
+    format!("msb-{id:08x}")
+}
+
+/// Format a duration for display.
+pub fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 60.0 {
+        format!("{secs:.1}s")
+    } else {
+        let mins = secs as u64 / 60;
+        let remaining = secs as u64 % 60;
+        format!("{mins}m{remaining}s")
+    }
+}
+
+/// Format a chrono NaiveDateTime for display.
+pub fn format_datetime(dt: &chrono::NaiveDateTime) -> String {
+    dt.format("%Y-%m-%d %H:%M:%S").to_string()
+}

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     MicrosandboxResult,
     agent::AgentBridge,
     db::entity::{
-        image as image_entity, sandbox as sandbox_entity, sandbox::SandboxStatus,
+        image as image_entity, sandbox as sandbox_entity,
         sandbox_image as sandbox_image_entity,
     },
     runtime::{SupervisorHandle, spawn_supervisor},
@@ -55,6 +55,7 @@ pub use types::{
     DiskImageFormat, ImageBuilder, ImageSource, IntoImage, MountBuilder, Patch, RootfsSource,
     SecretsConfig, SshConfig, VolumeMount,
 };
+pub use crate::db::entity::sandbox::SandboxStatus;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -235,6 +236,78 @@ impl Sandbox {
         model.into_active_model().delete(db).await?;
 
         Ok(())
+    }
+
+    /// Stop a running sandbox by name.
+    ///
+    /// Finds the supervisor PID from the database and sends SIGTERM.
+    pub async fn stop_by_name(name: &str) -> MicrosandboxResult<()> {
+        use crate::db::entity::supervisor as supervisor_entity;
+
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let sandbox = load_sandbox_record(db, name).await?;
+
+        if sandbox.status != SandboxStatus::Running && sandbox.status != SandboxStatus::Draining {
+            return Err(crate::MicrosandboxError::Custom(format!(
+                "sandbox '{name}' is not running"
+            )));
+        }
+
+        let supervisor = supervisor_entity::Entity::find()
+            .filter(supervisor_entity::Column::SandboxId.eq(sandbox.id))
+            .filter(
+                supervisor_entity::Column::Status
+                    .eq(supervisor_entity::SupervisorStatus::Running),
+            )
+            .order_by_desc(supervisor_entity::Column::StartedAt)
+            .one(db)
+            .await?;
+
+        match supervisor.and_then(|s| s.pid) {
+            Some(pid) => {
+                nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid),
+                    nix::sys::signal::Signal::SIGTERM,
+                )?;
+                Ok(())
+            }
+            None => Err(crate::MicrosandboxError::Custom(format!(
+                "no running supervisor found for sandbox '{name}'"
+            ))),
+        }
+    }
+
+    /// Kill a running sandbox by name (SIGKILL).
+    pub async fn kill_by_name(name: &str) -> MicrosandboxResult<()> {
+        use crate::db::entity::supervisor as supervisor_entity;
+
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        let sandbox = load_sandbox_record(db, name).await?;
+
+        let supervisor = supervisor_entity::Entity::find()
+            .filter(supervisor_entity::Column::SandboxId.eq(sandbox.id))
+            .filter(
+                supervisor_entity::Column::Status
+                    .eq(supervisor_entity::SupervisorStatus::Running),
+            )
+            .order_by_desc(supervisor_entity::Column::StartedAt)
+            .one(db)
+            .await?;
+
+        match supervisor.and_then(|s| s.pid) {
+            Some(pid) => {
+                nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid),
+                    nix::sys::signal::Signal::SIGKILL,
+                )?;
+                Ok(())
+            }
+            None => Err(crate::MicrosandboxError::Custom(format!(
+                "no running supervisor found for sandbox '{name}'"
+            ))),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add 12 user-facing CLI subcommands to `msb` covering the full sandbox lifecycle: create, run, start, stop, list, ps, remove, exec, attach, shell, pull, and inspect
- Implement a UI styling module following the CLI output design system with braille spinners, colored status badges, column-aligned tables, and styled error/success messages
- Add `Sandbox::stop_by_name()` and `Sandbox::kill_by_name()` to the SDK for cross-process sandbox management via supervisor PID lookup
- Hide internal `supervisor` and `microvm` subcommands from the help output so users only see the public interface

## Changes

- **New `crates/cli/lib/commands/` module** (12 files, ~1100 lines): Each subcommand is a separate module with clap-derived args struct and async handler:
  - `run.rs`: Create + exec/attach with ephemeral sandbox support (auto-remove unnamed sandboxes on exit), detach mode
  - `create.rs`: Boot a sandbox without launching a workload, shared `apply_volume()` helper for volume spec parsing
  - `start.rs`: Resume a stopped sandbox from persisted state
  - `stop.rs`: Graceful shutdown (SIGTERM) or forced kill (SIGKILL) via `--force`
  - `list.rs`: List sandboxes with `--running`/`--stopped` filters, `--format json`, and `-q` quiet mode
  - `ps.rs`: Quick running sandboxes view with `-a` for all
  - `remove.rs`: Remove stopped sandboxes with `--force` (stops first) and multi-name support
  - `exec.rs`: Execute commands with `-i`/`-t`/`-e`/`-w` flags; interactive+TTY mode delegates to attach
  - `attach.rs`: Interactive terminal session with `--detach-keys` and optional command
  - `shell.rs`: Attach alias with `--shell` override
  - `pull.rs`: Pull OCI images using always-pull policy with auth resolution from global config
  - `inspect.rs`: Detailed sandbox info with config, resources, environment, mounts sections; JSON output support
- **New `crates/cli/lib/ui.rs`** (~270 lines): Output design system implementation:
  - `Spinner` type with braille animation, TTY detection, duration display, success/error states
  - `Table` type with column-aligned output and cyan bold headers
  - Detail view helpers (`detail_header`, `detail_kv`, `detail_kv_indent`)
  - Styled message functions (`error`, `error_context`, `warn`, `success`)
  - Status badge formatting with color-coded sandbox states
  - Parsers for memory sizes (`512M`, `1G`) and environment variable specs (`KEY=value`)
  - Random sandbox name generation for ephemeral sandboxes
- **Modified `crates/microsandbox/lib/sandbox/mod.rs`**: Added `stop_by_name()` and `kill_by_name()` static methods that query the supervisor entity by sandbox name and send SIGTERM/SIGKILL to the supervisor PID; publicly re-exported `SandboxStatus` enum
- **Modified `crates/cli/bin/main.rs`**: Registered all 12 subcommands in the `Commands` enum with dispatch to handlers; unified error handling via `ui::error()`; added `#[command(hide = true)]` to internal subcommands
- **Modified `crates/cli/Cargo.toml`**: Added dependencies on `microsandbox`, `microsandbox-image`, `console`, `indicatif`, `anyhow`, `chrono`, `rand`, `serde_json`

## Test Plan

- [x] `cargo check --workspace` compiles cleanly with zero errors and zero warnings
- [x] `cargo test -p microsandbox-cli` passes all 3 existing tests
- [x] `cargo test -p microsandbox` passes all 57 SDK tests (no regressions from `SandboxStatus` re-export and new methods)
- [x] `cargo run -p microsandbox-cli -- --help` shows all 12 new commands with correct descriptions and aliases (`ls`, `rm`)
- [x] `cargo run -p microsandbox-cli -- run --help` shows all expected flags (`-n`, `-c`, `-m`, `-v`, `-w`, `-e`, `-d`, `--force`, `--shell`)
- [x] `cargo run -p microsandbox-cli -- exec --help` shows all expected flags (`-i`, `-t`, `-e`, `-w`, `-- <COMMAND>`)
- [ ] End-to-end: `msb pull alpine:3.20` pulls an image
- [ ] End-to-end: `msb run alpine:3.20 -- echo hello` creates ephemeral sandbox and runs command
- [ ] End-to-end: `msb create -n test alpine:3.20` followed by `msb list` and `msb stop test` and `msb rm test`