### PR TITLE
feat(cli): add `msb image` subcommands with DB persistence

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -1,8 +1,10 @@
 //! Entry point for the `msb` CLI binary.
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use microsandbox_cli::{
-    commands::{create, exec, inspect, list, ps, pull, remove, run, shell, start, stop, volume},
+    commands::{
+        create, exec, image, inspect, list, ps, pull, remove, run, shell, start, stop, volume,
+    },
     log_args::{self, LogArgs},
     microvm_cmd::{self, MicrovmArgs},
     supervisor_cmd::{self, SupervisorArgs},
@@ -16,6 +18,10 @@ use microsandbox_cli::{
 #[derive(Parser)]
 #[command(name = "msb", version, about = "Microsandbox CLI", styles = microsandbox_cli::styles::styles())]
 struct Cli {
+    /// Display the complete command tree with descriptions.
+    #[arg(long, global = true)]
+    tree: bool,
+
     #[command(flatten)]
     logs: LogArgs,
 
@@ -63,13 +69,25 @@ enum Commands {
     /// Shell in a sandbox (interactive or scripted).
     Shell(shell::ShellArgs),
 
-    /// Pull an image from a registry.
+    /// Manage OCI images.
+    Image(image::ImageArgs),
+
+    /// Pull an image from a registry (alias for `image pull`).
     Pull(pull::PullArgs),
+
+    /// List cached images (alias for `image ls`).
+    #[command(hide = true)]
+    Images(image::ImageListArgs),
+
+    /// Remove a cached image (alias for `image rm`).
+    #[command(hide = true)]
+    Rmi(image::ImageRemoveArgs),
 
     /// Show detailed sandbox information.
     Inspect(inspect::InspectArgs),
 
     /// Manage named volumes.
+    #[command(visible_alias = "vol")]
     Volume(volume::VolumeArgs),
 }
 
@@ -78,6 +96,10 @@ enum Commands {
 //--------------------------------------------------------------------------------------------------
 
 fn main() {
+    // Ensure terminal echo is restored even if a panic aborts the process
+    // (release profile sets `panic = "abort"`, so Drop impls don't run).
+    microsandbox_cli::ui::install_panic_hook();
+
     // Auto-set MSB_PATH so the library can find the msb binary
     // when spawning supervisor processes.
     // Safety: called before any threads are spawned (single-threaded at this point).
@@ -85,6 +107,13 @@ fn main() {
         && let Ok(exe) = std::env::current_exe()
     {
         unsafe { std::env::set_var("MSB_PATH", &exe) };
+    }
+
+    // Handle --tree before Cli::parse() so it works even when
+    // required arguments (e.g. `msb run --tree`) are missing.
+    if let Some(tree) = microsandbox_cli::tree::try_show_tree(&Cli::command()) {
+        println!("{tree}");
+        return;
     }
 
     let cli = Cli::parse();
@@ -128,7 +157,10 @@ fn run_async_command(
             Commands::Remove(args) => remove::run(args).await.map_err(Into::into),
             Commands::Exec(args) => exec::run(args).await.map_err(Into::into),
             Commands::Shell(args) => shell::run(args).await.map_err(Into::into),
-            Commands::Pull(args) => pull::run(args).await.map_err(Into::into),
+            Commands::Image(args) => image::run(args).await.map_err(Into::into),
+            Commands::Pull(args) => image::run_pull(args).await.map_err(Into::into),
+            Commands::Images(args) => image::run_list(args).await.map_err(Into::into),
+            Commands::Rmi(args) => image::run_remove(args).await.map_err(Into::into),
             Commands::Inspect(args) => inspect::run(args).await.map_err(Into::into),
             Commands::Volume(args) => volume::run(args).await.map_err(Into::into),
         }

--- a/crates/cli/lib/commands/image.rs
+++ b/crates/cli/lib/commands/image.rs
@@ -1,0 +1,433 @@
+//! `msb image` command — manage OCI images.
+
+use std::time::Instant;
+
+use clap::{Args, Subcommand};
+use console::style;
+use microsandbox::image::Image;
+
+use crate::ui;
+
+use super::pull;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Manage OCI images.
+#[derive(Debug, Args)]
+pub struct ImageArgs {
+    /// Image subcommand.
+    #[command(subcommand)]
+    pub command: ImageCommands,
+}
+
+/// Image subcommands.
+#[derive(Debug, Subcommand)]
+pub enum ImageCommands {
+    /// Pull an image from a registry.
+    Pull(pull::PullArgs),
+
+    /// List cached images.
+    #[command(visible_alias = "ls")]
+    List(ImageListArgs),
+
+    /// Show detailed image information.
+    Inspect(ImageInspectArgs),
+
+    /// Remove a cached image.
+    #[command(visible_alias = "rm")]
+    Remove(ImageRemoveArgs),
+}
+
+/// Arguments for `msb image list`.
+#[derive(Debug, Args)]
+pub struct ImageListArgs {
+    /// Output format (json).
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
+    pub format: Option<String>,
+
+    /// Show only image references.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+/// Arguments for `msb image inspect`.
+#[derive(Debug, Args)]
+pub struct ImageInspectArgs {
+    /// Image reference.
+    pub reference: String,
+
+    /// Output format (json).
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
+    pub format: Option<String>,
+}
+
+/// Arguments for `msb image remove`.
+#[derive(Debug, Args)]
+pub struct ImageRemoveArgs {
+    /// Image reference(s) to remove.
+    #[arg(required = true)]
+    pub references: Vec<String>,
+
+    /// Force removal even if used by sandboxes.
+    #[arg(short, long)]
+    pub force: bool,
+
+    /// Suppress output.
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb image` command.
+pub async fn run(args: ImageArgs) -> anyhow::Result<()> {
+    match args.command {
+        ImageCommands::Pull(args) => run_pull_inner(args.reference, args.force, args.quiet).await,
+        ImageCommands::List(args) => run_list(args).await,
+        ImageCommands::Inspect(args) => run_inspect(args).await,
+        ImageCommands::Remove(args) => run_remove(args).await,
+    }
+}
+
+/// Execute `msb pull` (top-level alias).
+pub async fn run_pull(args: pull::PullArgs) -> anyhow::Result<()> {
+    run_pull_inner(args.reference, args.force, args.quiet).await
+}
+
+/// Shared pull logic with DB persistence.
+async fn run_pull_inner(reference: String, force: bool, quiet: bool) -> anyhow::Result<()> {
+    let start = Instant::now();
+
+    let global = microsandbox::config::config();
+    let cache = microsandbox_image::GlobalCache::new(&global.cache_dir())?;
+    let platform = microsandbox_image::Platform::host_linux();
+    let image_ref: microsandbox_image::Reference = reference
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid image reference: {e}"))?;
+
+    let auth = global.resolve_registry_auth(image_ref.registry())?;
+    let registry = microsandbox_image::Registry::with_auth(platform, cache, auth)?;
+
+    let options = microsandbox_image::PullOptions {
+        pull_policy: microsandbox_image::PullPolicy::Always,
+        force,
+        ..Default::default()
+    };
+
+    let (mut progress, task) = registry.pull_with_progress(&image_ref, &options);
+
+    let mut display = if quiet {
+        ui::PullProgressDisplay::quiet(&reference)
+    } else {
+        ui::PullProgressDisplay::new(&reference)
+    };
+
+    while let Some(event) = progress.recv().await {
+        display.handle_event(event);
+    }
+
+    let result = match task.await {
+        Ok(Ok(result)) => result,
+        Ok(Err(e)) => {
+            display.finish();
+            pull_failure_line(quiet, &reference);
+            return Err(e.into());
+        }
+        Err(e) => {
+            display.finish();
+            pull_failure_line(quiet, &reference);
+            return Err(anyhow::anyhow!("pull task panicked: {e}"));
+        }
+    };
+
+    display.finish();
+
+    // Persist to database.
+    let cache = microsandbox_image::GlobalCache::new(&global.cache_dir())?;
+    match cache.read_image_metadata(&image_ref) {
+        Ok(Some(metadata)) => {
+            if let Err(e) = Image::persist(&reference, metadata).await {
+                tracing::warn!(error = %e, "failed to persist image metadata to database");
+            }
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to read cached image metadata");
+        }
+    }
+
+    if !quiet {
+        let elapsed = start.elapsed();
+        let duration = if elapsed.as_millis() > 500 {
+            format!(" ({})", ui::format_duration(elapsed))
+        } else {
+            String::new()
+        };
+
+        eprintln!(
+            "   {} {:<12} {}{}",
+            style("✓").green(),
+            "Pulled",
+            reference,
+            style(duration).dim()
+        );
+
+        if result.cached {
+            eprintln!("   (already cached)");
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `msb image list` / `msb images`.
+pub async fn run_list(args: ImageListArgs) -> anyhow::Result<()> {
+    let images = Image::list().await?;
+
+    if args.format.as_deref() == Some("json") {
+        let entries: Vec<serde_json::Value> = images
+            .iter()
+            .map(|img| {
+                serde_json::json!({
+                    "reference": img.reference(),
+                    "digest": img.manifest_digest(),
+                    "size_bytes": img.size_bytes(),
+                    "architecture": img.architecture(),
+                    "os": img.os(),
+                    "layer_count": img.layer_count(),
+                    "created_at": img.created_at().map(|dt| ui::format_datetime(&dt)),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
+    if args.quiet {
+        for img in &images {
+            println!("{}", img.reference());
+        }
+        return Ok(());
+    }
+
+    if images.is_empty() {
+        eprintln!("No images found.");
+        return Ok(());
+    }
+
+    let mut table = ui::Table::new(&["REFERENCE", "DIGEST", "SIZE", "CREATED"]);
+
+    for img in &images {
+        let digest = img
+            .manifest_digest()
+            .map(truncate_digest)
+            .unwrap_or_else(|| "-".to_string());
+        let size = img
+            .size_bytes()
+            .map(format_bytes)
+            .unwrap_or_else(|| "-".to_string());
+        let created = img
+            .created_at()
+            .as_ref()
+            .map(ui::format_datetime)
+            .unwrap_or_else(|| "-".to_string());
+
+        table.add_row(vec![img.reference().to_string(), digest, size, created]);
+    }
+
+    table.print();
+    Ok(())
+}
+
+/// Execute `msb image inspect`.
+pub async fn run_inspect(args: ImageInspectArgs) -> anyhow::Result<()> {
+    let detail = Image::inspect(&args.reference).await?;
+
+    if args.format.as_deref() == Some("json") {
+        let layers_json: Vec<serde_json::Value> = detail
+            .layers
+            .iter()
+            .map(|l| {
+                serde_json::json!({
+                    "digest": l.digest,
+                    "diff_id": l.diff_id,
+                    "media_type": l.media_type,
+                    "size_bytes": l.size_bytes,
+                    "position": l.position,
+                })
+            })
+            .collect();
+
+        let config_json = detail.config.as_ref().map(|c| {
+            serde_json::json!({
+                "digest": c.digest,
+                "architecture": c.architecture,
+                "os": c.os,
+                "env": c.env,
+                "cmd": c.cmd,
+                "entrypoint": c.entrypoint,
+                "working_dir": c.working_dir,
+                "user": c.user,
+                "exposed_ports": c.exposed_ports,
+                "volumes": c.volumes,
+            })
+        });
+
+        let json = serde_json::json!({
+            "reference": detail.handle.reference(),
+            "digest": detail.handle.manifest_digest(),
+            "size_bytes": detail.handle.size_bytes(),
+            "architecture": detail.handle.architecture(),
+            "os": detail.handle.os(),
+            "layer_count": detail.handle.layer_count(),
+            "created_at": detail.handle.created_at().map(|dt| ui::format_datetime(&dt)),
+            "config": config_json,
+            "layers": layers_json,
+        });
+
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+
+    // Default detail view.
+    let h = &detail.handle;
+
+    ui::detail_kv("Reference", h.reference());
+    ui::detail_kv("Digest", h.manifest_digest().unwrap_or("-"));
+    ui::detail_kv("Architecture", h.architecture().unwrap_or("-"));
+    ui::detail_kv("OS", h.os().unwrap_or("-"));
+    ui::detail_kv(
+        "Size",
+        &h.size_bytes()
+            .map(format_bytes)
+            .unwrap_or_else(|| "-".to_string()),
+    );
+    ui::detail_kv(
+        "Created",
+        &h.created_at()
+            .as_ref()
+            .map(ui::format_datetime)
+            .unwrap_or_else(|| "-".to_string()),
+    );
+
+    if let Some(config) = &detail.config {
+        ui::detail_header("Config");
+
+        ui::detail_kv_indent(
+            "Entrypoint",
+            &config
+                .entrypoint
+                .as_ref()
+                .map(|v| v.join(" "))
+                .unwrap_or_else(|| "-".to_string()),
+        );
+        ui::detail_kv_indent(
+            "Cmd",
+            &config
+                .cmd
+                .as_ref()
+                .map(|v| v.join(" "))
+                .unwrap_or_else(|| "-".to_string()),
+        );
+        ui::detail_kv_indent("WorkingDir", config.working_dir.as_deref().unwrap_or("-"));
+        ui::detail_kv_indent("User", config.user.as_deref().unwrap_or("-"));
+
+        if !config.env.is_empty() {
+            println!("  {}", style("Env:").cyan());
+            for var in &config.env {
+                println!("    {var}");
+            }
+        }
+    }
+
+    if !detail.layers.is_empty() {
+        ui::detail_header(&format!("Layers ({})", detail.layers.len()));
+        for layer in &detail.layers {
+            let size = layer
+                .size_bytes
+                .map(format_bytes)
+                .unwrap_or_else(|| "-".to_string());
+            let media = layer.media_type.as_deref().unwrap_or("-");
+            let short_digest = truncate_digest(&layer.digest);
+            println!(
+                "  {:<4}{:<16}{:<10}{}",
+                layer.position + 1,
+                short_digest,
+                size,
+                media
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `msb image rm` / `msb rmi`.
+pub async fn run_remove(args: ImageRemoveArgs) -> anyhow::Result<()> {
+    let mut failed = false;
+
+    for reference in &args.references {
+        let spinner = if args.quiet {
+            ui::Spinner::quiet()
+        } else {
+            ui::Spinner::start("Removing", reference)
+        };
+
+        match Image::remove(reference, args.force).await {
+            Ok(()) => {
+                spinner.finish_success("Removed");
+            }
+            Err(e) => {
+                spinner.finish_error();
+                if !args.quiet {
+                    ui::error(&format!("{e}"));
+                }
+                failed = true;
+            }
+        }
+    }
+
+    if failed {
+        anyhow::bail!("some images failed to remove");
+    }
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Format bytes as a human-readable string.
+fn format_bytes(bytes: i64) -> String {
+    let bytes = bytes as f64;
+    if bytes < 1024.0 {
+        format!("{} B", bytes as i64)
+    } else if bytes < 1024.0 * 1024.0 {
+        format!("{:.1} KB", bytes / 1024.0)
+    } else if bytes < 1024.0 * 1024.0 * 1024.0 {
+        format!("{:.1} MB", bytes / (1024.0 * 1024.0))
+    } else {
+        format!("{:.2} GB", bytes / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
+/// Print the pull failure indicator line to stderr.
+fn pull_failure_line(quiet: bool, reference: &str) {
+    if !quiet {
+        eprintln!("   {} {:<12} {}", style("✗").red(), "Pulling", reference);
+    }
+}
+
+/// Truncate a digest to a short form (first 12 hex chars after algorithm prefix).
+fn truncate_digest(digest: &str) -> String {
+    if let Some(hex) = digest.strip_prefix("sha256:") {
+        format!("sha256:{}", &hex[..hex.len().min(12)])
+    } else {
+        digest.chars().take(19).collect()
+    }
+}

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -10,6 +10,7 @@ use crate::ui;
 
 pub mod create;
 pub mod exec;
+pub mod image;
 pub mod inspect;
 pub mod list;
 pub mod ps;

--- a/crates/cli/lib/commands/pull.rs
+++ b/crates/cli/lib/commands/pull.rs
@@ -1,11 +1,9 @@
-//! `msb pull` command — pull an image from a registry.
-
-use std::time::Instant;
+//! `msb pull` argument definitions.
+//!
+//! The pull logic lives in [`super::image::run_pull`]; this module only
+//! defines the shared [`PullArgs`] struct.
 
 use clap::Args;
-use console::style;
-
-use crate::ui;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -24,95 +22,4 @@ pub struct PullArgs {
     /// Suppress progress output.
     #[arg(short, long)]
     pub quiet: bool,
-}
-
-//--------------------------------------------------------------------------------------------------
-// Functions
-//--------------------------------------------------------------------------------------------------
-
-/// Execute the `msb pull` command.
-pub async fn run(args: PullArgs) -> anyhow::Result<()> {
-    let start = Instant::now();
-
-    let global = microsandbox::config::config();
-    let cache = microsandbox_image::GlobalCache::new(&global.cache_dir())?;
-    let platform = microsandbox_image::Platform::host_linux();
-    let image_ref: microsandbox_image::Reference = args
-        .reference
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid image reference: {e}"))?;
-
-    let auth = global.resolve_registry_auth(image_ref.registry())?;
-    let registry = microsandbox_image::Registry::with_auth(platform, cache, auth)?;
-
-    let options = microsandbox_image::PullOptions {
-        pull_policy: microsandbox_image::PullPolicy::Always,
-        force: args.force,
-        ..Default::default()
-    };
-
-    let (mut progress, task) = registry.pull_with_progress(&image_ref, &options);
-
-    let mut display = if args.quiet {
-        ui::PullProgressDisplay::quiet(&args.reference)
-    } else {
-        ui::PullProgressDisplay::new(&args.reference)
-    };
-
-    while let Some(event) = progress.recv().await {
-        display.handle_event(event);
-    }
-
-    let result = match task.await {
-        Ok(Ok(result)) => result,
-        Ok(Err(e)) => {
-            display.finish();
-            if !args.quiet {
-                eprintln!(
-                    "   {} {:<12} {}",
-                    style("✗").red(),
-                    "Pulling",
-                    args.reference
-                );
-            }
-            return Err(e.into());
-        }
-        Err(e) => {
-            display.finish();
-            if !args.quiet {
-                eprintln!(
-                    "   {} {:<12} {}",
-                    style("✗").red(),
-                    "Pulling",
-                    args.reference
-                );
-            }
-            return Err(anyhow::anyhow!("pull task panicked: {e}"));
-        }
-    };
-
-    display.finish();
-
-    if !args.quiet {
-        let elapsed = start.elapsed();
-        let duration = if elapsed.as_millis() > 500 {
-            format!(" ({})", ui::format_duration(elapsed))
-        } else {
-            String::new()
-        };
-
-        eprintln!(
-            "   {} {:<12} {}{}",
-            style("✓").green(),
-            "Pulled",
-            args.reference,
-            style(duration).dim()
-        );
-
-        if result.cached {
-            eprintln!("   (already cached)");
-        }
-    }
-
-    Ok(())
 }

--- a/crates/cli/lib/lib.rs
+++ b/crates/cli/lib/lib.rs
@@ -13,4 +13,5 @@ pub mod log_args;
 pub mod microvm_cmd;
 pub mod styles;
 pub mod supervisor_cmd;
+pub mod tree;
 pub mod ui;

--- a/crates/cli/lib/tree.rs
+++ b/crates/cli/lib/tree.rs
@@ -1,0 +1,485 @@
+//! `--tree` flag: displays the complete command hierarchy with descriptions.
+//!
+//! An alternative to `--help` that shows every command, subcommand, and flag
+//! in a single tree view with aligned descriptions and color-coded depth.
+//!
+//! Must be checked **before** `Cli::parse()` to avoid clap validation errors
+//! when required arguments are missing.
+
+use std::fmt::Write;
+
+use clap::Command;
+use console::style;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Builds a formatted tree view of a clap [`Command`] hierarchy.
+pub struct TreeBuilder {
+    /// Accumulated output buffer.
+    output: String,
+
+    /// Stack tracking whether each ancestor still has remaining siblings.
+    /// `true` means the ancestor has more items after the current branch,
+    /// so a `│` continuation line is drawn; `false` means it was the last
+    /// item and we draw blank space instead.
+    indent_stack: Vec<bool>,
+
+    /// Maximum item width across the entire tree (computed in pass 1)
+    /// used to align descriptions into a single column.
+    max_item_width: usize,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl TreeBuilder {
+    /// Create a new builder.
+    fn new() -> Self {
+        Self {
+            output: String::with_capacity(4096),
+            indent_stack: Vec::with_capacity(8),
+            max_item_width: 0,
+        }
+    }
+
+    /// Two-pass build: measure widths, then render.
+    fn build(mut self, cmd: &Command, root_label: &str) -> String {
+        // Pass 1: compute max item width for column alignment.
+        self.measure_widths(cmd, 0);
+        self.max_item_width += 2; // padding between item and description
+
+        // Pass 2: render tree.
+        writeln!(&mut self.output, "{}", style(root_label).yellow().bold()).unwrap();
+        self.render_command(cmd);
+        self.output
+    }
+
+    // ----- Pass 1: width measurement -----
+
+    /// Recursively measure widths of all visible items.
+    fn measure_widths(&mut self, cmd: &Command, depth: usize) {
+        let indent = depth * 4; // each level adds "│   " or "    " (4 chars)
+        let branch = 4; // "├── " or "└── "
+
+        // Measure args (positionals + flags).
+        for arg in cmd.get_arguments() {
+            if Self::skip_arg(arg) {
+                continue;
+            }
+            let w = indent + branch + Self::arg_display_width(arg);
+            self.max_item_width = self.max_item_width.max(w);
+        }
+
+        // Measure visible subcommands.
+        for sub in cmd.get_subcommands() {
+            if sub.is_hide_set() {
+                continue;
+            }
+            let w = indent + branch + Self::subcommand_display_width(sub);
+            self.max_item_width = self.max_item_width.max(w);
+
+            self.measure_widths(sub, depth + 1);
+        }
+    }
+
+    /// Exact display width of a formatted argument string.
+    fn arg_display_width(arg: &clap::Arg) -> usize {
+        let id = arg.get_id().as_str();
+
+        // Positional argument: <NAME> or [NAME]
+        if arg.get_short().is_none() && arg.get_long().is_none() {
+            let name = arg
+                .get_value_names()
+                .and_then(|v| v.first().map(|n| n.as_str()))
+                .unwrap_or(id);
+
+            // Check for last(true) style: [-- VALUES...]
+            if arg.is_last_set() {
+                return "[-- ".len() + name.to_uppercase().len() + "...]".len();
+            }
+
+            return name.to_uppercase().len() + 2; // <> or []
+        }
+
+        let mut w = 0usize;
+
+        // Short flag: -x
+        if let Some(_short) = arg.get_short() {
+            w += 2; // "-x"
+            if arg.get_long().is_some() {
+                w += 2; // ", "
+            }
+        }
+
+        // Long flag: --name
+        if let Some(long) = arg.get_long() {
+            w += 2 + long.len(); // "--name"
+        }
+
+        // Value placeholder: <VALUE>
+        if arg.get_num_args().is_some() || arg.get_action().takes_values() {
+            if let Some(names) = arg.get_value_names() {
+                if let Some(name) = names.first() {
+                    w += 1 + name.to_uppercase().len() + 2; // " <NAME>"
+                }
+            } else {
+                w += " <VALUE>".len();
+            }
+        }
+
+        // Visible aliases: (aliases: --ref, -R)
+        let short_aliases: Vec<_> = arg.get_visible_short_aliases().unwrap_or_default();
+        let long_aliases: Vec<_> = arg.get_visible_aliases().unwrap_or_default();
+        if !short_aliases.is_empty() || !long_aliases.is_empty() {
+            w += " (aliases: ".len();
+            let mut first = true;
+            for _ in &short_aliases {
+                if !first {
+                    w += 2;
+                } // ", "
+                w += 2; // "-x"
+                first = false;
+            }
+            for a in &long_aliases {
+                if !first {
+                    w += 2;
+                }
+                w += 2 + a.len(); // "--name"
+                first = false;
+            }
+            w += 1; // ")"
+        }
+
+        w
+    }
+
+    /// Exact display width of a subcommand label (name + aliases).
+    fn subcommand_display_width(cmd: &Command) -> usize {
+        let mut w = cmd.get_name().len();
+
+        let aliases: Vec<_> = cmd.get_visible_aliases().collect();
+        if !aliases.is_empty() {
+            // " (aliases: a, b)"
+            w += " (aliases: ".len();
+            w += aliases.iter().map(|a| a.len()).sum::<usize>();
+            w += (aliases.len() - 1) * 2; // ", " separators
+            w += 1; // ")"
+        }
+
+        w
+    }
+
+    // ----- Pass 2: rendering -----
+
+    /// Render all visible items of a command (positionals, flags, subcommands).
+    fn render_command(&mut self, cmd: &Command) {
+        // Collect items in display order: positionals, then flags, then subcommands.
+        let mut positionals: Vec<&clap::Arg> = Vec::new();
+        let mut flags: Vec<&clap::Arg> = Vec::new();
+
+        for arg in cmd.get_arguments() {
+            if Self::skip_arg(arg) {
+                continue;
+            }
+            if arg.get_short().is_none() && arg.get_long().is_none() {
+                positionals.push(arg);
+            } else {
+                flags.push(arg);
+            }
+        }
+
+        let subcommands: Vec<&Command> =
+            cmd.get_subcommands().filter(|s| !s.is_hide_set()).collect();
+
+        let total = positionals.len() + flags.len() + subcommands.len();
+        let mut idx = 0;
+
+        for arg in &positionals {
+            idx += 1;
+            self.render_arg(arg, idx == total);
+        }
+
+        for arg in &flags {
+            idx += 1;
+            self.render_arg(arg, idx == total);
+        }
+
+        for sub in &subcommands {
+            idx += 1;
+            self.render_subcommand(sub, idx == total);
+        }
+    }
+
+    /// Render a single argument (positional or flag).
+    fn render_arg(&mut self, arg: &clap::Arg, is_last: bool) {
+        let label = Self::format_arg(arg);
+        let description = arg.get_help().map(|h| {
+            let s = h.to_string();
+            s.lines().next().unwrap_or("").to_string()
+        });
+
+        let prefix = self.build_prefix(is_last);
+        let styled_label = Self::style_arg(&label);
+
+        let current_indent = self.indent_stack.len() * 4;
+        let total_width = current_indent + 4 + label.len(); // 4 = branch chars
+        let pad = self.max_item_width.saturating_sub(total_width);
+
+        write!(&mut self.output, "{}{}", style(&prefix).dim(), styled_label).unwrap();
+        if let Some(desc) = description.filter(|d| !d.is_empty()) {
+            write!(&mut self.output, "{:width$}{}", "", desc, width = pad).unwrap();
+        }
+        writeln!(&mut self.output).unwrap();
+    }
+
+    /// Render a subcommand header and recurse into its children.
+    fn render_subcommand(&mut self, cmd: &Command, is_last: bool) {
+        let name = cmd.get_name();
+        let aliases: Vec<_> = cmd.get_visible_aliases().collect();
+
+        // Build display label for width calculation.
+        let label_width = Self::subcommand_display_width(cmd);
+        let current_indent = self.indent_stack.len() * 4;
+        let total_width = current_indent + 4 + label_width;
+        let pad = self.max_item_width.saturating_sub(total_width);
+
+        let prefix = self.build_prefix(is_last);
+
+        // Color subcommands by depth.
+        let colored_name = match self.indent_stack.len() {
+            0 => style(name).magenta().bold().to_string(),
+            1 => style(name).blue().bold().to_string(),
+            2 => style(name).green().bold().to_string(),
+            _ => style(name).cyan().bold().to_string(),
+        };
+
+        write!(&mut self.output, "{}{}", style(&prefix).dim(), colored_name).unwrap();
+
+        if !aliases.is_empty() {
+            write!(
+                &mut self.output,
+                " {}",
+                style(format!("(aliases: {})", aliases.join(", "))).dim()
+            )
+            .unwrap();
+        }
+
+        if let Some(about) = cmd.get_about() {
+            let about_str = about.to_string();
+            if let Some(line) = about_str.lines().next().filter(|l| !l.is_empty()) {
+                write!(&mut self.output, "{:width$}{}", "", line, width = pad).unwrap();
+            }
+        }
+
+        writeln!(&mut self.output).unwrap();
+
+        // Recurse if there are visible children.
+        let has_children = cmd.get_subcommands().any(|s| !s.is_hide_set())
+            || cmd.get_arguments().any(|a| !Self::skip_arg(a));
+
+        if has_children {
+            self.indent_stack.push(!is_last);
+            self.render_command(cmd);
+            self.indent_stack.pop();
+        }
+    }
+
+    // ----- Helpers -----
+
+    /// Build the tree prefix string (│/space continuations + ├──/└── branch).
+    fn build_prefix(&self, is_last: bool) -> String {
+        let depth = self.indent_stack.len();
+        let mut prefix = String::with_capacity(depth * 4 + 4);
+
+        for &continues in &self.indent_stack {
+            if continues {
+                prefix.push_str("│   ");
+            } else {
+                prefix.push_str("    ");
+            }
+        }
+
+        if is_last {
+            prefix.push_str("└── ");
+        } else {
+            prefix.push_str("├── ");
+        }
+
+        prefix
+    }
+
+    /// Format an argument into its display string (no ANSI codes).
+    fn format_arg(arg: &clap::Arg) -> String {
+        let id = arg.get_id().as_str();
+
+        // Positional argument.
+        if arg.get_short().is_none() && arg.get_long().is_none() {
+            let name = arg
+                .get_value_names()
+                .and_then(|v| v.first().map(|n| n.as_str()))
+                .unwrap_or(id);
+
+            // Trailing args: [-- COMMAND...]
+            if arg.is_last_set() {
+                return format!("[-- {}...]", name.to_uppercase());
+            }
+
+            return if arg.is_required_set() {
+                format!("<{}>", name.to_uppercase())
+            } else {
+                format!("[{}]", name.to_uppercase())
+            };
+        }
+
+        let mut s = String::with_capacity(32);
+
+        if let Some(short) = arg.get_short() {
+            write!(&mut s, "-{}", short).unwrap();
+            if arg.get_long().is_some() {
+                s.push_str(", ");
+            }
+        }
+
+        if let Some(long) = arg.get_long() {
+            write!(&mut s, "--{}", long).unwrap();
+        }
+
+        if arg.get_num_args().is_some() || arg.get_action().takes_values() {
+            if let Some(names) = arg.get_value_names() {
+                if let Some(name) = names.first() {
+                    write!(&mut s, " <{}>", name.to_uppercase()).unwrap();
+                }
+            } else {
+                s.push_str(" <VALUE>");
+            }
+        }
+
+        // Visible aliases.
+        let short_aliases: Vec<_> = arg.get_visible_short_aliases().unwrap_or_default();
+        let long_aliases: Vec<_> = arg.get_visible_aliases().unwrap_or_default();
+        if !short_aliases.is_empty() || !long_aliases.is_empty() {
+            s.push_str(" (aliases: ");
+            let mut first = true;
+            for a in &short_aliases {
+                if !first {
+                    s.push_str(", ");
+                }
+                write!(&mut s, "-{}", a).unwrap();
+                first = false;
+            }
+            for a in &long_aliases {
+                if !first {
+                    s.push_str(", ");
+                }
+                write!(&mut s, "--{}", a).unwrap();
+                first = false;
+            }
+            s.push(')');
+        }
+
+        s
+    }
+
+    /// Apply ANSI styling to an argument label.
+    fn style_arg(label: &str) -> String {
+        // Flags: dim
+        if label.starts_with('-') {
+            if let Some((flag_part, alias_part)) = label.split_once(" (aliases: ") {
+                // Flag with aliases: dim flag, dimmer aliases.
+                let styled_flag = if let Some((fl, val)) = flag_part.split_once(' ') {
+                    format!("{} {}", style(fl).dim(), style(val).dim())
+                } else {
+                    style(flag_part).dim().to_string()
+                };
+                return format!(
+                    "{} {}",
+                    styled_flag,
+                    style(format!("(aliases: {}", alias_part)).dim()
+                );
+            }
+
+            if let Some((fl, val)) = label.split_once(' ') {
+                return format!("{} {}", style(fl).dim(), style(val).dim());
+            }
+
+            return style(label).dim().to_string();
+        }
+
+        // Positionals: dim
+        if (label.starts_with('<') && label.ends_with('>'))
+            || (label.starts_with('[') && label.ends_with(']'))
+            || label.starts_with("[-- ")
+        {
+            return style(label).dim().to_string();
+        }
+
+        label.to_string()
+    }
+
+    /// Whether to skip an argument in the tree view.
+    fn skip_arg(arg: &clap::Arg) -> bool {
+        let id = arg.get_id().as_str();
+        id == "help" || id == "version" || id == "tree" || arg.is_hide_set()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Generate a tree view of all commands and options with descriptions.
+pub fn generate_tree(cmd: &Command) -> String {
+    TreeBuilder::new().build(cmd, cmd.get_name())
+}
+
+/// Generate a tree view with a custom root label (e.g. "msb image").
+pub fn generate_tree_with_root(cmd: &Command, root: &str) -> String {
+    TreeBuilder::new().build(cmd, root)
+}
+
+/// If `--tree` is present in `std::env::args`, generate the appropriate tree
+/// and return it. Must be called **before** `Cli::parse()`.
+pub fn try_show_tree(cmd: &Command) -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+
+    if !args.iter().any(|a| a == "--tree") {
+        return None;
+    }
+
+    let (path, deepest) = find_deepest_subcommand(cmd, &args);
+
+    let tree = if path.len() > 1 {
+        generate_tree_with_root(&deepest, &path.join(" "))
+    } else {
+        generate_tree(&deepest)
+    };
+
+    Some(tree)
+}
+
+/// Walk `args` to find the deepest subcommand the user specified before `--tree`.
+fn find_deepest_subcommand(cmd: &Command, args: &[String]) -> (Vec<String>, Command) {
+    let mut path = vec![cmd.get_name().to_string()];
+    let mut current = cmd.clone();
+
+    // Skip argv[0] (program name).
+    for arg in args.iter().skip(1) {
+        // Stop at flags.
+        if arg.starts_with('-') {
+            continue;
+        }
+
+        if let Some(sub) = current.find_subcommand(arg) {
+            if sub.is_hide_set() {
+                continue;
+            }
+            path.push(arg.to_string());
+            current = sub.clone();
+        }
+    }
+
+    (path, current)
+}

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -58,7 +58,7 @@ impl Spinner {
     /// target is the object name (e.g., "mybox").
     pub fn start(label: &str, target: &str) -> Self {
         let is_tty = std::io::stderr().is_terminal();
-        let pb = if is_tty {
+        let (pb, echo_guard) = if is_tty {
             let pb = ProgressBar::new_spinner();
             pb.set_style(
                 ProgressStyle::default_spinner()
@@ -68,9 +68,9 @@ impl Spinner {
             );
             pb.set_message(target.to_string());
             pb.enable_steady_tick(Duration::from_millis(80));
-            Some(pb)
+            (Some(pb), EchoGuard::acquire())
         } else {
-            None
+            (None, None)
         };
 
         Self {
@@ -79,7 +79,7 @@ impl Spinner {
             label: label.to_string(),
             target: target.to_string(),
             quiet: false,
-            _echo_guard: EchoGuard::acquire(),
+            _echo_guard: echo_guard,
         }
     }
 
@@ -188,6 +188,9 @@ impl Table {
     }
 
     /// Print the table to stdout with column alignment.
+    ///
+    /// Uses visible (display) width so ANSI escape codes in cell values
+    /// don't break column alignment.
     pub fn print(&self) {
         if self.rows.is_empty() {
             return;
@@ -199,7 +202,7 @@ impl Table {
         for row in &self.rows {
             for (i, cell) in row.iter().enumerate() {
                 if i < col_count {
-                    widths[i] = widths[i].max(cell.len());
+                    widths[i] = widths[i].max(console::measure_text_width(cell));
                 }
             }
         }
@@ -226,7 +229,9 @@ impl Table {
                 .enumerate()
                 .map(|(i, cell)| {
                     if i < col_count - 1 {
-                        format!("{:<width$}    ", cell, width = widths[i])
+                        let vis = console::measure_text_width(cell);
+                        let padding = widths[i].saturating_sub(vis) + 4;
+                        format!("{cell}{:padding$}", "", padding = padding)
                     } else {
                         cell.clone()
                     }
@@ -240,6 +245,29 @@ impl Table {
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Install a panic hook that restores terminal echo before aborting.
+///
+/// With `panic = "abort"` in the release profile, `Drop` impls are not called
+/// on panic, which would leave the terminal with echo disabled. This hook
+/// ensures echo is restored before the default panic handler runs.
+pub fn install_panic_hook() {
+    let default = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Best-effort: restore echo on stdin if it's a TTY.
+        if std::io::stdin().is_terminal() {
+            let fd = std::io::stdin().as_raw_fd();
+            let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+            if unsafe { libc::tcgetattr(fd, &mut termios) } == 0 {
+                termios.c_lflag |= libc::ECHO;
+                unsafe {
+                    libc::tcsetattr(fd, libc::TCSANOW, &termios);
+                }
+            }
+        }
+        default(info);
+    }));
+}
 
 /// Print a styled error message to stderr.
 pub fn error(msg: &str) {
@@ -299,10 +327,14 @@ pub fn parse_size_mib(s: &str) -> Result<u32, String> {
     let s = s.trim();
     if let Some(n) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
         let val: f64 = n.trim().parse().map_err(|e| format!("invalid size: {e}"))?;
-        if val < 0.0 {
-            return Err("size must not be negative".into());
+        if val.is_nan() || val.is_infinite() || val < 0.0 {
+            return Err("size must be a finite positive number".into());
         }
-        Ok((val * 1024.0) as u32)
+        let mib = val * 1024.0;
+        if mib > u32::MAX as f64 {
+            return Err("size too large".into());
+        }
+        Ok(mib as u32)
     } else if let Some(n) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
         n.trim()
             .parse::<u32>()

--- a/crates/image/lib/lib.rs
+++ b/crates/image/lib/lib.rs
@@ -31,4 +31,4 @@ pub use platform::Platform;
 pub use progress::{PullProgress, PullProgressHandle, PullProgressSender, progress_channel};
 pub use pull::{PullOptions, PullPolicy, PullResult};
 pub use registry::Registry;
-pub use store::GlobalCache;
+pub use store::{CachedImageMetadata, CachedLayerMetadata, GlobalCache};

--- a/crates/image/lib/manifest.rs
+++ b/crates/image/lib/manifest.rs
@@ -49,4 +49,12 @@ impl OciManifest {
     pub fn is_index(&self) -> bool {
         matches!(self, Self::Index(_))
     }
+
+    /// Return the config blob digest for a single-platform manifest.
+    pub fn config_digest(&self) -> Option<String> {
+        match self {
+            Self::Image(m) => Some(m.config().digest().to_string()),
+            Self::Index(_) => None,
+        }
+    }
 }

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -374,6 +374,7 @@ impl Registry {
         let layers = extracted_dirs;
         let cached_image = CachedImageMetadata {
             manifest_digest: manifest_digest.to_string(),
+            config_digest: manifest.config_digest().unwrap_or_default(),
             config: image_config.clone(),
             layers: layer_descriptors
                 .iter()
@@ -998,6 +999,9 @@ mod tests {
         let metadata = CachedImageMetadata {
             manifest_digest:
                 "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_string(),
+            config_digest:
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                     .to_string(),
             config: ImageConfig {
                 env: vec!["PATH=/usr/bin".into()],

--- a/crates/image/lib/store.rs
+++ b/crates/image/lib/store.rs
@@ -50,9 +50,11 @@ pub struct GlobalCache {
 
 /// Cached metadata for a pulled image reference.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct CachedImageMetadata {
+pub struct CachedImageMetadata {
     /// Content-addressable digest of the resolved manifest.
     pub manifest_digest: String,
+    /// Content-addressable digest of the config blob.
+    pub config_digest: String,
     /// Parsed OCI image configuration.
     pub config: ImageConfig,
     /// Layer metadata in bottom-to-top order.
@@ -61,7 +63,7 @@ pub(crate) struct CachedImageMetadata {
 
 /// Cached metadata for a single layer descriptor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct CachedLayerMetadata {
+pub struct CachedLayerMetadata {
     /// Compressed layer digest from the manifest.
     pub digest: String,
     /// OCI media type of the layer blob.
@@ -161,19 +163,17 @@ impl GlobalCache {
     }
 
     /// Read cached metadata for an image reference.
-    pub(crate) fn read_image_metadata(
+    pub fn read_image_metadata(
         &self,
         reference: &Reference,
     ) -> ImageResult<Option<CachedImageMetadata>> {
         let path = self.image_metadata_path(reference);
-        if !path.exists() {
-            return Ok(None);
-        }
 
-        let data = std::fs::read_to_string(&path).map_err(|e| ImageError::Cache {
-            path: path.clone(),
-            source: e,
-        })?;
+        let data = match std::fs::read_to_string(&path) {
+            Ok(data) => data,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(ImageError::Cache { path, source: e }),
+        };
 
         match serde_json::from_str::<CachedImageMetadata>(&data) {
             Ok(metadata) => Ok(Some(metadata)),
@@ -203,6 +203,16 @@ impl GlobalCache {
         std::fs::rename(&temp_path, &path).map_err(|e| ImageError::Cache { path, source: e })?;
 
         Ok(())
+    }
+
+    /// Delete cached metadata for an image reference.
+    pub fn delete_image_metadata(&self, reference: &Reference) -> ImageResult<()> {
+        let path = self.image_metadata_path(reference);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(ImageError::Cache { path, source: e }),
+        }
     }
 
     /// Path to the cached metadata file for an image reference.

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -66,6 +66,14 @@ pub enum MicrosandboxError {
     #[error("sandbox fs error: {0}")]
     SandboxFs(String),
 
+    /// The requested image was not found.
+    #[error("image not found: {0}")]
+    ImageNotFound(String),
+
+    /// The image is in use by one or more sandboxes.
+    #[error("image in use by sandbox(es): {0}")]
+    ImageInUse(String),
+
     /// The requested volume was not found.
     #[error("volume not found: {0}")]
     VolumeNotFound(String),

--- a/crates/microsandbox/lib/image/mod.rs
+++ b/crates/microsandbox/lib/image/mod.rs
@@ -1,0 +1,708 @@
+//! OCI image management.
+//!
+//! Provides a high-level interface for persisting, querying, and removing
+//! OCI image metadata in the database. The on-disk layer cache is managed
+//! by [`microsandbox_image::GlobalCache`]; this module owns the DB lifecycle.
+
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, EntityTrait, JoinType, PaginatorTrait, QueryFilter, QueryOrder,
+    QuerySelect, RelationTrait, Set, TransactionTrait, sea_query::OnConflict,
+};
+
+use crate::{
+    MicrosandboxError, MicrosandboxResult,
+    db::entity::{
+        config as config_entity, image as image_entity, layer as layer_entity,
+        manifest as manifest_entity, manifest_layer as manifest_layer_entity,
+        sandbox_image as sandbox_image_entity,
+    },
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Static methods namespace for OCI image operations.
+pub struct Image;
+
+/// A lightweight handle to a cached OCI image from the database.
+///
+/// Provides metadata access without requiring live queries. Obtained via
+/// [`Image::get`] or [`Image::list`].
+#[derive(Debug)]
+pub struct ImageHandle {
+    #[allow(dead_code)]
+    db_id: i32,
+    reference: String,
+    size_bytes: Option<i64>,
+    manifest_digest: Option<String>,
+    architecture: Option<String>,
+    os: Option<String>,
+    layer_count: usize,
+    last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+    created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Full detail for a single image, including config and layer information.
+#[derive(Debug)]
+pub struct ImageDetail {
+    /// Core image metadata.
+    pub handle: ImageHandle,
+    /// Parsed OCI config fields.
+    pub config: Option<ImageConfigDetail>,
+    /// Layers in bottom-to-top order.
+    pub layers: Vec<ImageLayerDetail>,
+}
+
+/// OCI image config fields extracted from the database.
+#[derive(Debug)]
+pub struct ImageConfigDetail {
+    /// Config blob digest.
+    pub digest: String,
+    /// CPU architecture (e.g. `amd64`).
+    pub architecture: Option<String>,
+    /// Operating system (e.g. `linux`).
+    pub os: Option<String>,
+    /// Environment variables in `KEY=VALUE` format.
+    pub env: Vec<String>,
+    /// Default command.
+    pub cmd: Option<Vec<String>>,
+    /// Entrypoint.
+    pub entrypoint: Option<Vec<String>>,
+    /// Working directory.
+    pub working_dir: Option<String>,
+    /// Default user.
+    pub user: Option<String>,
+    /// Exposed ports.
+    pub exposed_ports: Vec<String>,
+    /// Declared volume mount points.
+    pub volumes: Vec<String>,
+}
+
+/// Metadata for a single layer.
+#[derive(Debug)]
+pub struct ImageLayerDetail {
+    /// Compressed layer digest.
+    pub digest: String,
+    /// Uncompressed diff ID.
+    pub diff_id: String,
+    /// OCI media type.
+    pub media_type: Option<String>,
+    /// Compressed blob size in bytes.
+    pub size_bytes: Option<i64>,
+    /// Layer position (0 = bottom).
+    pub position: i32,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: ImageHandle
+//--------------------------------------------------------------------------------------------------
+
+impl ImageHandle {
+    /// Image reference (e.g. `docker.io/library/python:3.11`).
+    pub fn reference(&self) -> &str {
+        &self.reference
+    }
+
+    /// Total image size in bytes, if known.
+    pub fn size_bytes(&self) -> Option<i64> {
+        self.size_bytes
+    }
+
+    /// Content-addressable manifest digest.
+    pub fn manifest_digest(&self) -> Option<&str> {
+        self.manifest_digest.as_deref()
+    }
+
+    /// CPU architecture resolved during pull.
+    pub fn architecture(&self) -> Option<&str> {
+        self.architecture.as_deref()
+    }
+
+    /// Operating system resolved during pull.
+    pub fn os(&self) -> Option<&str> {
+        self.os.as_deref()
+    }
+
+    /// Number of layers in the image.
+    pub fn layer_count(&self) -> usize {
+        self.layer_count
+    }
+
+    /// When this image was last used by a sandbox or pull.
+    pub fn last_used_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.last_used_at
+    }
+
+    /// When this image was first pulled.
+    pub fn created_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.created_at
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Static
+//--------------------------------------------------------------------------------------------------
+
+impl Image {
+    /// Persist full image metadata to the database after a pull.
+    ///
+    /// Upserts the image, manifest, config, layers, and junction records
+    /// inside a single transaction.
+    pub async fn persist(
+        reference: &str,
+        metadata: microsandbox_image::CachedImageMetadata,
+    ) -> MicrosandboxResult<i32> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+
+        let reference = reference.to_string();
+
+        db.transaction::<_, i32, MicrosandboxError>(|txn| {
+            Box::pin(async move {
+                let total_size: i64 = metadata
+                    .layers
+                    .iter()
+                    .filter_map(|l| l.size_bytes)
+                    .map(|s| i64::try_from(s).unwrap_or(i64::MAX))
+                    .fold(0i64, |acc, s| acc.saturating_add(s));
+
+                // 1. Upsert image record.
+                let image_id = upsert_image_record(txn, &reference, Some(total_size)).await?;
+
+                // 2. Upsert manifest record.
+                let manifest_id =
+                    upsert_manifest_record(txn, image_id, &metadata.manifest_digest).await?;
+
+                // 3. Upsert config record.
+                let platform = microsandbox_image::Platform::host_linux();
+                upsert_config_record(
+                    txn,
+                    manifest_id,
+                    &metadata.config_digest,
+                    &metadata.config,
+                    &platform,
+                )
+                .await?;
+
+                // 4. Clear old manifest_layer entries.
+                manifest_layer_entity::Entity::delete_many()
+                    .filter(manifest_layer_entity::Column::ManifestId.eq(manifest_id))
+                    .exec(txn)
+                    .await?;
+
+                // 5. Upsert layers and insert junction records.
+                for (position, layer_meta) in metadata.layers.iter().enumerate() {
+                    let layer_id = upsert_layer_record(txn, layer_meta).await?;
+                    manifest_layer_entity::Entity::insert(manifest_layer_entity::ActiveModel {
+                        manifest_id: Set(manifest_id),
+                        layer_id: Set(layer_id),
+                        position: Set(position as i32),
+                        ..Default::default()
+                    })
+                    .exec(txn)
+                    .await?;
+                }
+
+                Ok(image_id)
+            })
+        })
+        .await
+        .map_err(|err| match err {
+            sea_orm::TransactionError::Connection(db_err) => db_err.into(),
+            sea_orm::TransactionError::Transaction(err) => err,
+        })
+    }
+
+    /// Get an image handle by reference.
+    pub async fn get(reference: &str) -> MicrosandboxResult<ImageHandle> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+
+        let image_model = image_entity::Entity::find()
+            .filter(image_entity::Column::Reference.eq(reference))
+            .one(db)
+            .await?
+            .ok_or_else(|| MicrosandboxError::ImageNotFound(reference.into()))?;
+
+        build_handle(db, image_model).await
+    }
+
+    /// List all cached images, ordered by creation time (newest first).
+    pub async fn list() -> MicrosandboxResult<Vec<ImageHandle>> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+
+        let image_models = image_entity::Entity::find()
+            .order_by_desc(image_entity::Column::CreatedAt)
+            .all(db)
+            .await?;
+
+        let mut handles = Vec::with_capacity(image_models.len());
+        for model in image_models {
+            handles.push(build_handle(db, model).await?);
+        }
+        Ok(handles)
+    }
+
+    /// Get full detail for an image (config + layers).
+    pub async fn inspect(reference: &str) -> MicrosandboxResult<ImageDetail> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+
+        let image_model = image_entity::Entity::find()
+            .filter(image_entity::Column::Reference.eq(reference))
+            .one(db)
+            .await?
+            .ok_or_else(|| MicrosandboxError::ImageNotFound(reference.into()))?;
+
+        let manifest = manifest_entity::Entity::find()
+            .filter(manifest_entity::Column::ImageId.eq(image_model.id))
+            .one(db)
+            .await?;
+
+        let (config_detail, layers) = if let Some(ref manifest) = manifest {
+            let config = config_entity::Entity::find()
+                .filter(config_entity::Column::ManifestId.eq(manifest.id))
+                .one(db)
+                .await?;
+
+            let config_detail = config.map(|c| {
+                let parse_vec = |field: &str, raw: Option<String>| -> Vec<String> {
+                    raw.and_then(|s| {
+                        serde_json::from_str::<Vec<String>>(&s)
+                            .map_err(|e| {
+                                tracing::warn!("failed to parse config {field}: {e}");
+                                e
+                            })
+                            .ok()
+                    })
+                    .unwrap_or_default()
+                };
+                let parse_opt_vec = |field: &str, raw: Option<String>| -> Option<Vec<String>> {
+                    raw.and_then(|s| {
+                        serde_json::from_str::<Vec<String>>(&s)
+                            .map_err(|e| {
+                                tracing::warn!("failed to parse config {field}: {e}");
+                                e
+                            })
+                            .ok()
+                    })
+                };
+
+                ImageConfigDetail {
+                    digest: c.digest,
+                    architecture: c.architecture,
+                    os: c.os,
+                    env: parse_vec("env", c.env),
+                    cmd: parse_opt_vec("cmd", c.cmd),
+                    entrypoint: parse_opt_vec("entrypoint", c.entrypoint),
+                    working_dir: c.working_dir,
+                    user: c.user,
+                    exposed_ports: parse_vec("exposed_ports", c.exposed_ports),
+                    volumes: parse_vec("volumes", c.volumes),
+                }
+            });
+
+            let ml_rows = manifest_layer_entity::Entity::find()
+                .filter(manifest_layer_entity::Column::ManifestId.eq(manifest.id))
+                .order_by_asc(manifest_layer_entity::Column::Position)
+                .all(db)
+                .await?;
+
+            let mut layers = Vec::with_capacity(ml_rows.len());
+            for ml in ml_rows {
+                if let Some(layer) = layer_entity::Entity::find_by_id(ml.layer_id)
+                    .one(db)
+                    .await?
+                {
+                    layers.push(ImageLayerDetail {
+                        digest: layer.digest,
+                        diff_id: layer.diff_id,
+                        media_type: layer.media_type,
+                        size_bytes: layer.size_bytes,
+                        position: ml.position,
+                    });
+                }
+            }
+
+            (config_detail, layers)
+        } else {
+            (None, Vec::new())
+        };
+
+        let handle = build_handle_from_parts(
+            &image_model,
+            manifest.as_ref().map(|m| m.digest.as_str()),
+            config_detail
+                .as_ref()
+                .and_then(|c| c.architecture.as_deref()),
+            config_detail.as_ref().and_then(|c| c.os.as_deref()),
+            layers.len(),
+        );
+
+        Ok(ImageDetail {
+            handle,
+            config: config_detail,
+            layers,
+        })
+    }
+
+    /// Remove an image from the database and clean up orphaned layers on disk.
+    ///
+    /// If `force` is false and the image is referenced by any sandbox, returns
+    /// [`MicrosandboxError::ImageInUse`].
+    pub async fn remove(reference: &str, force: bool) -> MicrosandboxResult<()> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+
+        let image_model = image_entity::Entity::find()
+            .filter(image_entity::Column::Reference.eq(reference))
+            .one(db)
+            .await?
+            .ok_or_else(|| MicrosandboxError::ImageNotFound(reference.into()))?;
+
+        // Run all DB mutations in a transaction to avoid orphaned state.
+        let image_id = image_model.id;
+        let layer_digests = db
+            .transaction::<_, Vec<String>, MicrosandboxError>(|txn| {
+                Box::pin(async move {
+                    // Check sandbox references inside transaction to avoid TOCTOU.
+                    if !force {
+                        let refs = sandbox_image_entity::Entity::find()
+                            .filter(sandbox_image_entity::Column::ImageId.eq(image_id))
+                            .all(txn)
+                            .await?;
+                        if !refs.is_empty() {
+                            let sandbox_ids: Vec<String> =
+                                refs.iter().map(|r| r.sandbox_id.to_string()).collect();
+                            return Err(MicrosandboxError::ImageInUse(sandbox_ids.join(", ")));
+                        }
+                    }
+
+                    // Collect layer digests before cascade delete removes junction rows.
+                    let layer_digests: Vec<String> = layer_entity::Entity::find()
+                        .join(
+                            JoinType::InnerJoin,
+                            layer_entity::Relation::ManifestLayer.def(),
+                        )
+                        .join(
+                            JoinType::InnerJoin,
+                            manifest_layer_entity::Relation::Manifest.def(),
+                        )
+                        .filter(manifest_entity::Column::ImageId.eq(image_id))
+                        .all(txn)
+                        .await?
+                        .into_iter()
+                        .map(|l| l.digest)
+                        .collect();
+
+                    // Delete sandbox_image references if forcing.
+                    if force {
+                        sandbox_image_entity::Entity::delete_many()
+                            .filter(sandbox_image_entity::Column::ImageId.eq(image_id))
+                            .exec(txn)
+                            .await?;
+                    }
+
+                    // Delete image (cascades to manifest, config, manifest_layer).
+                    image_entity::Entity::delete_by_id(image_id)
+                        .exec(txn)
+                        .await?;
+
+                    // Clean up orphaned layers — only collect digests with zero remaining refs.
+                    let mut orphaned_digests = Vec::new();
+                    for digest_str in &layer_digests {
+                        let refs = manifest_layer_entity::Entity::find()
+                            .join(
+                                JoinType::InnerJoin,
+                                manifest_layer_entity::Relation::Layer.def(),
+                            )
+                            .filter(layer_entity::Column::Digest.eq(digest_str.as_str()))
+                            .count(txn)
+                            .await?;
+
+                        if refs == 0 {
+                            layer_entity::Entity::delete_many()
+                                .filter(layer_entity::Column::Digest.eq(digest_str.as_str()))
+                                .exec(txn)
+                                .await?;
+                            orphaned_digests.push(digest_str.clone());
+                        }
+                    }
+
+                    Ok(orphaned_digests)
+                })
+            })
+            .await
+            .map_err(|err| match err {
+                sea_orm::TransactionError::Connection(db_err) => db_err.into(),
+                sea_orm::TransactionError::Transaction(err) => err,
+            })?;
+
+        // Best-effort on-disk cleanup (outside transaction).
+        let cache_dir = crate::config::config().cache_dir();
+        if let Ok(cache) = microsandbox_image::GlobalCache::new(&cache_dir) {
+            for digest_str in &layer_digests {
+                if let Ok(digest) = digest_str.parse::<microsandbox_image::Digest>() {
+                    let _ = tokio::fs::remove_dir_all(cache.extracted_dir(&digest)).await;
+                    let _ = tokio::fs::remove_file(cache.tar_path(&digest)).await;
+                    let _ = tokio::fs::remove_file(cache.index_path(&digest)).await;
+                    // Clean up ancillary files left by the download/extraction pipeline.
+                    let _ = tokio::fs::remove_file(cache.lock_path(&digest)).await;
+                    let _ = tokio::fs::remove_file(cache.download_lock_path(&digest)).await;
+                    let _ = tokio::fs::remove_file(cache.part_path(&digest)).await;
+                    let _ = tokio::fs::remove_file(cache.implicit_dirs_path(&digest)).await;
+                    let _ = tokio::fs::remove_dir_all(cache.extracting_dir(&digest)).await;
+                }
+            }
+
+            if let Ok(image_ref) = reference.parse::<microsandbox_image::Reference>() {
+                let _ = cache.delete_image_metadata(&image_ref);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build an [`ImageHandle`] from an image model by fetching related data.
+async fn build_handle<C: ConnectionTrait>(
+    db: &C,
+    model: image_entity::Model,
+) -> MicrosandboxResult<ImageHandle> {
+    let manifest = manifest_entity::Entity::find()
+        .filter(manifest_entity::Column::ImageId.eq(model.id))
+        .one(db)
+        .await?;
+
+    let (digest, arch, os, layer_count) = if let Some(ref manifest) = manifest {
+        let config = config_entity::Entity::find()
+            .filter(config_entity::Column::ManifestId.eq(manifest.id))
+            .one(db)
+            .await?;
+
+        let count = manifest_layer_entity::Entity::find()
+            .filter(manifest_layer_entity::Column::ManifestId.eq(manifest.id))
+            .count(db)
+            .await? as usize;
+
+        (
+            Some(manifest.digest.clone()),
+            config.as_ref().and_then(|c| c.architecture.clone()),
+            config.as_ref().and_then(|c| c.os.clone()),
+            count,
+        )
+    } else {
+        (None, None, None, 0)
+    };
+
+    Ok(build_handle_from_parts(
+        &model,
+        digest.as_deref(),
+        arch.as_deref(),
+        os.as_deref(),
+        layer_count,
+    ))
+}
+
+/// Build an [`ImageHandle`] from pre-fetched parts.
+fn build_handle_from_parts(
+    model: &image_entity::Model,
+    manifest_digest: Option<&str>,
+    architecture: Option<&str>,
+    os: Option<&str>,
+    layer_count: usize,
+) -> ImageHandle {
+    ImageHandle {
+        db_id: model.id,
+        reference: model.reference.clone(),
+        size_bytes: model.size_bytes,
+        manifest_digest: manifest_digest.map(|s| s.to_string()),
+        architecture: architecture.map(|s| s.to_string()),
+        os: os.map(|s| s.to_string()),
+        layer_count,
+        last_used_at: model.last_used_at.map(|dt| dt.and_utc()),
+        created_at: model.created_at.map(|dt| dt.and_utc()),
+    }
+}
+
+/// Upsert an image record by reference. Returns the image ID.
+pub(crate) async fn upsert_image_record<C: ConnectionTrait>(
+    db: &C,
+    reference: &str,
+    size_bytes: Option<i64>,
+) -> MicrosandboxResult<i32> {
+    let now = chrono::Utc::now().naive_utc();
+
+    let mut update_columns = vec![image_entity::Column::LastUsedAt];
+    if size_bytes.is_some() {
+        update_columns.push(image_entity::Column::SizeBytes);
+    }
+
+    image_entity::Entity::insert(image_entity::ActiveModel {
+        reference: Set(reference.to_string()),
+        size_bytes: Set(size_bytes),
+        last_used_at: Set(Some(now)),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    })
+    .on_conflict(
+        OnConflict::column(image_entity::Column::Reference)
+            .update_columns(update_columns)
+            .to_owned(),
+    )
+    .exec(db)
+    .await?;
+
+    image_entity::Entity::find()
+        .filter(image_entity::Column::Reference.eq(reference))
+        .one(db)
+        .await?
+        .map(|model| model.id)
+        .ok_or_else(|| {
+            crate::MicrosandboxError::Custom(format!("image '{}' missing after upsert", reference))
+        })
+}
+
+/// Upsert a manifest record by digest. Returns the manifest ID.
+async fn upsert_manifest_record<C: ConnectionTrait>(
+    db: &C,
+    image_id: i32,
+    digest: &str,
+) -> MicrosandboxResult<i32> {
+    let now = chrono::Utc::now().naive_utc();
+
+    // Use DO NOTHING on conflict — manifests are shared across images when
+    // multiple tags resolve to the same digest. We must not steal the manifest
+    // by overwriting image_id.
+    manifest_entity::Entity::insert(manifest_entity::ActiveModel {
+        image_id: Set(image_id),
+        digest: Set(digest.to_string()),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    })
+    .on_conflict(
+        OnConflict::column(manifest_entity::Column::Digest)
+            .do_nothing()
+            .to_owned(),
+    )
+    .exec(db)
+    .await
+    .ok(); // Ignore conflict — manifest already exists.
+
+    manifest_entity::Entity::find()
+        .filter(manifest_entity::Column::Digest.eq(digest))
+        .one(db)
+        .await?
+        .map(|model| model.id)
+        .ok_or_else(|| {
+            crate::MicrosandboxError::Custom(format!("manifest '{}' missing after upsert", digest))
+        })
+}
+
+/// Upsert a config record for a manifest.
+async fn upsert_config_record<C: ConnectionTrait>(
+    db: &C,
+    manifest_id: i32,
+    digest: &str,
+    config: &microsandbox_image::ImageConfig,
+    platform: &microsandbox_image::Platform,
+) -> MicrosandboxResult<()> {
+    let env_json = if config.env.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&config.env)?)
+    };
+    let cmd_json = config.cmd.as_ref().map(serde_json::to_string).transpose()?;
+    let entrypoint_json = config
+        .entrypoint
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
+    let volumes_json = if config.volumes.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&config.volumes)?)
+    };
+    let exposed_ports_json = if config.exposed_ports.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&config.exposed_ports)?)
+    };
+
+    let now = chrono::Utc::now().naive_utc();
+
+    // Delete existing config for this manifest (1:1 relationship).
+    config_entity::Entity::delete_many()
+        .filter(config_entity::Column::ManifestId.eq(manifest_id))
+        .exec(db)
+        .await?;
+
+    config_entity::Entity::insert(config_entity::ActiveModel {
+        manifest_id: Set(manifest_id),
+        digest: Set(digest.to_string()),
+        architecture: Set(Some(platform.arch.clone())),
+        os: Set(Some(platform.os.clone())),
+        os_variant: Set(None),
+        env: Set(env_json),
+        cmd: Set(cmd_json),
+        entrypoint: Set(entrypoint_json),
+        working_dir: Set(config.working_dir.clone()),
+        volumes: Set(volumes_json),
+        exposed_ports: Set(exposed_ports_json),
+        user: Set(config.user.clone()),
+        rootfs_type: Set(Some("layers".to_string())),
+        rootfs_diff_ids: Set(None),
+        history: Set(None),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    })
+    .exec(db)
+    .await?;
+
+    Ok(())
+}
+
+/// Upsert a layer record by digest. Returns the layer ID.
+async fn upsert_layer_record<C: ConnectionTrait>(
+    db: &C,
+    layer_meta: &microsandbox_image::CachedLayerMetadata,
+) -> MicrosandboxResult<i32> {
+    let now = chrono::Utc::now().naive_utc();
+
+    layer_entity::Entity::insert(layer_entity::ActiveModel {
+        digest: Set(layer_meta.digest.clone()),
+        diff_id: Set(layer_meta.diff_id.clone()),
+        media_type: Set(layer_meta.media_type.clone()),
+        size_bytes: Set(layer_meta
+            .size_bytes
+            .map(|s| i64::try_from(s).unwrap_or(i64::MAX))),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    })
+    .on_conflict(
+        OnConflict::column(layer_entity::Column::Digest)
+            .do_nothing()
+            .to_owned(),
+    )
+    .exec(db)
+    .await
+    .ok(); // Ignore conflict — layer already exists.
+
+    layer_entity::Entity::find()
+        .filter(layer_entity::Column::Digest.eq(&layer_meta.digest))
+        .one(db)
+        .await?
+        .map(|model| model.id)
+        .ok_or_else(|| {
+            crate::MicrosandboxError::Custom(format!(
+                "layer '{}' missing after upsert",
+                layer_meta.digest
+            ))
+        })
+}

--- a/crates/microsandbox/lib/lib.rs
+++ b/crates/microsandbox/lib/lib.rs
@@ -13,6 +13,7 @@ pub mod agent;
 pub mod config;
 #[allow(dead_code)]
 pub(crate) mod db;
+pub mod image;
 pub mod runtime;
 pub mod sandbox;
 pub mod setup;

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -22,8 +22,7 @@ use microsandbox_protocol::{
 };
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
-    QueryOrder, Set, TransactionTrait,
-    sea_query::{Expr, OnConflict},
+    QueryOrder, Set, TransactionTrait, sea_query::Expr,
 };
 use tokio::sync::{Mutex, mpsc};
 
@@ -31,7 +30,7 @@ use crate::{
     MicrosandboxResult,
     agent::AgentClient,
     db::entity::{
-        image as image_entity, microvm as microvm_entity, sandbox as sandbox_entity,
+        microvm as microvm_entity, sandbox as sandbox_entity,
         sandbox_image as sandbox_image_entity, supervisor as supervisor_entity,
     },
     runtime::{SupervisorHandle, SupervisorSpawnMode, spawn_supervisor},
@@ -193,7 +192,17 @@ impl Sandbox {
             // Store resolved layer paths for spawn_supervisor.
             config.resolved_rootfs_layers = pull_result.layers;
             pinned_manifest_digest = Some(pull_result.manifest_digest.to_string());
-            pinned_reference = Some(reference);
+            pinned_reference = Some(reference.clone());
+
+            // Persist full image metadata to database.
+            let cache_dir = crate::config::config().cache_dir();
+            if let Ok(cache) = microsandbox_image::GlobalCache::new(&cache_dir)
+                && let Ok(image_ref) = reference.parse::<microsandbox_image::Reference>()
+                && let Ok(Some(metadata)) = cache.read_image_metadata(&image_ref)
+                && let Err(e) = crate::image::Image::persist(&reference, metadata).await
+            {
+                tracing::warn!(error = %e, "failed to persist image metadata to database");
+            }
         }
 
         // Insert the sandbox record and keep its stable database ID.
@@ -1293,7 +1302,7 @@ async fn replace_oci_manifest_pin<C: ConnectionTrait>(
     reference: &str,
     manifest_digest: &str,
 ) -> MicrosandboxResult<()> {
-    let image_id = upsert_image_record(db, reference).await?;
+    let image_id = crate::image::upsert_image_record(db, reference, None).await?;
     let now = chrono::Utc::now().naive_utc();
 
     sandbox_image_entity::Entity::delete_many()
@@ -1312,36 +1321,6 @@ async fn replace_oci_manifest_pin<C: ConnectionTrait>(
     .await?;
 
     Ok(())
-}
-
-async fn upsert_image_record<C: ConnectionTrait>(
-    db: &C,
-    reference: &str,
-) -> MicrosandboxResult<i32> {
-    let now = chrono::Utc::now().naive_utc();
-
-    image_entity::Entity::insert(image_entity::ActiveModel {
-        reference: Set(reference.to_string()),
-        last_used_at: Set(Some(now)),
-        created_at: Set(Some(now)),
-        ..Default::default()
-    })
-    .on_conflict(
-        OnConflict::column(image_entity::Column::Reference)
-            .update_columns([image_entity::Column::LastUsedAt])
-            .to_owned(),
-    )
-    .exec(db)
-    .await?;
-
-    image_entity::Entity::find()
-        .filter(image_entity::Column::Reference.eq(reference))
-        .one(db)
-        .await?
-        .map(|model| model.id)
-        .ok_or_else(|| {
-            crate::MicrosandboxError::Custom(format!("image '{}' missing after upsert", reference))
-        })
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -35,9 +35,6 @@ msb shell devbox
 # Execute in a running sandbox
 msb exec devbox -- ls -la /app
 
-# Attach with detach keys
-msb attach devbox --detach-keys ctrl-q
-
 # Manage
 msb ls                   # List all sandboxes
 msb ps                   # Running sandboxes only
@@ -58,10 +55,27 @@ msb volume rm data
 
 | Flag | Description |
 |------|-------------|
+| `--tree` | Display the complete command tree with descriptions |
 | `--error` | Show only errors |
 | `--warn` | Show warnings and errors |
 | `--info` | Show info, warnings, and errors |
 | `--debug` | Show debug output |
 | `--trace` | Show all output including trace |
+
+## Command tree
+
+Use `--tree` as an alternative to `--help` to see every command, subcommand, and flag at once:
+
+```bash
+msb --tree
+```
+
+You can also scope it to a specific subcommand:
+
+```bash
+msb image --tree    # Show only image commands
+msb volume --tree   # Show only volume commands
+msb run --tree      # Show all flags for run
+```
 
 For detailed command reference, see [Sandbox Commands](/cli/sandbox-commands), [Volume Commands](/cli/volume-commands), and [Image Commands](/cli/image-commands).

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -78,44 +78,6 @@ sb = await Sandbox.create(
 ```
 </CodeGroup>
 
-## Image config inheritance
-
-OCI images carry runtime configuration set by the image author — environment variables, default command, entrypoint, working directory, and more. When you create a sandbox from an OCI image, microsandbox inherits these as defaults. Your sandbox configuration overrides them.
-
-### Merge rules
-
-| Field | Merge behavior | Example |
-|-------|---------------|---------|
-| `env` | Image env vars form the base. User env vars override by key, new keys are appended. | Image sets `PATH=/usr/local/bin`, user sets `PATH=/custom` → `PATH=/custom` |
-| `entrypoint` | Image value used unless user sets one. Full replacement, not appended. | Image sets `["/entrypoint.sh"]`, user doesn't override → `["/entrypoint.sh"]` |
-| `cmd` | Image value used unless user sets one. Full replacement. | Image sets `["python3"]`, user doesn't override → `["python3"]` |
-| `workdir` | Image value used unless user sets one. | Image sets `/app`, user sets `/workspace` → `/workspace` |
-| `user` | Image value used unless user sets one. | Image sets `postgres`, user doesn't override → `postgres` |
-| `stop_signal` | Image value used unless user sets one. | Image sets `SIGQUIT`, user doesn't override → `SIGQUIT` |
-| `labels` | Image labels form the base. User labels override on key conflict. | Image sets `version=1.0`, user sets `version=custom` → `version=custom` |
-
-For environment variables specifically, the merge is key-aware: if the image defines `PATH=/usr/local/bin:/usr/bin` and the user sets `PATH=/custom/bin`, the user's value replaces the image's `PATH` entirely. Image env vars with keys the user didn't set are preserved.
-
-### Command resolution
-
-When running a sandbox, microsandbox resolves the process to execute following OCI semantics:
-
-1. **User provides a command** (`-- <cmd>`): The image `entrypoint` is preserved as a prefix. The user command replaces the image `cmd` (default arguments).
-2. **No user command**: The image `entrypoint` + `cmd` are used together.
-3. **No user command, no image command**: Falls back to the configured shell (default `/bin/sh`).
-
-| Image config | User command | Effective process |
-|-------------|-------------|-------------------|
-| `entrypoint=["/entrypoint.sh"]`, `cmd=["postgres"]` | — | `/entrypoint.sh postgres` |
-| `entrypoint=["/entrypoint.sh"]`, `cmd=["postgres"]` | `-- bash` | `/entrypoint.sh bash` |
-| `entrypoint=null`, `cmd=["python3"]` | — | `python3` |
-| `entrypoint=null`, `cmd=["python3"]` | `-- bash` | `bash` |
-| `entrypoint=null`, `cmd=null` | — | `/bin/sh` (shell fallback) |
-
-<Note>
-  The `entrypoint` is always preserved when set. Providing a command via `--` replaces only the `cmd` portion (the default arguments), not the entrypoint itself. This matches standard OCI container behavior — the entrypoint typically handles initialization that must always run.
-</Note>
-
 ## Image storage
 
 Images are cached in the global microsandbox home directory:

--- a/justfile
+++ b/justfile
@@ -153,7 +153,7 @@ install:
 
     # Install libkrunfw to ~/.microsandbox/lib/.
     mkdir -p ~/.microsandbox/lib
-    cp build/libkrunfw.so.{{ LIBKRUNFW_VERSION }} ~/.microsandbox/lib/
+    install -m644 build/libkrunfw.so.{{ LIBKRUNFW_VERSION }} ~/.microsandbox/lib/libkrunfw.so.{{ LIBKRUNFW_VERSION }}
     ln -sf libkrunfw.so.{{ LIBKRUNFW_VERSION }} ~/.microsandbox/lib/libkrunfw.so.{{ LIBKRUNFW_ABI }}
     ln -sf libkrunfw.so.{{ LIBKRUNFW_ABI }} ~/.microsandbox/lib/libkrunfw.so
     echo "Installed libkrunfw → ~/.microsandbox/lib/"
@@ -170,16 +170,19 @@ install:
     test -f build/msbnet || { echo "error: build/msbnet not found. Run 'just build' first."; exit 1; }
     test -f build/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib || { echo "error: build/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib not found. Run 'just build-deps' first."; exit 1; }
 
-    # Install msb and msbnet to ~/.microsandbox/bin/ (cp preserves codesign; install strips it).
+    # Install msb and msbnet to ~/.microsandbox/bin/.
+    # Atomic mv to a fresh inode — macOS caches code signatures on the vnode,
+    # so cp over a running binary can block new executions.
     mkdir -p ~/.microsandbox/bin
-    cp build/msb ~/.microsandbox/bin/msb
-    cp build/msbnet ~/.microsandbox/bin/msbnet
+    install -m755 build/msb ~/.microsandbox/bin/msb.tmp && mv ~/.microsandbox/bin/msb.tmp ~/.microsandbox/bin/msb
+    install -m755 build/msbnet ~/.microsandbox/bin/msbnet.tmp && mv ~/.microsandbox/bin/msbnet.tmp ~/.microsandbox/bin/msbnet
     echo "Installed msb → ~/.microsandbox/bin/msb"
     echo "Installed msbnet → ~/.microsandbox/bin/msbnet"
 
     # Install libkrunfw to ~/.microsandbox/lib/.
+    # Atomic install to avoid corrupting a running VM's mmap'd library.
     mkdir -p ~/.microsandbox/lib
-    cp build/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib ~/.microsandbox/lib/
+    cp build/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib ~/.microsandbox/lib/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib.tmp && mv ~/.microsandbox/lib/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib.tmp ~/.microsandbox/lib/libkrunfw.{{ LIBKRUNFW_ABI }}.dylib
     ln -sf libkrunfw.{{ LIBKRUNFW_ABI }}.dylib ~/.microsandbox/lib/libkrunfw.dylib
     echo "Installed libkrunfw → ~/.microsandbox/lib/"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Microsandbox installer
-# Usage: curl -fsSL https://microsandbox.dev/install | sh
+# Usage: curl -fsSL https://get.microsandbox.dev | sh
 set -eu
 
 # ---------------------------------------------------------------------------
@@ -242,19 +242,23 @@ main() {
     info "Extracting..."
     tar -xzf "$_bundle"
 
-    # Install binaries
+    # Install binaries.
+    # install(1) unlinks the target first, so the binary gets a fresh inode
+    # even if a previous version is running.
     mkdir -p "$BIN_DIR"
     install -m 755 msb "$BIN_DIR/msb"
     install -m 755 msbnet "$BIN_DIR/msbnet"
 
-    # Install libkrunfw
+    # Install libkrunfw. Use install(1) on Linux (handles running binaries).
+    # On macOS, cp+mv for a fresh inode — macOS caches code signatures on the
+    # vnode, so overwriting a running library in-place can cause issues.
     mkdir -p "$LIB_DIR"
     if [ "$OS" = "linux" ]; then
-        cp "libkrunfw.so.${LIBKRUNFW_VERSION}" "$LIB_DIR/"
+        install -m 644 "libkrunfw.so.${LIBKRUNFW_VERSION}" "$LIB_DIR/libkrunfw.so.${LIBKRUNFW_VERSION}"
         ln -sf "libkrunfw.so.${LIBKRUNFW_VERSION}" "$LIB_DIR/libkrunfw.so.${LIBKRUNFW_ABI}"
         ln -sf "libkrunfw.so.${LIBKRUNFW_ABI}" "$LIB_DIR/libkrunfw.so"
     elif [ "$OS" = "darwin" ]; then
-        cp "libkrunfw.${LIBKRUNFW_ABI}.dylib" "$LIB_DIR/"
+        cp "libkrunfw.${LIBKRUNFW_ABI}.dylib" "$LIB_DIR/libkrunfw.${LIBKRUNFW_ABI}.dylib.tmp" && mv "$LIB_DIR/libkrunfw.${LIBKRUNFW_ABI}.dylib.tmp" "$LIB_DIR/libkrunfw.${LIBKRUNFW_ABI}.dylib"
         ln -sf "libkrunfw.${LIBKRUNFW_ABI}.dylib" "$LIB_DIR/libkrunfw.dylib"
     fi
 


### PR DESCRIPTION
## Summary

- Add `msb image {pull,ls,inspect,rm}` CLI subcommands for managing cached OCI images, backed by full SQLite persistence of image metadata (manifests, configs, layers, and junction records)
- Introduce a new `Image` business logic module in the microsandbox core crate with transactional DB operations (persist, get, list, inspect, remove) including content-addressable layer deduplication and orphaned-layer cleanup
- Add top-level aliases (`msb pull`, `msb images`, `msb rmi`, `msb vol`), a `--tree` flag for displaying the full command tree, and ANSI-aware table column alignment
- Fix macOS binary install atomicity (vnode code-signature caching issue) and TOCTOU races in image metadata read/delete

## Changes

- **New: `crates/cli/lib/commands/image.rs` (433 lines)** — CLI subcommand definitions for `msb image {pull,ls,inspect,rm}` with table, JSON, and quiet output modes. Pull logic moved from `pull.rs` with DB persistence added after successful pulls.
- **New: `crates/microsandbox/lib/image/mod.rs` (708 lines)** — Core business logic module: `Image::persist()` upserts image/manifest/config/layer records in a single transaction; `Image::get()`/`list()`/`inspect()` query with joined manifest/config/layer data; `Image::remove()` runs transactional cascade delete with orphaned-layer reference counting and best-effort on-disk cleanup.
- **New: `crates/cli/lib/tree.rs` (485 lines)** — `--tree` flag implementation that renders the full command tree with descriptions, arguments, and aliases.
- **Modified: `crates/cli/bin/main.rs`** — Added `Image`, `Images`, `Rmi` command variants with dispatch; `vol` visible alias for `volume`; panic hook for terminal echo restoration; `--tree` handling before `Cli::parse()`.
- **Modified: `crates/cli/lib/commands/pull.rs`** — Stripped to args-only module; pull logic moved to `image.rs`.
- **Modified: `crates/cli/lib/ui.rs`** — Table print now uses `console::measure_text_width()` for ANSI-aware column alignment; added `install_panic_hook()`.
- **Modified: `crates/image/lib/store.rs`** — Made `CachedImageMetadata`/`CachedLayerMetadata` public; added `delete_image_metadata()` with race-safe `NotFound` handling; fixed TOCTOU in `read_image_metadata()`.
- **Modified: `crates/image/lib/{lib.rs,manifest.rs,registry.rs}`** — Re-exported new public types; stored config digest in `CachedImageMetadata`; preserved parsed `ImageIndex` in `OciManifest::Index`.
- **Modified: `crates/microsandbox/lib/sandbox/mod.rs`** — Delegated `upsert_image_record` to `image::upsert_image_record`; added full image DB persistence after OCI pull during sandbox creation.
- **Modified: `crates/microsandbox/lib/error.rs`** — Added `ImageNotFound` and `ImageInUse` error variants.
- **Modified: `justfile`** — macOS install uses atomic `install+mv` for fresh inode; Linux uses `install` (which already unlinks); libkrunfw install made atomic on macOS.
- **Modified: `scripts/install.sh`** — Same atomic install pattern; fixed install URL in header comment.
- **Modified: `docs/cli/overview.mdx`** — Added `msb image` and `msb --tree` to CLI reference.
- **Modified: `docs/images/overview.mdx`** — Removed OCI config inheritance section (moved to design docs).

## Test Plan

- Run `cargo build` and `cargo test --lib -p microsandbox -p microsandbox-image` to verify compilation and all 98 existing tests pass
- Run `msb --help` to confirm `image`, `pull`, `inspect`, `volume [vol]` commands appear correctly
- Run `msb image --help` to verify `pull`, `list [ls]`, `inspect`, `remove [rm]` subcommands
- Run `msb --tree` to verify the full command tree renders correctly
- Run `msb image pull python:3.11` and verify DB persistence (image appears in `msb image ls`)
- Run `msb image inspect python:3.11` to verify config, layers, and metadata display
- Run `msb image rm python:3.11` and verify cleanup (image removed from `msb image ls`, orphaned layers cleaned from disk)
- Run `msb pull python:3.11` to verify the top-level alias works identically to `msb image pull`
- Run `msb images` and `msb rmi` to verify hidden aliases
- Verify table alignment is correct when status column contains ANSI color codes (e.g., `msb ls` with running/stopped sandboxes)