### PR TITLE
feat(sandbox): add rootfs patches, batch attach output, and improve I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,12 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1020,6 +1026,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,12 +1186,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1435,7 +1446,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1443,11 +1454,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashlink"
@@ -2142,15 +2148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2201,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "dirs",
+ "docker_credential",
  "flate2",
  "futures",
  "libc",
@@ -2238,13 +2236,16 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "dirs",
  "indicatif",
  "libc",
  "microsandbox",
  "microsandbox-image",
  "microsandbox-network",
  "microsandbox-runtime",
+ "microsandbox-utils",
  "rand 0.9.2",
+ "reqwest 0.13.2",
  "serde_json",
  "tokio",
  "tracing",
@@ -2314,7 +2315,7 @@ dependencies = [
  "hickory-resolver",
  "ipnetwork",
  "libc",
- "lru 0.12.5",
+ "lru",
  "microsandbox-utils",
  "msb_krun",
  "rcgen",
@@ -2495,7 +2496,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.16.3",
+ "lru",
  "msb_krun_arch",
  "msb_krun_hvf",
  "msb_krun_polly",
@@ -2629,6 +2630,15 @@ name = "net-policy"
 version = "0.1.0"
 dependencies = [
  "microsandbox",
+ "tokio",
+]
+
+[[package]]
+name = "net-ports"
+version = "0.1.0"
+dependencies = [
+ "microsandbox",
+ "reqwest 0.13.2",
  "tokio",
 ]
 
@@ -3508,6 +3518,14 @@ dependencies = [
 
 [[package]]
 name = "root-oci"
+version = "0.1.0"
+dependencies = [
+ "microsandbox",
+ "tokio",
+]
+
+[[package]]
+name = "rootfs-patch"
 version = "0.1.0"
 dependencies = [
  "microsandbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ members = [
     "examples/net-basic",
     "examples/net-dns",
     "examples/net-policy",
+    "examples/net-ports",
     "examples/net-secrets",
     "examples/net-tls",
     "examples/root-bind",
     "examples/root-block",
     "examples/root-oci",
+    "examples/rootfs-patch",
     "examples/volume-named",
 ]
 

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -102,13 +102,21 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64) -> AgentdResult<()> {
     flush_write_buf(&async_port, &mut serial_out_buf).await?;
 
     // Main loop.
-    loop {
+    'agent: loop {
         tokio::select! {
             // Read from serial port.
-            result = async_read_ready(&async_port) => {
-                if result.is_ok() {
-                    match read_from_fd(port_fd, &mut read_buf) {
-                        Ok(n) if n > 0 => {
+            result = async_port.readable() => {
+                let Ok(mut guard) = result else {
+                    break;
+                };
+
+                loop {
+                    match guard.try_io(|inner| read_from_fd(inner.get_ref().as_raw_fd(), &mut read_buf)) {
+                        Ok(Ok(0)) => {
+                            // EOF on serial — host disconnected.
+                            break 'agent;
+                        }
+                        Ok(Ok(n)) => {
                             serial_in_buf.extend_from_slice(&read_buf[..n]);
                             last_activity = Utc::now();
 
@@ -137,14 +145,9 @@ pub async fn run(boot_time_ns: u64, init_time_ns: u64) -> AgentdResult<()> {
                                 flush_write_buf(&async_port, &mut serial_out_buf).await?;
                             }
                         }
-                        Ok(_) => {
-                            // EOF on serial — host disconnected.
-                            break;
-                        }
-                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                            // No data available, continue.
-                        }
-                        Err(e) => return Err(e.into()),
+                        Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Ok(Err(e)) => return Err(e.into()),
+                        Err(_would_block) => break,
                     }
                 }
             }
@@ -377,13 +380,6 @@ fn set_nonblocking(fd: i32) -> AgentdResult<()> {
     Ok(())
 }
 
-/// Waits for the async fd to be readable.
-async fn async_read_ready(fd: &AsyncFd<std::fs::File>) -> std::io::Result<()> {
-    let mut guard = fd.readable().await?;
-    guard.clear_ready();
-    Ok(())
-}
-
 /// Reads from a raw fd (non-blocking).
 fn read_from_fd(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
     let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
@@ -398,18 +394,14 @@ fn read_from_fd(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
 async fn flush_write_buf(fd: &AsyncFd<std::fs::File>, buf: &mut Vec<u8>) -> AgentdResult<()> {
     while !buf.is_empty() {
         let mut guard = fd.writable().await?;
-        let raw_fd = fd.as_raw_fd();
-        match write_to_fd(raw_fd, buf) {
-            Ok(n) => {
+        match guard.try_io(|inner| write_to_fd(inner.get_ref().as_raw_fd(), buf)) {
+            Ok(Ok(n)) => {
                 buf.drain(..n);
             }
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                guard.clear_ready();
-                continue;
-            }
-            Err(e) => return Err(e.into()),
+            Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_would_block) => continue,
         }
-        guard.clear_ready();
     }
     Ok(())
 }

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -12,7 +12,7 @@ use nix::{
     unistd::Pid,
 };
 use tokio::{
-    io::{AsyncReadExt, unix::AsyncFd},
+    io::AsyncReadExt,
     process::{Child, Command},
     sync::mpsc,
 };
@@ -420,45 +420,46 @@ async fn pty_reader_task(
     master_fd: OwnedFd,
     tx: mpsc::UnboundedSender<(u32, SessionOutput)>,
 ) {
-    // Set non-blocking for async I/O.
-    let raw = master_fd.as_raw_fd();
-    let flags = unsafe { libc::fcntl(raw, libc::F_GETFL) };
-    if flags >= 0 {
-        unsafe { libc::fcntl(raw, libc::F_SETFL, flags | libc::O_NONBLOCK) };
-    }
+    let tx_output = tx.clone();
+    let read_result = tokio::task::spawn_blocking(move || {
+        // PTY masters are safer with a dedicated blocking read loop than with
+        // edge-driven readiness. Fast writers followed by process exit can
+        // strand the tail behind a missed wakeup/HUP transition.
+        let raw = master_fd.as_raw_fd();
+        let flags = unsafe { libc::fcntl(raw, libc::F_GETFL) };
+        if flags >= 0 {
+            unsafe { libc::fcntl(raw, libc::F_SETFL, flags & !libc::O_NONBLOCK) };
+        }
 
-    let Ok(async_fd) = AsyncFd::new(master_fd) else {
-        let code = wait_for_pid(pid).await;
-        let _ = tx.send((id, SessionOutput::Exited(code)));
-        return;
-    };
+        loop {
+            let mut buf = [0u8; 4096];
+            let n = unsafe { libc::read(raw, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
 
-    loop {
-        let Ok(mut guard) = async_fd.readable().await else {
-            break;
-        };
-
-        let fd = async_fd.as_raw_fd();
-        let mut buf = [0u8; 4096];
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
-
-        if n > 0 {
-            let _ = tx.send((id, SessionOutput::Stdout(buf[..n as usize].to_vec())));
-            guard.clear_ready();
-        } else if n == 0 {
-            break;
-        } else {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EAGAIN)
-                || err.raw_os_error() == Some(libc::EWOULDBLOCK)
-            {
-                guard.clear_ready();
+            if n > 0 {
+                if tx_output
+                    .send((id, SessionOutput::Stdout(buf[..n as usize].to_vec())))
+                    .is_err()
+                {
+                    break;
+                }
                 continue;
             }
-            // EIO or other error — PTY slave closed.
-            break;
+
+            if n == 0 {
+                break;
+            }
+
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::EINTR) => continue,
+                Some(libc::EIO) => break,
+                _ => break,
+            }
         }
-    }
+    })
+    .await;
+
+    let _ = read_result;
 
     let code = wait_for_pid(pid).await;
     let _ = tx.send((id, SessionOutput::Exited(code)));
@@ -541,4 +542,77 @@ async fn wait_for_pid(pid: i32) -> i32 {
     })
     .await
     .unwrap_or(-1)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use microsandbox_protocol::exec::ExecRequest;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pty_reader_drains_ready_fd() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let req = ExecRequest {
+            cmd: "/bin/sh".to_string(),
+            args: vec![
+                "-lc".to_string(),
+                "i=0; while [ $i -lt 1024 ]; do printf AAAA; i=$((i+1)); done; printf SECOND; sleep 1; printf '<END>\\n'; sleep 1"
+                    .to_string(),
+            ],
+            env: vec!["PATH=/usr/local/bin:/usr/bin:/bin".to_string()],
+            cwd: None,
+            tty: true,
+            rows: 24,
+            cols: 80,
+            rlimits: Vec::new(),
+        };
+
+        let session = ExecSession::spawn(7, &req, tx).expect("spawn pty session");
+        let mut stdout = Vec::new();
+        let mut exit = None;
+
+        let recv_result = timeout(Duration::from_secs(5), async {
+            while let Some((id, output)) = rx.recv().await {
+                assert_eq!(id, 7);
+                match output {
+                    SessionOutput::Stdout(data) => stdout.extend_from_slice(&data),
+                    SessionOutput::Exited(code) => {
+                        exit = Some(code);
+                        break;
+                    }
+                    SessionOutput::Stderr(_) | SessionOutput::Raw(_) => {}
+                }
+            }
+        })
+        .await;
+
+        if recv_result.is_err() {
+            let _ = session.send_signal(libc::SIGKILL);
+            panic!("timed out waiting for PTY output");
+        }
+
+        assert_eq!(exit, Some(0));
+
+        let second = stdout
+            .windows(b"SECOND".len())
+            .position(|window| window == b"SECOND");
+        let end = stdout
+            .windows(b"<END>".len())
+            .position(|window| window == b"<END>");
+
+        assert!(
+            matches!((second, end), (Some(second), Some(end)) if second < end),
+            "expected immediate PTY write to arrive before later output; got {:?}",
+            String::from_utf8_lossy(&stdout),
+        );
+    }
 }

--- a/crates/agentd/lib/tls.rs
+++ b/crates/agentd/lib/tls.rs
@@ -1,6 +1,6 @@
 //! Guest-side CA certificate installation for TLS interception.
 //!
-//! When the supervisor places a CA certificate at `/.msb/tls/ca.pem` via the
+//! When the sandbox process places a CA certificate at `/.msb/tls/ca.pem` via the
 //! runtime virtiofs mount, this module detects it during init and:
 //!
 //! 1. Copies the CA PEM to distro-specific trust directories (if they exist).

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,13 +25,16 @@ anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 console.workspace = true
+dirs.workspace = true
 indicatif.workspace = true
 libc.workspace = true
 microsandbox = { version = "0.3.2", path = "../microsandbox", default-features = false }
 microsandbox-image = { version = "0.3.2", path = "../image" }
 microsandbox-network = { version = "0.3.2", path = "../network", optional = true }
 microsandbox-runtime = { version = "0.3.2", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.2", path = "../utils" }
 rand.workspace = true
+reqwest.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -3,8 +3,8 @@
 use clap::{CommandFactory, Parser, Subcommand};
 use microsandbox_cli::{
     commands::{
-        create, exec, image, inspect, install, list, ps, pull, remove, run, shell, start, stop,
-        uninstall, volume,
+        create, exec, image, inspect, install, list, ps, pull, remove, run, self_cmd, shell, start,
+        stop, uninstall, volume,
     },
     log_args::{self, LogArgs},
     sandbox_cmd::{self, SandboxArgs},
@@ -91,6 +91,10 @@ enum Commands {
 
     /// Remove an installed sandbox alias.
     Uninstall(uninstall::UninstallArgs),
+
+    /// Manage the msb installation itself.
+    #[command(name = "self")]
+    Self_(self_cmd::SelfArgs),
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -138,7 +142,9 @@ fn run_async_command(
     command: Commands,
     _log_level: Option<microsandbox::LogLevel>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
+    // CLI commands are foreground and short-lived, so a current-thread
+    // runtime avoids worker startup overhead on each invocation.
+    let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
 
@@ -163,6 +169,7 @@ fn run_async_command(
             Commands::Volume(args) => volume::run(args).await.map_err(Into::into),
             Commands::Install(args) => install::run(args).await.map_err(Into::into),
             Commands::Uninstall(args) => uninstall::run(args).await.map_err(Into::into),
+            Commands::Self_(args) => self_cmd::run(args).await.map_err(Into::into),
         }
     })
 }

--- a/crates/cli/lib/commands/create.rs
+++ b/crates/cli/lib/commands/create.rs
@@ -76,7 +76,7 @@ pub async fn run(args: CreateArgs) -> anyhow::Result<()> {
         builder = builder.shell(shell);
     }
     if args.replace {
-        builder = builder.overwrite();
+        builder = builder.replace();
     }
     for env_str in &args.env {
         let (k, v) = ui::parse_env(env_str).map_err(anyhow::Error::msg)?;

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod ps;
 pub mod pull;
 pub mod remove;
 pub mod run;
+pub mod self_cmd;
 pub mod shell;
 pub mod start;
 pub mod stop;
@@ -41,14 +42,14 @@ pub async fn maybe_stop(sandbox: &Sandbox) {
 
 /// Resolve an existing sandbox by name and ensure it is accessible.
 ///
-/// If the sandbox is already running, connects to the existing supervisor
+/// If the sandbox is already running, connects to the existing sandbox process
 /// via the agent relay socket. If stopped or crashed, starts it with a spinner.
 pub async fn resolve_and_start(name: &str, quiet: bool) -> anyhow::Result<Sandbox> {
     let handle = Sandbox::get(name).await?;
 
     match handle.status() {
         SandboxStatus::Running | SandboxStatus::Draining => {
-            // Connect to the running supervisor via the agent relay.
+            // Connect to the running sandbox process via the agent relay.
             Ok(handle.connect().await?)
         }
         SandboxStatus::Stopped | SandboxStatus::Crashed => {

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -137,7 +137,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
         builder = builder.shell(shell);
     }
     if args.replace {
-        builder = builder.overwrite();
+        builder = builder.replace();
     }
     for env_str in &args.env {
         let (k, v) = ui::parse_env(env_str).map_err(anyhow::Error::msg)?;
@@ -188,7 +188,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
                 ui::warn(&format!("failed to stop sandbox: {e}"));
             }
             if !is_named {
-                let _ = Sandbox::remove(&name).await;
+                let _ = sandbox.remove_persisted().await;
             }
             return Ok(());
         }
@@ -203,7 +203,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
 
     // Remove unnamed (ephemeral) sandboxes.
     if !is_named {
-        let _ = Sandbox::remove(&name).await;
+        let _ = sandbox.remove_persisted().await;
     }
 
     handle_exit(result?)

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -1,0 +1,235 @@
+//! `msb self` subcommands for managing the msb installation itself.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Args, Subcommand};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const MARKER_START: &str = "# >>> microsandbox >>>";
+const MARKER_END: &str = "# <<< microsandbox <<<";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Manage the msb installation.
+#[derive(Debug, Args)]
+pub struct SelfArgs {
+    /// Subcommand to run.
+    #[command(subcommand)]
+    pub command: SelfCommand,
+}
+
+/// `msb self` subcommands.
+#[derive(Debug, Subcommand)]
+pub enum SelfCommand {
+    /// Update msb to the latest release.
+    #[command(visible_alias = "upgrade")]
+    Update(SelfUpdateArgs),
+
+    /// Uninstall msb and remove shell configuration.
+    Uninstall(SelfUninstallArgs),
+}
+
+/// Arguments for `msb self update`.
+#[derive(Debug, Args)]
+pub struct SelfUpdateArgs {
+    /// Force re-download even if already on the latest version.
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// Arguments for `msb self uninstall`.
+#[derive(Debug, Args)]
+pub struct SelfUninstallArgs {
+    /// Skip confirmation prompt.
+    #[arg(long, short)]
+    pub yes: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Run a `msb self` subcommand.
+pub async fn run(args: SelfArgs) -> anyhow::Result<()> {
+    match args.command {
+        SelfCommand::Update(args) => run_update(args).await,
+        SelfCommand::Uninstall(args) => run_uninstall(args).await,
+    }
+}
+
+async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
+    info(&format!("Current version: v{CURRENT_VERSION}"));
+
+    let spinner = ui::Spinner::start("Checking", "latest release");
+    let latest = fetch_latest_version().await?;
+    spinner.finish_clear();
+
+    info(&format!("Latest version: {latest}"));
+
+    let latest_clean = latest.strip_prefix('v').unwrap_or(&latest);
+    if !args.force && latest_clean == CURRENT_VERSION {
+        success("Already up to date.");
+        return Ok(());
+    }
+
+    let base_dir = resolve_base_dir()?;
+    let bin_dir = base_dir.join(microsandbox_utils::BIN_SUBDIR);
+    let lib_dir = base_dir.join(microsandbox_utils::LIB_SUBDIR);
+
+    let spinner = ui::Spinner::start("Updating", &format!("to {latest}"));
+    let result = microsandbox::setup::Setup::builder()
+        .base_dir(base_dir)
+        .force(true)
+        .build()
+        .install()
+        .await;
+
+    match result {
+        Ok(()) => {
+            spinner.finish_clear();
+            success(&format!("Updated msb in {}", bin_dir.display()));
+            success(&format!("Updated libkrunfw in {}/", lib_dir.display()));
+        }
+        Err(e) => {
+            spinner.finish_error();
+            anyhow::bail!("update failed: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_uninstall(args: SelfUninstallArgs) -> anyhow::Result<()> {
+    let base_dir = resolve_base_dir()?;
+
+    if !base_dir.exists() {
+        info("Nothing to uninstall.");
+        return Ok(());
+    }
+
+    if !args.yes {
+        eprintln!(
+            "{} This will remove {} and clean shell configuration.",
+            console::style("warn").yellow().bold(),
+            base_dir.display(),
+        );
+        eprint!("Continue? [y/N] ");
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            info("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Remove shell configuration first.
+    clean_shell_config()?;
+
+    // Remove the installation directory.
+    std::fs::remove_dir_all(&base_dir)?;
+    success(&format!("Removed {}", base_dir.display()));
+
+    success("Uninstall complete. Restart your shell to apply changes.");
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Fetch the latest release tag from GitHub.
+async fn fetch_latest_version() -> anyhow::Result<String> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/releases/latest",
+        microsandbox_utils::GITHUB_ORG,
+        microsandbox_utils::MICROSANDBOX_REPO,
+    );
+
+    let client = reqwest::Client::new();
+    let resp: serde_json::Value = client
+        .get(&url)
+        .header("User-Agent", format!("msb/{CURRENT_VERSION}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let tag = resp["tag_name"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("could not parse latest release tag"))?;
+
+    Ok(tag.to_string())
+}
+
+fn resolve_base_dir() -> anyhow::Result<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(microsandbox_utils::BASE_DIR_NAME))
+        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
+}
+
+fn info(msg: &str) {
+    eprintln!("{} {msg}", console::style("info").cyan().bold());
+}
+
+fn success(msg: &str) {
+    eprintln!("{} {msg}", console::style("done").green().bold());
+}
+
+/// Remove microsandbox marker blocks from shell config files.
+fn clean_shell_config() -> anyhow::Result<()> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+
+    for rc in [".profile", ".bash_profile", ".bashrc", ".zshrc"] {
+        let path = home.join(rc);
+        if path.exists() && remove_marker_block(&path)? {
+            success(&format!("Cleaned ~/{rc}"));
+        }
+    }
+
+    let fish_conf = home.join(".config/fish/conf.d/microsandbox.fish");
+    if fish_conf.exists() {
+        std::fs::remove_file(&fish_conf)?;
+        success("Removed ~/.config/fish/conf.d/microsandbox.fish");
+    }
+
+    Ok(())
+}
+
+/// Remove the marker block from a shell config file. Returns true if modified.
+fn remove_marker_block(path: &Path) -> anyhow::Result<bool> {
+    let content = std::fs::read_to_string(path)?;
+    if !content.contains(MARKER_START) {
+        return Ok(false);
+    }
+
+    let mut result = String::new();
+    let mut skip = false;
+    for line in content.lines() {
+        if line.contains(MARKER_START) {
+            skip = true;
+            continue;
+        }
+        if line.contains(MARKER_END) {
+            skip = false;
+            continue;
+        }
+        if !skip {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    std::fs::write(path, result)?;
+    Ok(true)
+}

--- a/crates/cli/lib/commands/start.rs
+++ b/crates/cli/lib/commands/start.rs
@@ -36,7 +36,7 @@ pub async fn run(args: StartArgs) -> anyhow::Result<()> {
         Ok(sandbox) => {
             sandbox.detach().await;
             spinner.finish_success("Started");
-            // Sandbox stays running — supervisor continues as background process.
+            // Sandbox stays running — the sandbox process continues in the background.
         }
         Err(e) => {
             spinner.finish_error();

--- a/crates/filesystem/lib/backends/overlayfs/inode.rs
+++ b/crates/filesystem/lib/backends/overlayfs/inode.rs
@@ -1194,19 +1194,12 @@ pub(crate) fn open_node_fd(fs: &OverlayFs, inode: u64, flags: i32) -> io::Result
             if fd >= 0 {
                 return Ok(fd);
             }
-            // Only fall back to O_SYMLINK for ELOOP (symlink with O_NOFOLLOW).
-            // Other errors (EACCES, ENOENT, etc.) should propagate immediately.
-            let err = io::Error::last_os_error();
-            if err.raw_os_error() != Some(libc::ELOOP) {
-                return Err(platform::linux_error(err));
-            }
-            // O_SYMLINK opens the symlink itself (not its target) on macOS.
-            let fd =
-                unsafe { libc::open(path.as_ptr(), flags | libc::O_CLOEXEC | libc::O_SYMLINK) };
-            if fd < 0 {
-                return Err(platform::linux_error(io::Error::last_os_error()));
-            }
-            Ok(fd)
+
+            // Match Linux and PassthroughFs semantics: opening a symlink inode for
+            // regular file I/O must fail with ELOOP instead of returning an fd to
+            // the link itself. readlink/stat use dedicated paths that can still
+            // access symlink metadata safely on macOS.
+            Err(platform::linux_error(io::Error::last_os_error()))
         }
     }
 }
@@ -1511,6 +1504,21 @@ fn open_lower_child_fd(
         if fd >= 0 {
             return Ok(fd);
         }
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ELOOP) {
+            // O_SYMLINK opens the symlink itself (not its target) on macOS.
+            let fd = unsafe {
+                libc::openat(
+                    parent_fd_node.raw(),
+                    name.as_ptr(),
+                    libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+                )
+            };
+            if fd < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+            return Ok(fd);
+        }
         // Try as directory.
         let fd = unsafe {
             libc::openat(
@@ -1522,23 +1530,7 @@ fn open_lower_child_fd(
         if fd >= 0 {
             return Ok(fd);
         }
-        // Only fall back to O_SYMLINK for ELOOP (symlink with O_NOFOLLOW).
-        let err = io::Error::last_os_error();
-        if err.raw_os_error() != Some(libc::ELOOP) {
-            return Err(platform::linux_error(err));
-        }
-        // O_SYMLINK opens the symlink itself (not its target) on macOS.
-        let fd = unsafe {
-            libc::openat(
-                parent_fd_node.raw(),
-                name.as_ptr(),
-                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
-            )
-        };
-        if fd < 0 {
-            return Err(platform::linux_error(io::Error::last_os_error()));
-        }
-        Ok(fd)
+        Err(platform::linux_error(io::Error::last_os_error()))
     }
 }
 
@@ -1631,25 +1623,23 @@ fn open_macos_vol(path: &CStr) -> io::Result<RawFd> {
     if fd >= 0 {
         return Ok(fd);
     }
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::ELOOP) {
+        let fd = unsafe {
+            libc::open(
+                path.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+            )
+        };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        return Ok(fd);
+    }
     let fd = unsafe {
         libc::open(
             path.as_ptr(),
             libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
-        )
-    };
-    if fd >= 0 {
-        return Ok(fd);
-    }
-    // Only fall back to O_SYMLINK for ELOOP (symlink with O_NOFOLLOW).
-    let err = io::Error::last_os_error();
-    if err.raw_os_error() != Some(libc::ELOOP) {
-        return Err(platform::linux_error(err));
-    }
-    // O_SYMLINK opens the symlink itself (not its target) on macOS.
-    let fd = unsafe {
-        libc::open(
-            path.as_ptr(),
-            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
         )
     };
     if fd >= 0 {

--- a/crates/filesystem/lib/backends/overlayfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/mod.rs
@@ -47,7 +47,6 @@ const LINUX_EBADF: i32 = 9;
 const LINUX_EACCES: i32 = 13;
 const LINUX_EEXIST: i32 = 17;
 const LINUX_EINVAL: i32 = 22;
-#[cfg(target_os = "linux")]
 const LINUX_ELOOP: i32 = 40;
 const LINUX_ENOTEMPTY: i32 = 39;
 const LINUX_EROFS: i32 = 30;

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_create_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_create_ops.rs
@@ -94,7 +94,6 @@ fn test_symlink() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn test_lower_host_symlink_open_rejected_but_readlink_allowed() {
     let sb = OverlayTestSandbox::with_lower(|lower| {
         std::os::unix::fs::symlink("/host/target", lower.join("host-link")).unwrap();

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_index.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_index.rs
@@ -5,10 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use microsandbox_utils::index::{
-    DIR_FLAG_OPAQUE, DIR_RECORD_IDX_NONE, ENTRY_FLAG_WHITEOUT, INDEX_MAGIC, INDEX_VERSION,
-    IndexBuilder, MmapIndex,
-};
+use microsandbox_utils::index::{DIR_RECORD_IDX_NONE, IndexBuilder, MmapIndex};
 
 use super::*;
 use crate::backends::overlayfs::inode;
@@ -112,6 +109,23 @@ fn mount_plain(lower: &Path, upper: &Path, staging: &Path) -> OverlayFs {
     fs
 }
 
+/// Mount an overlay with multiple lower layers, optionally using sidecar indexes.
+fn mount_layers(layers: &[PathBuf], use_index: bool, upper: &Path, staging: &Path) -> OverlayFs {
+    let mut builder = OverlayFs::builder();
+    for layer in layers {
+        let index_path = layer.with_extension("index");
+        if use_index && index_path.exists() {
+            builder = builder.layer_with_index(layer, &index_path);
+        } else {
+            builder = builder.layer(layer);
+        }
+    }
+
+    let fs = builder.writable(upper).staging(staging).build().unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+    fs
+}
+
 /// Collect readdir entry names from a directory inode.
 fn readdir_names(fs: &OverlayFs, ino: u64) -> Vec<Vec<u8>> {
     let (handle, _) = fs.opendir(ctx(), ino, 0).unwrap();
@@ -130,6 +144,77 @@ fn readdir_entries(fs: &OverlayFs, ino: u64) -> Vec<(Vec<u8>, u32)> {
     let result: Vec<(Vec<u8>, u32)> = entries.iter().map(|e| (e.name.to_vec(), e.type_)).collect();
     fs.releasedir(ctx(), ino, 0, handle).unwrap();
     result
+}
+
+/// Walk an absolute overlay path component-by-component starting from root.
+fn lookup_path(fs: &OverlayFs, path: &str) -> Entry {
+    let mut parent = ROOT_INODE;
+    let mut last = None;
+    for component in path.split('/').filter(|component| !component.is_empty()) {
+        let entry = fs
+            .lookup(ctx(), parent, &cstr(component))
+            .unwrap_or_else(|err| {
+                panic!("failed to lookup component '{component}' in '{path}': {err}")
+            });
+        parent = entry.inode;
+        last = Some(entry);
+    }
+
+    last.unwrap_or_else(|| panic!("path must contain at least one component: {path}"))
+}
+
+/// Assert that the `claude` symlink path resolves correctly on a mounted overlay.
+fn assert_claude_layout(fs: &OverlayFs) {
+    let usr_local_bin = lookup_path(fs, "/usr/local/bin");
+    assert_eq!(
+        usr_local_bin.attr.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFDIR as u32
+    );
+
+    let claude = lookup_path(fs, "/usr/local/bin/claude");
+    assert_eq!(
+        claude.attr.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFLNK as u32
+    );
+    let (claude_st, _timeout) = fs.getattr(ctx(), claude.inode, None).unwrap();
+    assert_eq!(
+        claude_st.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFLNK as u32
+    );
+
+    let target = fs.readlink(ctx(), claude.inode).unwrap();
+    assert_eq!(
+        target,
+        b"../lib/node_modules/@anthropic-ai/claude-code/cli.js"
+    );
+
+    let cli = lookup_path(
+        fs,
+        "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js",
+    );
+    assert_eq!(
+        cli.attr.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFREG as u32
+    );
+
+    let (handle, _) = fs
+        .open(ctx(), cli.inode, false, libc::O_RDONLY as u32)
+        .unwrap();
+    let handle = handle.expect("regular file open should return a handle");
+    let mut writer = crate::backends::overlayfs::tests::MockZeroCopyWriter::new();
+    let n = fs
+        .read(ctx(), cli.inode, handle, &mut writer, 64, 0, None, 0)
+        .unwrap();
+    fs.release(ctx(), cli.inode, 0, handle, false, false, None)
+        .unwrap();
+
+    let data = writer.into_data();
+    assert!(n > 0, "cli.js should be readable");
+    assert!(
+        data.starts_with(b"#!/usr/bin/env node"),
+        "unexpected cli.js header: {:?}",
+        &data[..n.min(data.len())]
+    );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1266,6 +1351,35 @@ fn test_index_readdir_d_type_from_mode() {
     assert_eq!(find(b"subdir"), Some(libc::DT_DIR as u32));
     #[cfg(unix)]
     assert_eq!(find(b"link"), Some(libc::DT_LNK as u32));
+}
+
+#[test]
+#[ignore = "debug probe for real pulled layer stacks"]
+fn test_probe_real_layers_claude_layout() {
+    let layers = std::env::var("MSB_REAL_LAYER_STACK")
+        .expect("MSB_REAL_LAYER_STACK must be set to a ':'-separated layer list");
+    let layers: Vec<PathBuf> = layers
+        .split(':')
+        .filter(|part| !part.is_empty())
+        .map(PathBuf::from)
+        .collect();
+    assert!(!layers.is_empty(), "MSB_REAL_LAYER_STACK must not be empty");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let indexed_upper = tmp.path().join("indexed-upper");
+    let indexed_staging = tmp.path().join("indexed-staging");
+    let plain_upper = tmp.path().join("plain-upper");
+    let plain_staging = tmp.path().join("plain-staging");
+    std::fs::create_dir(&indexed_upper).unwrap();
+    std::fs::create_dir(&indexed_staging).unwrap();
+    std::fs::create_dir(&plain_upper).unwrap();
+    std::fs::create_dir(&plain_staging).unwrap();
+
+    let fs_indexed = mount_layers(&layers, true, &indexed_upper, &indexed_staging);
+    let fs_plain = mount_layers(&layers, false, &plain_upper, &plain_staging);
+
+    assert_claude_layout(&fs_indexed);
+    assert_claude_layout(&fs_plain);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/filesystem/lib/backends/overlayfs/tests/test_metadata.rs
+++ b/crates/filesystem/lib/backends/overlayfs/tests/test_metadata.rs
@@ -21,6 +21,17 @@ fn test_getattr_lower_file() {
 }
 
 #[test]
+fn test_getattr_lower_symlink() {
+    let sb = OverlayTestSandbox::with_lower(|lower| {
+        std::os::unix::fs::symlink("../target", lower.join("lower-link")).unwrap();
+    });
+    let entry = sb.lookup_root("lower-link").unwrap();
+    let (st, _timeout) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    let mode = st.st_mode as u32;
+    assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFLNK as u32);
+}
+
+#[test]
 fn test_getattr_root() {
     let sb = OverlayTestSandbox::new();
     let (st, _timeout) = sb.fs.getattr(sb.ctx(), ROOT_INODE, None).unwrap();

--- a/crates/filesystem/lib/backends/passthroughfs/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/inode.rs
@@ -428,16 +428,10 @@ fn open_and_patch_stat_macos(
 ) -> io::Result<stat64> {
     let path = vol_path(dev, ino);
 
-    // Try regular file open.
-    if let Ok(fd) = open_macos_path_hardened(path.as_ptr(), libc::O_RDONLY) {
-        let result =
-            crate::backends::shared::stat_override::patched_stat(fd, st, xattr_enabled, strict);
-        unsafe { libc::close(fd) };
-        return result;
-    }
-
-    // Try directory open.
-    if let Ok(fd) = open_macos_path_hardened(path.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY) {
+    // Try regular file open first. If the inode is a symlink, fall back to
+    // O_SYMLINK so we can read override metadata from the link itself without
+    // following it.
+    if let Ok(fd) = open_macos_path_for_stat(path.as_ptr()) {
         let result =
             crate::backends::shared::stat_override::patched_stat(fd, st, xattr_enabled, strict);
         unsafe { libc::close(fd) };
@@ -446,6 +440,24 @@ fn open_and_patch_stat_macos(
 
     // Can't open — return unpatched stat.
     Ok(st)
+}
+
+#[cfg(target_os = "macos")]
+fn open_macos_path_for_stat(path: *const libc::c_char) -> io::Result<i32> {
+    match open_macos_path_hardened(path, libc::O_RDONLY) {
+        Ok(fd) => return Ok(fd),
+        Err(err) if err.raw_os_error() == platform::eloop().raw_os_error() => {
+            let fd =
+                unsafe { libc::open(path, libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK) };
+            if fd < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+            return Ok(fd);
+        }
+        Err(_) => {}
+    }
+
+    open_macos_path_hardened(path, libc::O_RDONLY | libc::O_DIRECTORY)
 }
 
 /// Decrement the reference count for an inode. Remove it from the table

--- a/crates/filesystem/lib/backends/passthroughfs/tests/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/mod.rs
@@ -43,7 +43,6 @@ const LINUX_EBADF: i32 = 9;
 const LINUX_EACCES: i32 = 13;
 const LINUX_EEXIST: i32 = 17;
 const LINUX_EINVAL: i32 = 22;
-#[cfg(target_os = "linux")]
 const LINUX_ELOOP: i32 = 40;
 const LINUX_ENOSYS: i32 = 38;
 const LINUX_ENOTEMPTY: i32 = 39;

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_create_ops.rs
@@ -231,7 +231,26 @@ fn test_symlink_stat_shows_link() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+fn test_symlink_stat_uses_guest_ownership() {
+    let sb = TestSandbox::new();
+    let entry = sb
+        .fs
+        .symlink(
+            sb.ctx_as(1234, 2345),
+            &TestSandbox::cstr("/owned/target"),
+            ROOT_INODE,
+            &TestSandbox::cstr("owned-link"),
+            Extensions::default(),
+        )
+        .unwrap();
+    let (st, _timeout) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    assert_eq!(st.st_uid, 1234);
+    assert_eq!(st.st_gid, 2345);
+    let mode = st.st_mode as u32;
+    assert_eq!(mode & libc::S_IFMT as u32, libc::S_IFLNK as u32);
+}
+
+#[test]
 fn test_host_symlink_open_rejected_but_readlink_allowed() {
     let sb = TestSandbox::new();
     std::os::unix::fs::symlink("/host/target", sb.root.join("host-link")).unwrap();

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -89,6 +89,16 @@ impl Registry {
         })
     }
 
+    /// Resolve a pull directly from the on-disk cache without building a registry client.
+    pub fn pull_cached(
+        cache: &GlobalCache,
+        reference: &oci_client::Reference,
+        options: &PullOptions,
+    ) -> ImageResult<Option<(PullResult, CachedImageMetadata)>> {
+        Ok(resolve_cached_pull_result(cache, reference, options)?
+            .map(|cached| (cached.result, cached.metadata)))
+    }
+
     /// Pull an image. Downloads, extracts, and indexes layers concurrently.
     pub async fn pull(
         &self,
@@ -807,6 +817,33 @@ mod tests {
 
         assert!(cached.is_some());
         assert!(cached.unwrap().result.cached);
+    }
+
+    #[test]
+    fn test_pull_cached_uses_complete_cache() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let reference: oci_client::Reference = "docker.io/library/alpine:latest".parse().unwrap();
+        let metadata = write_cached_image_fixture(&cache, &reference, &[true]);
+
+        let cached = super::Registry::pull_cached(
+            &cache,
+            &reference,
+            &PullOptions {
+                pull_policy: PullPolicy::IfMissing,
+                force: false,
+                build_index: true,
+            },
+        )
+        .unwrap()
+        .expect("expected cached pull result");
+
+        assert!(cached.0.cached);
+        assert_eq!(
+            cached.0.manifest_digest.to_string(),
+            metadata.manifest_digest
+        );
+        assert_eq!(cached.1.manifest_digest, metadata.manifest_digest);
     }
 
     #[tokio::test]

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -20,6 +20,7 @@ net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
 bytes.workspace = true
 chrono.workspace = true
 crossterm.workspace = true
+docker_credential = "1.3.2"
 dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true

--- a/crates/microsandbox/lib/agent/client.rs
+++ b/crates/microsandbox/lib/agent/client.rs
@@ -30,7 +30,7 @@ use crate::MicrosandboxResult;
 
 /// Client for communicating with agentd through the agent relay.
 ///
-/// Connects over a Unix domain socket to the supervisor's agent relay.
+/// Connects over a Unix domain socket to the sandbox process's agent relay.
 /// Correlation IDs are allocated from the range assigned during the relay
 /// handshake.
 pub struct AgentClient {

--- a/crates/microsandbox/lib/agent/mod.rs
+++ b/crates/microsandbox/lib/agent/mod.rs
@@ -1,7 +1,7 @@
 //! Agent communication with the guest VM.
 //!
 //! The [`AgentClient`] provides request/response messaging with agentd
-//! through the supervisor's agent relay socket.
+//! through the sandbox process's agent relay socket.
 
 mod client;
 

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -9,6 +9,7 @@ use std::{
     sync::OnceLock,
 };
 
+use docker_credential::{CredentialRetrievalError, DockerCredential};
 use microsandbox_image::RegistryAuth;
 use microsandbox_runtime::logging::LogLevel;
 use serde::{Deserialize, Serialize};
@@ -205,13 +206,29 @@ impl GlobalConfig {
     ///
     /// Looks up `registries.auth` in global config, resolving credentials from
     /// either `password_env` (environment variable) or `secret_name` (file-backed
-    /// secret in `{home}/secrets/registries/<name>`).
+    /// secret in `{home}/secrets/registries/<name>`). If there is no explicit
+    /// Microsandbox config entry, falls back to Docker's credential store/config.
     ///
     /// Returns `Anonymous` if no entry matches.
     pub fn resolve_registry_auth(&self, hostname: &str) -> MicrosandboxResult<RegistryAuth> {
+        if let Some(auth) = self.resolve_configured_registry_auth(hostname)? {
+            return Ok(auth);
+        }
+
+        if let Some(auth) = resolve_docker_registry_auth(hostname) {
+            return Ok(auth);
+        }
+
+        Ok(RegistryAuth::Anonymous)
+    }
+
+    fn resolve_configured_registry_auth(
+        &self,
+        hostname: &str,
+    ) -> MicrosandboxResult<Option<RegistryAuth>> {
         let entry = match self.registries.auth.get(hostname) {
             Some(entry) => entry,
-            None => return Ok(RegistryAuth::Anonymous),
+            None => return Ok(None),
         };
 
         let password = if let Some(ref env_var) = entry.password_env {
@@ -237,10 +254,10 @@ impl GlobalConfig {
             )));
         };
 
-        Ok(RegistryAuth::Basic {
+        Ok(Some(RegistryAuth::Basic {
             username: entry.username.clone(),
             password,
-        })
+        }))
     }
 }
 
@@ -271,6 +288,55 @@ impl Default for SandboxDefaults {
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+fn resolve_docker_registry_auth(hostname: &str) -> Option<RegistryAuth> {
+    resolve_registry_auth_with_lookup(hostname, docker_credential::get_credential)
+}
+
+fn resolve_registry_auth_with_lookup<F>(hostname: &str, mut lookup: F) -> Option<RegistryAuth>
+where
+    F: FnMut(&str) -> Result<DockerCredential, CredentialRetrievalError>,
+{
+    for server in docker_credential_servers(hostname) {
+        match lookup(&server) {
+            Ok(DockerCredential::UsernamePassword(username, password)) => {
+                tracing::debug!(registry = hostname, server = %server, "resolved registry auth from Docker credentials");
+                return Some(RegistryAuth::Basic { username, password });
+            }
+            Ok(DockerCredential::IdentityToken(_)) => {
+                tracing::debug!(registry = hostname, server = %server, "ignoring Docker identity token for registry auth");
+            }
+            Err(CredentialRetrievalError::NoCredentialConfigured)
+            | Err(CredentialRetrievalError::ConfigNotFound)
+            | Err(CredentialRetrievalError::ConfigReadError) => {}
+            Err(error) => {
+                tracing::debug!(registry = hostname, server = %server, ?error, "failed to resolve Docker registry credentials");
+            }
+        }
+    }
+
+    None
+}
+
+fn docker_credential_servers(hostname: &str) -> Vec<String> {
+    let mut servers = vec![hostname.to_string(), format!("https://{hostname}")];
+
+    if matches!(
+        hostname,
+        "docker.io" | "index.docker.io" | "registry-1.docker.io"
+    ) {
+        servers.extend([
+            "index.docker.io".to_string(),
+            "https://index.docker.io".to_string(),
+            "https://index.docker.io/v1/".to_string(),
+            "registry-1.docker.io".to_string(),
+            "https://registry-1.docker.io".to_string(),
+        ]);
+    }
+
+    dedupe_strings(&mut servers);
+    servers
+}
 
 /// Get the global configuration (lazy-loaded from disk on first call).
 pub fn config() -> &'static GlobalConfig {
@@ -447,6 +513,16 @@ fn dedupe_paths(paths: &mut Vec<PathBuf>) {
     *paths = deduped;
 }
 
+fn dedupe_strings(values: &mut Vec<String>) {
+    let mut deduped = Vec::new();
+    for value in values.drain(..) {
+        if !deduped.iter().any(|existing| existing == &value) {
+            deduped.push(value);
+        }
+    }
+    *values = deduped;
+}
+
 /// Resolve the default home directory (`~/.microsandbox`).
 fn resolve_default_home() -> PathBuf {
     dirs::home_dir()
@@ -473,6 +549,8 @@ fn load_config_from(path: &Path) -> Option<GlobalConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::collections::VecDeque;
 
     #[test]
     fn test_default_config() {
@@ -568,5 +646,106 @@ mod tests {
             temp.path().join("target").join("debug").join("msb")
         );
         assert_eq!(paths.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_configured_registry_auth_reads_secret_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let secret_dir = temp.path().join("registries");
+        std::fs::create_dir_all(&secret_dir).unwrap();
+        std::fs::write(secret_dir.join("ghcr-token"), "secret-token\n").unwrap();
+
+        let cfg = GlobalConfig {
+            home: Some(temp.path().to_path_buf()),
+            paths: PathsConfig {
+                secrets: Some(temp.path().to_path_buf()),
+                ..Default::default()
+            },
+            registries: RegistriesConfig {
+                auth: HashMap::from([(
+                    "ghcr.io".to_string(),
+                    RegistryAuthEntry {
+                        username: "user".to_string(),
+                        password_env: None,
+                        secret_name: Some("ghcr-token".to_string()),
+                    },
+                )]),
+            },
+            ..Default::default()
+        };
+
+        let auth = cfg.resolve_configured_registry_auth("ghcr.io").unwrap();
+        match auth {
+            Some(RegistryAuth::Basic { username, password }) => {
+                assert_eq!(username, "user");
+                assert_eq!(password, "secret-token");
+            }
+            other => panic!("expected basic auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_registry_auth_with_lookup_prefers_exact_hostname() {
+        let auth = resolve_registry_auth_with_lookup("ghcr.io", |server| match server {
+            "ghcr.io" => Ok(DockerCredential::UsernamePassword(
+                "user".to_string(),
+                "token".to_string(),
+            )),
+            other => panic!("unexpected server lookup: {other}"),
+        });
+
+        match auth {
+            Some(RegistryAuth::Basic { username, password }) => {
+                assert_eq!(username, "user");
+                assert_eq!(password, "token");
+            }
+            other => panic!("expected basic auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_registry_auth_with_lookup_tries_docker_hub_aliases() {
+        let auth = resolve_registry_auth_with_lookup("docker.io", |server| match server {
+            "https://index.docker.io/v1/" => Ok(DockerCredential::UsernamePassword(
+                "docker-user".to_string(),
+                "docker-pass".to_string(),
+            )),
+            _ => Err(CredentialRetrievalError::NoCredentialConfigured),
+        });
+
+        match auth {
+            Some(RegistryAuth::Basic { username, password }) => {
+                assert_eq!(username, "docker-user");
+                assert_eq!(password, "docker-pass");
+            }
+            other => panic!("expected basic auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_registry_auth_with_lookup_skips_identity_tokens() {
+        let mut responses = VecDeque::from([
+            Ok(DockerCredential::IdentityToken(
+                "identity-token".to_string(),
+            )),
+            Ok(DockerCredential::UsernamePassword(
+                "fallback-user".to_string(),
+                "fallback-pass".to_string(),
+            )),
+        ]);
+
+        let auth = resolve_registry_auth_with_lookup("ghcr.io", |_server| {
+            responses
+                .pop_front()
+                .unwrap_or(Err(CredentialRetrievalError::NoCredentialConfigured))
+        });
+
+        match auth {
+            Some(RegistryAuth::Basic { username, password }) => {
+                assert_eq!(username, "fallback-user");
+                assert_eq!(password, "fallback-pass");
+            }
+            other => panic!("expected basic auth, got {other:?}"),
+        }
     }
 }

--- a/crates/microsandbox/lib/error.rs
+++ b/crates/microsandbox/lib/error.rs
@@ -86,6 +86,10 @@ pub enum MicrosandboxError {
     #[error("image error: {0}")]
     Image(#[from] microsandbox_image::ImageError),
 
+    /// A rootfs patch operation failed.
+    #[error("patch failed: {0}")]
+    PatchFailed(String),
+
     /// A custom error message.
     #[error("{0}")]
     Custom(String),

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -26,7 +26,7 @@ struct StartupInfo {
     pid: u32,
 }
 
-/// How the supervisor should behave relative to the creating process.
+/// How the sandbox process should behave relative to the creating process.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SpawnMode {
     /// The creating process keeps the sandbox handle and agent bridge alive.
@@ -40,7 +40,7 @@ pub enum SpawnMode {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Spawn the supervisor process for a sandbox.
+/// Spawn the sandbox process for a sandbox.
 ///
 /// Returns a [`ProcessHandle`] and the path to the agent relay socket.
 ///
@@ -48,7 +48,7 @@ pub enum SpawnMode {
 /// 1. Resolves the `msb` binary path
 /// 2. Creates sandbox directories (logs, runtime, scripts)
 /// 3. Builds CLI arguments from the config
-/// 4. Spawns `msb supervisor` with `--agent-sock` for the relay
+/// 4. Spawns the hidden `msb sandbox` process with `--agent-sock` for the relay
 /// 5. Reads startup JSON from stdout to get child PIDs
 pub async fn spawn_sandbox(
     config: &SandboxConfig,
@@ -123,6 +123,7 @@ pub async fn spawn_sandbox(
 
     // Spawn the sandbox process.
     let mut child = cmd.spawn()?;
+
     let _pid = child.id().ok_or_else(|| {
         crate::MicrosandboxError::Runtime("sandbox process exited immediately".into())
     })?;

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -3,10 +3,14 @@
 use microsandbox_image::RegistryAuth;
 #[cfg(feature = "net")]
 use microsandbox_network::builder::{NetworkBuilder, SecretBuilder};
+#[cfg(feature = "net")]
+use microsandbox_network::config::{PortProtocol, PublishedPort};
+#[cfg(feature = "net")]
+use std::net::{IpAddr, Ipv4Addr};
 
 use super::{
     config::SandboxConfig,
-    types::{IntoImage, MountBuilder, RootfsSource},
+    types::{IntoImage, MountBuilder, Patch, PatchBuilder, RootfsSource},
 };
 use crate::{LogLevel, MicrosandboxResult, size::Mebibytes};
 
@@ -26,7 +30,7 @@ pub struct SandboxBuilder {
 
 impl SandboxBuilder {
     /// Start building a sandbox configuration. The name must be unique
-    /// among existing sandboxes (unless [`overwrite`](Self::overwrite) is set).
+    /// among existing sandboxes (unless [`replace`](Self::replace) is set).
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             config: SandboxConfig {
@@ -120,8 +124,11 @@ impl SandboxBuilder {
         self
     }
 
-    /// Replace an existing stopped sandbox with the same name during create.
-    pub fn overwrite(mut self) -> Self {
+    /// Replace an existing sandbox with the same name during create.
+    ///
+    /// If the existing sandbox is still active, microsandbox stops it and
+    /// waits for it to exit before recreating it.
+    pub fn replace(mut self) -> Self {
         self.config.replace_existing = true;
         self
     }
@@ -144,7 +151,46 @@ impl SandboxBuilder {
     /// ```
     #[cfg(feature = "net")]
     pub fn network(mut self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self {
-        self.config.network = f(NetworkBuilder::new()).build();
+        let network = std::mem::take(&mut self.config.network);
+        self.config.network = f(NetworkBuilder::from_config(network)).build();
+        self
+    }
+
+    /// Publish a TCP port directly on the sandbox builder.
+    ///
+    /// Repeatable: call multiple times to expose multiple ports.
+    ///
+    /// ```ignore
+    /// .port(8080, 80)
+    /// .port(3000, 3000)
+    /// ```
+    #[cfg(feature = "net")]
+    pub fn port(mut self, host_port: u16, guest_port: u16) -> Self {
+        self.config.network.ports.push(PublishedPort {
+            host_port,
+            guest_port,
+            protocol: PortProtocol::Tcp,
+            host_bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        });
+        self
+    }
+
+    /// Publish a UDP port directly on the sandbox builder.
+    ///
+    /// Repeatable: call multiple times to expose multiple ports.
+    ///
+    /// ```ignore
+    /// .port_udp(5353, 53)
+    /// .port_udp(8125, 8125)
+    /// ```
+    #[cfg(feature = "net")]
+    pub fn port_udp(mut self, host_port: u16, guest_port: u16) -> Self {
+        self.config.network.ports.push(PublishedPort {
+            host_port,
+            guest_port,
+            protocol: PortProtocol::Udp,
+            host_bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        });
         self
     }
 
@@ -269,6 +315,30 @@ impl SandboxBuilder {
         self
     }
 
+    /// Apply rootfs patches using a builder closure.
+    ///
+    /// Patches are applied before VM start. Only works with OverlayFs and
+    /// PassthroughFs roots. Returns an error at create time if used with
+    /// block device roots (Qcow2, Raw).
+    ///
+    /// ```ignore
+    /// .patch(|p| p
+    ///     .text("/etc/app.conf", config_str, None, false)
+    ///     .copy_file("./cert.pem", "/etc/ssl/cert.pem", None, false)
+    ///     .mkdir("/var/cache/app", None)
+    /// )
+    /// ```
+    pub fn patch(mut self, f: impl FnOnce(PatchBuilder) -> PatchBuilder) -> Self {
+        self.config.patches.extend(f(PatchBuilder::new()).build());
+        self
+    }
+
+    /// Add a single patch directly.
+    pub fn add_patch(mut self, patch: Patch) -> Self {
+        self.config.patches.push(patch);
+        self
+    }
+
     /// Build the configuration without creating the sandbox.
     pub fn build(mut self) -> MicrosandboxResult<SandboxConfig> {
         self.validate()?;
@@ -304,7 +374,7 @@ impl SandboxBuilder {
 
     /// Create a detached sandbox with pull progress reporting.
     ///
-    /// Like `create_with_pull_progress` but spawns the supervisor in detached
+    /// Like `create_with_pull_progress` but spawns the sandbox process in detached
     /// mode so the sandbox survives after the creating process exits.
     pub fn create_detached_with_pull_progress(
         self,
@@ -370,6 +440,8 @@ impl From<SandboxConfig> for SandboxBuilder {
 mod tests {
     use super::SandboxBuilder;
     use crate::LogLevel;
+    #[cfg(feature = "net")]
+    use microsandbox_network::config::PortProtocol;
 
     #[test]
     fn test_builder_sets_runtime_log_level() {
@@ -395,13 +467,55 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_overwrite_sets_replace_existing() {
+    fn test_builder_replace_sets_replace_existing() {
         let config = SandboxBuilder::new("test")
             .image("alpine:3.23")
-            .overwrite()
+            .replace()
             .build()
             .unwrap();
 
         assert!(config.replace_existing);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn test_builder_ports_are_repeatable() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine:3.23")
+            .port(8080, 80)
+            .port(3000, 3000)
+            .port_udp(5353, 53)
+            .build()
+            .unwrap();
+
+        assert_eq!(config.network.ports.len(), 3);
+        assert_eq!(config.network.ports[0].host_port, 8080);
+        assert_eq!(config.network.ports[0].guest_port, 80);
+        assert_eq!(config.network.ports[0].protocol, PortProtocol::Tcp);
+        assert_eq!(config.network.ports[1].host_port, 3000);
+        assert_eq!(config.network.ports[1].guest_port, 3000);
+        assert_eq!(config.network.ports[1].protocol, PortProtocol::Tcp);
+        assert_eq!(config.network.ports[2].host_port, 5353);
+        assert_eq!(config.network.ports[2].guest_port, 53);
+        assert_eq!(config.network.ports[2].protocol, PortProtocol::Udp);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn test_builder_network_preserves_top_level_settings() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine:3.23")
+            .port(8080, 80)
+            .secret_env("OPENAI_API_KEY", "secret", "api.openai.com")
+            .network(|n| n.max_connections(128))
+            .build()
+            .unwrap();
+
+        assert_eq!(config.network.ports.len(), 1);
+        assert_eq!(config.network.ports[0].host_port, 8080);
+        assert_eq!(config.network.ports[0].guest_port, 80);
+        assert_eq!(config.network.ports[0].protocol, PortProtocol::Tcp);
+        assert_eq!(config.network.secrets.secrets.len(), 1);
+        assert_eq!(config.network.max_connections, Some(128));
     }
 }

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -135,7 +135,10 @@ pub struct SandboxConfig {
     #[serde(default, skip_serializing)]
     pub registry_auth: Option<RegistryAuth>,
 
-    /// Replace an existing stopped sandbox with the same name during create.
+    /// Replace an existing sandbox with the same name during create.
+    ///
+    /// If the existing sandbox is still active, microsandbox stops it and
+    /// waits for it to exit before recreating it.
     ///
     /// This is an operation flag, not persisted sandbox state.
     #[serde(skip)]

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -372,13 +372,17 @@ impl ExecHandle {
 
         while let Some(event) = self.events.recv().await {
             match event {
-                ExecEvent::Stdout(data) => stdout.extend_from_slice(&data),
-                ExecEvent::Stderr(data) => stderr.extend_from_slice(&data),
+                ExecEvent::Started { pid: _ } => {}
+                ExecEvent::Stdout(data) => {
+                    stdout.extend_from_slice(&data);
+                }
+                ExecEvent::Stderr(data) => {
+                    stderr.extend_from_slice(&data);
+                }
                 ExecEvent::Exited { code } => {
                     exit_code = Some(code);
                     break;
                 }
-                ExecEvent::Started { .. } => {}
             }
         }
 

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -124,6 +124,7 @@ impl SandboxHandle {
         let config: SandboxConfig = serde_json::from_str(&self.config_json)?;
 
         Ok(Sandbox {
+            db_id: self.db_id,
             config,
             handle: None,
             client: Arc::new(client),

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -11,6 +11,7 @@ mod config;
 pub mod exec;
 pub mod fs;
 mod handle;
+mod patch;
 mod types;
 
 use std::{path::Path, process::ExitStatus, sync::Arc};
@@ -21,8 +22,8 @@ use microsandbox_protocol::{
     message::{Message, MessageType},
 };
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
-    QueryOrder, Set, TransactionTrait, sea_query::Expr,
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    sea_query::Expr,
 };
 use tokio::sync::{Mutex, mpsc};
 
@@ -57,8 +58,8 @@ pub use microsandbox_network::config::NetworkConfig;
 pub use microsandbox_network::policy::NetworkPolicy;
 pub use microsandbox_runtime::logging::LogLevel;
 pub use types::{
-    DiskImageFormat, ImageBuilder, ImageSource, IntoImage, MountBuilder, Patch, RootfsSource,
-    SecretsConfig, SshConfig, VolumeMount,
+    DiskImageFormat, ImageBuilder, ImageSource, IntoImage, MountBuilder, Patch, PatchBuilder,
+    RootfsSource, SecretsConfig, SshConfig, VolumeMount,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -70,22 +71,10 @@ pub use types::{
 /// Created via [`Sandbox::builder`] or [`Sandbox::create`]. Provides
 /// lifecycle management and access to the agent bridge for guest communication.
 pub struct Sandbox {
+    db_id: i32,
     config: SandboxConfig,
     handle: Option<Arc<Mutex<ProcessHandle>>>,
     client: Arc<AgentClient>,
-}
-
-/// Wrapper for using a raw stdin fd with [`tokio::io::unix::AsyncFd`].
-///
-/// `AsyncFd` requires `AsRawFd`. This wraps the raw fd without taking
-/// ownership — the fd is managed by the process's stdin and must not
-/// be closed by this wrapper.
-struct StdinRawFd(std::os::fd::RawFd);
-
-impl std::os::fd::AsRawFd for StdinRawFd {
-    fn as_raw_fd(&self) -> std::os::fd::RawFd {
-        self.0
-    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -131,7 +120,7 @@ impl Sandbox {
 
     /// Create a detached sandbox with pull progress reporting.
     ///
-    /// Like `create_with_pull_progress` but spawns the supervisor in detached
+    /// Like `create_with_pull_progress` but spawns the sandbox process in detached
     /// mode so the sandbox survives after the creating process exits.
     pub fn create_detached_with_pull_progress(
         config: SandboxConfig,
@@ -185,7 +174,7 @@ impl Sandbox {
         let sandbox_dir = crate::config::config().sandboxes_dir().join(&config.name);
         prepare_create_target(db, &config, &sandbox_dir).await?;
 
-        // Resolve OCI images before spawning the supervisor.
+        // Resolve OCI images before spawning the sandbox process.
         if let RootfsSource::Oci(reference) = config.image.clone() {
             let pull_result =
                 pull_oci_image(&reference, config.registry_auth.take(), progress).await?;
@@ -209,10 +198,21 @@ impl Sandbox {
             }
         }
 
+        // Apply rootfs patches before VM start.
+        if !config.patches.is_empty() {
+            patch::apply_patches(
+                &config.image,
+                &config.patches,
+                &sandbox_dir,
+                &config.resolved_rootfs_layers,
+            )
+            .await?;
+        }
+
         // Insert the sandbox record and keep its stable database ID.
         let sandbox_id = insert_sandbox_record(db, &config).await?;
 
-        // Spawn supervisor + create bridge. On failure, mark the sandbox
+        // Spawn the sandbox process and create the bridge. On failure, mark the sandbox
         // as stopped so it doesn't appear as a phantom "Running" entry.
         let sandbox = match Self::create_inner(config, sandbox_id, mode).await {
             Ok(sandbox) => sandbox,
@@ -292,8 +292,8 @@ impl Sandbox {
             ready_time_ms = ready.ready_time_ns / 1_000_000,
             "sandbox ready",
         );
-
         Ok(Self {
+            db_id: sandbox_id,
             config,
             handle: Some(Arc::new(Mutex::new(handle))),
             client: Arc::new(client),
@@ -347,6 +347,23 @@ impl Sandbox {
 //--------------------------------------------------------------------------------------------------
 
 impl Sandbox {
+    /// Remove this sandbox's persisted state after it has fully stopped.
+    pub async fn remove_persisted(self) -> MicrosandboxResult<()> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+
+        remove_dir_if_exists(
+            &crate::config::config()
+                .sandboxes_dir()
+                .join(&self.config.name),
+        )?;
+        sandbox_entity::Entity::delete_by_id(self.db_id)
+            .exec(db)
+            .await?;
+
+        Ok(())
+    }
+
     /// Unique name identifying this sandbox.
     pub fn name(&self) -> &str {
         &self.config.name
@@ -390,7 +407,7 @@ impl Sandbox {
     ///
     /// If this handle does not own the lifecycle (connected to an existing
     /// sandbox), only the stop signal is sent — wait is skipped since we
-    /// don't have a supervisor handle to wait on.
+    /// don't have a process handle to wait on.
     pub async fn stop_and_wait(&self) -> MicrosandboxResult<ExitStatus> {
         let stop_result = self.stop().await;
         if self.handle.is_none() {
@@ -649,35 +666,16 @@ impl Sandbox {
             let _ = crossterm::terminal::disable_raw_mode();
         });
 
-        // Set stdin to non-blocking so the async read can be cleanly cancelled.
-        // tokio::io::stdin() uses a blocking thread that can't be cancelled,
-        // causing the first keystroke after exit to be swallowed.
-        let stdin_fd = std::io::stdin().as_raw_fd();
-        let old_stdin_flags = unsafe { libc::fcntl(stdin_fd, libc::F_GETFL) };
-        if old_stdin_flags == -1 {
-            return Err(crate::MicrosandboxError::Terminal(format!(
-                "failed to get stdin flags: {}",
-                std::io::Error::last_os_error()
-            )));
-        }
-        if unsafe { libc::fcntl(stdin_fd, libc::F_SETFL, old_stdin_flags | libc::O_NONBLOCK) } == -1
-        {
-            return Err(crate::MicrosandboxError::Terminal(format!(
-                "failed to set stdin non-blocking: {}",
-                std::io::Error::last_os_error()
-            )));
-        }
-        let _nonblock_guard = scopeguard::guard((), |_| {
-            if unsafe { libc::fcntl(stdin_fd, libc::F_SETFL, old_stdin_flags) } == -1 {
-                tracing::warn!(
-                    error = %std::io::Error::last_os_error(),
-                    "failed to restore stdin blocking mode"
-                );
-            }
-        });
-
-        let stdin_async = AsyncFd::new(StdinRawFd(stdin_fd))
-            .map_err(|e| crate::MicrosandboxError::Terminal(format!("async stdin: {e}")))?;
+        // Re-open the controlling terminal for input and set only that fresh
+        // fd non-blocking. Toggling O_NONBLOCK on fd 0 would also affect
+        // stdout/stderr when all three stdio fds share the same TTY open file
+        // description, which truncates large terminal writes.
+        let tty_input_path = terminal_path_for_fd(std::io::stdin().as_raw_fd())
+            .map_err(|e| crate::MicrosandboxError::Terminal(format!("resolve tty path: {e}")))?;
+        let tty_input = open_nonblocking_terminal_input(&tty_input_path)
+            .map_err(|e| crate::MicrosandboxError::Terminal(format!("open tty input: {e}")))?;
+        let stdin_async = AsyncFd::new(tty_input)
+            .map_err(|e| crate::MicrosandboxError::Terminal(format!("async tty input: {e}")))?;
 
         // Set up async I/O.
         let mut stdout = tokio::io::stdout();
@@ -699,71 +697,102 @@ impl Sandbox {
                     };
 
                     let mut input_buf = [0u8; 1024];
-                    let n = unsafe {
-                        libc::read(
-                            stdin_fd,
-                            input_buf.as_mut_ptr() as *mut libc::c_void,
-                            input_buf.len(),
-                        )
-                    };
+                    match guard.try_io(|inner| {
+                        read_from_fd(inner.get_ref().as_raw_fd(), &mut input_buf)
+                    }) {
+                        Ok(Ok(0)) => break, // EOF
+                        Ok(Ok(n)) => {
+                            let data = &input_buf[..n];
 
-                    if n > 0 {
-                        let data = &input_buf[..n as usize];
-
-                        // Check for detach key sequence.
-                        let mut detached = false;
-                        for &b in data {
-                            if b == detach_seq[match_pos] {
-                                match_pos += 1;
-                                if match_pos == detach_seq.len() {
-                                    detached = true;
-                                    break;
-                                }
-                            } else {
-                                match_pos = 0;
-                                if b == detach_seq[0] {
-                                    match_pos = 1;
+                            // Check for detach key sequence.
+                            let mut detached = false;
+                            for &b in data {
+                                if b == detach_seq[match_pos] {
+                                    match_pos += 1;
+                                    if match_pos == detach_seq.len() {
+                                        detached = true;
+                                        break;
+                                    }
+                                } else {
+                                    match_pos = 0;
+                                    if b == detach_seq[0] {
+                                        match_pos = 1;
+                                    }
                                 }
                             }
-                        }
 
-                        if detached {
-                            break;
-                        }
+                            if detached {
+                                break;
+                            }
 
-                        // Forward to guest.
-                        let payload = ExecStdin { data: data.to_vec() };
-                        if let Ok(msg) = Message::with_payload(MessageType::ExecStdin, id, &payload) {
-                            let _ = self.client.send(&msg).await;
+                            // Forward to guest.
+                            let payload = ExecStdin { data: data.to_vec() };
+                            if let Ok(msg) = Message::with_payload(MessageType::ExecStdin, id, &payload) {
+                                let _ = self.client.send(&msg).await;
+                            }
                         }
-                    } else if n == 0 {
-                        break; // EOF
-                    } else {
-                        let err = std::io::Error::last_os_error();
-                        match err.kind() {
-                            std::io::ErrorKind::WouldBlock => guard.clear_ready(),
-                            std::io::ErrorKind::Interrupted => {} // EINTR — retry
-                            _ => break,
-                        }
+                        Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Ok(Err(_)) => break,
+                        Err(_would_block) => continue,
                     }
                 }
 
                 // Receive output from guest.
+                //
+                // TUI apps (e.g. Ink-based CLIs) write a full re-render as one
+                // write(), but the guest PTY reader chunks it into ~4 KB
+                // ExecStdout messages. Writing each chunk to the host terminal
+                // separately lets the terminal emulator render intermediate
+                // states — partial cursor movements, partially overwritten
+                // lines — producing visible afterimage artifacts.
+                //
+                // Fix: after receiving the first message, drain all immediately
+                // available ExecStdout messages and batch their data into a
+                // single write. This coalesces the output so the terminal
+                // processes each re-render atomically.
                 Some(msg) = rx.recv() => {
+                    let mut should_break = false;
+
                     match msg.t {
                         MessageType::ExecStdout => {
                             if let Ok(out) = msg.payload::<ExecStdout>() {
                                 let _ = stdout.write_all(&out.data).await;
-                                let _ = stdout.flush().await;
                             }
                         }
                         MessageType::ExecExited => {
                             if let Ok(exited) = msg.payload::<ExecExited>() {
                                 exit_code = exited.code;
                             }
-                            break;
+                            should_break = true;
                         }
                         _ => {}
+                    }
+
+                    // Drain all buffered messages before flushing.
+                    if !should_break {
+                        while let Ok(next) = rx.try_recv() {
+                            match next.t {
+                                MessageType::ExecStdout => {
+                                    if let Ok(out) = next.payload::<ExecStdout>() {
+                                        let _ = stdout.write_all(&out.data).await;
+                                    }
+                                }
+                                MessageType::ExecExited => {
+                                    if let Ok(exited) = next.payload::<ExecExited>() {
+                                        exit_code = exited.code;
+                                    }
+                                    should_break = true;
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    let _ = stdout.flush().await;
+
+                    if should_break {
+                        break;
                     }
                 }
 
@@ -799,17 +828,22 @@ impl Sandbox {
 
 /// Wait for the agent relay socket to become available and connect.
 ///
-/// The supervisor creates the relay socket asynchronously during startup.
+/// The sandbox process creates the relay socket asynchronously during startup.
 /// This function retries the connection with brief delays until it succeeds
 /// or a timeout is reached.
 async fn wait_for_relay(sock_path: &std::path::Path) -> MicrosandboxResult<AgentClient> {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    let max_backoff = std::time::Duration::from_millis(10);
+    let mut backoff = std::time::Duration::from_millis(1);
 
     loop {
         match AgentClient::connect(sock_path).await {
             Ok(client) => return Ok(client),
             Err(_) if tokio::time::Instant::now() < deadline => {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                // Keep early retries tight so relay readiness doesn't inherit a
+                // coarse fixed delay on warm starts.
+                tokio::time::sleep(backoff).await;
+                backoff = std::cmp::min(backoff.saturating_mul(2), max_backoff);
             }
             Err(e) => return Err(e),
         }
@@ -847,9 +881,9 @@ fn build_exec_request(
         .map(|(k, v)| format!("{k}={v}"))
         .collect();
 
-    // Inject TERM for TTY sessions if not already set (mirrors Docker behavior).
+    // Inject TERM for TTY sessions if not already set.
     if tty && !env.iter().any(|e| e.starts_with("TERM=")) {
-        env.push("TERM=xterm-256color".to_string());
+        env.push(format!("TERM={}", default_tty_term()));
     }
 
     let rlimits: Vec<ExecRlimit> = rlimits
@@ -870,6 +904,63 @@ fn build_exec_request(
         rows,
         cols,
         rlimits,
+    }
+}
+
+fn default_tty_term() -> String {
+    select_tty_term(std::env::var("TERM").ok().as_deref())
+}
+
+fn select_tty_term(term: Option<&str>) -> String {
+    match term {
+        Some(term) if !term.trim().is_empty() && term != "dumb" => term.to_string(),
+        _ => "xterm".to_string(),
+    }
+}
+
+fn terminal_path_for_fd(fd: std::os::fd::RawFd) -> std::io::Result<std::path::PathBuf> {
+    let mut buf = [0u8; 1024];
+    let rc = unsafe { libc::ttyname_r(fd, buf.as_mut_ptr().cast(), buf.len()) };
+    if rc != 0 {
+        return Err(std::io::Error::from_raw_os_error(rc));
+    }
+
+    let end = buf
+        .iter()
+        .position(|&byte| byte == 0)
+        .ok_or_else(|| std::io::Error::other("ttyname_r did not NUL-terminate"))?;
+
+    let path = std::str::from_utf8(&buf[..end]).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "tty path is not valid UTF-8",
+        )
+    })?;
+
+    Ok(std::path::PathBuf::from(path))
+}
+
+fn open_nonblocking_terminal_input(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    use std::os::fd::AsRawFd;
+
+    let file = std::fs::File::open(path)?;
+    let fd = file.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+fn read_from_fd(fd: std::os::fd::RawFd, buf: &mut [u8]) -> std::io::Result<usize> {
+    let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+    if n < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(n as usize)
     }
 }
 
@@ -1064,6 +1155,37 @@ async fn pull_oci_image(
     let image_ref: microsandbox_image::Reference = reference.parse().map_err(|e| {
         crate::MicrosandboxError::InvalidConfig(format!("invalid image reference: {e}"))
     })?;
+    let options = microsandbox_image::PullOptions::default();
+
+    // Warm runs spend most of their time outside the guest, so avoid
+    // constructing the registry client when the image is already complete
+    // in the local cache.
+    if let Some((result, metadata)) =
+        microsandbox_image::Registry::pull_cached(&cache, &image_ref, &options)?
+    {
+        if let Some(sender) = progress {
+            let reference: std::sync::Arc<str> = reference.to_string().into();
+            sender.send(microsandbox_image::PullProgress::Resolving {
+                reference: reference.clone(),
+            });
+            sender.send(microsandbox_image::PullProgress::Resolved {
+                reference: reference.clone(),
+                manifest_digest: metadata.manifest_digest.clone().into(),
+                layer_count: metadata.layers.len(),
+                total_download_bytes: metadata
+                    .layers
+                    .iter()
+                    .filter_map(|layer| layer.size_bytes)
+                    .reduce(|a, b| a + b),
+            });
+            sender.send(microsandbox_image::PullProgress::Complete {
+                reference,
+                layer_count: metadata.layers.len(),
+            });
+        }
+
+        return Ok(result);
+    }
 
     let auth = match explicit_auth {
         Some(auth) => auth,
@@ -1071,7 +1193,6 @@ async fn pull_oci_image(
     };
 
     let registry = microsandbox_image::Registry::with_auth(platform, cache, auth)?;
-    let options = microsandbox_image::PullOptions::default();
 
     if let Some(sender) = progress {
         let task = registry.pull_with_sender(&image_ref, &options, sender);
@@ -1159,7 +1280,7 @@ async fn prepare_create_target(
     if !config.replace_existing {
         if existing.is_some() || dir_exists {
             return Err(crate::MicrosandboxError::Custom(format!(
-                "sandbox '{}' already exists; remove it, start the stopped sandbox, or recreate with .overwrite()",
+                "sandbox '{}' already exists; remove it, start the stopped sandbox, or recreate with .replace()",
                 config.name
             )));
         }
@@ -1173,17 +1294,102 @@ async fn prepare_create_target(
             model.status,
             SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
         ) {
-            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
-                "cannot replace sandbox '{}': existing sandbox is still active",
-                config.name
-            )));
+            stop_sandbox_for_replacement(db, &model).await?;
         }
 
-        model.into_active_model().delete(db).await?;
+        sandbox_entity::Entity::delete_by_id(model.id)
+            .exec(db)
+            .await?;
     }
 
     remove_dir_if_exists(sandbox_dir)?;
     Ok(())
+}
+
+async fn stop_sandbox_for_replacement(
+    db: &sea_orm::DatabaseConnection,
+    sandbox: &sandbox_entity::Model,
+) -> MicrosandboxResult<()> {
+    let run = load_active_run(db, sandbox.id).await?;
+    let pids: Vec<i32> = run
+        .as_ref()
+        .and_then(|model| model.pid)
+        .filter(|pid| pid_is_alive(*pid))
+        .into_iter()
+        .collect();
+
+    for pid in &pids {
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(*pid),
+            nix::sys::signal::Signal::SIGTERM,
+        )?;
+    }
+
+    wait_for_pids_to_exit(&pids, std::time::Duration::from_secs(30)).await;
+
+    if pids.iter().any(|pid| pid_is_alive(*pid)) {
+        return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+            "cannot replace sandbox '{}': existing sandbox did not stop in time",
+            sandbox.name
+        )));
+    }
+
+    mark_sandbox_stopped_for_replacement(db, sandbox.id, run.as_ref().map(|model| model.id)).await
+}
+
+async fn mark_sandbox_stopped_for_replacement(
+    db: &sea_orm::DatabaseConnection,
+    sandbox_id: i32,
+    run_id: Option<i32>,
+) -> MicrosandboxResult<()> {
+    let txn = db.begin().await?;
+    let now = chrono::Utc::now().naive_utc();
+
+    if let Some(run_id) = run_id {
+        run_entity::Entity::update_many()
+            .col_expr(
+                run_entity::Column::Status,
+                Expr::value(run_entity::RunStatus::Terminated),
+            )
+            .col_expr(
+                run_entity::Column::TerminationReason,
+                Expr::value(run_entity::TerminationReason::Signal),
+            )
+            .col_expr(run_entity::Column::TerminatedAt, Expr::value(now))
+            .filter(run_entity::Column::Id.eq(run_id))
+            .exec(&txn)
+            .await?;
+    }
+
+    sandbox_entity::Entity::update_many()
+        .col_expr(
+            sandbox_entity::Column::Status,
+            Expr::value(SandboxStatus::Stopped),
+        )
+        .col_expr(sandbox_entity::Column::UpdatedAt, Expr::value(now))
+        .filter(sandbox_entity::Column::Id.eq(sandbox_id))
+        .exec(&txn)
+        .await?;
+
+    txn.commit().await?;
+    Ok(())
+}
+
+async fn wait_for_pids_to_exit(pids: &[i32], timeout: std::time::Duration) {
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(50);
+
+    loop {
+        if pids.iter().all(|pid| !pid_is_alive(*pid)) {
+            return;
+        }
+
+        if start.elapsed() >= timeout {
+            return;
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
 }
 
 fn validate_start_state(config: &SandboxConfig, sandbox_dir: &Path) -> MicrosandboxResult<()> {
@@ -1287,7 +1493,9 @@ async fn replace_oci_manifest_pin<C: ConnectionTrait>(
 mod tests {
     use std::{
         fs,
+        os::fd::{AsRawFd, FromRawFd, OwnedFd},
         path::PathBuf,
+        process::Command,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -1318,6 +1526,75 @@ mod tests {
             pid += 1;
         }
         pid
+    }
+
+    #[test]
+    fn test_default_tty_term_prefers_host_term() {
+        assert_eq!(super::select_tty_term(Some("wezterm")), "wezterm");
+    }
+
+    #[test]
+    fn test_default_tty_term_falls_back_from_dumb() {
+        assert_eq!(super::select_tty_term(Some("dumb")), "xterm");
+    }
+
+    #[test]
+    fn test_shared_tty_fd_flags_are_shared_across_dups() {
+        let pty = nix::pty::openpty(None, None).unwrap();
+        let shared_a = unsafe { OwnedFd::from_raw_fd(libc::dup(pty.slave.as_raw_fd())) };
+        let shared_b = unsafe { OwnedFd::from_raw_fd(libc::dup(shared_a.as_raw_fd())) };
+
+        let flags = unsafe { libc::fcntl(shared_a.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(flags, -1);
+        let ret = unsafe {
+            libc::fcntl(
+                shared_a.as_raw_fd(),
+                libc::F_SETFL,
+                flags | libc::O_NONBLOCK,
+            )
+        };
+        assert_ne!(ret, -1);
+
+        let other_flags = unsafe { libc::fcntl(shared_b.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(other_flags, -1);
+        assert_ne!(
+            other_flags & libc::O_NONBLOCK,
+            0,
+            "dup'd tty fds should share O_NONBLOCK state"
+        );
+    }
+
+    #[test]
+    fn test_open_nonblocking_terminal_input_keeps_existing_tty_fds_blocking() {
+        let pty = nix::pty::openpty(None, None).unwrap();
+        let shared_a = unsafe { OwnedFd::from_raw_fd(libc::dup(pty.slave.as_raw_fd())) };
+        let shared_b = unsafe { OwnedFd::from_raw_fd(libc::dup(shared_a.as_raw_fd())) };
+        let tty_path = super::terminal_path_for_fd(pty.slave.as_raw_fd()).unwrap();
+
+        let input = super::open_nonblocking_terminal_input(&tty_path).unwrap();
+
+        let input_flags = unsafe { libc::fcntl(input.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(input_flags, -1);
+        assert_ne!(
+            input_flags & libc::O_NONBLOCK,
+            0,
+            "re-opened tty input fd should be non-blocking"
+        );
+
+        let flags_a = unsafe { libc::fcntl(shared_a.as_raw_fd(), libc::F_GETFL) };
+        let flags_b = unsafe { libc::fcntl(shared_b.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(flags_a, -1);
+        assert_ne!(flags_b, -1);
+        assert_eq!(
+            flags_a & libc::O_NONBLOCK,
+            0,
+            "existing tty fd should remain blocking"
+        );
+        assert_eq!(
+            flags_b & libc::O_NONBLOCK,
+            0,
+            "dup'd tty fd should remain blocking"
+        );
     }
 
     #[test]
@@ -1689,7 +1966,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prepare_create_target_force_rejects_running_sandbox() {
+    async fn test_prepare_create_target_force_replaces_running_sandbox() {
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
         let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
@@ -1706,9 +1983,12 @@ mod tests {
         };
         let sandbox_id = insert_sandbox_record(&conn, &config).await.unwrap();
 
-        // Insert a run with the current process PID so reconciliation
-        // considers the sandbox genuinely alive.
-        let live_pid = std::process::id() as i32;
+        let child = Command::new("sleep").arg("30").spawn().unwrap();
+        let live_pid = child.id() as i32;
+        let waiter = std::thread::spawn(move || {
+            let mut child = child;
+            child.wait().unwrap()
+        });
         let run = run_entity::ActiveModel {
             sandbox_id: Set(sandbox_id),
             pid: Set(Some(live_pid)),
@@ -1723,14 +2003,21 @@ mod tests {
         };
         forced.replace_existing = true;
 
-        let err = prepare_create_target(&conn, &forced, &sandbox_dir)
+        prepare_create_target(&conn, &forced, &sandbox_dir)
             .await
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            crate::MicrosandboxError::SandboxStillRunning(_)
-        ));
-        assert!(sandbox_dir.exists());
+            .unwrap();
+
+        waiter.join().unwrap();
+
+        assert!(!super::pid_is_alive(live_pid));
+        assert!(!sandbox_dir.exists());
+        assert!(
+            super::sandbox_entity::Entity::find_by_id(sandbox_id)
+                .one(&conn)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/microsandbox/lib/sandbox/patch.rs
+++ b/crates/microsandbox/lib/sandbox/patch.rs
@@ -1,0 +1,255 @@
+//! Patch application logic for rootfs modification before VM start.
+
+use std::path::{Path, PathBuf};
+
+use tokio::fs;
+
+use super::types::{Patch, RootfsSource};
+use crate::MicrosandboxResult;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Apply patches to the rootfs before VM start.
+///
+/// For OCI images, patches are written to the `rw/` upper layer so that the shared
+/// extracted image layers remain untouched. For bind roots, patches are written
+/// directly to the host directory.
+pub(crate) async fn apply_patches(
+    image: &RootfsSource,
+    patches: &[Patch],
+    sandbox_dir: &Path,
+    resolved_layers: &[PathBuf],
+) -> MicrosandboxResult<()> {
+    if patches.is_empty() {
+        return Ok(());
+    }
+
+    let (target_dir, lower_layers) = match image {
+        RootfsSource::Oci(_) => {
+            let rw_dir = sandbox_dir.join("rw");
+            (rw_dir, resolved_layers)
+        }
+        RootfsSource::Bind(host_dir) => (host_dir.clone(), [].as_slice()),
+        RootfsSource::DiskImage { .. } => {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "patches are not compatible with disk image rootfs".into(),
+            ));
+        }
+    };
+
+    for patch in patches {
+        apply_one(&target_dir, lower_layers, patch).await?;
+    }
+
+    Ok(())
+}
+
+/// Apply a single patch operation.
+async fn apply_one(
+    target_dir: &Path,
+    lower_layers: &[PathBuf],
+    patch: &Patch,
+) -> MicrosandboxResult<()> {
+    match patch {
+        Patch::Text {
+            path,
+            content,
+            mode,
+            overwrite,
+        } => {
+            let dest = resolve_guest_path(target_dir, path)?;
+            check_overwrite(&dest, lower_layers, path, *overwrite)?;
+            ensure_parent(&dest).await?;
+            fs::write(&dest, content.as_bytes()).await?;
+            if let Some(mode) = mode {
+                set_permissions(&dest, *mode).await?;
+            }
+        }
+        Patch::File {
+            path,
+            content,
+            mode,
+            overwrite,
+        } => {
+            let dest = resolve_guest_path(target_dir, path)?;
+            check_overwrite(&dest, lower_layers, path, *overwrite)?;
+            ensure_parent(&dest).await?;
+            fs::write(&dest, content).await?;
+            if let Some(mode) = mode {
+                set_permissions(&dest, *mode).await?;
+            }
+        }
+        Patch::CopyFile {
+            src,
+            dst,
+            mode,
+            overwrite,
+        } => {
+            let dest = resolve_guest_path(target_dir, dst)?;
+            check_overwrite(&dest, lower_layers, dst, *overwrite)?;
+            ensure_parent(&dest).await?;
+            fs::copy(src, &dest).await?;
+            if let Some(mode) = mode {
+                set_permissions(&dest, *mode).await?;
+            }
+        }
+        Patch::CopyDir {
+            src,
+            dst,
+            overwrite,
+        } => {
+            let dest = resolve_guest_path(target_dir, dst)?;
+            check_overwrite(&dest, lower_layers, dst, *overwrite)?;
+            copy_dir_recursive(src, &dest).await?;
+        }
+        Patch::Symlink {
+            target,
+            link,
+            overwrite,
+        } => {
+            let link_path = resolve_guest_path(target_dir, link)?;
+            check_overwrite(&link_path, lower_layers, link, *overwrite)?;
+            ensure_parent(&link_path).await?;
+            // Remove existing if overwrite was allowed and something exists.
+            if link_path.exists() {
+                fs::remove_file(&link_path).await.ok();
+            }
+            #[cfg(unix)]
+            tokio::fs::symlink(target, &link_path).await?;
+        }
+        Patch::Mkdir { path, mode } => {
+            let dest = resolve_guest_path(target_dir, path)?;
+            fs::create_dir_all(&dest).await?;
+            if let Some(mode) = mode {
+                set_permissions(&dest, *mode).await?;
+            }
+        }
+        Patch::Remove { path } => {
+            let dest = resolve_guest_path(target_dir, path)?;
+            if dest.is_dir() {
+                fs::remove_dir_all(&dest).await.ok();
+            } else {
+                fs::remove_file(&dest).await.ok();
+            }
+        }
+        Patch::Append { path, content } => {
+            let dest = resolve_guest_path(target_dir, path)?;
+            // If the file doesn't exist in the target dir, try to copy up from lower layers.
+            if !dest.exists()
+                && let Some(source) = find_in_layers(lower_layers, path)
+            {
+                ensure_parent(&dest).await?;
+                fs::copy(&source, &dest).await?;
+            }
+            if dest.exists() {
+                use tokio::io::AsyncWriteExt;
+                let mut file = fs::OpenOptions::new().append(true).open(&dest).await?;
+                file.write_all(content.as_bytes()).await?;
+            } else {
+                return Err(crate::MicrosandboxError::PatchFailed(format!(
+                    "cannot append to '{path}': file not found in rootfs"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve a guest absolute path to a host path within the target directory.
+fn resolve_guest_path(target_dir: &Path, guest_path: &str) -> MicrosandboxResult<PathBuf> {
+    if !guest_path.starts_with('/') {
+        return Err(crate::MicrosandboxError::PatchFailed(format!(
+            "patch path must be absolute: '{guest_path}'"
+        )));
+    }
+    // Strip the leading `/` so joining works correctly.
+    let relative = guest_path.strip_prefix('/').unwrap_or(guest_path);
+    let resolved = target_dir.join(relative);
+
+    // Prevent path traversal.
+    if !resolved.starts_with(target_dir) {
+        return Err(crate::MicrosandboxError::PatchFailed(format!(
+            "patch path escapes rootfs: '{guest_path}'"
+        )));
+    }
+
+    Ok(resolved)
+}
+
+/// Check if a path already exists in the target dir or lower layers.
+/// Returns an error if it exists and `overwrite` is false.
+fn check_overwrite(
+    dest: &Path,
+    lower_layers: &[PathBuf],
+    guest_path: &str,
+    overwrite: bool,
+) -> MicrosandboxResult<()> {
+    if overwrite {
+        return Ok(());
+    }
+
+    // Check the target directory (rw layer for OCI, host dir for bind).
+    if dest.exists() {
+        return Err(crate::MicrosandboxError::PatchFailed(format!(
+            "path already exists in rootfs: '{guest_path}' (set overwrite to allow)"
+        )));
+    }
+
+    // Check lower layers (OCI image layers).
+    if find_in_layers(lower_layers, guest_path).is_some() {
+        return Err(crate::MicrosandboxError::PatchFailed(format!(
+            "path exists in image layer: '{guest_path}' (set overwrite to allow)"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Search lower layers (bottom-to-top) for a guest path. Returns the first match.
+fn find_in_layers(layers: &[PathBuf], guest_path: &str) -> Option<PathBuf> {
+    let relative = guest_path.strip_prefix('/').unwrap_or(guest_path);
+    // Search top-to-bottom (last layer = topmost).
+    for layer in layers.iter().rev() {
+        let candidate = layer.join(relative);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Ensure parent directories exist.
+async fn ensure_parent(path: &Path) -> MicrosandboxResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    Ok(())
+}
+
+/// Set Unix file permissions.
+#[cfg(unix)]
+async fn set_permissions(path: &Path, mode: u32) -> MicrosandboxResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(mode);
+    fs::set_permissions(path, perms).await?;
+    Ok(())
+}
+
+/// Recursively copy a directory.
+async fn copy_dir_recursive(src: &Path, dst: &Path) -> MicrosandboxResult<()> {
+    fs::create_dir_all(dst).await?;
+    let mut entries = fs::read_dir(src).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().await?.is_dir() {
+            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
+        } else {
+            fs::copy(&src_path, &dst_path).await?;
+        }
+    }
+    Ok(())
+}

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -132,11 +132,100 @@ enum MountKind {
     Unset,
 }
 
-/// A rootfs patch applied as an overlay layer before VM start.
+/// Rootfs patch applied before VM startup.
 ///
-/// Fully implemented in Phase 13 (Patches).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Patch {}
+/// How patches are applied depends on the root filesystem type:
+/// - **OCI images (OverlayFs):** Patches are written directly to the `rw/` upper layer
+///   (`sandboxes/<name>/rw/`). The extracted image layers remain shared and untouched.
+/// - **Bind/Passthrough roots:** Patches are applied directly to the host directory.
+/// - **Block device roots (Qcow2, Raw):** Patches are not supported. Returns an error at
+///   create time.
+///
+/// By default, patches that target a path already present in the rootfs (lower layers for
+/// OverlayFs, existing files for bind roots) will return an error. Set `overwrite: true` on
+/// the relevant variant to allow shadowing existing files.
+///
+/// For `Append` patches targeting a file in a lower layer, the file is first copied up to
+/// `rw/` before appending.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Patch {
+    /// Write text content to a file.
+    Text {
+        /// Absolute guest path (e.g., `/etc/app.conf`).
+        path: String,
+        /// Text content to write.
+        content: String,
+        /// File permissions (e.g., `0o644`). `None` uses the default.
+        mode: Option<u32>,
+        /// Allow overwriting a file that already exists in the rootfs.
+        overwrite: bool,
+    },
+    /// Write raw bytes to a file.
+    File {
+        /// Absolute guest path.
+        path: String,
+        /// Raw byte content to write.
+        content: Vec<u8>,
+        /// File permissions (e.g., `0o644`). `None` uses the default.
+        mode: Option<u32>,
+        /// Allow overwriting a file that already exists in the rootfs.
+        overwrite: bool,
+    },
+    /// Copy a file from host into the rootfs.
+    CopyFile {
+        /// Host path to copy from.
+        src: PathBuf,
+        /// Absolute guest destination path.
+        dst: String,
+        /// File permissions. `None` preserves source permissions.
+        mode: Option<u32>,
+        /// Allow overwriting a file that already exists in the rootfs.
+        overwrite: bool,
+    },
+    /// Copy a directory from host into the rootfs.
+    CopyDir {
+        /// Host directory to copy from.
+        src: PathBuf,
+        /// Absolute guest destination path.
+        dst: String,
+        /// Allow overwriting files that already exist in the rootfs.
+        overwrite: bool,
+    },
+    /// Create a symlink.
+    Symlink {
+        /// Symlink target path.
+        target: String,
+        /// Absolute guest path where the symlink is created.
+        link: String,
+        /// Allow overwriting a path that already exists in the rootfs.
+        overwrite: bool,
+    },
+    /// Create a directory (idempotent — does not error if the directory already exists).
+    Mkdir {
+        /// Absolute guest path.
+        path: String,
+        /// Directory permissions (e.g., `0o755`). `None` uses the default.
+        mode: Option<u32>,
+    },
+    /// Remove a file or directory (idempotent — does not error if the path does not exist).
+    Remove {
+        /// Absolute guest path to remove.
+        path: String,
+    },
+    /// Append content to an existing file. If the file lives in a lower layer,
+    /// it is copied up to `rw/` first, then the content is appended.
+    Append {
+        /// Absolute guest path of the file to append to.
+        path: String,
+        /// Content to append.
+        content: String,
+    },
+}
+
+/// Builder for constructing a list of [`Patch`] operations.
+pub struct PatchBuilder {
+    patches: Vec<Patch>,
+}
 
 /// Secrets configuration for a sandbox.
 ///
@@ -244,6 +333,131 @@ impl MountBuilder {
                 "MountBuilder: no mount type set (call .bind(), .named(), or .tmpfs())".into(),
             )),
         }
+    }
+}
+
+impl Default for PatchBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PatchBuilder {
+    /// Create a new patch builder.
+    pub fn new() -> Self {
+        Self {
+            patches: Vec::new(),
+        }
+    }
+
+    /// Write text content to a file.
+    pub fn text(
+        mut self,
+        path: impl Into<String>,
+        content: impl Into<String>,
+        mode: Option<u32>,
+        overwrite: bool,
+    ) -> Self {
+        self.patches.push(Patch::Text {
+            path: path.into(),
+            content: content.into(),
+            mode,
+            overwrite,
+        });
+        self
+    }
+
+    /// Write raw bytes to a file.
+    pub fn file(
+        mut self,
+        path: impl Into<String>,
+        content: impl Into<Vec<u8>>,
+        mode: Option<u32>,
+        overwrite: bool,
+    ) -> Self {
+        self.patches.push(Patch::File {
+            path: path.into(),
+            content: content.into(),
+            mode,
+            overwrite,
+        });
+        self
+    }
+
+    /// Copy a file from host into the rootfs.
+    pub fn copy_file(
+        mut self,
+        src: impl Into<PathBuf>,
+        dst: impl Into<String>,
+        mode: Option<u32>,
+        overwrite: bool,
+    ) -> Self {
+        self.patches.push(Patch::CopyFile {
+            src: src.into(),
+            dst: dst.into(),
+            mode,
+            overwrite,
+        });
+        self
+    }
+
+    /// Copy a directory from host into the rootfs.
+    pub fn copy_dir(
+        mut self,
+        src: impl Into<PathBuf>,
+        dst: impl Into<String>,
+        overwrite: bool,
+    ) -> Self {
+        self.patches.push(Patch::CopyDir {
+            src: src.into(),
+            dst: dst.into(),
+            overwrite,
+        });
+        self
+    }
+
+    /// Create a symlink.
+    pub fn symlink(
+        mut self,
+        target: impl Into<String>,
+        link: impl Into<String>,
+        overwrite: bool,
+    ) -> Self {
+        self.patches.push(Patch::Symlink {
+            target: target.into(),
+            link: link.into(),
+            overwrite,
+        });
+        self
+    }
+
+    /// Create a directory (idempotent).
+    pub fn mkdir(mut self, path: impl Into<String>, mode: Option<u32>) -> Self {
+        self.patches.push(Patch::Mkdir {
+            path: path.into(),
+            mode,
+        });
+        self
+    }
+
+    /// Remove a file or directory (idempotent).
+    pub fn remove(mut self, path: impl Into<String>) -> Self {
+        self.patches.push(Patch::Remove { path: path.into() });
+        self
+    }
+
+    /// Append content to an existing file. Copies up from lower layer if needed.
+    pub fn append(mut self, path: impl Into<String>, content: impl Into<String>) -> Self {
+        self.patches.push(Patch::Append {
+            path: path.into(),
+            content: content.into(),
+        });
+        self
+    }
+
+    /// Build the list of patches.
+    pub fn build(self) -> Vec<Patch> {
+        self.patches
     }
 }
 

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -53,6 +53,11 @@ impl NetworkBuilder {
         }
     }
 
+    /// Start building from an existing network configuration.
+    pub fn from_config(config: NetworkConfig) -> Self {
+        Self { config }
+    }
+
     /// Enable or disable networking.
     pub fn enabled(mut self, enabled: bool) -> Self {
         self.config.enabled = enabled;

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -105,7 +105,7 @@ pub const ENV_MOUNTS: &str = "MSB_MOUNTS";
 
 /// Guest-side path to the CA certificate for TLS interception.
 ///
-/// Placed by the supervisor via the runtime virtiofs mount.
+/// Placed by the sandbox process via the runtime virtiofs mount.
 /// agentd checks for this file during init and installs it into the guest
 /// trust store.
 pub const GUEST_TLS_CA_PATH: &str = "/.msb/tls/ca.pem";

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -23,7 +23,7 @@ pub const FLAG_SESSION_START: u8 = 0b0000_0010;
 
 /// Frame flag: this message requests sandbox shutdown.
 ///
-/// Set on `Shutdown` messages. The supervisor relay uses this to trigger
+/// Set on `Shutdown` messages. The sandbox-process relay uses this to trigger
 /// drain escalation (SIGTERM → SIGKILL) if the guest doesn't exit voluntarily.
 pub const FLAG_SHUTDOWN: u8 = 0b0000_0100;
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsandbox-runtime"
-description = "Runtime library for the microsandbox supervisor and microVM entry points."
+description = "Runtime library for the microsandbox sandbox process and microVM entry points."
 version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/runtime/lib/console.rs
+++ b/crates/runtime/lib/console.rs
@@ -110,6 +110,10 @@ impl ConsolePortBackend for AgentConsoleBackend {
     /// `WouldBlock` if both are empty. Never truncates — excess bytes are
     /// buffered for the next call.
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        // Reset the wake pipe before checking queues so future host->guest
+        // notifications are not lost if the VMM uses edge-triggered polling.
+        self.shared.rx_wake.drain();
+
         let mut pending = self.pending.lock().unwrap();
 
         // Serve from leftover bytes first (use memcpy via slices).
@@ -211,5 +215,31 @@ mod tests {
         // Second push fails — ring is full.
         let err = backend.write(b"b").unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn backend_read_drains_rx_wake_pipe() {
+        let shared = Arc::new(ConsoleSharedState::new());
+        let backend = AgentConsoleBackend::new(Arc::clone(&shared));
+
+        shared.rx_ring.push(b"ping".to_vec()).unwrap();
+        shared.rx_wake.wake();
+
+        let mut pollfd = libc::pollfd {
+            fd: backend.read_wake_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ret = unsafe { libc::poll(&mut pollfd, 1, 0) };
+        assert_eq!(ret, 1, "wake pipe should be readable before read()");
+        assert_ne!(pollfd.revents & libc::POLLIN, 0);
+
+        let mut buf = [0u8; 8];
+        let n = backend.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"ping");
+
+        pollfd.revents = 0;
+        let ret = unsafe { libc::poll(&mut pollfd, 1, 0) };
+        assert_eq!(ret, 0, "wake pipe should be drained by read()");
     }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -525,6 +525,8 @@ fn build_vm(
     });
 
     // Console — ring-buffer-based custom backend.
+    // NOTE: The implicit console must remain enabled (do not call
+    // `disable_implicit()`) because disk image rootfs boots depend on it.
     builder = builder.console(|c| {
         c.custom(
             microsandbox_protocol::AGENT_PORT_NAME,

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -211,42 +211,39 @@ When you create a sandbox, a few things start running behind the scenes. Here's 
 graph TD
     subgraph Host["Host"]
         A["Your Application<br/><small>microsandbox library, AgentBridge</small>"]
-        B["Supervisor<br/><small>msb supervisor</small>"]
-        D["MicroVM Process<br/><small>msb microvm + in-process networking</small>"]
+        B["Sandbox Process<br/><small>msb sandbox<br/>VMM + relay + lifecycle</small>"]
     end
 
     subgraph Guest["Guest VM"]
         F["agentd (PID 1)<br/><small>exec, fs, events</small>"]
     end
 
-    A -- "fork+exec" --> B
-    B -- "fork+exec" --> D
-    D -- "Vm::enter()" --> F
-    A -. "virtio-console (CBOR)" .-> F
+    A -- "spawn" --> B
+    B -- "Vm::enter()" --> F
+    A -. "Unix socket -> relay -> virtio-console (CBOR)" .-> F
 
     style Host fill:#f5f0ff,stroke:#a770ef,color:#333
     style Guest fill:#fef4e8,stroke:#e8a838,color:#333
     style A fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
     style B fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
-    style D fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
     style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
 ```
 
-There are two separate communication paths here. Your application talks to the guest agent (`agentd`) directly over a virtio-console channel using CBOR-encoded messages. This is how `exec`, `attach`, `fs`, and `emit` calls work. The supervisor is not involved in this path at all.
+There are two separate layers here. Your application talks to the host-side sandbox process over the agent relay socket, and the sandbox process forwards CBOR-encoded messages to the guest agent (`agentd`) over virtio-console. This is how `exec`, `attach`, `fs`, and `emit` calls work.
 
-The **supervisor** is a separate host process that watches over the MicroVM process. It handles:
+The **sandbox process** is the host-side runtime process created by `msb sandbox`. It hosts the VMM and handles:
 
 - Forwarding signals (SIGTERM for graceful stop, SIGUSR1 for drain)
-- Detecting child exits and applying restart/shutdown policies
+- Driving VM exit and shutdown policies
 - Monitoring idle state via the agentd heartbeat
 - Enforcing maximum sandbox lifetime
 - Writing logs and updating sandbox status in the database
 
-The supervisor does *not* handle command execution or the agent protocol. That's all between your application and `agentd`.
+The sandbox process does *not* execute guest commands itself. It relays agent protocol traffic between your application and `agentd`.
 
-## Supervisor policies
+## Sandbox Process Policies
 
-For production workloads, you can configure how the supervisor handles shutdown, idle detection, and maximum lifetime.
+For production workloads, you can configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/networking.mdx
+++ b/docs/sandboxes/networking.mdx
@@ -80,15 +80,16 @@ sb4 = await Sandbox.create("scoped-agent", image="python:3.12",
 ## Port mapping
 
 Expose ports from the sandbox to the host to make services accessible.
+In Rust, `SandboxBuilder::port()` and `port_udp()` are top-level shorthands,
+so you can publish ports without nesting everything inside `.network(...)`.
 
 <CodeGroup>
 ```rust Rust
 let sb = Sandbox::builder("api")
     .image("python:3.12")
-    .network(|n| n
-        .policy(NetworkPolicy::public_only())
-        .port(8080, 80)
-    )
+    .port(8080, 80)
+    .port_udp(5353, 5353)
+    .network(|n| n.policy(NetworkPolicy::public_only()))
     .create()
     .await?;
 ```

--- a/docs/sdk/networking.mdx
+++ b/docs/sdk/networking.mdx
@@ -198,6 +198,9 @@ sb = await Sandbox.create(
 ## Port mapping
 
 Expose ports from the sandbox to the host to make services accessible.
+For simple Rust cases, use top-level `SandboxBuilder::port()` and `port_udp()`.
+They are repeatable, and they compose with `.network(...)` when you also need
+policy, DNS, or TLS settings.
 
 <CodeGroup>
 ```rust Rust
@@ -205,10 +208,9 @@ use microsandbox::{Sandbox, NetworkPolicy};
 
 let sb = Sandbox::builder("api")
     .image("python:3.12")
-    .network(|n| n
-        .policy(NetworkPolicy::public_only())
-        .port(8080, 80)
-    )
+    .port(8080, 80)
+    .port_udp(5353, 5353)
+    .network(|n| n.policy(NetworkPolicy::public_only()))
     .create()
     .await?;
 ```

--- a/docs/sdk/sandbox.mdx
+++ b/docs/sdk/sandbox.mdx
@@ -94,7 +94,7 @@ sb = await Sandbox.create("worker", image="python:3.12", detached=True)
 ```
 </CodeGroup>
 
-## Overwrite existing
+## Replace existing
 
 Replace a stopped sandbox with the same name instead of failing on conflict.
 
@@ -102,7 +102,7 @@ Replace a stopped sandbox with the same name instead of failing on conflict.
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python:3.12")
-    .overwrite()
+    .replace()
     .create()
     .await?;
 ```
@@ -111,12 +111,12 @@ let sb = Sandbox::builder("worker")
 const sb = await Sandbox.create({
     name: "worker",
     image: "python:3.12",
-    overwrite: true,
+    replace: true,
 })
 ```
 
 ```python Python
-sb = await Sandbox.create("worker", image="python:3.12", overwrite=True)
+sb = await Sandbox.create("worker", image="python:3.12", replace=True)
 ```
 </CodeGroup>
 
@@ -503,9 +503,9 @@ except asyncio.TimeoutError:
 ```
 </CodeGroup>
 
-## Supervisor policies
+## Sandbox Process Policies
 
-Configure how the supervisor handles shutdown escalation, idle detection, and maximum sandbox lifetime.
+Configure how the sandbox process handles shutdown escalation, idle detection, and maximum sandbox lifetime.
 
 <CodeGroup>
 ```rust Rust
@@ -553,11 +553,11 @@ sb = await Sandbox.create(
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `shutdown_mode` | `Terminate` | How the supervisor escalates shutdown signals |
+| `shutdown_mode` | `Terminate` | How the sandbox process escalates shutdown signals |
 | `grace_period` | `10` | Seconds between escalation steps |
 | `max_duration` | none | Maximum sandbox lifetime in seconds; triggers drain when exceeded |
 | `idle_timeout` | none | Auto-drain after this many seconds of inactivity |
-| `log_level` | none | Override supervisor log verbosity |
+| `log_level` | none | Override sandbox-process log verbosity |
 
 ## Custom init
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,16 @@ submodule.
 cargo run -p block-root
 ```
 
+## net-ports
+
+Publishes one TCP port and one UDP port from the guest to the host using the
+top-level `SandboxBuilder::port()` and `port_udp()` helpers, then exercises
+both mappings from the host.
+
+```sh
+cargo run -p net-ports
+```
+
 ## named-volume
 
 Creates a named volume, mounts it into two sandboxes (writer and reader),

--- a/examples/net-basic/bin/main.rs
+++ b/examples/net-basic/bin/main.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .image("alpine:latest")
         .cpus(1)
         .memory(512)
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/net-dns/bin/main.rs
+++ b/examples/net-dns/bin/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             n.block_domain("blocked.example.com")
                 .block_domain_suffix(".evil.com")
         })
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/net-policy/bin/main.rs
+++ b/examples/net-policy/bin/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .image("alpine:latest")
         .cpus(1)
         .memory(512)
-        .overwrite()
+        .replace()
         .create()
         .await?;
 
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .cpus(1)
         .memory(512)
         .network(|n| n.policy(NetworkPolicy::allow_all()))
-        .overwrite()
+        .replace()
         .create()
         .await?;
 
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .cpus(1)
         .memory(512)
         .network(|n| n.policy(NetworkPolicy::none()))
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/net-ports/Cargo.toml
+++ b/examples/net-ports/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "net-ports"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "net-ports"
+path = "bin/main.rs"
+
+[dependencies]
+microsandbox = { path = "../../crates/microsandbox" }
+reqwest = { version = "0.13" }
+tokio = { version = "1.42", features = ["full"] }

--- a/examples/net-ports/bin/main.rs
+++ b/examples/net-ports/bin/main.rs
@@ -1,0 +1,47 @@
+//! Port publishing — expose a guest HTTP server on a host port.
+//!
+//! Starts a simple HTTP server inside the sandbox and publishes it
+//! to the host via `.port(host, guest)`.
+
+use microsandbox::sandbox::Sandbox;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Creating sandbox with published port 8080 → 80");
+
+    let sandbox = Sandbox::builder("net-ports")
+        .image("alpine:latest")
+        .cpus(1)
+        .memory(512)
+        .port(8080, 80)
+        .replace()
+        .create()
+        .await?;
+
+    // Start a tiny HTTP responder using BusyBox nc. Alpine's BusyBox build in
+    // this image does not include the httpd applet.
+    let output = sandbox
+        .shell(
+            "(while true; do printf 'HTTP/1.1 200 OK\\r\\nContent-Length: 24\\r\\nConnection: close\\r\\n\\r\\nHello from microsandbox!' | nc -l -p 80; done) >/tmp/net-ports.log 2>&1 & echo ok",
+        )
+        .await?;
+
+    println!(
+        "HTTP server started with BusyBox nc: {}",
+        output.stdout()?.trim()
+    );
+
+    // Fetch from the host side via the published port.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    match client.get("http://127.0.0.1:8080/index.html").send().await {
+        Ok(resp) => println!("Host-side:  {}", resp.text().await?.trim()),
+        Err(e) => eprintln!("Host-side:  could not reach guest server: {e}"),
+    }
+
+    // Stop the sandbox.
+    sandbox.stop_and_wait().await?;
+    println!("Sandbox stopped.");
+    Ok(())
+}

--- a/examples/net-secrets/bin/main.rs
+++ b/examples/net-secrets/bin/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .cpus(1)
         .memory(512)
         .secret_env("API_KEY", "sk-real-secret-123", "example.com")
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/net-tls/bin/main.rs
+++ b/examples/net-tls/bin/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .cpus(1)
         .memory(512)
         .network(|n| n.tls(|t| t.bypass("*.bypass-example.com")))
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/root-bind/bin/main.rs
+++ b/examples/root-bind/bin/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .image(rootfs_path)
         .cpus(1)
         .memory(512)
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/root-block/bin/main.rs
+++ b/examples/root-block/bin/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .image(|image: ImageBuilder| image.disk(image_path).fstype("ext4"))
         .cpus(1)
         .memory(512)
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/root-oci/bin/main.rs
+++ b/examples/root-oci/bin/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .image("alpine:latest")
         .cpus(1)
         .memory(512)
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/examples/rootfs-patch/Cargo.toml
+++ b/examples/rootfs-patch/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rootfs-patch"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "rootfs-patch"
+path = "bin/main.rs"
+
+[dependencies]
+microsandbox = { path = "../../crates/microsandbox" }
+tokio = { version = "1.42", features = ["full"] }

--- a/examples/rootfs-patch/bin/main.rs
+++ b/examples/rootfs-patch/bin/main.rs
@@ -1,0 +1,63 @@
+//! Rootfs patch example demonstrating pre-boot filesystem modifications.
+//!
+//! See [examples/README.md](../../README.md) for prerequisites and usage.
+
+use microsandbox::sandbox::Sandbox;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Creating sandbox with rootfs patches (image=alpine:latest)");
+
+    // Create a sandbox with patches applied before the VM boots.
+    let sandbox = Sandbox::builder("rootfs-patch")
+        .image("alpine:latest")
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .patch(|p| {
+            p.text(
+                "/etc/greeting.txt",
+                "Hello from a patched rootfs!\n",
+                None,
+                false,
+            )
+            .text(
+                "/etc/motd",
+                "Welcome to a patched microsandbox.\n",
+                None,
+                true, // overwrite — /etc/motd exists in alpine
+            )
+            .mkdir("/app", Some(0o755))
+            .text(
+                "/app/config.json",
+                r#"{"version": "1.0", "debug": true}"#,
+                Some(0o644),
+                false,
+            )
+            .append("/etc/hosts", "127.0.0.1 myapp.local\n")
+        })
+        .create()
+        .await?;
+
+    // Verify the patches were applied.
+    let output = sandbox.shell("cat /etc/greeting.txt").await?;
+    println!("greeting: {}", output.stdout()?.trim_end());
+
+    let output = sandbox.shell("cat /etc/motd").await?;
+    println!("motd: {}", output.stdout()?.trim_end());
+
+    let output = sandbox.shell("cat /app/config.json").await?;
+    println!("config: {}", output.stdout()?.trim_end());
+
+    let output = sandbox.shell("grep myapp.local /etc/hosts").await?;
+    println!("hosts entry: {}", output.stdout()?.trim_end());
+
+    let output = sandbox.shell("stat -c '%a' /app").await?;
+    println!("/app permissions: {}", output.stdout()?.trim_end());
+
+    // Stop the sandbox gracefully.
+    sandbox.stop_and_wait().await?;
+
+    println!("Sandbox stopped.");
+    Ok(())
+}

--- a/examples/volume-named/bin/main.rs
+++ b/examples/volume-named/bin/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let writer = Sandbox::builder("writer")
         .image("alpine:latest")
         .volume("/data", |v| v.named(data.name()))
-        .overwrite()
+        .replace()
         .create()
         .await?;
 
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reader = Sandbox::builder("reader")
         .image("alpine:latest")
         .volume("/data", |v| v.named(data.name()).readonly())
-        .overwrite()
+        .replace()
         .create()
         .await?;
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -247,7 +247,7 @@ progress_bar() {
     _current_mb=$(( _current / 1048576 ))
     _total_mb=$(( _total / 1048576 ))
 
-    printf "\r    ${DIM}[${RESET}${GREEN}%s${RESET}${DIM}%s${RESET}${DIM}]${RESET} %3d%%  %dMB/%dMB  %s" \
+    printf "\r${DIM}[${RESET}${GREEN}%s${RESET}${DIM}%s${RESET}${DIM}]${RESET} %3d%%  %dMB/%dMB  %s" \
         "$_filled_bar" "$_empty_bar" \
         "$_percent" "$_current_mb" "$_total_mb" "$_label"
 }
@@ -435,7 +435,7 @@ main() {
         printf "\n"
     fi
 
-    success "Installation complete! Run 'msb --help' to get started."
+    success "Installation complete! Run 'msb --tree' to get started."
     printf "\n"
 }
 


### PR DESCRIPTION
## Summary

- Add a rootfs patch system that lets users inject files, symlinks, directories, and appended content into the guest filesystem before VM boot
- Fix TUI afterimage/ghosting artifacts during interactive `attach()` sessions by batching fragmented ExecStdout messages into single terminal writes
- Fix a shared file-description bug where setting O_NONBLOCK on stdin also made stdout non-blocking, truncating large terminal writes
- Overhaul agentd I/O: switch serial reads to try_io guard pattern and PTY reader to blocking spawn_blocking loop to eliminate missed wakeup/HUP edge cases
- Add `msb self update` CLI subcommand, docker_credential registry auth, cached OCI pull fast-path, graceful stop-and-replace for running sandboxes

## Changes

Rootfs patches (`crates/microsandbox/lib/sandbox/patch.rs`, `types.rs`, `mod.rs`):
- New `Patch` enum with variants: `Text`, `File`, `CopyFile`, `CopyDir`, `Symlink`, `Mkdir`, `Remove`, `Append`
- `PatchBuilder` API for ergonomic patch construction from SDK code
- `apply_patches()` writes to the OCI rw/ upper layer for overlay roots and directly for bind roots; errors on block device roots
- Patches run between OCI image resolution and VM spawn in `create_inner()`
- New `examples/rootfs-patch/` example demonstrating the feature

Terminal attach output batching (`crates/microsandbox/lib/sandbox/mod.rs`):
- After receiving the first `ExecStdout` message, drain all immediately-available messages via `try_recv()` and write them before a single `flush()` — coalesces ~4KB output fragments so the terminal processes each TUI re-render atomically
- Replace the O_NONBLOCK-on-fd-0 approach with `open_nonblocking_terminal_input()` that re-opens the controlling terminal via a fresh fd, keeping the original stdin/stdout/stderr blocking
- Add tests verifying shared tty fd flag behavior and that the new approach isolates non-blocking state

Agent I/O (`crates/agentd/lib/agent.rs`, `session.rs`):
- Serial port reads now use `AsyncFd::readable()` + `guard.try_io()` instead of a custom `async_read_ready` helper, for correct edge-triggered readiness
- PTY reader task switched from async `AsyncFd`-based edge-driven reads to a dedicated `spawn_blocking` loop with blocking `libc::read()`, avoiding tail-stranding when fast writers exit before the last wakeup fires
- Graceful shutdown path: `Shutdown` message sends SIGTERM to all sessions then requests guest poweroff via `reboot(RB_POWER_OFF)`

CLI and registry (`crates/cli/`, `crates/image/`):
- New `msb self update` subcommand (`self_cmd.rs`) for in-place binary updates
- `docker_credential` crate added for Docker Hub auth resolution
- `pull_oci_image()` now checks the local cache first and skips registry client construction on cache hit
- `prepare_create_target()` gracefully stops running sandboxes on `--replace` instead of erroring, with `wait_for_pids_to_exit()` + DB status updates
- `Sandbox::remove_persisted()` method for cleanup of ephemeral sandboxes

Other:
- New `examples/net-ports/` example
- Filesystem test coverage additions (overlayfs index, metadata, passthrough create ops)
- Doc updates for lifecycle, networking, and SDK pages
- Note in `vm.rs` that implicit console must remain enabled for disk image boots

## Test Plan

- Run `cargo build` and `cargo test` to verify compilation and existing tests pass
- Run the `rootfs-patch` example to verify patch application: `cargo run --example rootfs-patch`
- Test interactive TUI rendering by running a full-screen TUI app (e.g., Claude Code image) via `msb run` and pressing arrow keys — verify no afterimage artifacts appear on re-render
- Verify `msb run --replace` on a running named sandbox gracefully stops the old sandbox before recreating
- Run `msb self update` to verify the self-update flow