### PR TITLE
refactor(sandbox): simplify exec/attach/image APIs with _with variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-authors = ["Team MicroSandbox <team@microsandbox.dev>"]
+authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 version = "0.3.8"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Today, AI agents operate with whatever permissions you give them, and that's usu
 - <img height="15" src="https://octicons-col.vercel.app/globe/A770EF"> **Programmable Filesystem & Network Stack**: Customizable filesystems and network operations.
 - <img height="15" src="https://octicons-col.vercel.app/package/A770EF"> **OCI Compatible**: Runs standard container images from Docker Hub, GHCR, or any OCI registry.
 - <img height="15" src="https://octicons-col.vercel.app/database/A770EF"> **Long-Running**: Sandboxes can run in detached mode. They are great for long-lived sessions.
-- <img height="15" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills) and [MCP server].
+- <img height="15" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills) and [MCP server](https://github.com/superradcompany/microsandbox-mcp).
 
 > Microsandbox is still **beta software**. Expect breaking changes, missing features, and rough edges.
 
@@ -158,41 +158,6 @@ The SDK lets you create and control sandboxes directly from your application. `S
 >   <a href="./typescript_examples.md#port-publishing"><img src="https://img.shields.io/badge/-→ Typescript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript"></a>&nbsp;<a href="./python_examples.md"><img src="https://img.shields.io/badge/-→ Python-FFD43B?style=flat-square&logo=python&logoColor=306998" alt="Python"></a>
 > </div>
 
-#### <img height="14" src="https://octicons-col.vercel.app/database/A770EF">&nbsp;&nbsp;Named Volumes
-
-> Persistent storage that survives sandbox restarts and can be shared across sandboxes:
->
-> ```rs
-> use microsandbox::{Sandbox, Volume, size::SizeExt};
->
-> // Create a volume with a quota.
-> let data = Volume::builder("shared-data").quota(100.mib()).create().await?;
->
-> // Sandbox A writes to it.
-> let writer = Sandbox::builder("writer")
->     .image("alpine")
->     .volume("/data", |v| v.named(data.name()))
->     .create()
->     .await?;
->
-> writer.shell("echo 'hello' > /data/message.txt").await?;
-> writer.stop_and_wait().await?;
->
-> // Sandbox B reads from it.
-> let reader = Sandbox::builder("reader")
->     .image("alpine")
->     .volume("/data", |v| v.named(data.name()).readonly())
->     .create()
->     .await?;
->
-> let output = reader.shell("cat /data/message.txt").await?;
-> println!("{}", output.stdout()?); // hello
-> ```
->
-> <div align="left">
->   <a href="./typescript_examples.md#named-volumes"><img src="https://img.shields.io/badge/-→ Typescript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript"></a>&nbsp;<a href="./python_examples.md"><img src="https://img.shields.io/badge/-→ Python-FFD43B?style=flat-square&logo=python&logoColor=306998" alt="Python"></a>
-> </div>
-
 #### <img height="14" src="https://octicons-col.vercel.app/pencil/A770EF">&nbsp;&nbsp;Scripts & Patches
 
 > Register named scripts that get mounted at `/.msb/scripts/` and added to `PATH`, so you can invoke them by name:
@@ -243,8 +208,7 @@ The SDK lets you create and control sandboxes directly from your application. `S
 > Sandbox::builder("bind").image("./my-rootfs")
 >
 > // QCOW2 disk image
-> use microsandbox::sandbox::ImageBuilder;
-> Sandbox::builder("block").image(|img: ImageBuilder| img.disk("./disk.qcow2").fstype("ext4"))
+> Sandbox::builder("block").image_with(|img| img.disk("./disk.qcow2").fstype("ext4"))
 > ```
 >
 > <div align="left">
@@ -332,7 +296,7 @@ The `msb` CLI provides a complete interface for managing sandboxes, images, and 
 
 > ```sh
 > msb pull python           # Pull an image
-> msb image ls                   # List cached images
+> msb image ls              # List cached images
 > msb image rm python       # Remove an image
 > ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 The microsandbox team welcomes security reports and is committed to
 providing prompt attention to security issues. Security issues should be
-reported privately via [appcypher@outlook.com][support-email]. Security issues should
+reported privately via [security@superrad.company][support-email]. Security issues should
 not be reported via the public GitHub Issue tracker.
 
 ## Security advisories
@@ -14,4 +14,4 @@ Github respository's [security portal][sec-advisories] and and the
 
 [rustsec-db]: https://github.com/RustSec/advisory-db
 [sec-advisories]: https://github.com/microsandbox/microsandbox/security/advisories
-[support-email]: mailto:appcypher@outlook.com
+[support-email]: mailto:security@superrad.company

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["."]
 
 [workspace.package]
-authors = ["Team MicroSandbox <team@microsandbox.dev>"]
+authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 version = "0.3.8"
 license = "Apache-2.0"

--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -4,7 +4,7 @@ use std::io::{IsTerminal, Write};
 use std::time::Duration;
 
 use clap::Args;
-use microsandbox::sandbox::{AttachOptionsBuilder, ExecOptionsBuilder, ExecOutput};
+use microsandbox::sandbox::ExecOutput;
 
 use crate::ui;
 
@@ -89,7 +89,7 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
     if interactive {
         // Interactive mode with TTY — use attach.
         let exit_code = sandbox
-            .attach(cmd, |a: AttachOptionsBuilder| {
+            .attach_with(cmd, |a| {
                 let mut a = a.args(cmd_args);
                 for (k, v) in &env_pairs {
                     a = a.env(k, v);
@@ -115,7 +115,7 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
     } else {
         // Non-interactive: exec and capture output.
         let output: ExecOutput = sandbox
-            .exec(cmd, |e: ExecOptionsBuilder| {
+            .exec_with(cmd, |e| {
                 let mut e = e.args(cmd_args);
                 for (k, v) in &env_pairs {
                     e = e.env(k, v);

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -3,8 +3,8 @@
 use std::io::{IsTerminal, Write};
 
 use clap::Args;
+use microsandbox::sandbox::ExecOutput;
 use microsandbox::sandbox::Sandbox;
-use microsandbox::sandbox::{AttachOptionsBuilder, ExecOptionsBuilder, ExecOutput};
 
 use super::common::{SandboxOpts, apply_sandbox_opts};
 use crate::ui;
@@ -190,13 +190,9 @@ async fn exec_in_sandbox(
     interactive: bool,
 ) -> anyhow::Result<i32> {
     if interactive {
-        Ok(sandbox
-            .attach(cmd, |a: AttachOptionsBuilder| a.args(cmd_args))
-            .await?)
+        Ok(sandbox.attach(cmd, cmd_args).await?)
     } else {
-        let output: ExecOutput = sandbox
-            .exec(cmd, |e: ExecOptionsBuilder| e.args(cmd_args))
-            .await?;
+        let output: ExecOutput = sandbox.exec(cmd, cmd_args).await?;
 
         std::io::stdout().write_all(output.stdout_bytes())?;
         std::io::stderr().write_all(output.stderr_bytes())?;

--- a/crates/cli/lib/commands/shell.rs
+++ b/crates/cli/lib/commands/shell.rs
@@ -3,7 +3,7 @@
 use std::io::{IsTerminal, Write};
 
 use clap::Args;
-use microsandbox::sandbox::{AttachOptionsBuilder, ExecOptionsBuilder, ExecOutput};
+use microsandbox::sandbox::ExecOutput;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -66,7 +66,7 @@ pub async fn run(args: ShellArgs) -> anyhow::Result<()> {
 
         let exit_code = if let Some(ref script) = script {
             sandbox
-                .attach(shell, |a: AttachOptionsBuilder| {
+                .attach_with(shell, |a| {
                     let mut a = a.args(["-c", script.as_str()]);
                     if let Some(ref user) = args.user {
                         a = a.user(user);
@@ -76,7 +76,7 @@ pub async fn run(args: ShellArgs) -> anyhow::Result<()> {
                 .await?
         } else {
             sandbox
-                .attach(shell, |a: AttachOptionsBuilder| {
+                .attach_with(shell, |a| {
                     let mut a = a;
                     if let Some(ref user) = args.user {
                         a = a.user(user);
@@ -118,7 +118,7 @@ pub async fn run(args: ShellArgs) -> anyhow::Result<()> {
         };
 
         let output: ExecOutput = sandbox
-            .exec(shell, |e: ExecOptionsBuilder| {
+            .exec_with(shell, |e| {
                 let mut e = e.args(["-c", &script]);
                 if let Some(ref user) = args.user {
                     e = e.user(user);

--- a/crates/microsandbox/README.md
+++ b/crates/microsandbox/README.md
@@ -2,7 +2,7 @@
 
 Lightweight VM sandboxes for running AI agents and untrusted code with hardware-level isolation.
 
-`microsandbox` is the core Rust library for the [MicroSandbox](https://github.com/superradcompany/microsandbox) project. It provides a high-level async API for creating, managing, and interacting with microVM sandboxes — real virtual machines that boot in under 100ms and run standard OCI (Docker) images.
+`microsandbox` is the core Rust library for the [microsandbox](https://github.com/superradcompany/microsandbox) project. It provides a high-level async API for creating, managing, and interacting with microVM sandboxes — real virtual machines that boot in under 100ms and run standard OCI (Docker) images.
 
 ## Features
 
@@ -234,7 +234,6 @@ let output = sandbox.shell("echo reconnected").await?;
 
 ```rust
 use microsandbox::Sandbox;
-use microsandbox::sandbox::ImageBuilder;
 
 // OCI image (most common).
 Sandbox::builder("a").image("python")
@@ -243,7 +242,7 @@ Sandbox::builder("a").image("python")
 Sandbox::builder("b").image("/path/to/rootfs")
 
 // QCOW2 disk image.
-Sandbox::builder("c").image(|img: ImageBuilder| img.disk("/path/to/disk.qcow2").fstype("ext4"))
+Sandbox::builder("c").image_with(|img| img.disk("/path/to/disk.qcow2").fstype("ext4"))
 ```
 
 ## API Overview

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -720,7 +720,7 @@ mod tests {
     #[test]
     fn test_sandbox_cli_args_disk_image_with_fstype() {
         let config = SandboxBuilder::new("test")
-            .image(|i: crate::sandbox::ImageBuilder| i.disk("/tmp/ubuntu.qcow2").fstype("ext4"))
+            .image_with(|i| i.disk("/tmp/ubuntu.qcow2").fstype("ext4"))
             .build()
             .unwrap();
 
@@ -760,7 +760,7 @@ mod tests {
     #[test]
     fn test_sandbox_cli_args_disk_image_without_fstype() {
         let config = SandboxBuilder::new("test")
-            .image(|i: crate::sandbox::ImageBuilder| i.disk("/tmp/alpine.raw"))
+            .image_with(|i| i.disk("/tmp/alpine.raw"))
             .build()
             .unwrap();
 

--- a/crates/microsandbox/lib/sandbox/attach.rs
+++ b/crates/microsandbox/lib/sandbox/attach.rs
@@ -43,16 +43,6 @@ pub struct AttachOptionsBuilder {
     options: AttachOptions,
 }
 
-/// Trait for types that can be converted to attach options.
-///
-/// Enables ergonomic calling patterns:
-/// - `sandbox.attach("bash", ["-l"])` — args array
-/// - `sandbox.attach("zsh", |a| a.env("TERM", "xterm"))` — closure
-pub trait IntoAttachOptions {
-    /// Convert into attach options.
-    fn into_attach_options(self) -> AttachOptions;
-}
-
 /// Parsed detach key sequence.
 ///
 /// Matches raw stdin bytes against the configured detach sequence.
@@ -214,30 +204,6 @@ impl DetachKeys {
     /// Returns the detach key sequence bytes.
     pub fn sequence(&self) -> &[u8] {
         &self.sequence
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-// Trait Implementations
-//--------------------------------------------------------------------------------------------------
-
-/// Closure pattern: `sandbox.attach("zsh", |a| a.env("TERM", "xterm"))`
-impl<F> IntoAttachOptions for F
-where
-    F: FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder,
-{
-    fn into_attach_options(self) -> AttachOptions {
-        self(AttachOptionsBuilder::default()).build()
-    }
-}
-
-/// Args array: `sandbox.attach("bash", ["-l", "--norc"])`
-impl<const N: usize> IntoAttachOptions for [&str; N] {
-    fn into_attach_options(self) -> AttachOptions {
-        AttachOptions {
-            args: self.iter().map(|s| s.to_string()).collect(),
-            ..Default::default()
-        }
     }
 }
 

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -10,7 +10,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use super::{
     config::SandboxConfig,
-    types::{IntoImage, MountBuilder, Patch, PatchBuilder, RootfsSource},
+    types::{ImageBuilder, IntoImage, MountBuilder, Patch, PatchBuilder, RootfsSource},
 };
 use crate::{LogLevel, MicrosandboxResult, size::Mebibytes};
 
@@ -43,22 +43,37 @@ impl SandboxBuilder {
 
     /// Set the root filesystem image source.
     ///
-    /// Accepts a string, path, or closure:
     /// - **`&str` / `String`**: Paths starting with `/`, `./`, or `../` are treated as local
     ///   paths. Everything else is treated as an OCI image reference. Disk image extensions
     ///   (`.qcow2`, `.raw`, `.vmdk`) resolve to virtio-blk block device rootfs.
     /// - **`PathBuf`**: Always treated as a local path.
-    /// - **Closure**: `|i| i.disk("./image.qcow2").fstype("ext4")` for explicit disk image
-    ///   configuration.
+    ///
+    /// For explicit disk image configuration, see [`image_with`](Self::image_with).
     ///
     /// ```ignore
-    /// .image("python:3.12")                                // OCI image
-    /// .image("./rootfs")                                   // local directory (bind mount)
-    /// .image("./ubuntu.qcow2")                             // disk image (auto-detect fs)
-    /// .image(|i| i.disk("./ubuntu.qcow2").fstype("ext4"))  // disk image (explicit fs)
+    /// .image("python:3.12")       // OCI image
+    /// .image("./rootfs")          // local directory (bind mount)
+    /// .image("./ubuntu.qcow2")   // disk image (auto-detect fs)
     /// ```
     pub fn image(mut self, image: impl IntoImage) -> Self {
         match image.into_rootfs_source() {
+            Ok(rootfs) => self.config.image = rootfs,
+            Err(e) => {
+                if self.build_error.is_none() {
+                    self.build_error = Some(e);
+                }
+            }
+        }
+        self
+    }
+
+    /// Set the root filesystem image using a builder closure.
+    ///
+    /// ```ignore
+    /// .image_with(|i| i.disk("./ubuntu.qcow2").fstype("ext4"))
+    /// ```
+    pub fn image_with(mut self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self {
+        match f(ImageBuilder::new()).build() {
             Ok(rootfs) => self.config.image = rootfs,
             Err(e) => {
                 if self.build_error.is_none() {

--- a/crates/microsandbox/lib/sandbox/exec.rs
+++ b/crates/microsandbox/lib/sandbox/exec.rs
@@ -180,16 +180,6 @@ pub enum RlimitResource {
     Rttime,
 }
 
-/// Trait for types that can be converted to [`ExecOptions`].
-///
-/// Enables ergonomic calling patterns:
-/// - `sandbox.exec("ls", ["-la"])` — args array
-/// - `sandbox.exec("python", |e| e.args(["-c", "print('hi')"]))` — closure
-pub trait IntoExecOptions {
-    /// Convert into exec options.
-    fn into_exec_options(self) -> ExecOptions;
-}
-
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -473,26 +463,6 @@ impl RlimitResource {
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
-
-/// Closure pattern: `sandbox.exec("python", |e| e.args(["-c", "print('hi')"]))`
-impl<F> IntoExecOptions for F
-where
-    F: FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
-{
-    fn into_exec_options(self) -> ExecOptions {
-        self(ExecOptionsBuilder::default()).build()
-    }
-}
-
-/// Args array: `sandbox.exec("ls", ["-la", "/tmp"])`
-impl<const N: usize> IntoExecOptions for [&str; N] {
-    fn into_exec_options(self) -> ExecOptions {
-        ExecOptions {
-            args: self.iter().map(|s| s.to_string()).collect(),
-            ..Default::default()
-        }
-    }
-}
 
 /// String to `RlimitResource` conversion.
 ///

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     runtime::{ProcessHandle, SpawnMode, spawn_sandbox},
 };
 
+use self::attach::AttachOptions;
 use self::exec::{ExecEvent, ExecHandle, ExecOptions, ExecSink, StdinMode};
 
 //--------------------------------------------------------------------------------------------------
@@ -44,10 +45,10 @@ use self::exec::{ExecEvent, ExecHandle, ExecOptions, ExecSink, StdinMode};
 //--------------------------------------------------------------------------------------------------
 
 pub use crate::db::entity::sandbox::SandboxStatus;
-pub use attach::{AttachOptionsBuilder, IntoAttachOptions};
+pub use attach::AttachOptionsBuilder;
 pub use builder::SandboxBuilder;
 pub use config::SandboxConfig;
-pub use exec::{ExecOptionsBuilder, ExecOutput, IntoExecOptions, Rlimit, RlimitResource};
+pub use exec::{ExecOptionsBuilder, ExecOutput, Rlimit, RlimitResource};
 pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, SandboxFs};
 pub use handle::SandboxHandle;
 pub use metrics::{SandboxMetrics, all_sandbox_metrics};
@@ -496,16 +497,32 @@ impl Sandbox {
 impl Sandbox {
     /// Execute a command and return a streaming handle.
     ///
-    /// This is the foundational exec method. All other exec methods delegate to it.
-    ///
-    /// - `sandbox.exec_stream("tail", ["-f", "/var/log/app.log"])` — args array
-    /// - `sandbox.exec_stream("python", |e| e.args(["-c", "x"]).env("K", "V"))` — closure
+    /// ```ignore
+    /// let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
+    /// ```
     pub async fn exec_stream(
         &self,
         cmd: impl Into<String>,
-        opts: impl exec::IntoExecOptions,
+        args: impl IntoIterator<Item = impl Into<String>>,
     ) -> MicrosandboxResult<ExecHandle> {
-        let opts = opts.into_exec_options();
+        let opts = ExecOptions {
+            args: args.into_iter().map(Into::into).collect(),
+            ..Default::default()
+        };
+        self.exec_stream_inner(cmd.into(), opts).await
+    }
+
+    /// Execute a command with full options and return a streaming handle.
+    ///
+    /// ```ignore
+    /// let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+    /// ```
+    pub async fn exec_stream_with(
+        &self,
+        cmd: impl Into<String>,
+        f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+    ) -> MicrosandboxResult<ExecHandle> {
+        let opts = f(ExecOptionsBuilder::default()).build();
         self.exec_stream_inner(cmd.into(), opts).await
     }
 
@@ -590,18 +607,43 @@ impl Sandbox {
 
     /// Execute a command and wait for completion.
     ///
-    /// Returns captured stdout/stderr.
-    ///
-    /// - `sandbox.exec("python", ["-c", "print('hi')"])` — args array
-    /// - `sandbox.exec("python", |e| e.args(["compute.py"]).env("HOME", "/root"))` — closure
+    /// ```ignore
+    /// let output = sb.exec("python", ["-c", "print('hi')"]).await?;
+    /// ```
     pub async fn exec(
         &self,
         cmd: impl Into<String>,
-        opts: impl exec::IntoExecOptions,
+        args: impl IntoIterator<Item = impl Into<String>>,
     ) -> MicrosandboxResult<ExecOutput> {
-        let opts = opts.into_exec_options();
+        let opts = ExecOptions {
+            args: args.into_iter().map(Into::into).collect(),
+            ..Default::default()
+        };
+        self.exec_with_opts(cmd.into(), opts).await
+    }
+
+    /// Execute a command with full options and wait for completion.
+    ///
+    /// ```ignore
+    /// let output = sb.exec_with("python", |e| e.args(["compute.py"]).cwd("/app")).await?;
+    /// ```
+    pub async fn exec_with(
+        &self,
+        cmd: impl Into<String>,
+        f: impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder,
+    ) -> MicrosandboxResult<ExecOutput> {
+        let opts = f(ExecOptionsBuilder::default()).build();
+        self.exec_with_opts(cmd.into(), opts).await
+    }
+
+    /// Shared implementation for exec and exec_with.
+    async fn exec_with_opts(
+        &self,
+        cmd: String,
+        opts: ExecOptions,
+    ) -> MicrosandboxResult<ExecOutput> {
         let timeout_duration = opts.timeout;
-        let mut handle = self.exec_stream_inner(cmd.into(), opts).await?;
+        let mut handle = self.exec_stream_inner(cmd, opts).await?;
 
         match timeout_duration {
             Some(duration) => {
@@ -656,29 +698,46 @@ impl Sandbox {
 impl Sandbox {
     /// Attach to the sandbox with an interactive terminal session.
     ///
-    /// Bridges the host terminal to a guest process running in a PTY.
-    /// Returns the exit code when the process exits or the user detaches.
-    ///
-    /// - `sandbox.attach("bash", ["-l"])` — command with args
-    /// - `sandbox.attach("/bin/sh", |a| a.detach_keys("ctrl-q"))` — with options
-    /// - `sandbox.attach("zsh", |a| a.env("TERM", "xterm"))` — command with options
+    /// ```ignore
+    /// let exit_code = sb.attach("bash", ["-l"]).await?;
+    /// ```
     pub async fn attach(
         &self,
         cmd: impl Into<String>,
-        opts: impl attach::IntoAttachOptions,
+        args: impl IntoIterator<Item = impl Into<String>>,
     ) -> MicrosandboxResult<i32> {
+        let opts = AttachOptions {
+            args: args.into_iter().map(Into::into).collect(),
+            ..Default::default()
+        };
+        self.attach_inner(cmd.into(), opts).await
+    }
+
+    /// Attach to the sandbox with full options.
+    ///
+    /// ```ignore
+    /// let exit_code = sb.attach_with("zsh", |a| a.env("TERM", "xterm").detach_keys("ctrl-q")).await?;
+    /// ```
+    pub async fn attach_with(
+        &self,
+        cmd: impl Into<String>,
+        f: impl FnOnce(AttachOptionsBuilder) -> AttachOptionsBuilder,
+    ) -> MicrosandboxResult<i32> {
+        let opts = f(AttachOptionsBuilder::default()).build();
+        self.attach_inner(cmd.into(), opts).await
+    }
+
+    /// Shared implementation for attach and attach_with.
+    async fn attach_inner(&self, cmd: String, opts: AttachOptions) -> MicrosandboxResult<i32> {
         use std::os::fd::AsRawFd;
 
         use microsandbox_protocol::exec::ExecResize;
         use tokio::io::{AsyncWriteExt, unix::AsyncFd};
 
-        let opts = opts.into_attach_options();
         let detach_keys = match &opts.detach_keys {
             Some(spec) => attach::DetachKeys::parse(spec)?,
             None => attach::DetachKeys::default_keys(),
         };
-
-        let cmd = cmd.into();
 
         // Get terminal size.
         let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
@@ -859,10 +918,10 @@ impl Sandbox {
     /// Attach to the sandbox's default shell.
     ///
     /// Uses the sandbox's configured shell (default: `/bin/sh`).
-    /// Equivalent to `attach(shell, |a| a)` with the configured shell.
     pub async fn attach_shell(&self) -> MicrosandboxResult<i32> {
         let shell = self.config.shell.as_deref().unwrap_or("/bin/sh");
-        self.attach(shell, |a| a).await
+        self.attach_inner(shell.into(), AttachOptions::default())
+            .await
     }
 }
 

--- a/crates/microsandbox/lib/sandbox/types.rs
+++ b/crates/microsandbox/lib/sandbox/types.rs
@@ -64,10 +64,10 @@ pub enum ImageSource {
 
 /// Builder for configuring a disk image rootfs.
 ///
-/// Used with the closure form of [`crate::sandbox::SandboxBuilder::image`]:
+/// Used with [`crate::sandbox::SandboxBuilder::image_with`]:
 ///
 /// ```ignore
-/// .image(|i| i.disk("./ubuntu.qcow2").fstype("ext4"))
+/// .image_with(|i| i.disk("./ubuntu.qcow2").fstype("ext4"))
 /// ```
 #[derive(Default)]
 pub struct ImageBuilder {
@@ -549,8 +549,8 @@ impl ImageBuilder {
     /// `.qcow2`, `.raw`, `.vmdk`.
     ///
     /// ```ignore
-    /// .image(|i| i.disk("./ubuntu.qcow2"))
-    /// .image(|i| i.disk("./alpine.raw").fstype("ext4"))
+    /// .image_with(|i| i.disk("./ubuntu.qcow2"))
+    /// .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
     /// ```
     pub fn disk(mut self, path: impl Into<PathBuf>) -> Self {
         let path = path.into();
@@ -578,7 +578,7 @@ impl ImageBuilder {
     /// `/proc/filesystems`.
     ///
     /// ```ignore
-    /// .image(|i| i.disk("./ubuntu.raw").fstype("ext4"))
+    /// .image_with(|i| i.disk("./ubuntu.raw").fstype("ext4"))
     /// ```
     pub fn fstype(mut self, fstype: impl Into<String>) -> Self {
         let fstype = fstype.into();
@@ -635,15 +635,6 @@ impl IntoImage for String {
 impl IntoImage for PathBuf {
     fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
         ImageSource::from(self).into_rootfs_source()
-    }
-}
-
-impl<F> IntoImage for F
-where
-    F: FnOnce(ImageBuilder) -> ImageBuilder,
-{
-    fn into_rootfs_source(self) -> crate::MicrosandboxResult<RootfsSource> {
-        self(ImageBuilder::new()).build()
     }
 }
 
@@ -899,8 +890,10 @@ mod tests {
 
     #[test]
     fn test_image_builder_disk_with_fstype() {
-        let rootfs = (|i: ImageBuilder| i.disk("./test.qcow2").fstype("ext4"))
-            .into_rootfs_source()
+        let rootfs = ImageBuilder::new()
+            .disk("./test.qcow2")
+            .fstype("ext4")
+            .build()
             .unwrap();
         match rootfs {
             RootfsSource::DiskImage { format, fstype, .. } => {
@@ -913,9 +906,7 @@ mod tests {
 
     #[test]
     fn test_image_builder_disk_without_fstype() {
-        let rootfs = (|i: ImageBuilder| i.disk("./test.raw"))
-            .into_rootfs_source()
-            .unwrap();
+        let rootfs = ImageBuilder::new().disk("./test.raw").build().unwrap();
         match rootfs {
             RootfsSource::DiskImage { format, fstype, .. } => {
                 assert_eq!(format, DiskImageFormat::Raw);
@@ -927,27 +918,31 @@ mod tests {
 
     #[test]
     fn test_image_builder_bad_extension_errors() {
-        let result = (|i: ImageBuilder| i.disk("./test.txt")).into_rootfs_source();
+        let result = ImageBuilder::new().disk("./test.txt").build();
         assert!(result.is_err());
     }
 
     #[test]
     fn test_image_builder_fstype_without_disk_errors() {
-        let result = (|i: ImageBuilder| i.fstype("ext4")).into_rootfs_source();
+        let result = ImageBuilder::new().fstype("ext4").build();
         assert!(result.is_err());
     }
 
     #[test]
     fn test_image_builder_fstype_rejects_comma() {
-        let result =
-            (|i: ImageBuilder| i.disk("./test.qcow2").fstype("ext4,size=100")).into_rootfs_source();
+        let result = ImageBuilder::new()
+            .disk("./test.qcow2")
+            .fstype("ext4,size=100")
+            .build();
         assert!(result.is_err());
     }
 
     #[test]
     fn test_image_builder_fstype_rejects_equals() {
-        let result =
-            (|i: ImageBuilder| i.disk("./test.qcow2").fstype("key=value")).into_rootfs_source();
+        let result = ImageBuilder::new()
+            .disk("./test.qcow2")
+            .fstype("key=value")
+            .build();
         assert!(result.is_err());
     }
 }

--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -34,7 +34,7 @@ let sb = Sandbox::builder("custom-vm")
 
 // Explicit
 let sb2 = Sandbox::builder("custom-vm")
-    .image(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
     .cpus(1)
     .memory(512)
     .create()

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -34,7 +34,7 @@ These options apply to a single execution and don't change the sandbox's default
 
 <CodeGroup>
 ```rust Rust
-let output = sb.exec("python", |e| e
+let output = sb.exec_with("python", |e| e
     .args(["compute.py"])
     .cwd("/app")
     .env("PYTHONPATH", "/app/lib")
@@ -111,7 +111,7 @@ Bridges your terminal directly to a process inside the sandbox for a fully inter
 ```rust Rust
 let exit_code = sb.attach_shell().await?;
 
-let exit_code = sb.attach("python", |a| a
+let exit_code = sb.attach_with("python", |a| a
     .env("DEBUG", "1")
     .cwd("/app")
     .detach_keys("ctrl-q")
@@ -138,7 +138,7 @@ Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to 
 
 <CodeGroup>
 ```rust Rust
-let mut handle = sb.exec_stream("python", |e| e.stdin_pipe().tty(true)).await?;
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
 let stdin = handle.take_stdin().unwrap();
 stdin.write(b"print('hello')\n").await?;
 stdin.write(b"exit()\n").await?;

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -128,7 +128,7 @@ Boot from a QCOW2, Raw, or VMDK disk image. Unlike OCI images (which use a copy-
 <CodeGroup>
 ```rust Rust
 Sandbox::builder("worker")
-    .image(|i| i.disk("./alpine.qcow2").fstype("ext4"))
+    .image_with(|i| i.disk("./alpine.qcow2").fstype("ext4"))
     .create()
     .await?;
 ```

--- a/docs/sdk/execution.mdx
+++ b/docs/sdk/execution.mdx
@@ -51,7 +51,7 @@ Per-execution overrides for working directory, environment variables, resource l
 use std::time::Duration;
 use microsandbox::RlimitResource;
 
-let output = sb.exec("python", |e| e
+let output = sb.exec_with("python", |e| e
     .args(["compute.py"])
     .cwd("/app")
     .env("PYTHONPATH", "/app/lib")
@@ -114,7 +114,7 @@ Pipe data into a running process by opening a streaming handle with `stdin_pipe`
 
 <CodeGroup>
 ```rust Rust
-let mut handle = sb.exec_stream("python", |e| e.stdin_pipe().tty(true)).await?;
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
 let stdin = handle.take_stdin().unwrap();
 stdin.write(b"print('hello')\n").await?;
 stdin.write(b"exit()\n").await?;
@@ -141,7 +141,7 @@ Bridge your terminal to a fully interactive PTY session inside the sandbox. Pres
 let exit_code = sb.attach_shell().await?;
 
 // Attach to a specific command with options
-let exit_code = sb.attach("python", |a| a
+let exit_code = sb.attach_with("python", |a| a
     .env("DEBUG", "1")
     .cwd("/app")
     .detach_keys("ctrl-q")

--- a/docs/sdk/sandbox.mdx
+++ b/docs/sdk/sandbox.mdx
@@ -144,7 +144,7 @@ let sb = Sandbox::builder("vm-sandbox")
 
 // Explicit filesystem type
 let sb = Sandbox::builder("vm-sandbox")
-    .image(|i| i.disk("./alpine.raw").fstype("ext4"))
+    .image_with(|i| i.disk("./alpine.raw").fstype("ext4"))
     .cpus(1)
     .memory(512)
     .create()

--- a/examples/rust/root-block/bin/main.rs
+++ b/examples/rust/root-block/bin/main.rs
@@ -3,7 +3,6 @@
 //! See [examples/README.md](../../../README.md) for prerequisites and usage.
 
 use microsandbox::Sandbox;
-use microsandbox::sandbox::ImageBuilder;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a sandbox with a qcow2 disk image rootfs.
     let sandbox = Sandbox::builder("block-root")
-        .image(|image: ImageBuilder| image.disk(image_path).fstype("ext4"))
+        .image_with(|image| image.disk(image_path).fstype("ext4"))
         .cpus(1)
         .memory(512)
         .replace()

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -2,7 +2,7 @@
 
 Lightweight VM sandboxes for Node.js — run AI agents and untrusted code with hardware-level isolation.
 
-The `microsandbox` npm package provides native bindings to the [MicroSandbox](https://github.com/superradcompany/microsandbox) runtime. It spins up real microVMs (not containers) in under 100ms, runs standard OCI (Docker) images, and gives you full control over execution, filesystem, networking, and secrets — all from a simple async API.
+The `microsandbox` npm package provides native bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime. It spins up real microVMs (not containers) in under 100ms, runs standard OCI (Docker) images, and gives you full control over execution, filesystem, networking, and secrets — all from a simple async API.
 
 ## Features
 

--- a/sdk/node-ts/lib/exec.rs
+++ b/sdk/node-ts/lib/exec.rs
@@ -1,5 +1,5 @@
+use microsandbox::sandbox::ExecOptionsBuilder;
 use microsandbox::sandbox::exec::{ExecEvent as RustExecEvent, ExecHandle, ExecSink};
-use microsandbox::sandbox::{ExecOptionsBuilder, IntoExecOptions};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use tokio::sync::Mutex;
@@ -231,8 +231,10 @@ fn exec_event_to_js(event: RustExecEvent) -> ExecEvent {
     }
 }
 
-/// Convert a JS exec config into the Rust `IntoExecOptions` closure form.
-pub fn convert_exec_config(config: &ExecConfig) -> impl IntoExecOptions + '_ {
+/// Convert a JS exec config into a builder closure.
+pub fn convert_exec_config(
+    config: &ExecConfig,
+) -> impl FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder + '_ {
     |mut b: ExecOptionsBuilder| {
         if let Some(ref args) = config.args {
             b = b.args(args.clone());

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -1,9 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use microsandbox::sandbox::{
-    ExecOptionsBuilder, NetworkPolicy, PullPolicy, SandboxConfig as RustSandboxConfig,
-};
+use microsandbox::sandbox::{NetworkPolicy, PullPolicy, SandboxConfig as RustSandboxConfig};
 use microsandbox::{LogLevel, RegistryAuth};
 use microsandbox_network::policy::{
     Action, Destination, DestinationGroup, Direction, PortRange, Protocol, Rule,
@@ -156,10 +154,7 @@ impl Sandbox {
         let guard = self.inner.lock().await;
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
         let args_owned = args.unwrap_or_default();
-        let output = sb
-            .exec(&cmd, |b: ExecOptionsBuilder| b.args(args_owned))
-            .await
-            .map_err(to_napi_error)?;
+        let output = sb.exec(&cmd, args_owned).await.map_err(to_napi_error)?;
         Ok(ExecOutput::from_rust(output))
     }
 
@@ -168,8 +163,8 @@ impl Sandbox {
     pub async fn exec_with_config(&self, config: ExecConfig) -> Result<ExecOutput> {
         let guard = self.inner.lock().await;
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
-        let opts = convert_exec_config(&config);
-        let output = sb.exec(&config.cmd, opts).await.map_err(to_napi_error)?;
+        let f = convert_exec_config(&config);
+        let output = sb.exec_with(&config.cmd, f).await.map_err(to_napi_error)?;
         Ok(ExecOutput::from_rust(output))
     }
 
@@ -184,7 +179,7 @@ impl Sandbox {
         let sb = guard.as_ref().ok_or_else(consumed_error)?;
         let args_owned = args.unwrap_or_default();
         let handle = sb
-            .exec_stream(&cmd, |b: ExecOptionsBuilder| b.args(args_owned))
+            .exec_stream(&cmd, args_owned)
             .await
             .map_err(to_napi_error)?;
         Ok(JsExecHandle::from_rust(handle))


### PR DESCRIPTION
## Summary

- Split closure-based sandbox APIs (`exec`, `attach`, `exec_stream`, `image`) into simple and `_with` method pairs, so common cases like `sb.exec("ls", ["-la"])` no longer require closures or importing builder types
- Remove the `IntoExecOptions`, `IntoAttachOptions`, and closure-based `IntoImage` traits in favor of explicit method pairs (`exec`/`exec_with`, `attach`/`attach_with`, `image`/`image_with`, `exec_stream`/`exec_stream_with`)
- Update org branding from "Team MicroSandbox" to "Super Rad Company" across Cargo.toml, SECURITY.md, and README files
- Remove the unimplemented Named Volumes section from the main README

## Changes

- **crates/microsandbox/lib/sandbox/mod.rs**: Core API refactor -- `exec`, `attach`, and `exec_stream` now take `args: impl IntoIterator<Item = impl Into<String>>` for the simple case; new `exec_with`, `attach_with`, and `exec_stream_with` methods accept `FnOnce(Builder) -> Builder` closures for full options; added private `exec_with_opts` and `attach_inner` shared implementations
- **crates/microsandbox/lib/sandbox/builder.rs**: Added `image_with` method that accepts a closure over `ImageBuilder`; narrowed `image` to only accept `impl IntoImage` (no longer closures); updated doc comments
- **crates/microsandbox/lib/sandbox/types.rs**: Removed `impl<F> IntoImage for F where F: FnOnce(ImageBuilder) -> ImageBuilder`; updated doc examples to reference `image_with`; updated tests to use `ImageBuilder::new()` directly instead of closure-based `into_rootfs_source`
- **crates/microsandbox/lib/sandbox/exec.rs**: Removed `IntoExecOptions` trait and its closure/array impls
- **crates/microsandbox/lib/sandbox/attach.rs**: Removed `IntoAttachOptions` trait and its closure/array impls
- **crates/cli/lib/commands/exec.rs, run.rs, shell.rs**: Migrated CLI commands to use `exec_with`/`attach_with` for option closures, and simple `exec`/`attach` for args-only calls; removed `AttachOptionsBuilder`/`ExecOptionsBuilder` imports
- **sdk/node-ts/lib/sandbox.rs**: Migrated Node.js SDK bindings to use `exec`/`exec_stream` with args directly and `exec_with` for config-based execution
- **sdk/node-ts/lib/exec.rs**: Changed `convert_exec_config` return type from `impl IntoExecOptions` to explicit `FnOnce(ExecOptionsBuilder) -> ExecOptionsBuilder`
- **crates/microsandbox/lib/runtime/spawn.rs**: Updated tests to use `image_with` instead of closure-based `image`
- **examples/rust/root-block/bin/main.rs**: Updated example to use `image_with` and removed `ImageBuilder` import
- **docs/**: Updated all SDK and sandbox documentation to reflect the new `_with` method names
- **Cargo.toml, crates/agentd/Cargo.toml**: Updated authors to "Super Rad Company"
- **SECURITY.md**: Updated security contact email to security@superrad.company
- **README.md**: Removed unimplemented Named Volumes section; fixed MCP server link; updated `image` example to `image_with`; fixed whitespace alignment
- **sdk/node-ts/README.md, crates/microsandbox/README.md**: Updated project name casing from "MicroSandbox" to "microsandbox"

## Test Plan

- Verify compilation: `cargo build --all`
- Run the full test suite: `cargo test --all`
- Verify clippy passes: `cargo clippy --all -- -D warnings`
- Verify docs build: `cargo doc --no-deps`
- Check that the root-block example compiles: `cargo build -p root-block`
- Verify Node.js SDK bindings compile: `cd sdk/node-ts && cargo build`