### PR TITLE
feat(docs,sandbox): rewrite docs and rename Patch overwrite to replace

### DIFF
--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -139,6 +139,20 @@ impl SandboxBuilder {
         self
     }
 
+    /// Disable all network access for this sandbox.
+    ///
+    /// Sets the policy to [`NetworkPolicy::none()`](microsandbox_network::policy::NetworkPolicy::none),
+    /// denying all inbound and outbound traffic.
+    ///
+    /// ```ignore
+    /// .disable_network()
+    /// ```
+    #[cfg(feature = "net")]
+    pub fn disable_network(mut self) -> Self {
+        self.config.network.policy = microsandbox_network::policy::NetworkPolicy::none();
+        self
+    }
+
     /// Configure networking via a closure.
     ///
     /// ```ignore
@@ -498,6 +512,21 @@ mod tests {
         assert_eq!(config.network.ports[2].host_port, 5353);
         assert_eq!(config.network.ports[2].guest_port, 53);
         assert_eq!(config.network.ports[2].protocol, PortProtocol::Udp);
+    }
+
+    #[cfg(feature = "net")]
+    #[test]
+    fn test_builder_disable_network_denies_all() {
+        use microsandbox_network::policy::Action;
+
+        let config = SandboxBuilder::new("test")
+            .image("alpine:3.23")
+            .disable_network()
+            .build()
+            .unwrap();
+
+        assert_eq!(config.network.policy.default_action, Action::Deny);
+        assert!(config.network.policy.rules.is_empty());
     }
 
     #[cfg(feature = "net")]

--- a/crates/microsandbox/lib/sandbox/patch.rs
+++ b/crates/microsandbox/lib/sandbox/patch.rs
@@ -57,10 +57,10 @@ async fn apply_one(
             path,
             content,
             mode,
-            overwrite,
+            replace,
         } => {
             let dest = resolve_guest_path(target_dir, path)?;
-            check_overwrite(&dest, lower_layers, path, *overwrite)?;
+            check_replace(&dest, lower_layers, path, *replace)?;
             ensure_parent(&dest).await?;
             fs::write(&dest, content.as_bytes()).await?;
             if let Some(mode) = mode {
@@ -71,10 +71,10 @@ async fn apply_one(
             path,
             content,
             mode,
-            overwrite,
+            replace,
         } => {
             let dest = resolve_guest_path(target_dir, path)?;
-            check_overwrite(&dest, lower_layers, path, *overwrite)?;
+            check_replace(&dest, lower_layers, path, *replace)?;
             ensure_parent(&dest).await?;
             fs::write(&dest, content).await?;
             if let Some(mode) = mode {
@@ -85,34 +85,30 @@ async fn apply_one(
             src,
             dst,
             mode,
-            overwrite,
+            replace,
         } => {
             let dest = resolve_guest_path(target_dir, dst)?;
-            check_overwrite(&dest, lower_layers, dst, *overwrite)?;
+            check_replace(&dest, lower_layers, dst, *replace)?;
             ensure_parent(&dest).await?;
             fs::copy(src, &dest).await?;
             if let Some(mode) = mode {
                 set_permissions(&dest, *mode).await?;
             }
         }
-        Patch::CopyDir {
-            src,
-            dst,
-            overwrite,
-        } => {
+        Patch::CopyDir { src, dst, replace } => {
             let dest = resolve_guest_path(target_dir, dst)?;
-            check_overwrite(&dest, lower_layers, dst, *overwrite)?;
+            check_replace(&dest, lower_layers, dst, *replace)?;
             copy_dir_recursive(src, &dest).await?;
         }
         Patch::Symlink {
             target,
             link,
-            overwrite,
+            replace,
         } => {
             let link_path = resolve_guest_path(target_dir, link)?;
-            check_overwrite(&link_path, lower_layers, link, *overwrite)?;
+            check_replace(&link_path, lower_layers, link, *replace)?;
             ensure_parent(&link_path).await?;
-            // Remove existing if overwrite was allowed and something exists.
+            // Remove existing if replace was allowed and something exists.
             if link_path.exists() {
                 fs::remove_file(&link_path).await.ok();
             }
@@ -180,28 +176,28 @@ fn resolve_guest_path(target_dir: &Path, guest_path: &str) -> MicrosandboxResult
 }
 
 /// Check if a path already exists in the target dir or lower layers.
-/// Returns an error if it exists and `overwrite` is false.
-fn check_overwrite(
+/// Returns an error if it exists and `replace` is false.
+fn check_replace(
     dest: &Path,
     lower_layers: &[PathBuf],
     guest_path: &str,
-    overwrite: bool,
+    replace: bool,
 ) -> MicrosandboxResult<()> {
-    if overwrite {
+    if replace {
         return Ok(());
     }
 
     // Check the target directory (rw layer for OCI, host dir for bind).
     if dest.exists() {
         return Err(crate::MicrosandboxError::PatchFailed(format!(
-            "path already exists in rootfs: '{guest_path}' (set overwrite to allow)"
+            "path already exists in rootfs: '{guest_path}' (set replace to allow)"
         )));
     }
 
     // Check lower layers (OCI image layers).
     if find_in_layers(lower_layers, guest_path).is_some() {
         return Err(crate::MicrosandboxError::PatchFailed(format!(
-            "path exists in image layer: '{guest_path}' (set overwrite to allow)"
+            "path exists in image layer: '{guest_path}' (set replace to allow)"
         )));
     }
 

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -142,7 +142,7 @@ enum MountKind {
 ///   create time.
 ///
 /// By default, patches that target a path already present in the rootfs (lower layers for
-/// OverlayFs, existing files for bind roots) will return an error. Set `overwrite: true` on
+/// OverlayFs, existing files for bind roots) will return an error. Set `replace: true` on
 /// the relevant variant to allow shadowing existing files.
 ///
 /// For `Append` patches targeting a file in a lower layer, the file is first copied up to
@@ -157,8 +157,8 @@ pub enum Patch {
         content: String,
         /// File permissions (e.g., `0o644`). `None` uses the default.
         mode: Option<u32>,
-        /// Allow overwriting a file that already exists in the rootfs.
-        overwrite: bool,
+        /// Allow replacing a file that already exists in the rootfs.
+        replace: bool,
     },
     /// Write raw bytes to a file.
     File {
@@ -168,8 +168,8 @@ pub enum Patch {
         content: Vec<u8>,
         /// File permissions (e.g., `0o644`). `None` uses the default.
         mode: Option<u32>,
-        /// Allow overwriting a file that already exists in the rootfs.
-        overwrite: bool,
+        /// Allow replacing a file that already exists in the rootfs.
+        replace: bool,
     },
     /// Copy a file from host into the rootfs.
     CopyFile {
@@ -179,8 +179,8 @@ pub enum Patch {
         dst: String,
         /// File permissions. `None` preserves source permissions.
         mode: Option<u32>,
-        /// Allow overwriting a file that already exists in the rootfs.
-        overwrite: bool,
+        /// Allow replacing a file that already exists in the rootfs.
+        replace: bool,
     },
     /// Copy a directory from host into the rootfs.
     CopyDir {
@@ -188,8 +188,8 @@ pub enum Patch {
         src: PathBuf,
         /// Absolute guest destination path.
         dst: String,
-        /// Allow overwriting files that already exist in the rootfs.
-        overwrite: bool,
+        /// Allow replacing files that already exist in the rootfs.
+        replace: bool,
     },
     /// Create a symlink.
     Symlink {
@@ -197,8 +197,8 @@ pub enum Patch {
         target: String,
         /// Absolute guest path where the symlink is created.
         link: String,
-        /// Allow overwriting a path that already exists in the rootfs.
-        overwrite: bool,
+        /// Allow replacing a path that already exists in the rootfs.
+        replace: bool,
     },
     /// Create a directory (idempotent — does not error if the directory already exists).
     Mkdir {
@@ -356,13 +356,13 @@ impl PatchBuilder {
         path: impl Into<String>,
         content: impl Into<String>,
         mode: Option<u32>,
-        overwrite: bool,
+        replace: bool,
     ) -> Self {
         self.patches.push(Patch::Text {
             path: path.into(),
             content: content.into(),
             mode,
-            overwrite,
+            replace,
         });
         self
     }
@@ -373,13 +373,13 @@ impl PatchBuilder {
         path: impl Into<String>,
         content: impl Into<Vec<u8>>,
         mode: Option<u32>,
-        overwrite: bool,
+        replace: bool,
     ) -> Self {
         self.patches.push(Patch::File {
             path: path.into(),
             content: content.into(),
             mode,
-            overwrite,
+            replace,
         });
         self
     }
@@ -390,13 +390,13 @@ impl PatchBuilder {
         src: impl Into<PathBuf>,
         dst: impl Into<String>,
         mode: Option<u32>,
-        overwrite: bool,
+        replace: bool,
     ) -> Self {
         self.patches.push(Patch::CopyFile {
             src: src.into(),
             dst: dst.into(),
             mode,
-            overwrite,
+            replace,
         });
         self
     }
@@ -406,12 +406,12 @@ impl PatchBuilder {
         mut self,
         src: impl Into<PathBuf>,
         dst: impl Into<String>,
-        overwrite: bool,
+        replace: bool,
     ) -> Self {
         self.patches.push(Patch::CopyDir {
             src: src.into(),
             dst: dst.into(),
-            overwrite,
+            replace,
         });
         self
     }
@@ -421,12 +421,12 @@ impl PatchBuilder {
         mut self,
         target: impl Into<String>,
         link: impl Into<String>,
-        overwrite: bool,
+        replace: bool,
     ) -> Self {
         self.patches.push(Patch::Symlink {
             target: target.into(),
             link: link.into(),
-            overwrite,
+            replace,
         });
         self
     }

--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -6,7 +6,7 @@ icon: "layer-group"
 
 ## msb pull
 
-Pre-pull an image to the local cache. This avoids pull latency when creating sandboxes later.
+Pre-pull an image to the local cache. Layers are fetched in parallel with per-layer progress bars. Once cached, layers are content-addressable and deduplicated, so shared layers across images are only stored once.
 
 ```bash
 msb pull python:3.11
@@ -14,15 +14,13 @@ msb pull alpine:latest
 msb pull ghcr.io/my-org/my-image:v1
 ```
 
-Per-layer progress bars show download status as layers are fetched in parallel.
-
 | Flag | Description |
 |------|-------------|
 | `-f`, `--force` | Force re-download even if cached |
 | `-q`, `--quiet` | Suppress progress output |
 
 <Tip>
-  Pre-pulling images is especially useful in CI/CD pipelines or when you want sandboxes to start instantly without waiting for an image download.
+  Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.
 </Tip>
 
 ## msb images
@@ -35,7 +33,7 @@ msb images
 
 ## msb image inspect
 
-Show detailed metadata for a cached image.
+Show detailed metadata for a cached image (manifest, layers, config).
 
 ```bash
 msb image inspect python:3.11
@@ -43,7 +41,7 @@ msb image inspect python:3.11
 
 ## msb rmi
 
-Remove a cached image.
+Remove a cached image and its layers (layers shared with other images are kept).
 
 ```bash
 msb rmi python:3.11

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -4,7 +4,7 @@ description: Manage sandboxes from the terminal
 icon: "book"
 ---
 
-The `msb` CLI lets you create, manage, and interact with sandboxes directly from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed.
+The `msb` CLI lets you create, manage, and interact with sandboxes from the terminal. It auto-detects TTY and interactivity, so no `-it` flags are needed. If your terminal is interactive, `msb` acts accordingly.
 
 ## Install
 
@@ -13,7 +13,7 @@ curl -fsSL https://get.microsandbox.dev | sh
 ```
 
 <Note>
-  microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip).
+  microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
 </Note>
 
 ## Quick reference
@@ -51,6 +51,10 @@ msb volume ls
 msb volume rm data
 ```
 
+<Tip>
+  Unnamed sandboxes (no `--name` flag) are ephemeral. They're automatically removed when the command finishes. Named sandboxes persist and can be stopped, restarted, and inspected later.
+</Tip>
+
 ## Global options
 
 | Flag | Description |
@@ -70,7 +74,7 @@ Use `--tree` as an alternative to `--help` to see every command, subcommand, and
 msb --tree
 ```
 
-You can also scope it to a specific subcommand:
+You can scope it to a specific subcommand:
 
 ```bash
 msb image --tree    # Show only image commands

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -6,7 +6,7 @@ icon: "cube"
 
 ## msb run
 
-Create a sandbox and optionally run a command. If no `--name` is given, the sandbox is ephemeral and removed after the command finishes.
+Create a sandbox and optionally run a command. Without `--name`, the sandbox is ephemeral and removed when the command finishes. With `--name`, it persists for later use.
 
 ```bash
 # Ephemeral: runs and cleans up
@@ -50,16 +50,16 @@ When no `--` command is given, the image's `entrypoint` and `cmd` are used as th
 
 ## msb create
 
-Create and boot a sandbox without running a command. Takes the same resource and configuration flags as `msb run`, plus:
-
-| Flag | Description |
-|------|-------------|
-| `--force` | Replace existing sandbox with same name |
+Create and boot a sandbox without running a command. Takes the same flags as `msb run`.
 
 ```bash
 msb create python:3.11 --name worker -c 2 -m 1G
 msb create --force python:3.11 --name worker   # Replace existing
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Replace existing sandbox with same name |
 
 ## msb start
 
@@ -72,8 +72,8 @@ msb start devbox
 ## msb stop
 
 ```bash
-msb stop devbox           # Graceful shutdown (SIGTERM)
-msb stop --force devbox   # Force kill (SIGKILL)
+msb stop devbox           # Graceful shutdown
+msb stop --force devbox   # Force kill
 ```
 
 ## msb exec
@@ -94,7 +94,7 @@ msb exec devbox -- ls -la /app
 
 ## msb shell
 
-Open an interactive shell session inside a sandbox.
+Open an interactive shell session.
 
 ```bash
 msb shell devbox
@@ -103,7 +103,7 @@ msb shell devbox --shell /bin/zsh
 
 ## msb attach
 
-Attach your terminal to the sandbox's main process. Press `Ctrl+]` to detach.
+Attach your terminal to the sandbox's main process. Press `Ctrl+]` to detach without stopping.
 
 ```bash
 msb attach devbox
@@ -120,7 +120,7 @@ msb ls --format json      # JSON output
 
 ## msb inspect
 
-Show detailed configuration and status for a sandbox.
+Show detailed configuration and status.
 
 ```bash
 msb inspect devbox

--- a/docs/cli/volume-commands.mdx
+++ b/docs/cli/volume-commands.mdx
@@ -42,7 +42,7 @@ msb volume rm --force my-data   # Remove even if in use
 
 ## Using volumes with sandboxes
 
-Mount a named volume when creating or running a sandbox:
+Mount a named volume when creating or running a sandbox. The volume name goes before the colon, the guest path after.
 
 ```bash
 # Create a volume, then mount it
@@ -53,3 +53,7 @@ msb run --name worker -v app-data:/data python:3.11
 msb run --name writer -v shared:/data alpine -- sh -c "echo hello > /data/msg.txt"
 msb run --name reader -v shared:/data alpine -- cat /data/msg.txt
 ```
+
+<Tip>
+  The CLI distinguishes bind mounts from named volumes by looking for a `/` or `.` prefix. `./src:/app` is a bind mount (host path). `myvolume:/data` is a named volume. This matches Docker's convention.
+</Tip>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "aspen",
+  "theme": "mint",
   "name": "microsandbox",
   "logo": {
     "light": "/logo/light.svg",

--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -4,19 +4,23 @@ description: Boot from QCOW2, Raw, or VMDK disk images
 icon: "compact-disc"
 ---
 
-In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file using virtio-blk. This is useful when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
+In addition to OCI container images, microsandbox can boot a sandbox directly from a disk image file. The guest gets raw block device access, and its kernel mounts the filesystem from the device directly.
+
+This is a fundamentally different path from OCI images. With OCI, microsandbox stacks image layers as a copy-on-write filesystem. With disk images, the guest owns the block device. No overlay, no copy-on-write between sandboxes.
+
+Use disk images when you need a pre-built VM template, a custom kernel configuration, or an OS that isn't available as a container image.
 
 ## Supported formats
 
 | Format | Description |
 |--------|-------------|
-| **QCOW2** | QEMU Copy-On-Write v2, the most common format. Supports snapshots and thin provisioning |
-| **Raw** | Uncompressed raw disk image |
-| **VMDK** | VMware virtual disk format |
+| **QCOW2** | QEMU Copy-On-Write v2. Supports thin provisioning and backing files. The most common format. |
+| **Raw** | Uncompressed raw disk image. No overhead, but no thin provisioning. |
+| **VMDK** | VMware virtual disk format. |
 
 ## Usage
 
-When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For raw images or when the format can't be inferred, you can specify it explicitly along with the filesystem type.
+When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For ambiguous cases, specify the format and filesystem type explicitly.
 
 <CodeGroup>
 ```rust Rust
@@ -67,5 +71,5 @@ sb2 = await Sandbox.create("custom-vm",
 </CodeGroup>
 
 <Note>
-  Disk images are mounted via virtio-blk, which means the sandbox has raw block device access. The filesystem type must match what's on the disk image.
+  The filesystem type (`ext4`, `xfs`, etc.) must match what's actually on the disk image. The guest kernel mounts it using the specified filesystem driver.
 </Note>

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -4,11 +4,13 @@ description: Use standard container images from any registry
 icon: "layer-group"
 ---
 
-microsandbox uses standard OCI container images as root filesystems. You can pull from Docker Hub, GitHub Container Registry, or any private registry. The same images you already use with Docker work out of the box.
+microsandbox uses standard OCI container images as root filesystems. Docker Hub, GHCR, ECR, GCR, any OCI-compatible registry works. Existing images run as-is.
+
+When you specify an image like `python:3.12`, microsandbox pulls the manifest, downloads the layers in parallel, and stacks them as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. Two sandboxes using the same image share the same cached layers on disk.
 
 ## Pull policies
 
-By default, microsandbox pulls an image only if it isn't already cached locally. You can change this behavior with pull policies.
+By default, microsandbox pulls an image only if it isn't already cached. You can change this behavior.
 
 | Policy | Behavior |
 |--------|----------|
@@ -42,9 +44,13 @@ sb = await Sandbox.create("worker", image="python:3.12", pull_policy=PullPolicy.
 ```
 </CodeGroup>
 
+<Tip>
+  Once an image reference is resolved, microsandbox pins the exact layers. `python:3.12` is resolved to a specific set of immutable layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag moves.
+</Tip>
+
 ## Private registries
 
-Authenticate to private registries by passing credentials when creating a sandbox.
+Authenticate to private registries by passing credentials.
 
 <CodeGroup>
 ```rust Rust
@@ -85,10 +91,10 @@ Images are cached in the global microsandbox home directory:
 | Path | Description |
 |------|-------------|
 | `~/.microsandbox/cache/layers/` | Downloaded and extracted image layers |
-| `~/.microsandbox/db/` | SQLite database tracking image metadata |
+| `~/.microsandbox/db/` | Database tracking image metadata and digests |
 
-Layers are content-addressable and deduplicated, so if two images share a layer, it's only stored once.
+Layers are content-addressable and deduplicated. If `python:3.12` and `python:3.11` share a base layer, it's stored once.
 
 <Tip>
-  Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids pull latency during sandbox creation.
+  Use `msb pull` from the CLI to pre-pull images before creating sandboxes. This avoids blocking on a download during `Sandbox.create`.
 </Tip>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,14 +1,12 @@
 ---
 title: Introduction
-description: Every agent deserves its own machine
+description: Every agent deserves its own computer
 icon: "house"
 ---
 
-When AI agents run, they write code, pull packages from the internet, call tools, and sometimes do things they were never meant to do because of prompt injection. All of that happens with your API keys, on your network, touching your filesystem. Containers can isolate the compute, but they share the host kernel, they can't prevent a secret from leaking over a DNS query, and they don't give you any way to see or control what's happening at the network or filesystem level.
+AI agents run with whatever privileges you give them, and most of the time that's too many. They can see API keys sitting in the environment, reach the network freely (including cloud metadata at `169.254.169.254`), and nothing stops a prompt injection from running `rm -rf /` on the host filesystem. Containers help with some of this, but they share the host kernel, and namespace escapes are a well-documented class of vulnerability.
 
-microsandbox takes a different approach. Every sandbox is a real microVM with its own kernel. The networking and filesystem are programmable from the host, and secrets are protected at the network layer so they can't be exfiltrated even if the guest is compromised.
-
-You can put the agent itself inside a sandbox, give an agent a sandbox it controls through the SDK, or just run the code and tools it uses in isolation.
+microsandbox takes a different approach: every sandbox is a real microVM with its own Linux kernel. But isolation alone isn't the interesting part. What matters is that the networking, filesystem, and secrets are all **programmable from the host side**, so instead of just walling off an agent, you actually get to see and control what it does.
 
 <CodeGroup>
 ```rust Rust
@@ -63,11 +61,19 @@ sb = await Sandbox.create(
 ```
 </CodeGroup>
 
+<Callout icon="bolt" color="#7C3AED">
+  microsandbox spins up lightweight VMs in **under a second**, right from your code on your machine. **No servers, no daemons**, no infrastructure to manage.
+</Callout>
+
 ## What makes it different
 
 ### Secrets that can't leak
 
-The guest never sees real credentials. microsandbox injects random placeholders into environment variables, and only substitutes the real values at the network layer when the request goes to a verified TLS connection on an allowed host. DNS rebinding protection, cloud metadata blocking, and DNS-to-IP binding activate automatically when secrets are configured.
+Most sandboxes protect secrets by restricting what the guest can do. microsandbox goes further: **the guest never has the secret at all**.
+
+Instead of injecting real credentials into the sandbox, microsandbox generates random placeholders. The actual value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to exfiltrate. The credential was never there. DNS rebinding protection and cloud metadata blocking kick in automatically when secrets are configured, closing the remaining side channels.
 
 <CodeGroup>
 ```rust Rust
@@ -104,7 +110,9 @@ sb = await Sandbox.create(
 
 ### Programmable network layer
 
-Every packet leaving a sandbox passes through an in-process networking stack that enforces network policies. You can inspect DNS queries, analyze HTTP traffic, drop packets at the IP level, or build custom data loss prevention. The guest sees a normal network stack. For full control, implement the `NetBackend` trait to handle raw ethernet frames.
+Every packet leaving a sandbox passes through a networking stack controlled entirely from the host side, where policy is enforced at the IP, DNS, or HTTP level. From inside the sandbox it looks like a normal network interface, but on the host side you decide what gets through.
+
+There's no underlying host network to bridge to, no rules to circumvent, and no way for the guest to reach around the filter.
 
 <CodeGroup>
 ```rust Rust
@@ -136,7 +144,7 @@ sb = await Sandbox.create(
 
 ### Extensible filesystem backends
 
-Mount custom filesystem implementations into any sandbox. Intercept reads and writes with hooks, build virtual filesystems, or proxy to remote storage. microsandbox provides a POSIX-compatible `DynFileSystem` trait and built-in backends for passthrough, overlay, in-memory, and proxy filesystems. All with zero-copy I/O.
+The host controls what the guest sees at the filesystem level. Mount host directories, use managed volumes, or attach custom filesystem backends entirely. Hooks let you intercept reads and writes to do things like encrypt everything going to disk or proxy to remote storage, and the guest never knows the difference.
 
 <CodeGroup>
 ```rust Rust
@@ -180,9 +188,9 @@ sb = await Sandbox.create(
 ```
 </CodeGroup>
 
-### Snapshot, fork, restore
+### Snapshot, fork, restore <sup>coming soon</sup>
 
-Capture the full VM state (memory, CPU registers, filesystem) at any point. Then fork hundreds of identical sandboxes from that single baseline with sub-millisecond restore and no re-boot. Install your dependencies once, snapshot, and fork workers on demand. Each fork gets a copy-on-write filesystem overlay, and you can override memory, CPUs, or environment variables per fork.
+Take a snapshot of a running sandbox (full VM state, memory, filesystem, everything) and fork hundreds of identical copies from that single baseline. Install dependencies once, snapshot, then spin up workers that skip the entire setup phase. Each fork gets its own copy-on-write filesystem and can override memory, CPUs, or environment variables.
 
 <CodeGroup>
 ```rust Rust
@@ -234,7 +242,7 @@ Extend microsandbox with in-process Rust plugins or out-of-process plugins in an
 
 ### Bidirectional events
 
-Guest processes can emit typed events to the host via `/run/agent.sock`, and the host can send events back. No special libraries required in the guest since any language can write JSON to a Unix socket. This enables structured communication beyond stdin/stdout, like progress reporting, task completion signals, or custom RPC.
+Guest processes can emit typed events to the host, and the host can send events back. No special libraries required in the guest since any language can write JSON to a socket. This enables structured communication beyond stdin/stdout, like progress reporting, task completion signals, or custom RPC.
 
 <CodeGroup>
 ```rust Rust
@@ -279,14 +287,12 @@ await sb.emit("task.start", {
 
 ## The basics
 
-On top of all this, microsandbox handles the fundamentals well:
-
-- **Under 200ms boot.** libkrun microVMs, not QEMU. Pre-patched kernel loaded as a shared library. Zero-copy mmap.
-- **No daemon.** The runtime embeds directly into your application. No root process, no socket, no background service.
-- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Your existing images work.
-- **Cross-platform.** Native on macOS and Linux. Same CLI, same SDKs, same Sandboxfile.
-- **Multi-language SDKs.** Rust, TypeScript, and Python with consistent APIs across all of them.
-- **Declarative projects.** Define multi-sandbox environments in a `Sandboxfile` with per-sandbox secrets, network policies, dependency ordering, and scripts. Think Compose, but for microVMs.
+- **Under 100ms boot.** Sandboxes share the same kernel in memory. No QEMU, no disk images to load.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root process, no socket, no background service.
+- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
+- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
+- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
+- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
 
 ## Next steps
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -34,12 +34,12 @@ icon: "bolt"
     ```
 
     <Note>
-      microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip).
+      microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
     </Note>
   </Step>
 
   <Step title="Run code in a sandbox">
-    Create a sandbox, execute code inside it, and get the result back in just a few lines.
+    Create a sandbox, execute code inside it, and get the result back.
 
     <CodeGroup>
     ```rust Rust
@@ -97,17 +97,22 @@ icon: "bolt"
 
 ## What just happened?
 
-When you called `Sandbox.create`, microsandbox:
+Here's what actually happened behind that `Sandbox.create` call:
 
-1. Pulled the `python:3.12` image from Docker Hub (if not already cached)
-2. Booted a microVM with its own Linux kernel, capped at 512 MiB
-3. Mounted the image layers as a copy-on-write filesystem
-4. Started the guest agent (`agentd`) inside the VM to accept commands
+1. **Pulled the image** from Docker Hub (or skipped this if it was already cached, since shared layers are deduplicated).
+2. **Assembled the filesystem** by stacking the image layers into a copy-on-write filesystem, so nothing you do inside the sandbox modifies the base image.
+3. **Booted a microVM** as a child process. The 512 MiB you specified is a limit, not a reservation, so the VM only uses what it actually needs.
+4. **Started the guest agent** inside the VM, which set up the environment and opened a communication channel back to the host.
 
-When you called `exec`, the SDK sent a command to the guest agent over a virtio-console channel, which spawned the process inside the VM and streamed the output back.
+The `exec` call sent a message to that guest agent, which spawned `python` inside the VM, streamed stdout back, and returned the exit code. No SSH involved, no network overhead. The command channel is completely separate from the sandbox's network stack.
+
+<Tip>
+  Because exec doesn't go through the network, it works even when a sandbox has networking disabled via `.disable_network()` and no network interfaces at all.
+</Tip>
 
 ## Next steps
 
-- [Understand sandbox configuration](/sandboxes/overview): images, resources, volumes, and networking
+- [Understand sandbox configuration](/sandboxes/overview): how the VM, filesystem, and networking fit together
 - [Run commands and stream output](/sandboxes/commands): `exec`, `shell`, `attach`, and streaming
+- [Control network access](/sandboxes/networking): policies, DNS interception, and secret protection
 - [Manage sandboxes with the CLI](/cli/overview): create, inspect, and manage sandboxes from the terminal

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -4,7 +4,9 @@ description: Execute commands, stream output, and interact with sandboxes
 icon: "terminal"
 ---
 
-Once a sandbox is running, you can execute commands inside it, stream their output in real time, or attach an interactive terminal session. All communication happens over a virtio-console channel between the host and the guest agent, with no SSH or network overhead.
+Command execution doesn't use SSH or the network. There's a dedicated channel between the host and a guest agent running inside the VM, completely separate from the sandbox's network stack. The agent spawns processes, streams output back, and reports exit codes.
+
+One nice consequence: `exec` works even when a sandbox has networking fully disabled.
 
 ## Execute a command
 
@@ -34,7 +36,7 @@ print(output.status.success)   # True
 
 ## Execution options
 
-You can override the working directory, set environment variables, apply resource limits, and set a timeout, all on a per-command basis.
+These options apply to a single execution and don't change the sandbox's defaults.
 
 <CodeGroup>
 ```rust Rust
@@ -71,7 +73,7 @@ output = await sb.exec(
 
 ## Shell commands
 
-Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines and shell syntax.
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
 
 <CodeGroup>
 ```rust Rust
@@ -89,7 +91,7 @@ output = await sb.shell("ls -la /app && echo done")
 
 ## Stream output
 
-For long-running processes or large output, use streaming to get events as they happen instead of waiting for the command to finish.
+For long-running processes or large output, streaming gives you stdout, stderr, and exit events as they happen instead of buffering everything until the command finishes.
 
 <CodeGroup>
 ```rust Rust
@@ -133,7 +135,7 @@ async for event in handle.events():
 
 ## Interactive attach
 
-Bridge your terminal directly to a process running inside the sandbox. This gives you a fully interactive PTY session, useful for debugging or running interactive tools like shells, REPLs, or editors.
+Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
 
 <CodeGroup>
 ```rust Rust
@@ -162,12 +164,12 @@ await sb.attach("bash", env={"DEBUG": "1"}, cwd="/app", detach_keys="ctrl-q")
 </CodeGroup>
 
 <Tip>
-  Press `Ctrl+]` (or your configured detach keys) to detach from the session without stopping the process.
+  Press `Ctrl+]` (or your configured detach keys) to detach from the session without stopping the process. The process keeps running inside the VM and you can reattach later via its session ID.
 </Tip>
 
 ## Write stdin
 
-When streaming, you can pipe data into the process's stdin.
+Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to it. Combined with `tty: true`, this lets you drive interactive processes programmatically.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/filesystem.mdx
+++ b/docs/sandboxes/filesystem.mdx
@@ -4,9 +4,9 @@ description: Read and write files inside a running sandbox
 icon: "folder-open"
 ---
 
-You can read, write, and manage files inside a sandbox without mounting volumes or using SSH. The filesystem API communicates directly with the guest agent over a virtio-console channel, giving you programmatic access to the guest filesystem from the host.
+The filesystem API lets you read, write, and manage files inside a sandbox without mounting volumes or SSH. It uses the same channel as command execution, so it doesn't touch the sandbox's network.
 
-This is particularly useful for AI agent workflows where you need to write generated code into the sandbox, read back results, or inspect logs.
+Handy for pushing generated code into a sandbox, pulling back results, or inspecting logs without having to pre-mount a shared directory.
 
 ## Write a file
 
@@ -68,7 +68,7 @@ for entry in entries:
 
 ## Stream large files
 
-For files that are too large to read into memory at once, use streaming. Chunks are transferred at approximately 3 MiB granularity.
+For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
 
 <CodeGroup>
 ```rust Rust
@@ -108,3 +108,7 @@ await sb.fs.copyFromHost("./local-file.txt", "/app/remote-file.txt")
 await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
 ```
 </CodeGroup>
+
+<Tip>
+  If you need to transfer many files at once, consider using a [bind-mounted volume](/sandboxes/volumes) instead. Volumes give the guest direct filesystem access, whereas the filesystem API transfers each file individually. For bulk operations, volumes are significantly faster.
+</Tip>

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -4,7 +4,9 @@ description: Create, start, stop, and manage sandbox state
 icon: "rotate"
 ---
 
-Sandboxes move through a simple set of states. Understanding the lifecycle helps you manage long-running sandboxes, implement graceful shutdown, and build resilient agent workflows.
+Each sandbox runs as a child process of whatever application creates it. `Sandbox.create` boots a microVM, starts the guest agent inside it, and establishes a communication channel back to the host.
+
+Understanding the lifecycle is useful once you start managing long-running sandboxes, graceful shutdown, or resilient agent workflows.
 
 ```mermaid
 stateDiagram-v2
@@ -25,23 +27,23 @@ stateDiagram-v2
 
 | Status | Description |
 |--------|-------------|
-| **Creating** | The VM is booting and the filesystem is being prepared |
-| **Running** | The VM is up and the guest agent is ready to accept commands |
-| **Paused** | All processes are frozen. No CPU usage. Resumes instantly |
-| **Draining** | Graceful shutdown is in progress. Existing commands finish, but new ones are rejected |
-| **Stopped** | The VM has shut down. State is preserved on disk and can be restarted |
-| **Crashed** | The VM exited unexpectedly |
+| **Creating** | The VM is booting. The kernel is loaded, the filesystem is mounted, and the guest agent is initializing (configuring network, setting up the environment). |
+| **Running** | The guest agent is ready. You can call `exec`, `shell`, `fs`, and `emit`. |
+| **Paused** | All guest processes are frozen. No CPU cycles consumed. Resume is instant with no re-boot or re-init. |
+| **Draining** | Graceful shutdown in progress. Existing commands run to completion, but new `exec` calls are rejected. Transitions to Stopped when all commands finish. |
+| **Stopped** | The VM has shut down. Sandbox configuration and state are persisted to the database and can be restarted. |
+| **Crashed** | The VM exited unexpectedly (e.g., kernel panic, OOM kill). |
 
 ## Create a sandbox
 
-Creating a sandbox boots the microVM, mounts the filesystem, and starts the guest agent. Once creation completes, the sandbox is `Running` and ready for commands.
+Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands.
 
 <CodeGroup>
 ```rust Rust
-// Attached
+// Attached: sandbox stops when your process exits
 let sb = Sandbox::builder("worker").image("python:3.12").create().await?;
 
-// Detached
+// Detached: sandbox survives after your process exits
 let sb = Sandbox::builder("worker").image("python:3.12").create_detached().await?;
 ```
 
@@ -60,7 +62,7 @@ sb = await Sandbox.create("worker", image="python:3.12")
 
 ## Stop and restart
 
-Stopping sends a graceful shutdown signal to the guest agent. The sandbox moves to `Stopped` and can be restarted later with all its state preserved.
+Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
 
 <CodeGroup>
 ```rust Rust
@@ -85,7 +87,7 @@ sb = await Sandbox.start("worker")
 
 ## Kill immediately
 
-If a sandbox is unresponsive, you can force-kill it with SIGKILL. This is instant but doesn't give the guest a chance to clean up.
+If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
 
 <CodeGroup>
 ```rust Rust
@@ -103,7 +105,7 @@ await sb.kill()
 
 ## Pause and resume
 
-Freeze all processes in a sandbox without shutting it down. The VM stays in memory but uses no CPU. Resume is instant with no boot time.
+Freeze all guest processes without shutting down. The VM uses zero CPU while paused, and resume is instant. The guest continues exactly where it left off with no boot time and no re-init.
 
 <CodeGroup>
 ```rust Rust
@@ -125,7 +127,7 @@ await sb.resume()
 
 ## Detach
 
-Keep a sandbox running after your process exits. Useful for long-running agents or background workers.
+Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
 
 <CodeGroup>
 ```rust Rust
@@ -141,9 +143,13 @@ await sb.detach()
 ```
 </CodeGroup>
 
+<Tip>
+  Detached sandboxes are tracked at `~/.microsandbox/db/`. A background reaper periodically checks for stale sandboxes that have exited unexpectedly and cleans up their records.
+</Tip>
+
 ## Drain
 
-Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and eventually to `Stopped`.
+Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
 
 <CodeGroup>
 ```rust Rust
@@ -205,22 +211,22 @@ for info in sandboxes:
 
 ## Runtime process architecture
 
-When you create a sandbox, a few things start running behind the scenes. Here's what runs where and how they talk to each other.
+Here's what's running and how the pieces talk to each other.
 
 ```mermaid
 graph TD
     subgraph Host["Host"]
-        A["Your Application<br/><small>microsandbox library, AgentBridge</small>"]
-        B["Sandbox Process<br/><small>msb sandbox<br/>VMM + relay + lifecycle</small>"]
+        A["Your Application<br/><small>microsandbox SDK</small>"]
+        B["Sandbox Process<br/><small>VM + networking + lifecycle</small>"]
     end
 
     subgraph Guest["Guest VM"]
-        F["agentd (PID 1)<br/><small>exec, fs, events</small>"]
+        F["agentd<br/><small>exec, fs, events</small>"]
     end
 
     A -- "spawn" --> B
-    B -- "Vm::enter()" --> F
-    A -. "Unix socket -> relay -> virtio-console (CBOR)" .-> F
+    B -- "boot" --> F
+    A -. "commands & responses" .-> F
 
     style Host fill:#f5f0ff,stroke:#a770ef,color:#333
     style Guest fill:#fef4e8,stroke:#e8a838,color:#333
@@ -229,28 +235,25 @@ graph TD
     style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
 ```
 
-There are two separate layers here. Your application talks to the host-side sandbox process over the agent relay socket, and the sandbox process forwards CBOR-encoded messages to the guest agent (`agentd`) over virtio-console. This is how `exec`, `attach`, `fs`, and `emit` calls work.
+There are two layers here. The **sandbox process** runs the VM and the networking stack on the host side, and relays messages between the application and the **guest agent** inside the VM. Up to 16 clients can connect to the same sandbox simultaneously.
 
-The **sandbox process** is the host-side runtime process created by `msb sandbox`. It hosts the VMM and handles:
+The sandbox process also handles:
 
-- Forwarding signals (SIGTERM for graceful stop, SIGUSR1 for drain)
-- Driving VM exit and shutdown policies
-- Monitoring idle state via the agentd heartbeat
-- Enforcing maximum sandbox lifetime
-- Writing logs and updating sandbox status in the database
+- Graceful stop and drain signals
+- Cleanup when the sandbox exits
+- Idle detection (auto-drain after a configurable timeout)
+- Maximum sandbox lifetime enforcement
 
-The sandbox process does *not* execute guest commands itself. It relays agent protocol traffic between your application and `agentd`.
+The sandbox process does not execute guest commands itself. It only relays traffic between your application and the guest agent.
 
 ## Sandbox Process Policies
 
-For production workloads, you can configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
 
 <CodeGroup>
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python:3.12")
-    .shutdown_mode(ShutdownMode::Terminate)
-    .grace_period(30)
     .max_duration(3600)
     .idle_timeout(300)
     .create()
@@ -261,21 +264,17 @@ let sb = Sandbox::builder("worker")
 const sb = await Sandbox.create({
     name: "worker",
     image: "python:3.12",
-    shutdownMode: ShutdownMode.Graceful, // Graceful → Terminate → Kill escalation
-    gracePeriod: 30,    // seconds between escalation steps
     maxDuration: 3600,  // maximum sandbox lifetime in seconds
     idleTimeout: 300,   // auto-drain after 5 minutes of inactivity
 })
 ```
 
 ```python Python
-from microsandbox import Sandbox, ShutdownMode
+from microsandbox import Sandbox
 
 sb = await Sandbox.create(
     "worker",
     image="python:3.12",
-    shutdown_mode=ShutdownMode.TERMINATE,
-    grace_period=30,
     max_duration=3600,
     idle_timeout=300,
 )

--- a/docs/sandboxes/networking.mdx
+++ b/docs/sandboxes/networking.mdx
@@ -4,13 +4,13 @@ description: Control network access and isolation
 icon: "network-wired"
 ---
 
-By default, sandboxes use a `public` network policy, which means they can reach the public internet but not private address ranges. You can change this to fully isolate a sandbox, restrict it to specific hosts, or allow unrestricted access. This is critical for AI agent workflows where you need to allow API calls to specific services while blocking everything else.
+All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere.
 
-microsandbox enforces network policies using an in-process networking stack that handles packet filtering, port forwarding, and DNS interception.
+The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
 
 ## Network presets
 
-The simplest way to configure networking is with presets that cover common scenarios.
+The simplest way to configure networking. `public_only` is the default.
 
 <CodeGroup>
 ```rust Rust
@@ -79,9 +79,9 @@ sb4 = await Sandbox.create("scoped-agent", image="python:3.12",
 
 ## Port mapping
 
-Expose ports from the sandbox to the host to make services accessible.
-In Rust, `SandboxBuilder::port()` and `port_udp()` are top-level shorthands,
-so you can publish ports without nesting everything inside `.network(...)`.
+Expose ports from the sandbox to the host so services running inside the VM are accessible from your machine.
+
+In Rust, `SandboxBuilder::port()` and `port_udp()` are top-level shorthands, so you can publish ports without nesting everything inside `.network(...)`.
 
 <CodeGroup>
 ```rust Rust
@@ -121,7 +121,11 @@ sb = await Sandbox.create(
 
 ## DNS interception
 
-microsandbox can intercept DNS queries from sandboxes to block specific domains or prevent DNS rebinding attacks.
+DNS queries from the guest are intercepted and resolved on the host side, which opens up a few useful controls:
+
+- **Domain blocking** by exact match or suffix (e.g. `*.tracking.com`).
+- **Rebinding protection**: if a DNS response resolves to a private IP (`10.x`, `172.16.x`, `192.168.x`, `127.x`, link-local), the query is blocked. This prevents the trick where an attacker registers a public domain that points to an internal service.
+- **DNS-to-IP binding**: when secrets are configured, domains can be pinned to the IPs they resolved to, preventing TOCTOU attacks where DNS changes between the policy check and the actual connection.
 
 <CodeGroup>
 ```rust Rust
@@ -166,15 +170,11 @@ sb = await Sandbox.create(
 ```
 </CodeGroup>
 
-<Note>
-  DNS interception is handled by the in-process networking stack that runs alongside the sandbox's microVM. It handles both DNS queries and packet-level policy enforcement.
-</Note>
-
 ## How it works
 
-When networking is enabled, microsandbox runs an in-process networking stack alongside each sandbox's microVM. Network traffic from the sandbox passes through this stack, which enforces packet filtering rules based on the configured policy:
+Policy rules are evaluated first-match-wins. Allowed traffic goes to the real network; everything else is dropped.
 
-- **`none`:** No network interfaces are created. The sandbox is completely isolated.
-- **`public_only`:** Traffic to private address ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) is blocked. Only public internet is accessible. This is the default.
-- **`allow_all`:** No filtering. The sandbox can reach any address.
-- **`allowlist`** / **`denylist`:** Fine-grained control over which hosts the sandbox can communicate with.
+- **`none`**: no network interface at all. The guest is fully offline, though `exec` and `fs` still work since they don't use the network.
+- **`public_only`**: blocks private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) and only allows routable public addresses. This is the default.
+- **`allow_all`**: no filtering, including access to the host machine and local network.
+- **`allowlist`** / **`denylist`**: fine-grained per-host control.

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -4,13 +4,13 @@ description: What sandboxes are and how to configure them
 icon: "circle-info"
 ---
 
-A sandbox is a lightweight microVM: a real virtual machine with its own Linux kernel, filesystem, and network stack. You create one from a container image, run code inside it, and tear it down when you're done. Each sandbox is fully isolated from the host and from other sandboxes.
+A sandbox is a microVM: a real virtual machine with its own Linux kernel, filesystem, and network stack, running as a child process of whatever application creates it.
 
-Unlike containers, which share the host kernel and rely on namespace isolation, microsandbox gives every sandbox its own kernel. This means an escape from a sandbox would require exploiting a KVM hypervisor vulnerability, which is a fundamentally harder attack than a container breakout.
+The security boundary here is hardware virtualization, not Linux namespaces. Container escapes are a well-documented class of vulnerability; breaking out of a microVM requires exploiting the hypervisor itself, which is a fundamentally harder problem.
 
 ## Creating a sandbox
 
-At minimum, a sandbox needs a name and an image. Everything else has sensible defaults.
+At minimum, a sandbox needs a name and an image. Everything else has sensible defaults: 1 vCPU, 512 MiB memory, public-only networking, `/bin/sh` as the shell.
 
 <CodeGroup>
 ```rust Rust
@@ -34,8 +34,6 @@ sb = await Sandbox.create("worker", image="python:3.12")
 </CodeGroup>
 
 ## Configuration options
-
-You can customize CPU, memory, environment variables, working directory, shell, and more.
 
 <CodeGroup>
 ```rust Rust
@@ -100,16 +98,16 @@ sb = await Sandbox.create(
 | `scripts` | `{}` | Named scripts stored at `/.msb/scripts/` |
 
 <Tip>
-  The `cpus` and `memory` values are limits, not reservations. A sandbox with `memory: 512` doesn't hold 512 MiB at all times. It only uses what it actually needs, up to that limit. This means you can run many sandboxes on a single host without overcommitting resources.
+  `cpus` and `memory` are **limits, not reservations**. Setting `memory: 512` doesn't allocate 512 MiB upfront. Physical pages are only allocated as the guest actually touches them, so you can comfortably run many sandboxes on a single host without worrying about overcommitting.
 </Tip>
 
 ## Rootfs sources
 
-microsandbox supports three ways to provide a root filesystem for a sandbox.
+microsandbox supports three ways to provide a root filesystem. The choice affects how the filesystem is assembled and what features are available.
 
 ### OCI images
 
-The most common option. Pull any image from any container registry.
+The most common option. microsandbox pulls the image and stacks its layers as a copy-on-write filesystem. Changes inside the sandbox don't modify the base image. If two sandboxes use the same image, they share the same cached layers on disk.
 
 <CodeGroup>
 ```rust Rust
@@ -127,7 +125,7 @@ await Sandbox.create("worker", image="python:3.12")
 
 ### Bind mounts
 
-Use a local directory on the host as the root filesystem directly.
+Use a local directory on the host as the root filesystem directly. The guest sees the directory contents as its `/`. This is useful for development when you have a pre-built rootfs, or for minimal environments where you've assembled the filesystem yourself.
 
 <CodeGroup>
 ```rust Rust
@@ -143,9 +141,13 @@ await Sandbox.create("worker", image="./my-rootfs")
 ```
 </CodeGroup>
 
+<Note>
+  The guest agent is automatically included in the rootfs during sandbox creation, regardless of rootfs source. You don't need to add anything to your image or directory.
+</Note>
+
 ### Disk images
 
-Boot from a QCOW2, Raw, or VMDK disk image via virtio-blk. See [Disk Images](/images/disk-images) for details.
+Boot from a QCOW2, Raw, or VMDK disk image. Unlike OCI images (which use a copy-on-write overlay), disk images give the guest raw block device access. See [Disk Images](/images/disk-images) for details.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -4,11 +4,13 @@ description: Persist and share data across sandboxes
 icon: "hard-drive"
 ---
 
-Volumes let you persist data across sandbox restarts, share data between sandboxes, and mount host directories into the guest. microsandbox supports three types of mounts: bind mounts, named volumes, and tmpfs.
+Volumes give a sandbox direct filesystem access to host-side directories. They're useful for persisting data across restarts, sharing data between sandboxes, or mounting host directories into the guest. They're also significantly faster than the [filesystem API](/sandboxes/filesystem) (which transfers files individually), so for anything beyond ad-hoc reads and writes, volumes are the way to go.
+
+microsandbox supports three types of mounts: bind mounts, named volumes, and tmpfs.
 
 ## Bind mounts
 
-Mount a directory from the host machine directly into the sandbox. Changes made inside the sandbox are reflected on the host, and vice versa.
+Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
 
 <CodeGroup>
 ```rust Rust
@@ -45,7 +47,7 @@ sb = await Sandbox.create(
 
 ## Named volumes
 
-Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox and can be shared between multiple sandboxes.
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox, so you can create a volume, populate it, and mount it into different sandboxes over time.
 
 ### Create a volume
 
@@ -99,7 +101,7 @@ sb = await Sandbox.create(
 
 ### Share between sandboxes
 
-Named volumes are the simplest way to share data between sandboxes. One sandbox writes, another reads.
+Named volumes are the simplest way to share data between sandboxes. Mount the same volume into multiple sandboxes: one writes, another reads.
 
 <CodeGroup>
 ```rust Rust
@@ -158,9 +160,13 @@ output = await reader.exec("cat", ["/data/message.txt"])
 ```
 </CodeGroup>
 
+<Tip>
+  When sharing volumes between sandboxes, both sandboxes access the same underlying host directory. There's no built-in locking, so if two sandboxes write to the same file concurrently, you'll get the usual race conditions. Use the read-only flag on the reader side to make intent explicit.
+</Tip>
+
 ### Host-side access
 
-You can read and write files in a named volume from the host without a running sandbox.
+Named volumes are accessible from the host even without a running sandbox, which is handy for pre-populating data before any sandbox mounts it.
 
 <CodeGroup>
 ```rust Rust
@@ -201,7 +207,7 @@ await Volume.remove("old-cache")
 
 ## Tmpfs
 
-An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space that doesn't need to persist.
+An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space, build artifacts, or anything that doesn't need to outlive the sandbox.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -4,7 +4,7 @@ description: Typed errors and resource cleanup patterns
 icon: "triangle-exclamation"
 ---
 
-Each SDK surfaces typed errors so you can match on specific failure modes. Rust uses an `Error` enum, TypeScript uses a `MicrosandboxError` class with a `type` discriminant, and Python uses an exception hierarchy.
+All three SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript has `MicrosandboxError` with a `type` discriminant, and Python uses an exception hierarchy.
 
 ## Matching errors
 
@@ -92,7 +92,7 @@ except MicrosandboxError as e:
 
 ## Resource cleanup
 
-Sandboxes hold compute resources that should be released when no longer needed. In Rust, the `Drop` trait handles cleanup automatically. In TypeScript and Python, use `try`/`finally` or context managers.
+Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript and Python, use `try`/`finally` or context managers.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/events.mdx
+++ b/docs/sdk/events.mdx
@@ -4,7 +4,9 @@ description: Bidirectional host-guest communication
 icon: "tower-broadcast"
 ---
 
-The events API lets the host and guest exchange typed messages over a Unix domain socket. The host subscribes to named events from the guest and emits events into the guest, all without polling or SSH.
+The events API is for structured communication between host and guest beyond stdin/stdout. The host can subscribe to named events from the guest and emit events back, all through the same channel used by `exec`.
+
+On the guest side, processes just write JSON to `/run/agent.sock`, which is a standard Unix domain socket. No special library needed. Any language that can open a socket and write a newline-delimited JSON message will work.
 
 ## Receive events from guest
 
@@ -85,14 +87,12 @@ await sb.emit("task.start", {
 ```
 </CodeGroup>
 
-## Guest socket
+## Guest-side emitting
 
-Guest processes communicate with the host by connecting to `/run/agent.sock` inside the sandbox. This is a standard Unix domain socket, so no special library is needed. Any language that can open a socket and write JSON can emit events.
-
-For example, a Python script running inside the guest can send a progress event:
+Inside the guest, any process can emit events by writing JSON to the Unix domain socket at `/run/agent.sock`. No SDK required.
 
 ```python
-# Inside the guest -- plain Python, no SDK required
+# Inside the guest, plain Python, no SDK
 import json, socket
 
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/docs/sdk/execution.mdx
+++ b/docs/sdk/execution.mdx
@@ -4,6 +4,8 @@ description: Run commands, stream output, and interact with sandboxes
 icon: "terminal"
 ---
 
+Command execution goes through a dedicated channel between the host and the guest agent, not the network. So `exec` works even when a sandbox has networking fully disabled.
+
 ## exec
 
 Run a command and collect stdout, stderr, and the exit code once it completes.
@@ -30,7 +32,7 @@ print(output.status.code)      # 0
 
 ## shell
 
-Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax.
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
 
 <CodeGroup>
 ```rust Rust
@@ -51,7 +53,7 @@ print(output.stdout.decode())
 
 ## Execution options
 
-Override the working directory, environment variables, resource limits, and timeout on a per-command basis.
+Per-execution overrides for working directory, environment variables, resource limits, and timeout. These don't change the sandbox's defaults.
 
 <CodeGroup>
 ```rust Rust
@@ -92,7 +94,7 @@ output = await sb.exec(
 
 ## Streaming
 
-Use `exec_stream` to receive stdout, stderr, and exit events as they happen instead of waiting for the command to finish.
+`exec_stream` returns a handle that emits stdout, stderr, and exit events as they happen. Output shows up the moment the guest agent reads it from the process.
 
 <CodeGroup>
 ```rust Rust
@@ -141,7 +143,7 @@ async for event in handle.events():
 
 ## Interactive stdin
 
-Pipe data into a running process by opening a streaming handle with `stdin_pipe` enabled.
+Pipe data into a running process by opening a streaming handle with `stdin_pipe` enabled. Combined with `tty: true`, this lets you drive interactive processes (REPLs, shells) programmatically.
 
 <CodeGroup>
 ```rust Rust
@@ -169,7 +171,7 @@ await handle.wait()
 
 ## Attach
 
-Bridge your terminal to a fully interactive PTY session inside the sandbox. Press the detach keys (default `Ctrl+]`) to disconnect without stopping the process.
+Bridge your terminal to a fully interactive PTY session inside the sandbox. Press the detach keys (default `Ctrl+]`) to disconnect without stopping the process. The process keeps running and can be reattached via its session ID.
 
 <CodeGroup>
 ```rust Rust
@@ -203,7 +205,7 @@ await sb.attach("bash", env={"DEBUG": "1"}, cwd="/app", detach_keys="ctrl-q")
 
 ## Sessions
 
-List background processes and reattach to them by session ID.
+Each streaming exec or attach creates a session. You can list active sessions and reattach to them by ID. Up to 16 simultaneous client connections are supported, so multiple sessions can run concurrently without interfering with each other.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/filesystem.mdx
+++ b/docs/sdk/filesystem.mdx
@@ -4,9 +4,11 @@ description: Read, write, and manage files inside sandboxes
 icon: "folder-open"
 ---
 
-## Write a file
+The filesystem API uses the same channel as command execution. No SSH, no network involved.
 
-Write string or binary content to a path inside the sandbox.
+For bulk operations or ongoing file access, [volumes](/sdk/volumes) are significantly faster since they give the guest direct filesystem access. The filesystem API is better suited for ad-hoc work: pushing generated code into a sandbox, pulling back results, checking logs.
+
+## Write a file
 
 <CodeGroup>
 ```rust Rust
@@ -24,8 +26,6 @@ await sb.fs.write("/app/config.json", '{"debug": true}')
 
 ## Read a file
 
-Read the entire contents of a file as a string.
-
 <CodeGroup>
 ```rust Rust
 let content = sb.fs().read_to_string("/app/config.json").await?;
@@ -41,8 +41,6 @@ content = await sb.fs.read_string("/app/config.json")
 </CodeGroup>
 
 ## List a directory
-
-Enumerate entries in a directory, returning each entry's path and kind (file, directory, symlink, etc.).
 
 <CodeGroup>
 ```rust Rust
@@ -68,7 +66,7 @@ for entry in entries:
 
 ## Stream large files
 
-For files too large to read into memory at once, stream them in chunks.
+For files too large to fit in memory, stream them in chunks (~3 MiB each).
 
 <CodeGroup>
 ```rust Rust
@@ -95,7 +93,7 @@ async for chunk in sb.fs.read_stream("/app/data.bin"):
 
 ## Copy from host
 
-Copy a file from the host machine into the sandbox in a single call.
+Copy a file from the host into the sandbox in a single call.
 
 <CodeGroup>
 ```rust Rust
@@ -113,11 +111,11 @@ await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
 
 ## Extensible backends
 
-The default filesystem backend handles most use cases automatically. For advanced scenarios, you can attach hooks to intercept reads and writes, or implement a full custom backend.
+The default filesystem backends handle most use cases. For advanced scenarios, you can attach hooks to intercept operations on a volume, or implement a full custom backend.
 
 ### Hooks
 
-Intercept file operations on a volume without replacing the entire backend. Hooks receive the path and data, and return transformed data.
+Intercept file reads and writes on a volume without replacing the entire backend. Hooks receive the path and data, and return transformed data. The underlying filesystem handles everything else (permissions, directories, metadata).
 
 <CodeGroup>
 ```rust Rust
@@ -171,7 +169,7 @@ sb = await Sandbox.create(
 
 ### Custom backend
 
-For full control, implement the `FsBackend` trait (Rust), class (TypeScript), or protocol (Python) and pass it as the volume backend.
+For full control, implement the `FsBackend` trait (Rust), class (TypeScript), or protocol (Python). This gives you access to every POSIX operation: `read`, `write`, `lookup`, `getattr`, `readdir`, etc. You can delegate to a built-in backend (like `PassthroughFs`) for operations you don't need to customize.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/metrics.mdx
+++ b/docs/sdk/metrics.mdx
@@ -4,7 +4,7 @@ description: Monitor sandbox resource usage
 icon: "chart-line"
 ---
 
-Retrieve a point-in-time snapshot of resource usage, or open a streaming subscription that delivers updates at a fixed interval.
+Query resource usage for a running sandbox: CPU, memory, and more. Get a single point-in-time snapshot, or open a streaming subscription that delivers updates at a fixed interval.
 
 ## Point-in-time
 
@@ -28,6 +28,8 @@ print(f"CPU: {m.cpu_percent:.1f}%, Mem: {m.memory_bytes // 1024 // 1024} MB")
 </CodeGroup>
 
 ## Streaming
+
+Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
 
 <CodeGroup>
 ```rust Rust
@@ -55,7 +57,7 @@ async for m in sb.metrics_stream(interval=1.0):
 
 ## Fleet-wide metrics
 
-Get metrics for all running sandboxes at once.
+Get metrics for all running sandboxes at once. Useful for dashboards or capacity planning.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/networking.mdx
+++ b/docs/sdk/networking.mdx
@@ -4,9 +4,11 @@ description: Network policies, secrets, and TLS interception
 icon: "network-wired"
 ---
 
+All sandbox network traffic passes through a host-controlled networking stack where policies are enforced at the packet level. There's no underlying host network to bypass. See [Networking concepts](/sandboxes/networking) for more on how this works.
+
 ## Preset policies
 
-microsandbox ships with preset policies that cover common scenarios. `public_only` is the default and blocks private address ranges while allowing public internet access.
+`public_only` is the default. It blocks private address ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) while allowing public internet access.
 
 <CodeGroup>
 ```rust Rust
@@ -15,7 +17,7 @@ use microsandbox::{Sandbox, NetworkPolicy};
 // No network access
 let sb1 = Sandbox::builder("isolated")
     .image("python:3.12")
-    .network(|n| n.policy(NetworkPolicy::none()))
+    .disable_network()
     .create()
     .await?;
 
@@ -123,7 +125,7 @@ sb5 = await Sandbox.create("safe-agent", image="python:3.12",
 
 ## Custom policies
 
-Build a policy with explicit egress and ingress rules for fine-grained control.
+Build a policy with explicit egress and ingress rules. Rules are evaluated first-match-wins.
 
 <CodeGroup>
 ```rust Rust
@@ -197,10 +199,9 @@ sb = await Sandbox.create(
 
 ## Port mapping
 
-Expose ports from the sandbox to the host to make services accessible.
-For simple Rust cases, use top-level `SandboxBuilder::port()` and `port_udp()`.
-They are repeatable, and they compose with `.network(...)` when you also need
-policy, DNS, or TLS settings.
+Expose ports from the sandbox to the host so services running inside the VM are accessible from your machine.
+
+For Rust, `SandboxBuilder::port()` and `port_udp()` are top-level shorthands that compose with `.network(...)` when you also need policy, DNS, or TLS settings.
 
 <CodeGroup>
 ```rust Rust
@@ -244,7 +245,7 @@ sb = await Sandbox.create(
 
 ## DNS interception
 
-Intercept DNS queries from sandboxes to block specific domains or prevent DNS rebinding attacks.
+All DNS queries are intercepted and resolved on the host side. This enables domain blocking, suffix blocking, and rebinding protection.
 
 <CodeGroup>
 ```rust Rust
@@ -295,11 +296,11 @@ sb = await Sandbox.create(
 
 ## Secrets
 
-Bind secrets to allowed hosts so credentials are never sent to unauthorized destinations.
+Secrets use a **placeholder substitution** model. The guest VM never sees the real credential.
 
-<Note>
-  Secrets are future work and not yet available in the current SDK.
-</Note>
+When you bind a secret to an environment variable and one or more allowed hosts, microsandbox generates a random placeholder (e.g., `OPENAI_API_KEY=msb_ph_a8f3c2...`) and injects that into the guest instead. The real value never enters the VM. The only way it reaches the outside world is when a request goes to an allowed host, at which point microsandbox swaps the placeholder for the real value. Everywhere else, the placeholder is just a meaningless string.
+
+So even with full code execution inside the sandbox, there's nothing to steal. The credential was never there.
 
 <CodeGroup>
 ```rust Rust
@@ -363,11 +364,7 @@ sb = await Sandbox.create(
 
 ## TLS interception
 
-Inspect HTTPS traffic with an auto-generated CA. Cert-pinned domains can be bypassed.
-
-<Note>
-  TLS interception is future work and not yet available in the current SDK.
-</Note>
+Enable HTTPS traffic inspection with an auto-generated CA certificate. microsandbox generates a per-sandbox CA during creation, installs it in the guest's trust store, and generates per-domain certificates on first connection. Domains that use certificate pinning (or that you don't want to intercept) can be bypassed.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -4,6 +4,8 @@ description: Install the SDK and create your first sandbox
 icon: "play"
 ---
 
+The SDK embeds the microsandbox runtime directly into whatever application uses it. `Sandbox.create` spawns the VM as a child process. No daemon to install, no server to connect to.
+
 ## Installation
 
 <CodeGroup>
@@ -95,3 +97,5 @@ async def main():
 asyncio.run(main())
 ```
 </CodeGroup>
+
+The rest of the SDK reference covers each area in detail: [sandbox configuration](/sdk/sandbox), [execution](/sdk/execution), [filesystem](/sdk/filesystem), [networking](/sdk/networking), [volumes](/sdk/volumes), [snapshots](/sdk/snapshots), [scripts](/sdk/scripts), [events](/sdk/events), [errors](/sdk/errors), and [metrics](/sdk/metrics).

--- a/docs/sdk/sandbox.mdx
+++ b/docs/sdk/sandbox.mdx
@@ -6,7 +6,7 @@ icon: "cube"
 
 ## Create with options
 
-Configure memory, CPUs, working directory, shell, environment variables, volumes, and network when creating a sandbox.
+The builder/options pattern lets you configure everything about a sandbox before booting it.
 
 <CodeGroup>
 ```rust Rust
@@ -71,7 +71,7 @@ sb = await Sandbox.create(
 
 ## Detached creation
 
-Create a sandbox that keeps running after your process exits. Useful for long-running agents or background workers.
+By default, a sandbox is "attached" to your process: when your process exits, the sandbox is stopped and cleaned up. Detached sandboxes survive independently and you can reconnect to them later.
 
 <CodeGroup>
 ```rust Rust
@@ -96,7 +96,7 @@ sb = await Sandbox.create("worker", image="python:3.12", detached=True)
 
 ## Replace existing
 
-Replace a stopped sandbox with the same name instead of failing on conflict.
+Replace a stopped sandbox with the same name instead of failing on conflict. This stops the old sandbox (if still running), removes it, and creates a fresh one.
 
 <CodeGroup>
 ```rust Rust
@@ -122,7 +122,7 @@ sb = await Sandbox.create("worker", image="python:3.12", replace=True)
 
 ## Config inspection
 
-Build a sandbox configuration without booting the VM. Useful for serializing, storing, or modifying configs before creation.
+Build a sandbox configuration without booting the VM. Useful for serializing, storing, validating, or modifying configs before creation.
 
 <CodeGroup>
 ```rust Rust
@@ -131,7 +131,7 @@ use microsandbox::Sandbox;
 let config = Sandbox::builder("preview")
     .image("python:3.12")
     .memory(1024)
-    .build();
+    .build()?;
 
 println!("{}", serde_json::to_string_pretty(&config)?);
 let sb = Sandbox::create(config).await?;
@@ -164,7 +164,7 @@ sb = await Sandbox.create_from_config(config)
 
 ## Disk image rootfs
 
-Boot from a qcow2 or raw disk image instead of an OCI container image. The filesystem type is auto-detected by default.
+Boot from a QCOW2, Raw, or VMDK disk image instead of an OCI container image. The guest gets raw block device access. The format is auto-detected from the file extension, or you can specify it explicitly along with the filesystem type.
 
 <CodeGroup>
 ```rust Rust
@@ -227,6 +227,10 @@ sb = await Sandbox.create(
 )
 ```
 </CodeGroup>
+
+<Note>
+  With OCI images, microsandbox stacks layers and adds a copy-on-write overlay so sandboxes share the base. With disk images, the guest gets the block device directly, so there's no copy-on-write isolation between sandboxes using the same disk image. Each sandbox needs its own copy (or use QCOW2's built-in snapshot/backing file support).
+</Note>
 
 ## Private registry
 
@@ -303,11 +307,15 @@ Pull policies control whether the SDK fetches the image from the registry:
 | `IfMissing` | Pull only if the image is not already cached (default) |
 | `Never` | Never pull; fail if the image is not cached |
 
+<Tip>
+  Once an OCI image is resolved, microsandbox pins the exact layers. A `python:3.12` reference is resolved to an immutable set of layers at first pull. Subsequent `start()` calls use the pinned layers without re-resolving the mutable tag, so your sandbox is reproducible even if the upstream tag is updated.
+</Tip>
+
 ## Lifecycle
 
 ### Stop, start, kill
 
-Stop sends a graceful shutdown signal. Start reboots a stopped sandbox from persisted state. Kill sends SIGKILL for unresponsive sandboxes.
+Stop gracefully terminates guest processes. Start reboots a stopped sandbox from persisted state. Kill force-terminates when the guest is unresponsive.
 
 <CodeGroup>
 ```rust Rust
@@ -343,7 +351,7 @@ await sb.kill()
 
 ### Pause and resume
 
-Freeze all processes without shutting down. The VM stays in memory but uses no CPU. Resume is instant with no boot time.
+Freeze all guest processes. Zero CPU usage while paused. Resume is instant with no re-boot.
 
 <CodeGroup>
 ```rust Rust
@@ -364,7 +372,7 @@ await sb.resume()
 
 ### Drain
 
-Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox transitions to `Draining` and eventually to `Stopped`.
+Graceful shutdown that lets existing commands finish but rejects new ones. Transitions to `Stopped` when all in-flight commands complete.
 
 <CodeGroup>
 ```rust Rust
@@ -382,7 +390,7 @@ await sb.drain()
 
 ### Detach
 
-Release the sandbox handle without stopping the sandbox. The sandbox continues running in the background.
+Release the sandbox handle without stopping it. The sandbox continues running as a background process.
 
 <CodeGroup>
 ```rust Rust
@@ -400,7 +408,7 @@ await sb.detach()
 
 ### Wait
 
-Wait for the sandbox to terminate without triggering a stop. Blocks until the sandbox exits on its own.
+Block until the sandbox exits on its own, without triggering a stop.
 
 <CodeGroup>
 ```rust Rust
@@ -417,8 +425,6 @@ exit_status = await sb.wait()
 </CodeGroup>
 
 ### List, get, remove
-
-Query sandbox inventory and clean up stopped sandboxes.
 
 <CodeGroup>
 ```rust Rust
@@ -462,7 +468,7 @@ await Sandbox.remove("old-sandbox")
 
 ### Graceful shutdown with timeout fallback
 
-Attempt a graceful stop, then force-kill if the sandbox does not shut down in time.
+Attempt a graceful stop, then force-kill if the sandbox doesn't shut down in time.
 
 <CodeGroup>
 ```rust Rust
@@ -505,16 +511,14 @@ except asyncio.TimeoutError:
 
 ## Sandbox Process Policies
 
-Configure how the sandbox process handles shutdown escalation, idle detection, and maximum sandbox lifetime.
+Configure how the sandbox handles shutdown escalation, idle detection, and maximum lifetime. These policies are enforced on the host side, so the guest can't override them.
 
 <CodeGroup>
 ```rust Rust
-use microsandbox::{Sandbox, ShutdownMode, LogLevel};
+use microsandbox::{Sandbox, LogLevel};
 
 let sb = Sandbox::builder("worker")
     .image("python:3.12")
-    .shutdown_mode(ShutdownMode::Terminate)
-    .grace_period(30)
     .max_duration(3600)
     .idle_timeout(300)
     .log_level(LogLevel::Debug)
@@ -523,13 +527,11 @@ let sb = Sandbox::builder("worker")
 ```
 
 ```typescript TypeScript
-import { Sandbox, ShutdownMode, LogLevel } from 'microsandbox'
+import { Sandbox, LogLevel } from 'microsandbox'
 
 const sb = await Sandbox.create({
     name: "worker",
     image: "python:3.12",
-    shutdownMode: ShutdownMode.Graceful,
-    gracePeriod: 30,
     maxDuration: 3600,
     idleTimeout: 300,
     logLevel: LogLevel.Debug,
@@ -537,13 +539,11 @@ const sb = await Sandbox.create({
 ```
 
 ```python Python
-from microsandbox import Sandbox, ShutdownMode, LogLevel
+from microsandbox import Sandbox, LogLevel
 
 sb = await Sandbox.create(
     "worker",
     image="python:3.12",
-    shutdown_mode=ShutdownMode.TERMINATE,
-    grace_period=30,
     max_duration=3600,
     idle_timeout=300,
     log_level=LogLevel.DEBUG,
@@ -553,38 +553,13 @@ sb = await Sandbox.create(
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `shutdown_mode` | `Terminate` | How the sandbox process escalates shutdown signals |
-| `grace_period` | `10` | Seconds between escalation steps |
 | `max_duration` | none | Maximum sandbox lifetime in seconds; triggers drain when exceeded |
 | `idle_timeout` | none | Auto-drain after this many seconds of inactivity |
 | `log_level` | none | Override sandbox-process log verbosity |
 
-## Custom init
+## Customizing the guest environment
 
-Replace the default init binary with your own. The custom init must exist in the guest filesystem (from the image or a volume). When set, the embedded init is not patched into the filesystem.
+If you need to run setup logic, install packages, or inject files before a sandbox starts doing real work, there are two ways to do it without building a custom image:
 
-<CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("worker")
-    .image("ubuntu:22.04")
-    .init("/usr/local/bin/my-init")
-    .create()
-    .await?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.create({
-    name: "worker",
-    image: "ubuntu:22.04",
-    init: "/usr/local/bin/my-init",
-})
-```
-
-```python Python
-sb = await Sandbox.create(
-    "worker",
-    image="ubuntu:22.04",
-    init="/usr/local/bin/my-init",
-)
-```
-</CodeGroup>
+- **[Scripts](/sdk/scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
+- **[Patches](/sdk/scripts#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.

--- a/docs/sdk/scripts.mdx
+++ b/docs/sdk/scripts.mdx
@@ -1,12 +1,14 @@
 ---
 title: Scripts & Patches
-description: Inject scripts and overlay files into sandboxes
+description: Inject scripts and modify the rootfs before boot
 icon: "scroll"
 ---
 
 ## Scripts
 
-Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The scripts directory is added to `PATH` by the guest agent during init, so each script is callable by name through `exec()` or `run()`.
+Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The directory is on `PATH`, so each script is callable by name through `exec()` or `shell()`.
+
+It provides a clean way to bundle setup procedures or entry points with a sandbox without baking them into the image.
 
 <CodeGroup>
 ```rust Rust
@@ -72,24 +74,27 @@ output = await sb.run("run")
 
 ## Patches
 
-Patches overlay arbitrary files onto the rootfs before boot. You can copy directories, write text files, create directories, and add symlinks.
+Patches modify the rootfs **before the VM boots**. Write config files, copy directories from the host, create symlinks, append to existing files, remove things you don't need. The base image stays untouched since patches are written to the writable layer on top.
 
-<Note>
-  Patches are future work and not yet available.
-</Note>
+Patches are applied in order and work with OCI images and bind-mounted rootfs. They're not supported with disk image roots (QCOW2, Raw).
+
+<Tip>
+  By default, patching a path that already exists in the image will error. Pass `replace: true` on the operation to allow it. `Mkdir` and `Remove` are idempotent and won't error either way.
+</Tip>
 
 <CodeGroup>
 ```rust Rust
-use microsandbox::{Sandbox, Patch};
+use microsandbox::Sandbox;
 
 let sb = Sandbox::builder("worker")
-    .image("ubuntu:22.04")
+    .image("alpine:latest")
     .patch(|p| p
-        .image("my-python-deps:v1")
-        .copy_dir("./src", "/app")
-        .text("/app/config.json", r#"{"env": "production"}"#)
-        .mkdir("/var/log/app")
-        .symlink("/usr/bin/python3", "/usr/bin/python")
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n", None, false)
+        .text("/etc/motd", "Custom message of the day.\n", None, true) // replace existing
+        .mkdir("/app", Some(0o755))
+        .text("/app/config.json", r#"{"debug": true}"#, Some(0o644), false)
+        .copy_file("./cert.pem", "/etc/ssl/cert.pem", None, false)
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n")
     )
     .create()
     .await?;
@@ -100,13 +105,14 @@ import { Patch, Sandbox } from 'microsandbox'
 
 const sb = await Sandbox.create({
     name: "worker",
-    image: "ubuntu:22.04",
+    image: "alpine:latest",
     patches: [
-        Patch.image("my-python-deps:v1"),
-        Patch.copyDir("./src", "/app"),
-        Patch.text("/app/config.json", '{"env": "production"}'),
-        Patch.mkdir("/var/log/app"),
-        Patch.symlink("/usr/bin/python3", "/usr/bin/python"),
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", { replace: true }),
+        Patch.mkdir("/app"),
+        Patch.text("/app/config.json", '{"debug": true}'),
+        Patch.copyFile("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
     ],
 })
 ```
@@ -116,13 +122,28 @@ from microsandbox import Sandbox, Patch
 
 sb = await Sandbox.create(
     "worker",
-    image="ubuntu:22.04",
-    patches=Patch(
-        image="my-python-deps:v1",
-        copy_files=[("./src", "/app")],
-        files={"/app/config.json": '{"env": "production"}'},
-        mkdir=["/var/log/app"],
-    ),
+    image="alpine:latest",
+    patches=[
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", replace=True),
+        Patch.mkdir("/app"),
+        Patch.text("/app/config.json", '{"debug": true}'),
+        Patch.copy_file("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    ],
 )
 ```
 </CodeGroup>
+
+### Available operations
+
+| Operation | Description |
+|-----------|-------------|
+| `text` | Write text content to a file |
+| `file` | Write raw bytes to a file |
+| `copy_file` | Copy a file from the host into the rootfs |
+| `copy_dir` | Recursively copy a directory from the host |
+| `symlink` | Create a symlink |
+| `mkdir` | Create a directory (idempotent) |
+| `remove` | Delete a file or directory (idempotent) |
+| `append` | Append content to an existing file |

--- a/docs/sdk/snapshots.mdx
+++ b/docs/sdk/snapshots.mdx
@@ -4,9 +4,17 @@ description: Capture VM state, fork workers, and restore
 icon: "camera"
 ---
 
+<Note>
+  Snapshots are coming soon and not yet available in the current SDK.
+</Note>
+
+Snapshots capture the full VM state: memory, CPU registers, filesystem, everything. From a single snapshot you can fork hundreds of sandboxes, each starting exactly where the original left off with no re-boot or dependency reinstall. Forks are cheap because each one gets its own copy-on-write filesystem.
+
+Particularly useful for agent workloads where every sandbox needs the same base environment (Python + packages, Node + node_modules, etc). Install once, snapshot, fork on demand.
+
 ## Create a snapshot
 
-Pause a running sandbox and capture its full VM state. The sandbox is paused during the snapshot and can be resumed afterward.
+Capturing a snapshot pauses the sandbox, saves its state, and returns a handle. You can resume the original sandbox afterward.
 
 <CodeGroup>
 ```rust Rust
@@ -46,7 +54,7 @@ await sb.resume()
 
 ## Save and load named snapshots
 
-Persist a snapshot under a name so it can be retrieved later without keeping the original sandbox around.
+Persist a snapshot under a name so it survives beyond the lifetime of the original sandbox. Load it later to fork workers without keeping the base sandbox around.
 
 <CodeGroup>
 ```rust Rust
@@ -85,7 +93,7 @@ saved = await Snapshot.get("after-pip-install")
 
 ## Fork workers
 
-Restore multiple sandboxes from a single snapshot to skip repeated setup work like dependency installation.
+Restore multiple sandboxes from a single snapshot. Each fork skips the entire setup phase and starts running immediately from the captured state.
 
 <CodeGroup>
 ```rust Rust
@@ -120,7 +128,7 @@ workers = await asyncio.gather(*(saved.restore(f"worker-{i}") for i in range(10)
 
 ## Restore with overrides
 
-Override memory, CPU count, or environment variables when restoring from a snapshot.
+Override memory, CPU count, or environment variables when restoring. The VM state is restored from the snapshot, but the overridden configuration takes effect on the new sandbox.
 
 <CodeGroup>
 ```rust Rust

--- a/docs/sdk/volumes.mdx
+++ b/docs/sdk/volumes.mdx
@@ -4,6 +4,10 @@ description: Create, mount, and manage persistent storage
 icon: "hard-drive"
 ---
 
+Volumes give the guest direct filesystem access to host-side directories, which is much faster than the [filesystem API](/sdk/filesystem) since that transfers files individually. The guest handles caching and readahead natively, so performance is close to native disk I/O.
+
+See [Volume concepts](/sandboxes/volumes) for more on bind mounts, named volumes, and tmpfs.
+
 ## Create a named volume
 
 Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. You can set a storage quota at creation time.
@@ -33,7 +37,7 @@ cache = await Volume.create("pip-cache", quota=1024)
 
 ## Mount volumes
 
-Sandboxes support three mount types: bind mounts from the host, named volumes for persistent shared storage, and tmpfs for ephemeral scratch space.
+Three mount types: bind mounts (host directory), named volumes (managed storage), and tmpfs (in-memory, ephemeral).
 
 <CodeGroup>
 ```rust Rust
@@ -88,7 +92,7 @@ sb = await Sandbox.create(
 
 ## Host-side file access
 
-You can read and write files in a named volume from the host without a running sandbox.
+Read and write files in a named volume from the host without a running sandbox. Useful for pre-populating data before creating a sandbox.
 
 <CodeGroup>
 ```rust Rust

--- a/examples/rootfs-patch/bin/main.rs
+++ b/examples/rootfs-patch/bin/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "/etc/motd",
                 "Welcome to a patched microsandbox.\n",
                 None,
-                true, // overwrite — /etc/motd exists in alpine
+                true, // replace — /etc/motd exists in alpine
             )
             .mkdir("/app", Some(0o755))
             .text(


### PR DESCRIPTION
## Summary

- Rewrite all 25 documentation pages to focus on user-facing behavior and practical tips, removing references to internal implementation details
- Rename the `overwrite` field to `replace` across the Patch API for consistency with `SandboxBuilder::replace()`
- Add `SandboxBuilder::disable_network()` convenience method
- Update patches and scripts docs to reflect the current API, mark snapshots as coming soon, and remove future-work tags from secrets and TLS interception

## Changes

**Documentation (25 files):**
- `docs/introduction.mdx`: Add Callout banner highlighting sub-second boot and no-daemon architecture. Rewrite prose to remove AI writing patterns (staccato "Your X. Your Y." constructions, em dashes, implementation jargon). Replace "Declarative projects" with "Programmable" in basics section. Fix boot time from 200ms to 100ms.
- `docs/quickstart.mdx`: Rewrite "What just happened" section to explain user-visible behavior without mentioning libkrun, CBOR, virtio-console, or agentd internals.
- `docs/sandboxes/*.mdx`: Rewrite all 6 pages (overview, networking, commands, filesystem, volumes, lifecycle). Strip smoltcp/virtio-fs/agentd references. Add tips about memory-as-limits, exec-without-network, volumes-vs-filesystem-API tradeoffs. Simplify lifecycle architecture diagram labels.
- `docs/sdk/*.mdx`: Rewrite all 11 SDK reference pages. Remove implementation details, add cross-references to concepts pages, update patches section with all 8 operations and real API signatures. Replace custom-init section with scripts/patches guidance. Mark snapshots as coming soon. Remove future-work notes from secrets and TLS interception.
- `docs/cli/*.mdx` and `docs/images/*.mdx`: Minor prose cleanup and practical tips.

**Code (3 files):**
- `crates/microsandbox/lib/sandbox/types.rs`: Rename `overwrite` to `replace` on all Patch enum variants (Text, File, CopyFile, CopyDir, Symlink) and corresponding PatchBuilder methods. Update doc comments.
- `crates/microsandbox/lib/sandbox/patch.rs`: Rename `check_overwrite` to `check_replace`, update all pattern matches and error messages.
- `crates/microsandbox/lib/sandbox/builder.rs`: Add `disable_network()` method and test.

**Example (1 file):**
- `examples/rootfs-patch/bin/main.rs`: Update comment from `overwrite` to `replace`.

## Test Plan

- `cargo check` passes with no errors
- `cargo fmt --all --check` passes
- `cargo clippy --workspace` passes
- All pre-commit hooks pass (fmt, clippy, doc, build)
- Review rendered docs on Mintlify preview to verify formatting, Callout component rendering, and code examples