### PR TITLE
chore: bump workspace version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2545,14 +2545,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2590,14 +2590,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "crossbeam-queue",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "crc32c",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/zerocore-ai/microsandbox"
-version = "0.3.2"
+version = "0.3.3"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/Dockerfile.agentd
+++ b/Dockerfile.agentd
@@ -18,7 +18,7 @@ members = ["crates/protocol"]
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/zerocore-ai/microsandbox"
-version = "0.3.2"
+version = "0.3.3"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Team MicroSandbox <team@microsandbox.dev>"]
 repository = "https://github.com/zerocore-ai/microsandbox"
-version = "0.3.2"
+version = "0.3.3"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
+microsandbox-protocol = { version = "0.3.3", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,11 +28,11 @@ console.workspace = true
 dirs.workspace = true
 indicatif.workspace = true
 libc.workspace = true
-microsandbox = { version = "0.3.2", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.3.2", path = "../image" }
-microsandbox-network = { version = "0.3.2", path = "../network", optional = true }
-microsandbox-runtime = { version = "0.3.2", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox = { version = "0.3.3", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.3.3", path = "../image" }
+microsandbox-network = { version = "0.3.3", path = "../network", optional = true }
+microsandbox-runtime = { version = "0.3.3", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 rand.workspace = true
 reqwest.workspace = true
 rpassword.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 msb_krun = "0.1.9"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 oci-client.workspace = true
 oci-spec.workspace = true
 scopeguard.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -25,14 +25,14 @@ dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.3.2", path = "../db" }
-microsandbox-filesystem = { version = "0.3.2", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.3.2", path = "../image" }
-microsandbox-migration = { version = "0.3.2", path = "../migration" }
-microsandbox-network = { version = "0.3.2", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
-microsandbox-runtime = { version = "0.3.2", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox-db = { version = "0.3.3", path = "../db" }
+microsandbox-filesystem = { version = "0.3.3", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.3.3", path = "../image" }
+microsandbox-migration = { version = "0.3.3", path = "../migration" }
+microsandbox-network = { version = "0.3.3", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.3.3", path = "../protocol" }
+microsandbox-runtime = { version = "0.3.3", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 reqwest.workspace = true
 scopeguard.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -19,7 +19,7 @@ hickory-resolver = { workspace = true }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 msb_krun = { version = "0.1.9", features = ["net"] }
 rcgen = { workspace = true }
 rustls = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.3.2", path = "../db" }
-microsandbox-filesystem = { version = "0.3.2", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.3.2", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.2", path = "../protocol" }
-microsandbox-utils = { version = "0.3.2", path = "../utils" }
+microsandbox-db = { version = "0.3.3", path = "../db" }
+microsandbox-filesystem = { version = "0.3.3", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.3.3", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.3.3", path = "../protocol" }
+microsandbox-utils = { version = "0.3.3", path = "../utils" }
 msb_krun = { version = "0.1.9", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }


### PR DESCRIPTION
## Summary
- Patch bump all publishable crates from 0.3.2 to 0.3.3
- Updates workspace version definitions, all inter-crate dependency version strings, lock files, and Dockerfile.agentd
- Prepares the workspace for the next release

## Changes
- Updated `[workspace.package] version` in root `Cargo.toml` and `crates/agentd/Cargo.toml`
- Bumped all internal dependency version strings (e.g., `microsandbox-utils = { version = "0.3.3", ... }`) across `crates/microsandbox`, `crates/cli`, `crates/runtime`, `crates/network`, `crates/image`, and `crates/filesystem` Cargo.toml files
- Updated inline workspace version in `Dockerfile.agentd`
- Regenerated `Cargo.lock` and `crates/agentd/Cargo.lock`

## Test Plan
- `just build` passes successfully with all crates compiling at 0.3.3
- Pre-commit hooks (fmt, clippy, doc, release build) all pass