### PR TITLE
docs: add recipe for pulling images from local docker registry

### DIFF
--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -18,6 +18,8 @@ msb pull ghcr.io/my-org/my-image:v1
 |------|-------------|
 | `-f`, `--force` | Force re-download even if cached |
 | `-q`, `--quiet` | Suppress progress output |
+| `--insecure` | Connect over plain HTTP instead of HTTPS |
+| `--ca-certs <PATH>` | Path to a PEM file with additional CA root certificates |
 
 <Tip>
   Pre-pulling is useful when you want sandbox creation to be instant. Without a pre-pull, the first `Sandbox.create` with a new image will block on the download.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -151,7 +151,8 @@
             "group": "Container Integration",
             "icon": "docker",
             "pages": [
-              "recipes/docker"
+              "recipes/docker",
+              "recipes/local-images"
             ]
           }
         ]

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -56,10 +56,10 @@ Authenticate to private registries by passing credentials.
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("registry.corp.io/team/app:latest")
-    .registry_auth(RegistryAuth::Basic {
+    .registry(|r| r.auth(RegistryAuth::Basic {
         username: "deploy".into(),
         password: std::env::var("REGISTRY_PASSWORD")?,
-    })
+    }))
     .pull_policy(PullPolicy::Always)
     .create()
     .await?;
@@ -69,7 +69,7 @@ let sb = Sandbox::builder("worker")
 const sb = await Sandbox.create({
     name: "worker",
     image: "registry.corp.io/team/app:latest",
-    registryAuth: { username: "deploy", password: process.env.REGISTRY_TOKEN },
+    registry: { auth: { username: "deploy", password: process.env.REGISTRY_TOKEN } },
     pullPolicy: PullPolicy.Always,
 })
 ```
@@ -84,6 +84,79 @@ sb = await Sandbox.create(
     registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
     pull_policy=PullPolicy.ALWAYS,
 )
+```
+</CodeGroup>
+
+## Registry TLS
+
+By default, microsandbox connects to registries over HTTPS using system CA roots. You can customize this per-registry in `~/.microsandbox/config.json`.
+
+### Plain HTTP registries
+
+Local registries often run without TLS. Mark them as insecure to connect over plain HTTP:
+
+```json
+{
+  "registries": {
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true
+      }
+    }
+  }
+}
+```
+
+### Custom CA certificates
+
+For registries using self-signed or internal CA certificates, point `ca_certs` to a PEM file. This applies globally to all registry connections:
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/ca-bundle.pem"
+  }
+}
+```
+
+The certificates are added to the default system roots — public registries continue to work normally.
+
+### Combined configuration
+
+```json
+{
+  "registries": {
+    "ca_certs": "/path/to/corporate-ca.pem",
+    "hosts": {
+      "localhost:5050": {
+        "insecure": true,
+        "auth": { "username": "deploy", "password_env": "REGISTRY_TOKEN" }
+      },
+      "ghcr.io": {
+        "auth": { "username": "user", "store": "keyring" }
+      }
+    }
+  }
+}
+```
+
+These settings can also be set per-sandbox via the SDK, overriding global config:
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const sb = await Sandbox.create({
+    name: "worker",
+    image: "localhost:5050/my-app:latest",
+    registry: { insecure: true },
+})
 ```
 </CodeGroup>
 

--- a/docs/recipes/local-images.mdx
+++ b/docs/recipes/local-images.mdx
@@ -1,0 +1,71 @@
+---
+title: Using Local Docker Images
+description: Use locally built Docker images with microsandbox via a local registry
+icon: "docker"
+---
+
+microsandbox pulls images from OCI-compatible registries. If you build an image locally with `docker build`, microsandbox can't access it directly from Docker's local store. The workaround is to run a local registry and push your image there.
+
+## Step 1: Start a local registry
+
+Run a local OCI registry on port 5050:
+
+```bash
+docker run -d -p 5050:5000 --name registry registry:2
+```
+
+<Tip>
+  Port 5000 is used by AirPlay on macOS. This guide uses port 5050 to avoid conflicts.
+</Tip>
+
+## Step 2: Build, tag, and push your image
+
+Build your Docker image and tag it for the local registry:
+
+```bash
+docker build -t localhost:5050/my-image:latest .
+```
+
+If you already have an existing image, re-tag it:
+
+```bash
+docker tag my-image:latest localhost:5050/my-image:latest
+```
+
+Push to the local registry:
+
+```bash
+docker push localhost:5050/my-image:latest
+```
+
+## Step 3: Pull with microsandbox
+
+Since the local registry runs over plain HTTP, use the `--insecure` flag:
+
+```bash
+msb pull localhost:5050/my-image:latest --insecure
+```
+
+## Step 4: Use it in microsandbox
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const sb = await Sandbox.create({
+    name: "worker",
+    image: "localhost:5050/my-image:latest",
+    registry: { insecure: true },
+})
+```
+</CodeGroup>
+
+<Tip>
+  For persistent configuration that applies to all CLI and SDK operations, add the registry to `~/.microsandbox/config.json` instead. See [Registry TLS](/images/overview#registry-tls).
+</Tip>


### PR DESCRIPTION
## Summary
- Adds a new **Recipe** top-level tab to the docs navigation
- First recipe: **Using Local Docker Images** — step-by-step guide for bridging locally built Docker images to microsandbox via a local registry

Fixes #315

## Test plan
- [x] Verify Mintlify renders the new page correctly
- [x] Confirm navigation shows the Cookbook tab