### PR TITLE
fix(cli): prevent ghost lines and stale progress in pull UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "clap",
  "console",
  "indicatif",
+ "libc",
  "microsandbox",
  "microsandbox-image",
  "microsandbox-runtime",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,7 @@ chrono.workspace = true
 clap.workspace = true
 console.workspace = true
 indicatif.workspace = true
+libc.workspace = true
 microsandbox = { version = "0.3.2", path = "../microsandbox", default-features = false }
 microsandbox-image = { version = "0.3.2", path = "../image" }
 microsandbox-runtime = { version = "0.3.2", path = "../runtime", default-features = false }

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -6,6 +6,7 @@
 
 use std::{
     io::IsTerminal,
+    os::fd::AsRawFd,
     time::{Duration, Instant},
 };
 
@@ -30,6 +31,16 @@ pub struct Spinner {
     label: String,
     target: String,
     quiet: bool,
+    _echo_guard: Option<EchoGuard>,
+}
+
+/// RAII guard that disables terminal echo while held.
+///
+/// Prevents stray keypresses (e.g. Enter) from injecting newlines that
+/// desync indicatif's cursor tracking, which causes ghost lines.
+struct EchoGuard {
+    original: libc::termios,
+    fd: i32,
 }
 
 /// Minimal table renderer with column alignment.
@@ -68,6 +79,7 @@ impl Spinner {
             label: label.to_string(),
             target: target.to_string(),
             quiet: false,
+            _echo_guard: EchoGuard::acquire(),
         }
     }
 
@@ -79,6 +91,7 @@ impl Spinner {
             label: String::new(),
             target: String::new(),
             quiet: true,
+            _echo_guard: None,
         }
     }
 
@@ -121,6 +134,41 @@ impl Spinner {
         }
         if !self.quiet {
             eprintln!("   {} {:<12} {}", style("✗").red(), self.label, self.target);
+        }
+    }
+}
+
+impl EchoGuard {
+    /// Disable terminal echo on stdin. Returns `None` if stdin is not a TTY.
+    fn acquire() -> Option<Self> {
+        if !std::io::stdin().is_terminal() {
+            return None;
+        }
+
+        let fd = std::io::stdin().as_raw_fd();
+        let mut original: libc::termios = unsafe { std::mem::zeroed() };
+
+        if unsafe { libc::tcgetattr(fd, &mut original) } != 0 {
+            return None;
+        }
+
+        let mut modified = original;
+        modified.c_lflag &= !libc::ECHO;
+        if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &modified) } != 0 {
+            return None;
+        }
+
+        Some(Self { original, fd })
+    }
+}
+
+impl Drop for EchoGuard {
+    fn drop(&mut self) {
+        // Flush any keypresses that accumulated while echo was off,
+        // so they don't spill into the shell prompt after we restore.
+        unsafe {
+            libc::tcflush(self.fd, libc::TCIFLUSH);
+            libc::tcsetattr(self.fd, libc::TCSANOW, &self.original);
         }
     }
 }
@@ -318,6 +366,7 @@ pub struct PullProgressDisplay {
     extract_style: ProgressStyle,
     index_style: ProgressStyle,
     done_style: ProgressStyle,
+    _echo_guard: Option<EchoGuard>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -358,6 +407,7 @@ impl PullProgressDisplay {
             header,
             layer_bars: Vec::new(),
             reference: reference.to_string(),
+            _echo_guard: if is_tty { EchoGuard::acquire() } else { None },
             download_style: ProgressStyle::default_bar()
                 .template(
                     "     {prefix}  {bar:36.magenta/dim}  {bytes}/{total_bytes}  {msg:.magenta}",
@@ -422,6 +472,7 @@ impl PullProgressDisplay {
                 ..
             } => {
                 if let Some(pb) = self.layer_bars.get(layer_index) {
+                    pb.set_length(downloaded_bytes);
                     pb.set_position(downloaded_bytes);
                 }
             }

--- a/crates/image/lib/layer/mod.rs
+++ b/crates/image/lib/layer/mod.rs
@@ -112,8 +112,11 @@ impl Layer {
         // Acquire cross-process download lock.
         let lock_file = open_lock_file(&self.download_lock_path)?;
         flock_exclusive(&lock_file)?;
+        let download_lock_path = self.download_lock_path.clone();
         let _guard = scopeguard::guard(lock_file, |f| {
             let _ = flock_unlock(&f);
+            drop(f);
+            let _ = std::fs::remove_file(&download_lock_path);
         });
 
         if force {
@@ -284,8 +287,11 @@ impl Layer {
         // Cross-process lock.
         let lock_file = open_lock_file(&self.lock_path)?;
         flock_exclusive(&lock_file)?;
+        let lock_path = self.lock_path.clone();
         let _flock_guard = scopeguard::guard(lock_file, |f| {
             let _ = flock_unlock(&f);
+            drop(f);
+            let _ = std::fs::remove_file(&lock_path);
         });
 
         // Re-check after lock.

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -303,6 +303,12 @@ impl Registry {
 
                         result
                     } else {
+                        // Already extracted — send completion events so the UI
+                        // advances this layer's bar to the done state.
+                        if let Some(ref p) = progress {
+                            p.send(PullProgress::LayerIndexComplete { layer_index: i });
+                        }
+
                         crate::layer::extraction::ExtractionResult {
                             implicit_dirs: match layer.pending_implicit_dirs() {
                                 Ok(implicit_dirs) => implicit_dirs,


### PR DESCRIPTION
## Summary

- Fix terminal UI glitches during image pull operations where stray keypresses (e.g. Enter) inject newlines that desync indicatif's cursor tracking, causing ghost lines in spinner and progress bar output
- Ensure already-extracted (cached) layers correctly advance to the done state in pull progress display instead of appearing stuck
- Clean up stale lock files from disk after releasing flocks to prevent accumulation over time

## Changes

- Added `EchoGuard` RAII struct in `crates/cli/lib/ui.rs` that disables terminal echo via `libc::tcsetattr` while spinners and pull progress bars are active, restoring echo and flushing buffered input on drop
- Integrated `EchoGuard` into both `Spinner` and `PullProgressDisplay` structs as an `Option<EchoGuard>` field, acquired automatically for TTY sessions
- Added `libc` dependency to `crates/cli/Cargo.toml` for terminal attribute manipulation
- Added `pb.set_length(downloaded_bytes)` call before `set_position` in `PullProgressDisplay` to fix progress bar rendering for download-complete events
- Sent `LayerIndexComplete` progress event for already-extracted layers in `crates/image/lib/registry.rs` so the UI advances cached layers to the done state
- Added `std::fs::remove_file` calls in lock guard drop logic in `crates/image/lib/layer/mod.rs` for both download and extraction locks, removing stale `.lock` files after release

## Test Plan

- Run `cargo build` to verify successful compilation with the new `libc` dependency
- Run `msb pull alpine:latest` in a terminal and press Enter/keys during the pull — verify no ghost lines or cursor desync occurs
- Run `msb pull alpine:latest` again (cached layers) — verify all layer progress bars advance to done state instead of appearing stuck
- Check that no `.lock` files remain in the image store directory after a successful pull completes
- Run the same pull in a non-TTY context (e.g. piped) to verify `EchoGuard` gracefully returns `None` and doesn't interfere