### PR TITLE
feat(cli): add per-command exec flags to msb run and AI Agents README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,29 @@ The `msb` CLI provides a complete interface for managing sandboxes, images, and 
 
 <br />
 
+## <a href="./#gh-dark-mode-only" target="_blank"><img height="13" src="https://octicons-col.vercel.app/dependabot/ffffff" alt="agents-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="13" src="https://octicons-col.vercel.app/dependabot/000000" alt="agents"></a>&nbsp;&nbsp;AI Agents
+
+Give your AI agents the ability to create and manage their own sandboxes.
+
+#### <img height="14" src="https://octicons-col.vercel.app/book/A770EF">&nbsp;&nbsp;Agent Skills
+
+> Teach any AI coding agent how to use microsandbox by installing the [Agent Skills](https://github.com/superradcompany/skills). Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and more.
+>
+> ```sh
+> npx skills add superradcompany/skills
+> ```
+
+#### <img height="14" src="https://octicons-col.vercel.app/plug/A770EF">&nbsp;&nbsp;MCP Server
+
+> Connect any MCP-compatible agent to microsandbox with the [MCP server](https://github.com/superradcompany/microsandbox-mcp). Provides structured tool calls for sandbox lifecycle, command execution, filesystem access, volumes, and monitoring.
+>
+> ```sh
+> # Claude Code
+> claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+> ```
+
+<br />
+
 ## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/gear/ffffff" alt="contributing-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/gear/000000" alt="contributing"></a>&nbsp;&nbsp;Contributing
 
 Interested in contributing to `microsandbox`? Check out our [Development Guide](./DEVELOPMENT.md) for instructions on setting up your development environment, building the project, running tests, and creating releases. For contribution guidelines, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -1,10 +1,10 @@
 //! `msb run` command — create and start a new sandbox.
 
 use std::io::{IsTerminal, Write};
+use std::time::Duration;
 
 use clap::Args;
-use microsandbox::sandbox::ExecOutput;
-use microsandbox::sandbox::Sandbox;
+use microsandbox::sandbox::{ExecOutput, RlimitResource, Sandbox};
 
 use super::common::{SandboxOpts, apply_sandbox_opts};
 use crate::ui;
@@ -23,6 +23,22 @@ pub struct RunArgs {
     #[arg(short, long)]
     pub detach: bool,
 
+    /// Allocate a pseudo-terminal (enables colors, line editing).
+    #[arg(short = 't', long)]
+    pub tty: bool,
+
+    /// Kill the command after this duration (e.g. 30s, 5m, 1h).
+    #[arg(long)]
+    pub timeout: Option<String>,
+
+    /// Set a POSIX resource limit (e.g. nofile=1024, nproc=64, as=1073741824).
+    #[arg(long)]
+    pub rlimit: Vec<String>,
+
+    /// Key sequence to detach from interactive session (default: ctrl-]).
+    #[arg(long)]
+    pub detach_keys: Option<String>,
+
     /// Command to run inside the sandbox (after --).
     #[arg(last = true)]
     pub command: Vec<String>,
@@ -30,6 +46,36 @@ pub struct RunArgs {
     /// Sandbox configuration options.
     #[command(flatten)]
     pub sandbox: SandboxOpts,
+}
+
+/// Parsed per-command execution options for `msb run`.
+struct ExecOpts {
+    tty: bool,
+    timeout: Option<Duration>,
+    rlimits: Vec<(RlimitResource, u64, u64)>,
+    detach_keys: Option<String>,
+}
+
+impl ExecOpts {
+    fn parse(args: &RunArgs) -> anyhow::Result<Self> {
+        let rlimits: Vec<_> = args
+            .rlimit
+            .iter()
+            .map(|s| super::common::parse_rlimit(s))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let timeout = match &args.timeout {
+            Some(t) => Some(Duration::from_secs(super::common::parse_duration_secs(t)?)),
+            None => None,
+        };
+
+        Ok(Self {
+            tty: args.tty,
+            timeout,
+            rlimits,
+            detach_keys: args.detach_keys.clone(),
+        })
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -65,12 +111,13 @@ async fn run_existing(name: String, args: RunArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let exec_opts = ExecOpts::parse(&args)?;
     let interactive = std::io::stdin().is_terminal();
 
     let result: anyhow::Result<i32> = async {
         let (cmd, cmd_args) = resolve_command(sandbox.config(), args.command, interactive)?;
         match cmd {
-            Some(cmd) => exec_in_sandbox(&sandbox, &cmd, cmd_args, interactive).await,
+            Some(cmd) => exec_in_sandbox(&sandbox, &cmd, cmd_args, interactive, &exec_opts).await,
             None => Ok(0),
         }
     }
@@ -119,6 +166,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
         return Ok(());
     }
 
+    let exec_opts = ExecOpts::parse(&args)?;
     let interactive = std::io::stdin().is_terminal();
 
     let (cmd, cmd_args) = resolve_command(sandbox.config(), args.command, interactive)?;
@@ -135,7 +183,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
         }
     };
 
-    let result = exec_in_sandbox(&sandbox, &cmd, cmd_args, interactive).await;
+    let result = exec_in_sandbox(&sandbox, &cmd, cmd_args, interactive, &exec_opts).await;
 
     // Cleanup always runs, even on exec/attach/IO errors.
     if let Err(e) = sandbox.stop_and_wait().await {
@@ -188,11 +236,52 @@ async fn exec_in_sandbox(
     cmd: &str,
     cmd_args: Vec<String>,
     interactive: bool,
+    opts: &ExecOpts,
 ) -> anyhow::Result<i32> {
     if interactive {
-        Ok(sandbox.attach(cmd, cmd_args).await?)
+        let rlimits = opts.rlimits.clone();
+        let detach_keys = opts.detach_keys.clone();
+        let has_opts = !rlimits.is_empty() || detach_keys.is_some();
+        if has_opts {
+            Ok(sandbox
+                .attach_with(cmd, |a| {
+                    let mut a = a.args(cmd_args);
+                    for (resource, soft, hard) in rlimits {
+                        a = a.rlimit_range(resource, soft, hard);
+                    }
+                    if let Some(keys) = detach_keys {
+                        a = a.detach_keys(keys);
+                    }
+                    a
+                })
+                .await?)
+        } else {
+            Ok(sandbox.attach(cmd, cmd_args).await?)
+        }
     } else {
-        let output: ExecOutput = sandbox.exec(cmd, cmd_args).await?;
+        let rlimits = opts.rlimits.clone();
+        let timeout = opts.timeout;
+        let tty = opts.tty;
+        let has_opts = tty || timeout.is_some() || !rlimits.is_empty();
+        let output: ExecOutput = if has_opts {
+            sandbox
+                .exec_with(cmd, |e| {
+                    let mut e = e.args(cmd_args);
+                    if tty {
+                        e = e.tty(true);
+                    }
+                    if let Some(t) = timeout {
+                        e = e.timeout(t);
+                    }
+                    for (resource, soft, hard) in rlimits {
+                        e = e.rlimit_range(resource, soft, hard);
+                    }
+                    e
+                })
+                .await?
+        } else {
+            sandbox.exec(cmd, cmd_args).await?
+        };
 
         std::io::stdout().write_all(output.stdout_bytes())?;
         std::io::stderr().write_all(output.stderr_bytes())?;


### PR DESCRIPTION
## Summary

- Add `--tty`, `--timeout`, `--rlimit`, and `--detach-keys` per-command execution flags to `msb run`, bringing it to parity with `msb exec` for one-shot sandbox workflows
- Add an "AI Agents" section to the README with install commands for Agent Skills and the MCP server
- Fix the broken `[MCP server]` link in the feature list

## Changes

- `crates/cli/lib/commands/run.rs`: Add four new CLI flags to `RunArgs` (`--tty`, `--timeout`, `--rlimit`, `--detach-keys`), introduce `ExecOpts` struct with a `parse` method to validate and convert them, thread `ExecOpts` through `run_existing` and `run_new` into `exec_in_sandbox`, and apply them to `AttachOptionsBuilder` (interactive: rlimits, detach-keys) and `ExecOptionsBuilder` (non-interactive: tty, timeout, rlimits)
- `README.md`: Add "AI Agents" section after CLI section with Agent Skills (`npx skills add`) and MCP server (`claude mcp add`) install commands, and fix the broken `[MCP server]` reference link to point to `https://github.com/superradcompany/microsandbox-mcp`

## Test Plan

- [x] `cargo build -p microsandbox-cli` compiles
- [x] `cargo test` passes all 1004 tests
- [x] `msb run --help` shows `--tty`, `--timeout`, `--rlimit`, `--detach-keys`
- [x] `msb run --timeout 3s alpine -- sleep 60` kills the process after 3s with "exec timed out after 3s"
- [x] `msb run --rlimit nofile=16 alpine -- sh -c 'ulimit -Sn'` prints `16`
- [x] `msb run --rlimit nofile=32:128 alpine -- sh -c 'ulimit -Sn; ulimit -Hn'` prints `32` / `128`
- [x] `echo "" | msb run --tty alpine -- sh -c 'test -t 1 && echo tty'` prints `tty` (piped stdin forced to tty)
- [x] Same command without `--tty` prints `no tty` (control)