### PR TITLE
feat(sandbox,cli): add live metrics sampling and enhance status command

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -3,8 +3,8 @@
 use clap::{CommandFactory, Parser, Subcommand};
 use microsandbox_cli::{
     commands::{
-        create, exec, image, inspect, install, list, ps, pull, remove, run, self_cmd, shell, start,
-        stop, uninstall, volume,
+        create, exec, image, inspect, install, list, metrics, ps, pull, remove, run, self_cmd,
+        shell, start, stop, uninstall, volume,
     },
     log_args::{self, LogArgs},
     sandbox_cmd::{self, SandboxArgs},
@@ -52,8 +52,12 @@ enum Commands {
     #[command(visible_alias = "ls")]
     List(list::ListArgs),
 
-    /// Show running sandboxes.
-    Ps(ps::PsArgs),
+    /// Show sandbox status.
+    #[command(name = "status", visible_alias = "ps")]
+    Status(ps::PsArgs),
+
+    /// Show live metrics for a running sandbox.
+    Metrics(metrics::MetricsArgs),
 
     /// Remove one or more sandboxes.
     #[command(visible_alias = "rm")]
@@ -162,7 +166,8 @@ fn run_async_command(
             Commands::Start(args) => start::run(args).await.map_err(Into::into),
             Commands::Stop(args) => stop::run(args).await.map_err(Into::into),
             Commands::List(args) => list::run(args).await.map_err(Into::into),
-            Commands::Ps(args) => ps::run(args).await.map_err(Into::into),
+            Commands::Status(args) => ps::run(args).await.map_err(Into::into),
+            Commands::Metrics(args) => metrics::run(args).await.map_err(Into::into),
             Commands::Remove(args) => remove::run(args).await.map_err(Into::into),
             Commands::Exec(args) => exec::run(args).await.map_err(Into::into),
             Commands::Shell(args) => shell::run(args).await.map_err(Into::into),

--- a/crates/cli/lib/commands/inspect.rs
+++ b/crates/cli/lib/commands/inspect.rs
@@ -16,7 +16,7 @@ pub struct InspectArgs {
     pub name: String,
 
     /// Output format (json).
-    #[arg(long, value_name = "FORMAT")]
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
     pub format: Option<String>,
 }
 

--- a/crates/cli/lib/commands/install.rs
+++ b/crates/cli/lib/commands/install.rs
@@ -56,7 +56,7 @@ pub struct InstallArgs {
     pub env: Vec<String>,
 
     /// Overwrite an existing alias with the same name.
-    #[arg(long)]
+    #[arg(short, long)]
     pub force: bool,
 
     /// Don't pull the image before installing.

--- a/crates/cli/lib/commands/list.rs
+++ b/crates/cli/lib/commands/list.rs
@@ -21,7 +21,7 @@ pub struct ListArgs {
     pub stopped: bool,
 
     /// Output format (json).
-    #[arg(long, value_name = "FORMAT")]
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
     pub format: Option<String>,
 
     /// Show only sandbox names.

--- a/crates/cli/lib/commands/metrics.rs
+++ b/crates/cli/lib/commands/metrics.rs
@@ -1,0 +1,119 @@
+//! `msb metrics` command — show live sandbox metrics.
+
+use clap::Args;
+use microsandbox::sandbox::{Sandbox, SandboxMetrics, all_sandbox_metrics};
+
+use crate::ui;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Show live metrics for a running sandbox.
+#[derive(Debug, Args)]
+pub struct MetricsArgs {
+    /// Sandbox to inspect. Omit to show all running sandboxes.
+    pub name: Option<String>,
+
+    /// Output format (json).
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
+    pub format: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Execute the `msb metrics` command.
+pub async fn run(args: MetricsArgs) -> anyhow::Result<()> {
+    if let Some(name) = args.name.as_deref() {
+        let handle = Sandbox::get(name).await?;
+        let metrics = handle.metrics().await?;
+
+        if args.format.as_deref() == Some("json") {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&metrics_json(handle.name(), &metrics))?
+            );
+            return Ok(());
+        }
+
+        print_table(&[(handle.name().to_string(), metrics)]);
+        return Ok(());
+    }
+
+    let mut metrics = all_sandbox_metrics()
+        .await?
+        .into_iter()
+        .collect::<Vec<(String, SandboxMetrics)>>();
+    metrics.sort_by(|left, right| left.0.cmp(&right.0));
+
+    if args.format.as_deref() == Some("json") {
+        let json = serde_json::Value::Array(
+            metrics
+                .iter()
+                .map(|(name, metrics)| metrics_json(name, metrics))
+                .collect(),
+        );
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+
+    if metrics.is_empty() {
+        eprintln!("No running sandboxes.");
+        return Ok(());
+    }
+
+    print_table(&metrics);
+
+    Ok(())
+}
+
+fn print_table(metrics: &[(String, SandboxMetrics)]) {
+    let mut table = ui::Table::new(&[
+        "NAME",
+        "CPU",
+        "MEMORY",
+        "DISK READ",
+        "DISK WRITE",
+        "NET RX",
+        "NET TX",
+        "UPTIME",
+        "TIMESTAMP",
+    ]);
+
+    for (name, metric) in metrics {
+        table.add_row(vec![
+            name.clone(),
+            format!("{:.1}%", metric.cpu_percent),
+            format!(
+                "{} / {}",
+                ui::format_bytes(metric.memory_bytes),
+                ui::format_bytes(metric.memory_limit_bytes)
+            ),
+            ui::format_bytes(metric.disk_read_bytes),
+            ui::format_bytes(metric.disk_write_bytes),
+            ui::format_bytes(metric.net_rx_bytes),
+            ui::format_bytes(metric.net_tx_bytes),
+            ui::format_duration(metric.uptime),
+            metric.timestamp.to_rfc3339(),
+        ]);
+    }
+
+    table.print();
+}
+
+fn metrics_json(name: &str, metrics: &SandboxMetrics) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "timestamp": metrics.timestamp.to_rfc3339(),
+        "cpu_percent": metrics.cpu_percent,
+        "memory_bytes": metrics.memory_bytes,
+        "memory_limit_bytes": metrics.memory_limit_bytes,
+        "disk_read_bytes": metrics.disk_read_bytes,
+        "disk_write_bytes": metrics.disk_write_bytes,
+        "net_rx_bytes": metrics.net_rx_bytes,
+        "net_tx_bytes": metrics.net_tx_bytes,
+        "uptime_secs": metrics.uptime.as_secs_f64(),
+    })
+}

--- a/crates/cli/lib/commands/mod.rs
+++ b/crates/cli/lib/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod image;
 pub mod inspect;
 pub mod install;
 pub mod list;
+pub mod metrics;
 pub mod ps;
 pub mod pull;
 pub mod remove;

--- a/crates/cli/lib/commands/ps.rs
+++ b/crates/cli/lib/commands/ps.rs
@@ -1,7 +1,7 @@
-//! `msb ps` command — show running sandboxes (quick view).
+//! `msb status` command — show sandbox status.
 
 use clap::Args;
-use microsandbox::sandbox::{Sandbox, SandboxConfig, SandboxStatus};
+use microsandbox::sandbox::{Sandbox, SandboxConfig, SandboxHandle, SandboxStatus};
 
 use crate::ui;
 
@@ -9,45 +9,66 @@ use crate::ui;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Show running sandboxes.
+/// Show sandbox status.
 #[derive(Debug, Args)]
 pub struct PsArgs {
+    /// Sandbox to inspect. Omit to show running sandboxes.
+    pub name: Option<String>,
+
     /// Show all sandboxes, not just running ones.
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "name")]
     pub all: bool,
+
+    /// Output format (json).
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
+    pub format: Option<String>,
 
     /// Show only sandbox names.
     #[arg(short, long)]
     pub quiet: bool,
 }
 
+struct StatusRow {
+    name: String,
+    image: String,
+    command: String,
+    status: String,
+    ports: String,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Execute the `msb ps` command.
+/// Execute the `msb status` command.
 pub async fn run(args: PsArgs) -> anyhow::Result<()> {
-    let sandboxes = Sandbox::list().await?;
-
-    let filtered: Vec<_> = if args.all {
-        sandboxes
+    let single = args.name.is_some();
+    let handles: Vec<SandboxHandle> = if let Some(name) = args.name.as_deref() {
+        vec![Sandbox::get(name).await?]
     } else {
-        sandboxes
-            .into_iter()
-            .filter(|s| {
+        let mut sandboxes = Sandbox::list().await?;
+        if !args.all {
+            sandboxes.retain(|s| {
                 s.status() == SandboxStatus::Running || s.status() == SandboxStatus::Draining
-            })
-            .collect()
+            });
+        }
+        sandboxes.sort_by(|left, right| left.name().cmp(right.name()));
+        sandboxes
     };
 
+    if args.format.as_deref() == Some("json") {
+        print_json(&handles, single)?;
+        return Ok(());
+    }
+
     if args.quiet {
-        for s in &filtered {
+        for s in &handles {
             println!("{}", s.name());
         }
         return Ok(());
     }
 
-    if filtered.is_empty() {
+    if handles.is_empty() {
         if args.all {
             eprintln!("No sandboxes found.");
         } else {
@@ -56,15 +77,14 @@ pub async fn run(args: PsArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let mut table = ui::Table::new(&["NAME", "IMAGE", "STATUS"]);
-
-    for s in &filtered {
-        let image = extract_image(s.config_json());
-        let status = format!("{:?}", s.status());
+    let mut table = ui::Table::new(&["NAME", "IMAGE", "COMMAND", "STATUS", "PORTS"]);
+    for row in handles.iter().map(status_row) {
         table.add_row(vec![
-            s.name().to_string(),
-            image,
-            ui::format_status(&status),
+            row.name,
+            row.image,
+            row.command,
+            row.status,
+            row.ports,
         ]);
     }
 
@@ -72,16 +92,142 @@ pub async fn run(args: PsArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Extract image name from config JSON.
-fn extract_image(config_json: &str) -> String {
-    serde_json::from_str::<SandboxConfig>(config_json)
-        .ok()
-        .map(|c| match c.image {
-            microsandbox::sandbox::RootfsSource::Oci(ref s) => s.clone(),
-            microsandbox::sandbox::RootfsSource::Bind(ref p) => p.display().to_string(),
-            microsandbox::sandbox::RootfsSource::DiskImage { ref path, .. } => {
-                path.display().to_string()
-            }
-        })
-        .unwrap_or_else(|| "-".to_string())
+fn print_json(handles: &[SandboxHandle], single: bool) -> anyhow::Result<()> {
+    if single {
+        let row = handles
+            .first()
+            .map(status_json)
+            .unwrap_or(serde_json::Value::Null);
+        println!("{}", serde_json::to_string_pretty(&row)?);
+        return Ok(());
+    }
+
+    let rows: Vec<_> = handles.iter().map(status_json).collect();
+    println!("{}", serde_json::to_string_pretty(&rows)?);
+    Ok(())
+}
+
+fn status_row(handle: &SandboxHandle) -> StatusRow {
+    let config = serde_json::from_str::<SandboxConfig>(handle.config_json()).ok();
+    let image = config
+        .as_ref()
+        .map(extract_image)
+        .unwrap_or_else(|| "-".to_string());
+    let command = config
+        .as_ref()
+        .map(format_command)
+        .unwrap_or_else(|| "-".to_string());
+    let ports = config
+        .as_ref()
+        .map(format_ports)
+        .unwrap_or_else(|| "-".to_string());
+    let status = format!("{:?}", handle.status());
+
+    StatusRow {
+        name: handle.name().to_string(),
+        image,
+        command,
+        status: ui::format_status(&status),
+        ports,
+    }
+}
+
+fn status_json(handle: &SandboxHandle) -> serde_json::Value {
+    let config = serde_json::from_str::<SandboxConfig>(handle.config_json()).ok();
+    let status = format!("{:?}", handle.status());
+
+    serde_json::json!({
+        "name": handle.name(),
+        "status": status,
+        "image": config.as_ref().map(extract_image_raw).unwrap_or_else(|| "-".to_string()),
+        "command": config.as_ref().map(format_command_raw).unwrap_or_else(|| "-".to_string()),
+        "ports": config.as_ref().map(format_ports_raw).unwrap_or_default(),
+    })
+}
+
+fn extract_image(config: &SandboxConfig) -> String {
+    truncate(&extract_image_raw(config), 36)
+}
+
+fn format_command(config: &SandboxConfig) -> String {
+    truncate(&format_command_raw(config), 40)
+}
+
+fn format_ports(config: &SandboxConfig) -> String {
+    let ports = format_ports_raw(config);
+    if ports.is_empty() {
+        return "-".to_string();
+    }
+
+    truncate(&ports.join(", "), 32)
+}
+
+fn extract_image_raw(config: &SandboxConfig) -> String {
+    match &config.image {
+        microsandbox::sandbox::RootfsSource::Oci(s) => s.clone(),
+        microsandbox::sandbox::RootfsSource::Bind(p) => p.display().to_string(),
+        microsandbox::sandbox::RootfsSource::DiskImage { path, .. } => path.display().to_string(),
+    }
+}
+
+fn format_command_raw(config: &SandboxConfig) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(entrypoint) = &config.entrypoint {
+        parts.extend(entrypoint.iter().cloned());
+    }
+    if let Some(cmd) = &config.cmd {
+        parts.extend(cmd.iter().cloned());
+    }
+
+    if parts.is_empty() {
+        return "-".to_string();
+    }
+
+    format!("\"{}\"", parts.join(" "))
+}
+
+fn format_ports_raw(config: &SandboxConfig) -> Vec<String> {
+    #[cfg(feature = "net")]
+    {
+        if !config.network.enabled || config.network.ports.is_empty() {
+            return Vec::new();
+        }
+
+        config
+            .network
+            .ports
+            .iter()
+            .map(|port| {
+                let protocol = match port.protocol {
+                    microsandbox_network::config::PortProtocol::Tcp => "tcp",
+                    microsandbox_network::config::PortProtocol::Udp => "udp",
+                };
+                format!(
+                    "{}:{}->{}/{}",
+                    port.host_bind, port.host_port, port.guest_port, protocol
+                )
+            })
+            .collect()
+    }
+
+    #[cfg(not(feature = "net"))]
+    {
+        let _ = config;
+        Vec::new()
+    }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    let char_count = value.chars().count();
+    if char_count <= max_chars {
+        return value.to_string();
+    }
+
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+
+    let truncated: String = value.chars().take(max_chars - 3).collect();
+    format!("{truncated}...")
 }

--- a/crates/cli/lib/commands/remove.rs
+++ b/crates/cli/lib/commands/remove.rs
@@ -17,7 +17,7 @@ pub struct RemoveArgs {
     pub names: Vec<String>,
 
     /// Stop the sandbox if running, then remove it.
-    #[arg(long)]
+    #[arg(short, long)]
     pub force: bool,
 
     /// Suppress progress output.

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -42,7 +42,7 @@ pub enum SelfCommand {
 #[derive(Debug, Args)]
 pub struct SelfUpdateArgs {
     /// Re-download even if already on the latest version.
-    #[arg(long)]
+    #[arg(short, long)]
     pub force: bool,
 }
 

--- a/crates/cli/lib/commands/stop.rs
+++ b/crates/cli/lib/commands/stop.rs
@@ -16,7 +16,7 @@ pub struct StopArgs {
     pub name: String,
 
     /// Immediately kill the sandbox without graceful shutdown.
-    #[arg(long)]
+    #[arg(short, long)]
     pub force: bool,
 
     /// Seconds to wait for graceful shutdown before force-killing.

--- a/crates/cli/lib/ui.rs
+++ b/crates/cli/lib/ui.rs
@@ -379,6 +379,24 @@ pub fn format_duration(d: Duration) -> String {
     }
 }
 
+/// Format a byte count with binary units.
+pub fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+    let mut value = bytes as f64;
+    let mut unit = 0usize;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
 /// Format a chrono DateTime for display.
 pub fn format_datetime(dt: &chrono::DateTime<chrono::Utc>) -> String {
     dt.format("%Y-%m-%d %H:%M:%S").to_string()

--- a/crates/microsandbox/lib/sandbox/handle.rs
+++ b/crates/microsandbox/lib/sandbox/handle.rs
@@ -85,6 +85,25 @@ impl SandboxHandle {
         self.updated_at
     }
 
+    /// Get the latest metrics snapshot for this sandbox.
+    pub async fn metrics(&self) -> MicrosandboxResult<super::SandboxMetrics> {
+        if self.status != SandboxStatus::Running && self.status != SandboxStatus::Draining {
+            return Err(crate::MicrosandboxError::Custom(format!(
+                "sandbox '{}' is not running (status: {:?})",
+                self.name, self.status
+            )));
+        }
+
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        super::metrics::metrics_for_sandbox(
+            db,
+            self.db_id,
+            u64::from(self.config()?.memory_mib) * 1024 * 1024,
+        )
+        .await
+    }
+
     /// Start this sandbox and return a live handle.
     ///
     /// Boots the VM using the persisted configuration and pinned rootfs state.

--- a/crates/microsandbox/lib/sandbox/metrics.rs
+++ b/crates/microsandbox/lib/sandbox/metrics.rs
@@ -1,0 +1,197 @@
+//! Sandbox metrics APIs backed by persisted runtime samples.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use futures::stream;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::{
+    MicrosandboxError, MicrosandboxResult,
+    db::entity::{sandbox as sandbox_entity, sandbox_metric as sandbox_metric_entity},
+};
+
+use super::{Sandbox, SandboxConfig, SandboxStatus};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Point-in-time metrics for a running sandbox.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SandboxMetrics {
+    /// CPU usage as a percentage across all host CPUs.
+    pub cpu_percent: f32,
+    /// Resident memory usage in bytes.
+    pub memory_bytes: u64,
+    /// Configured guest memory limit in bytes.
+    pub memory_limit_bytes: u64,
+    /// Cumulative disk bytes read by the sandbox process.
+    pub disk_read_bytes: u64,
+    /// Cumulative disk bytes written by the sandbox process.
+    pub disk_write_bytes: u64,
+    /// Cumulative network bytes delivered from the runtime to the guest.
+    pub net_rx_bytes: u64,
+    /// Cumulative network bytes transmitted from the guest into the runtime.
+    pub net_tx_bytes: u64,
+    /// Sandbox uptime at the moment the sample was taken.
+    pub uptime: Duration,
+    /// Timestamp of the sample.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl Sandbox {
+    /// Get the latest metrics snapshot for this running sandbox.
+    pub async fn metrics(&self) -> MicrosandboxResult<SandboxMetrics> {
+        let db =
+            crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+        metrics_for_sandbox(db, self.db_id, memory_limit_bytes(&self.config)).await
+    }
+
+    /// Stream metrics snapshots at the requested interval.
+    pub fn metrics_stream(
+        &self,
+        interval: Duration,
+    ) -> impl futures::Stream<Item = MicrosandboxResult<SandboxMetrics>> + Send + 'static {
+        let db_id = self.db_id;
+        let memory_limit_bytes = memory_limit_bytes(&self.config);
+        let interval = if interval.is_zero() {
+            Duration::from_millis(1)
+        } else {
+            interval
+        };
+
+        stream::unfold(
+            tokio::time::interval(interval),
+            move |mut ticker| async move {
+                ticker.tick().await;
+                let db =
+                    crate::db::init_global(Some(crate::config::config().database.max_connections))
+                        .await;
+                let item = match db {
+                    Ok(db) => metrics_for_sandbox(db, db_id, memory_limit_bytes).await,
+                    Err(err) => Err(err),
+                };
+                Some((item, ticker))
+            },
+        )
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Get the latest metrics snapshot for every running sandbox.
+pub async fn all_sandbox_metrics() -> MicrosandboxResult<HashMap<String, SandboxMetrics>> {
+    let db = crate::db::init_global(Some(crate::config::config().database.max_connections)).await?;
+    let sandboxes = sandbox_entity::Entity::find()
+        .filter(
+            sandbox_entity::Column::Status.is_in([SandboxStatus::Running, SandboxStatus::Draining]),
+        )
+        .order_by_asc(sandbox_entity::Column::Name)
+        .all(db)
+        .await?;
+
+    let mut metrics = HashMap::with_capacity(sandboxes.len());
+    for sandbox in sandboxes {
+        let sandbox = super::reconcile_sandbox_runtime_state(db, sandbox).await?;
+        if !matches!(
+            sandbox.status,
+            SandboxStatus::Running | SandboxStatus::Draining
+        ) {
+            continue;
+        }
+
+        let config: SandboxConfig = serde_json::from_str(&sandbox.config)?;
+        let snapshot = metrics_for_sandbox(db, sandbox.id, memory_limit_bytes(&config)).await?;
+        metrics.insert(sandbox.name, snapshot);
+    }
+
+    Ok(metrics)
+}
+
+pub(super) async fn metrics_for_sandbox(
+    db: &sea_orm::DatabaseConnection,
+    sandbox_id: i32,
+    memory_limit_bytes: u64,
+) -> MicrosandboxResult<SandboxMetrics> {
+    let run = super::load_active_run(db, sandbox_id)
+        .await?
+        .ok_or_else(|| {
+            MicrosandboxError::Custom(format!(
+                "sandbox {sandbox_id} is not running; metrics are unavailable"
+            ))
+        })?;
+
+    let started_at = run
+        .started_at
+        .map(|dt| dt.and_utc())
+        .unwrap_or_else(chrono::Utc::now);
+
+    let metric = latest_metric(db, sandbox_id).await?;
+    let timestamp = metric
+        .as_ref()
+        .and_then(|row| row.sampled_at.or(row.created_at))
+        .map(|dt| dt.and_utc())
+        .unwrap_or_else(chrono::Utc::now);
+    let uptime = timestamp
+        .signed_duration_since(started_at)
+        .to_std()
+        .unwrap_or_default();
+
+    Ok(SandboxMetrics {
+        cpu_percent: metric
+            .as_ref()
+            .and_then(|row| row.cpu_percent)
+            .unwrap_or(0.0),
+        memory_bytes: metric
+            .as_ref()
+            .and_then(|row| row.memory_bytes)
+            .map_or(0, i64_to_u64),
+        memory_limit_bytes,
+        disk_read_bytes: metric
+            .as_ref()
+            .and_then(|row| row.disk_read_bytes)
+            .map_or(0, i64_to_u64),
+        disk_write_bytes: metric
+            .as_ref()
+            .and_then(|row| row.disk_write_bytes)
+            .map_or(0, i64_to_u64),
+        net_rx_bytes: metric
+            .as_ref()
+            .and_then(|row| row.net_rx_bytes)
+            .map_or(0, i64_to_u64),
+        net_tx_bytes: metric
+            .as_ref()
+            .and_then(|row| row.net_tx_bytes)
+            .map_or(0, i64_to_u64),
+        uptime,
+        timestamp,
+    })
+}
+
+async fn latest_metric(
+    db: &sea_orm::DatabaseConnection,
+    sandbox_id: i32,
+) -> MicrosandboxResult<Option<sandbox_metric_entity::Model>> {
+    sandbox_metric_entity::Entity::find()
+        .filter(sandbox_metric_entity::Column::SandboxId.eq(sandbox_id))
+        .order_by_desc(sandbox_metric_entity::Column::SampledAt)
+        .order_by_desc(sandbox_metric_entity::Column::Id)
+        .one(db)
+        .await
+        .map_err(Into::into)
+}
+
+fn memory_limit_bytes(config: &SandboxConfig) -> u64 {
+    u64::from(config.memory_mib) * 1024 * 1024
+}
+
+fn i64_to_u64(value: i64) -> u64 {
+    u64::try_from(value).unwrap_or_default()
+}

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -11,6 +11,7 @@ mod config;
 pub mod exec;
 pub mod fs;
 mod handle;
+mod metrics;
 mod patch;
 mod types;
 
@@ -49,6 +50,7 @@ pub use config::SandboxConfig;
 pub use exec::{ExecOptionsBuilder, ExecOutput, IntoExecOptions, Rlimit, RlimitResource};
 pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, SandboxFs};
 pub use handle::SandboxHandle;
+pub use metrics::{SandboxMetrics, all_sandbox_metrics};
 pub use microsandbox_image::{PullPolicy, PullProgress, PullProgressHandle};
 #[cfg(feature = "net")]
 pub use microsandbox_network::builder::SecretBuilder;

--- a/crates/network/lib/backend.rs
+++ b/crates/network/lib/backend.rs
@@ -61,6 +61,7 @@ impl NetBackend for SmoltcpBackend {
     /// the raw ethernet frame for smoltcp.
     fn write_frame(&mut self, hdr_len: usize, buf: &mut [u8]) -> Result<(), WriteError> {
         let ethernet_frame = buf[hdr_len..].to_vec();
+        self.shared.add_tx_bytes(ethernet_frame.len());
         self.shared
             .tx_ring
             .push(ethernet_frame)

--- a/crates/network/lib/device.rs
+++ b/crates/network/lib/device.rs
@@ -146,6 +146,7 @@ impl<'a> phy::TxToken for SmoltcpTxToken<'a> {
         let result = f(&mut buf);
         // Push the frame to rx_ring for the guest. Don't wake yet —
         // the poll loop will coalesce wakes after the egress loop.
+        self.device.shared.add_rx_bytes(buf.len());
         let _ = self.device.shared.rx_ring.push(buf);
         self.device.frames_emitted.store(true, Ordering::Relaxed);
         result

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -62,6 +62,12 @@ pub struct TerminationHandle {
     shared: Arc<SharedState>,
 }
 
+/// Read-only view of aggregate network byte counters.
+#[derive(Clone)]
+pub struct MetricsHandle {
+    shared: Arc<SharedState>,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -228,12 +234,31 @@ impl SmoltcpNetwork {
             shared: self.shared.clone(),
         }
     }
+
+    /// Create a handle for reading aggregate network byte counters.
+    pub fn metrics_handle(&self) -> MetricsHandle {
+        MetricsHandle {
+            shared: self.shared.clone(),
+        }
+    }
 }
 
 impl TerminationHandle {
     /// Install the termination hook.
     pub fn set_hook(&self, hook: Arc<dyn Fn() + Send + Sync>) {
         self.shared.set_termination_hook(hook);
+    }
+}
+
+impl MetricsHandle {
+    /// Total guest -> runtime bytes observed at the virtio-net boundary.
+    pub fn tx_bytes(&self) -> u64 {
+        self.shared.tx_bytes()
+    }
+
+    /// Total runtime -> guest bytes observed at the virtio-net boundary.
+    pub fn rx_bytes(&self) -> u64 {
+        self.shared.rx_bytes()
     }
 }
 

--- a/crates/network/lib/shared.rs
+++ b/crates/network/lib/shared.rs
@@ -6,7 +6,10 @@
 
 use crossbeam_queue::ArrayQueue;
 pub use microsandbox_utils::wake_pipe::WakePipe;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -55,6 +58,15 @@ pub struct SharedState {
 
     /// Optional host-side termination hook used for fatal policy violations.
     termination_hook: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+
+    /// Aggregate network byte counters at the guest/runtime boundary.
+    metrics: NetworkMetrics,
+}
+
+/// Aggregate network byte counters shared with the runtime metrics sampler.
+pub struct NetworkMetrics {
+    tx_bytes: AtomicU64,
+    rx_bytes: AtomicU64,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -71,6 +83,7 @@ impl SharedState {
             tx_wake: WakePipe::new(),
             proxy_wake: WakePipe::new(),
             termination_hook: Mutex::new(None),
+            metrics: NetworkMetrics::default(),
         }
     }
 
@@ -84,6 +97,39 @@ impl SharedState {
         let hook = self.termination_hook.lock().unwrap().clone();
         if let Some(hook) = hook {
             hook();
+        }
+    }
+
+    /// Increment the guest -> runtime byte counter.
+    pub fn add_tx_bytes(&self, bytes: usize) {
+        self.metrics
+            .tx_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Increment the runtime -> guest byte counter.
+    pub fn add_rx_bytes(&self, bytes: usize) {
+        self.metrics
+            .rx_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Total bytes transmitted by the guest into the runtime.
+    pub fn tx_bytes(&self) -> u64 {
+        self.metrics.tx_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes delivered by the runtime to the guest.
+    pub fn rx_bytes(&self) -> u64 {
+        self.metrics.rx_bytes.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for NetworkMetrics {
+    fn default() -> Self {
+        Self {
+            tx_bytes: AtomicU64::new(0),
+            rx_bytes: AtomicU64::new(0),
         }
     }
 }

--- a/crates/runtime/lib/lib.rs
+++ b/crates/runtime/lib/lib.rs
@@ -13,6 +13,7 @@ mod error;
 pub mod console;
 pub mod heartbeat;
 pub mod logging;
+pub mod metrics;
 pub mod policy;
 pub mod relay;
 pub mod vm;

--- a/crates/runtime/lib/metrics.rs
+++ b/crates/runtime/lib/metrics.rs
@@ -1,0 +1,292 @@
+//! Sandbox process metrics sampling and persistence.
+
+use std::time::{Duration, Instant};
+
+use microsandbox_db::entity::sandbox_metric as sandbox_metric_entity;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
+
+use crate::{RuntimeError, RuntimeResult};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Fixed sampling interval for persisted sandbox metrics.
+pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Optional runtime-supplied network byte counters.
+pub trait NetworkMetrics: Send + Sync {
+    /// Bytes transmitted by the guest into the runtime.
+    fn tx_bytes(&self) -> u64;
+
+    /// Bytes received by the guest from the runtime.
+    fn rx_bytes(&self) -> u64;
+}
+
+impl NetworkMetrics for () {
+    fn tx_bytes(&self) -> u64 {
+        0
+    }
+
+    fn rx_bytes(&self) -> u64 {
+        0
+    }
+}
+
+#[cfg(feature = "net")]
+impl NetworkMetrics for microsandbox_network::network::MetricsHandle {
+    fn tx_bytes(&self) -> u64 {
+        microsandbox_network::network::MetricsHandle::tx_bytes(self)
+    }
+
+    fn rx_bytes(&self) -> u64 {
+        microsandbox_network::network::MetricsHandle::rx_bytes(self)
+    }
+}
+
+/// Process metrics sampled from the host OS.
+#[derive(Clone, Copy, Debug)]
+struct ProcessSample {
+    cpu_time_secs: f64,
+    memory_bytes: u64,
+    disk_read_bytes: u64,
+    disk_write_bytes: u64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Run the background metrics sampler until the sandbox process exits.
+pub async fn run_metrics_sampler(
+    db: DatabaseConnection,
+    sandbox_id: i32,
+    pid: u32,
+    network_metrics: Option<Box<dyn NetworkMetrics>>,
+) {
+    let pid = pid as i32;
+
+    let mut previous = match sample_process(pid) {
+        Ok(sample) => sample,
+        Err(err) => {
+            tracing::warn!(sandbox_id, pid, error = %err, "failed to capture initial sandbox metrics");
+            return;
+        }
+    };
+    let mut previous_instant = Instant::now();
+
+    if let Err(err) =
+        persist_sample(&db, sandbox_id, 0.0, previous, network_metrics.as_deref()).await
+    {
+        tracing::warn!(sandbox_id, pid, error = %err, "failed to persist initial sandbox metrics");
+    }
+
+    loop {
+        tokio::time::sleep(SAMPLE_INTERVAL).await;
+
+        let current = match sample_process(pid) {
+            Ok(sample) => sample,
+            Err(err) => {
+                tracing::debug!(sandbox_id, pid, error = %err, "stopping metrics sampler");
+                break;
+            }
+        };
+
+        let now = Instant::now();
+        let wall_secs = now
+            .checked_duration_since(previous_instant)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0);
+        let cpu_percent = if wall_secs > 0.0 {
+            (((current.cpu_time_secs - previous.cpu_time_secs).max(0.0)) / wall_secs) * 100.0
+        } else {
+            0.0
+        };
+
+        if let Err(err) = persist_sample(
+            &db,
+            sandbox_id,
+            cpu_percent as f32,
+            current,
+            network_metrics.as_deref(),
+        )
+        .await
+        {
+            tracing::warn!(sandbox_id, pid, error = %err, "failed to persist sandbox metrics");
+        }
+
+        previous = current;
+        previous_instant = now;
+    }
+}
+
+async fn persist_sample(
+    db: &DatabaseConnection,
+    sandbox_id: i32,
+    cpu_percent: f32,
+    process: ProcessSample,
+    network_metrics: Option<&dyn NetworkMetrics>,
+) -> RuntimeResult<()> {
+    let now = chrono::Utc::now().naive_utc();
+    let (net_rx_bytes, net_tx_bytes) = if let Some(metrics) = network_metrics {
+        (
+            Some(to_i64(metrics.rx_bytes())?),
+            Some(to_i64(metrics.tx_bytes())?),
+        )
+    } else {
+        (Some(0), Some(0))
+    };
+
+    sandbox_metric_entity::ActiveModel {
+        sandbox_id: Set(sandbox_id),
+        cpu_percent: Set(Some(cpu_percent)),
+        memory_bytes: Set(Some(to_i64(process.memory_bytes)?)),
+        disk_read_bytes: Set(Some(to_i64(process.disk_read_bytes)?)),
+        disk_write_bytes: Set(Some(to_i64(process.disk_write_bytes)?)),
+        net_rx_bytes: Set(net_rx_bytes),
+        net_tx_bytes: Set(net_tx_bytes),
+        sampled_at: Set(Some(now)),
+        created_at: Set(Some(now)),
+        ..Default::default()
+    }
+    .insert(db)
+    .await?;
+
+    Ok(())
+}
+
+fn to_i64(value: u64) -> RuntimeResult<i64> {
+    i64::try_from(value)
+        .map_err(|_| RuntimeError::Custom(format!("metric value overflowed i64: {value}")))
+}
+
+#[cfg(target_os = "linux")]
+fn sample_process(pid: i32) -> RuntimeResult<ProcessSample> {
+    let stat_path = format!("/proc/{pid}/stat");
+    let stat = std::fs::read_to_string(&stat_path)?;
+    let rest = stat
+        .rsplit_once(") ")
+        .map(|(_, rest)| rest)
+        .ok_or_else(|| RuntimeError::Custom(format!("unexpected stat format: {stat_path}")))?;
+    let fields: Vec<&str> = rest.split_whitespace().collect();
+    if fields.len() <= 12 {
+        return Err(RuntimeError::Custom(format!(
+            "unexpected stat field count for pid {pid}: {}",
+            fields.len()
+        )));
+    }
+
+    let clk_tck = sysconf(libc::_SC_CLK_TCK)? as f64;
+    let utime_ticks: u64 = parse_u64(fields[11], "utime")?;
+    let stime_ticks: u64 = parse_u64(fields[12], "stime")?;
+
+    let statm_path = format!("/proc/{pid}/statm");
+    let statm = std::fs::read_to_string(&statm_path)?;
+    let statm_fields: Vec<&str> = statm.split_whitespace().collect();
+    if statm_fields.len() < 2 {
+        return Err(RuntimeError::Custom(format!(
+            "unexpected statm field count for pid {pid}: {}",
+            statm_fields.len()
+        )));
+    }
+    let resident_pages: u64 = parse_u64(statm_fields[1], "resident_pages")?;
+    let page_size = sysconf(libc::_SC_PAGESIZE)? as u64;
+
+    let io_path = format!("/proc/{pid}/io");
+    let io = std::fs::read_to_string(&io_path)?;
+    let mut disk_read_bytes = None;
+    let mut disk_write_bytes = None;
+    for line in io.lines() {
+        if let Some(value) = line.strip_prefix("read_bytes:") {
+            disk_read_bytes = Some(parse_u64(value.trim(), "read_bytes")?);
+        } else if let Some(value) = line.strip_prefix("write_bytes:") {
+            disk_write_bytes = Some(parse_u64(value.trim(), "write_bytes")?);
+        }
+    }
+
+    Ok(ProcessSample {
+        cpu_time_secs: (utime_ticks + stime_ticks) as f64 / clk_tck,
+        memory_bytes: resident_pages.saturating_mul(page_size),
+        disk_read_bytes: disk_read_bytes.unwrap_or(0),
+        disk_write_bytes: disk_write_bytes.unwrap_or(0),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn sample_process(pid: i32) -> RuntimeResult<ProcessSample> {
+    let mut info = RusageInfoV2::default();
+    let result = unsafe {
+        proc_pid_rusage(
+            pid,
+            RUSAGE_INFO_V2,
+            (&mut info as *mut RusageInfoV2).cast::<std::ffi::c_void>(),
+        )
+    };
+    if result != 0 {
+        return Err(RuntimeError::Io(std::io::Error::last_os_error()));
+    }
+
+    Ok(ProcessSample {
+        cpu_time_secs: (info.ri_user_time + info.ri_system_time) as f64 / 1_000_000_000.0,
+        memory_bytes: info.ri_resident_size,
+        disk_read_bytes: info.ri_diskio_bytesread,
+        disk_write_bytes: info.ri_diskio_byteswritten,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_u64(value: &str, field: &str) -> RuntimeResult<u64> {
+    value.parse::<u64>().map_err(|err| {
+        RuntimeError::Custom(format!("failed to parse {field}='{value}' as u64: {err}"))
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn sysconf(name: libc::c_int) -> RuntimeResult<i64> {
+    let value = unsafe { libc::sysconf(name) };
+    if value <= 0 {
+        return Err(RuntimeError::Io(std::io::Error::last_os_error()));
+    }
+    Ok(value)
+}
+
+#[cfg(target_os = "macos")]
+const RUSAGE_INFO_V2: libc::c_int = 2;
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Default)]
+struct RusageInfoV2 {
+    ri_uuid: [u8; 16],
+    ri_user_time: u64,
+    ri_system_time: u64,
+    ri_pkg_idle_wkups: u64,
+    ri_interrupt_wkups: u64,
+    ri_pageins: u64,
+    ri_wired_size: u64,
+    ri_resident_size: u64,
+    ri_phys_footprint: u64,
+    ri_proc_start_abstime: u64,
+    ri_proc_exit_abstime: u64,
+    ri_child_user_time: u64,
+    ri_child_system_time: u64,
+    ri_child_pkg_idle_wkups: u64,
+    ri_child_interrupt_wkups: u64,
+    ri_child_pageins: u64,
+    ri_child_elapsed_abstime: u64,
+    ri_diskio_bytesread: u64,
+    ri_diskio_byteswritten: u64,
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn proc_pid_rusage(
+        pid: libc::c_int,
+        flavor: libc::c_int,
+        buffer: *mut std::ffi::c_void,
+    ) -> libc::c_int;
+}

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
 use crate::console::{AgentConsoleBackend, ConsoleSharedState};
 use crate::heartbeat::HeartbeatReader;
 use crate::logging::LogLevel;
+use crate::metrics::run_metrics_sampler;
 use crate::relay::AgentRelay;
 use crate::{RuntimeError, RuntimeResult};
 
@@ -151,6 +152,12 @@ type NetworkTerminationHandle = microsandbox_network::network::TerminationHandle
 #[cfg(not(feature = "net"))]
 type NetworkTerminationHandle = ();
 
+#[cfg(feature = "net")]
+type NetworkMetricsHandle = microsandbox_network::network::MetricsHandle;
+
+#[cfg(not(feature = "net"))]
+type NetworkMetricsHandle = ();
+
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
@@ -241,7 +248,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let exit_run_id = run_db_id;
     let exit_reason_for_observer = Arc::clone(&exit_reason);
     let exit_sock_path = config.agent_sock_path.clone();
-    let (vm, _network_termination_handle) = match build_vm(
+    let (vm, _network_termination_handle, network_metrics_handle) = match build_vm(
         &config,
         console_backend,
         move |exit_code: i32| {
@@ -311,6 +318,14 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             network_exit_handle.trigger();
         }));
     }
+
+    tokio_rt.spawn(run_metrics_sampler(
+        db.clone(),
+        config.sandbox_id,
+        pid,
+        network_metrics_handle
+            .map(|handle| Box::new(handle) as Box<dyn crate::metrics::NetworkMetrics>),
+    ));
 
     // Spawn background tasks.
     let (_relay_shutdown_tx, relay_shutdown_rx) = tokio::sync::watch::channel(false);
@@ -412,7 +427,11 @@ fn build_vm(
     console_backend: AgentConsoleBackend,
     on_exit: impl Fn(i32) + Send + 'static,
     tokio_handle: tokio::runtime::Handle,
-) -> RuntimeResult<(msb_krun::Vm, Option<NetworkTerminationHandle>)> {
+) -> RuntimeResult<(
+    msb_krun::Vm,
+    Option<NetworkTerminationHandle>,
+    Option<NetworkMetricsHandle>,
+)> {
     let mut exec_env = config.vm.env.clone();
     let vm = &config.vm;
 
@@ -497,6 +516,7 @@ fn build_vm(
     }
 
     let mut network_termination_handle = None;
+    let mut network_metrics_handle = None;
 
     // Network.
     #[cfg(feature = "net")]
@@ -506,6 +526,7 @@ fn build_vm(
         let mut network =
             microsandbox_network::network::SmoltcpNetwork::new(vm.network.clone(), vm.sandbox_slot);
         network_termination_handle = Some(network.termination_handle());
+        network_metrics_handle = Some(network.metrics_handle());
 
         network.start(tokio_handle.clone());
 
@@ -562,7 +583,7 @@ fn build_vm(
         .build()
         .map_err(|e| RuntimeError::Custom(format!("build VM: {e}")))?;
 
-    Ok((vm, network_termination_handle))
+    Ok((vm, network_termination_handle, network_metrics_handle))
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a full metrics pipeline: the runtime samples CPU, memory, disk I/O, and network counters from the host OS and persists them to the database at 1-second intervals
- Introduce a new `msb metrics` CLI command that displays live resource usage for running sandboxes in table or JSON format
- Rename `ps` to `status` (keeping `ps` as alias) and extend it with COMMAND, PORTS columns, single-sandbox inspection, JSON output, and sorted results
- Add network byte counters at the virtio-net boundary so the metrics sampler can report per-sandbox network throughput

## Changes

- **runtime (292 new lines)**: New `crates/runtime/lib/metrics.rs` implements the background metrics sampler with platform-specific process sampling (Linux via `/proc/{pid}/stat`, `/proc/{pid}/statm`, `/proc/{pid}/io`; macOS via `proc_pid_rusage` with `RusageInfoV2`). Computes delta-based CPU percentage and persists all counters to the `sandbox_metric` DB table every second.
- **runtime/vm.rs**: Wire up the metrics sampler as a tokio background task, passing the DB connection, sandbox ID, PID, and an optional `NetworkMetricsHandle`.
- **network/shared.rs**: Add `NetworkMetrics` struct with `AtomicU64` counters for tx/rx bytes. Expose `add_tx_bytes`/`add_rx_bytes` increment methods and read accessors.
- **network/backend.rs, network/device.rs**: Increment tx/rx byte counters on every frame written/emitted at the virtio-net boundary.
- **network/network.rs**: Add `MetricsHandle` type providing read-only access to the shared byte counters, with a `metrics_handle()` constructor on `SmoltcpNetwork`.
- **microsandbox/sandbox/metrics.rs (197 new lines)**: New module with `SandboxMetrics` struct, `metrics_for_sandbox()` DB query, `all_sandbox_metrics()` bulk query, and `Sandbox::metrics_stream()` for continuous polling via `futures::Stream`.
- **microsandbox/sandbox/handle.rs**: Add `SandboxHandle::metrics()` method for single-sandbox metric retrieval.
- **cli/commands/metrics.rs (119 new lines)**: New `msb metrics` command with optional sandbox name argument, `--format json` support, and a table view showing CPU%, memory (used/limit), disk read/write, net rx/tx, uptime, and timestamp.
- **cli/commands/ps.rs**: Rename to `status` command with `ps` alias. Add optional positional `name` argument for single-sandbox mode, `--format json` output, COMMAND and PORTS columns, and helper functions for extracting/formatting image, command, and port mappings.
- **cli/ui.rs**: Add `format_bytes()` utility for human-readable binary unit formatting (B, KiB, MiB, GiB, TiB).
- **cli (misc)**: Add `value_parser = ["json"]` validation to `--format` args in inspect and list commands. Add `-f` short flag for `--force` in install, remove, stop, and self-update commands.

## Test Plan

- Run `cargo build --release` to verify compilation across all crates
- Run `cargo clippy --workspace` to confirm no lint warnings
- Start a sandbox and run `msb metrics` to verify table output with CPU, memory, disk, and network columns
- Run `msb metrics <name>` for single-sandbox metrics
- Run `msb metrics --format json` to verify JSON output structure
- Run `msb status` and verify NAME, IMAGE, COMMAND, STATUS, PORTS columns
- Run `msb status <name>` for single-sandbox status view
- Run `msb status --format json` and `msb status -a --format json` for JSON output
- Verify `msb ps` still works as an alias for `msb status`
- Verify `msb remove -f`, `msb stop -f`, `msb install -f` short flags work
- Verify `msb list --format invalid` and `msb inspect --format invalid` are rejected by the value parser