### PR TITLE
chore: bump crates to v0.3.2 and pin prebuilt download version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2176,14 +2176,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2221,14 +2221,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "block2",
  "clap",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2270,7 +2270,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "crc32c",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/zerocore-ai/microsandbox"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/zerocore-ai/microsandbox"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.3.1", path = "../protocol" }
+microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "mount",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,9 +25,9 @@ chrono.workspace = true
 clap.workspace = true
 console.workspace = true
 indicatif.workspace = true
-microsandbox = { version = "0.3.1", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.3.1", path = "../image" }
-microsandbox-runtime = { version = "0.3.1", path = "../runtime", default-features = false }
+microsandbox = { version = "0.3.2", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.3.2", path = "../image" }
+microsandbox-runtime = { version = "0.3.2", path = "../runtime", default-features = false }
 rand.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.3.1", path = "../utils" }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 msb_krun = "0.1.6"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.3.1", path = "../utils" }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.3.1", path = "../utils" }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 oci-client.workspace = true
 oci-spec.workspace = true
 scopeguard.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -23,14 +23,14 @@ dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.3.1", path = "../db" }
-microsandbox-filesystem = { version = "0.3.1", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.3.1", path = "../image" }
-microsandbox-migration = { version = "0.3.1", path = "../migration" }
-microsandbox-network = { version = "0.3.1", path = "../network" }
-microsandbox-protocol = { version = "0.3.1", path = "../protocol" }
-microsandbox-runtime = { version = "0.3.1", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.1", path = "../utils" }
+microsandbox-db = { version = "0.3.2", path = "../db" }
+microsandbox-filesystem = { version = "0.3.2", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.3.2", path = "../image" }
+microsandbox-migration = { version = "0.3.2", path = "../migration" }
+microsandbox-network = { version = "0.3.2", path = "../network" }
+microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
+microsandbox-runtime = { version = "0.3.2", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 reqwest.workspace = true
 scopeguard.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -34,8 +34,8 @@ hickory-resolver = { workspace = true }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true, optional = true }
-microsandbox-protocol = { version = "0.3.1", path = "../protocol" }
-microsandbox-utils = { version = "0.3.1", path = "../utils" }
+microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 nix = { workspace = true, features = ["user"] }
 rcgen = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,11 +19,11 @@ prebuilt = ["microsandbox-filesystem/prebuilt"]
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 libc.workspace = true
-microsandbox-db = { version = "0.3.1", path = "../db" }
-microsandbox-filesystem = { version = "0.3.1", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.3.1", path = "../network" }
-microsandbox-protocol = { version = "0.3.1", path = "../protocol" }
-microsandbox-utils = { version = "0.3.1", path = "../utils" }
+microsandbox-db = { version = "0.3.2", path = "../db" }
+microsandbox-filesystem = { version = "0.3.2", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.3.2", path = "../network" }
+microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 msb_krun = { version = "0.1.6", features = ["blk", "net"] }
 nix = { workspace = true, features = ["process", "signal"] }
 sea-orm.workspace = true

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -59,7 +59,7 @@ pub const MSB_BINARY: &str = "msb";
 
 /// Pinned version for downloading prebuilt release artifacts.
 /// Update this after publishing a new GitHub release.
-pub const PREBUILT_VERSION: &str = "0.3.0";
+pub const PREBUILT_VERSION: &str = "0.3.1";
 
 /// libkrunfw release version. Keep in sync with justfile.
 pub const LIBKRUNFW_VERSION: &str = "5.2.1";


### PR DESCRIPTION
## Summary
- Bump all microsandbox workspace crates and agentd from v0.3.1 to v0.3.2
- Update PREBUILT_VERSION from v0.3.0 to v0.3.1 to track the last published GitHub release for prebuilt artifact downloads

## Changes
- Updated workspace version in root `Cargo.toml` from 0.3.1 to 0.3.2
- Updated agentd workspace version and microsandbox-protocol dependency in `crates/agentd/Cargo.toml`
- Updated all internal crate dependency version pins across `crates/cli/Cargo.toml`, `crates/filesystem/Cargo.toml`, `crates/image/Cargo.toml`, `crates/microsandbox/Cargo.toml`, `crates/network/Cargo.toml`, and `crates/runtime/Cargo.toml`
- Updated `PREBUILT_VERSION` constant in `crates/utils/lib/lib.rs` from "0.3.0" to "0.3.1"
- Regenerated `Cargo.lock` and `crates/agentd/Cargo.lock` to reflect new versions

## Test Plan
- Pre-commit hooks passed: cargo fmt, cargo clippy, cargo doc, and release build (`cargo build --release`)
- Run `cargo build` to verify successful compilation
- Run `cargo clippy` to verify no new warnings