### PR TITLE
fix(filesystem): remove O_RESOLVE_BENEATH from macOS /.vol inode reopen

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The `msb` CLI provides a complete interface for managing sandboxes, images, and 
 
 <br />
 
-## <a href="./#gh-dark-mode-only" target="_blank"><img height="13" src="https://octicons-col.vercel.app/dependabot/ffffff" alt="agents-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="13" src="https://octicons-col.vercel.app/dependabot/000000" alt="agents"></a>&nbsp;&nbsp;AI Agents
+## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/ffffff" alt="agents-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/000000" alt="agents"></a>&nbsp;&nbsp;AI Agents
 
 Give your AI agents the ability to create and manage their own sandboxes.
 

--- a/crates/filesystem/lib/backends/passthroughfs/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/inode.rs
@@ -98,9 +98,6 @@ mod linux_flags {
 ))]
 compile_error!("unsupported macOS architecture for Linux open-flag translation");
 
-#[cfg(target_os = "macos")]
-const O_RESOLVE_BENEATH: i32 = 0x0000_1000;
-
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -156,42 +153,35 @@ pub(crate) fn store_unlinked_fd(data: &InodeData, fd: i32) {
 }
 
 #[cfg(target_os = "macos")]
-fn is_unsupported_macos_open_flag(err: &io::Error) -> bool {
+fn is_unsupported_macos_reopen_flag(err: &io::Error) -> bool {
     matches!(
         err.raw_os_error(),
         Some(libc::EINVAL | libc::ENOTSUP | libc::EOPNOTSUPP)
     )
 }
 
+/// Reopen a trusted `/.vol/<dev>/<ino>` identity path on macOS.
+///
+/// These paths are derived from already-admitted inode identity, not from
+/// guest-provided path bytes, so `O_NOFOLLOW_ANY` is the relevant safety
+/// boundary here. `O_RESOLVE_BENEATH` is intentionally omitted because it
+/// applies to fd-relative containment, not absolute `/.vol/` identity paths.
 #[cfg(target_os = "macos")]
-fn open_macos_path_hardened(path: *const libc::c_char, flags: i32) -> io::Result<i32> {
+fn open_macos_inode_reopen(path: *const libc::c_char, flags: i32) -> io::Result<i32> {
     let attempts = [
-        (
-            (flags | libc::O_CLOEXEC | libc::O_NOFOLLOW_ANY | O_RESOLVE_BENEATH) & !libc::O_EXLOCK,
-            true,
-        ),
-        (
-            (flags | libc::O_CLOEXEC | libc::O_NOFOLLOW_ANY) & !libc::O_EXLOCK,
-            false,
-        ),
-        (
-            (flags | libc::O_CLOEXEC | libc::O_NOFOLLOW) & !libc::O_EXLOCK,
-            false,
-        ),
+        (flags | libc::O_CLOEXEC | libc::O_NOFOLLOW_ANY) & !libc::O_EXLOCK,
+        (flags | libc::O_CLOEXEC | libc::O_NOFOLLOW) & !libc::O_EXLOCK,
     ];
 
     let mut last_err: Option<io::Error> = None;
-    for (attempt, allow_access_denied_fallback) in attempts {
+    for attempt in attempts {
         let fd = unsafe { libc::open(path, attempt) };
         if fd >= 0 {
             return Ok(fd);
         }
 
         let err = io::Error::last_os_error();
-        let fallback_ok = is_unsupported_macos_open_flag(&err)
-            || (allow_access_denied_fallback
-                && matches!(err.raw_os_error(), Some(libc::EACCES | libc::EPERM)));
-        if !fallback_ok {
+        if !is_unsupported_macos_reopen_flag(&err) {
             return Err(platform::linux_error(err));
         }
         last_err = Some(err);
@@ -452,7 +442,7 @@ fn open_and_patch_stat_macos(
 
 #[cfg(target_os = "macos")]
 fn open_macos_path_for_stat(path: *const libc::c_char) -> io::Result<i32> {
-    match open_macos_path_hardened(path, libc::O_RDONLY) {
+    match open_macos_inode_reopen(path, libc::O_RDONLY) {
         Ok(fd) => return Ok(fd),
         Err(err) if err.raw_os_error() == platform::eloop().raw_os_error() => {
             let fd =
@@ -465,7 +455,7 @@ fn open_macos_path_for_stat(path: *const libc::c_char) -> io::Result<i32> {
         Err(_) => {}
     }
 
-    open_macos_path_hardened(path, libc::O_RDONLY | libc::O_DIRECTORY)
+    open_macos_inode_reopen(path, libc::O_RDONLY | libc::O_DIRECTORY)
 }
 
 /// Decrement the reference count for an inode. Remove it from the table
@@ -576,12 +566,12 @@ fn open_vol_fd(dev: u64, ino: u64) -> io::Result<i32> {
     let path = vol_path(dev, ino);
 
     // Try directory open first (most callers want a parent fd).
-    if let Ok(fd) = open_macos_path_hardened(path.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY) {
+    if let Ok(fd) = open_macos_inode_reopen(path.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY) {
         return Ok(fd);
     }
 
     // Fall back to regular open.
-    if let Ok(fd) = open_macos_path_hardened(path.as_ptr(), libc::O_RDONLY) {
+    if let Ok(fd) = open_macos_inode_reopen(path.as_ptr(), libc::O_RDONLY) {
         return Ok(fd);
     }
 
@@ -628,7 +618,7 @@ pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::R
         }
 
         let path = vol_path(data.dev, data.ino);
-        open_macos_path_hardened(path.as_ptr(), flags)
+        open_macos_inode_reopen(path.as_ptr(), flags)
     }
 }
 

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_lookup_inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_lookup_inode.rs
@@ -110,6 +110,15 @@ fn test_lookup_nested() {
 }
 
 #[test]
+fn test_lookup_nested_nonexistent() {
+    let sb = TestSandbox::new();
+    sb.host_create_dir("dir");
+    let dir_entry = sb.lookup_root("dir").unwrap();
+    let result = sb.lookup(dir_entry.inode, "nested.txt");
+    TestSandbox::assert_errno(result, LINUX_ENOENT);
+}
+
+#[test]
 fn test_lookup_after_forget() {
     let sb = TestSandbox::new();
     sb.host_create_file("file.txt", b"data");


### PR DESCRIPTION
## Summary

- Fix a macOS Tahoe regression where `O_RESOLVE_BENEATH` on absolute `/.vol/<dev>/<ino>` paths returns `ENOTCAPABLE` (errno 107), breaking nested PassthroughFs lookups
- The resulting errno was translated to guest `EIO`, which poisoned PATH lookup through `/.msb/scripts` and prevented bare command execution (e.g., `msb run python:3.11 -- python -c "print(1+1)"`)
- The fix narrows the macOS inode-reopen helper to use only `O_NOFOLLOW_ANY` with `O_NOFOLLOW` fallback, which is the correct security boundary for trusted inode-identity reopens
- Guest-controlled path lookup security is unchanged — only the trusted `/.vol` reopen path is affected

## Changes

- Removed the `O_RESOLVE_BENEATH` constant and its usage from the macOS inode-reopen path in `crates/filesystem/lib/backends/passthroughfs/inode.rs`
- Renamed `open_macos_path_hardened` to `open_macos_inode_reopen` to clarify that this helper is for trusted inode-identity reopens, not guest path containment
- Renamed `is_unsupported_macos_open_flag` to `is_unsupported_macos_reopen_flag` for consistency
- Simplified the fallback logic by removing the `allow_access_denied_fallback` parameter that only existed for the `O_RESOLVE_BENEATH` attempt
- Reduced the attempt chain from 3 strategies to 2: `O_NOFOLLOW_ANY` then `O_NOFOLLOW`
- Updated all 5 call sites: `open_macos_path_for_stat` (x2), `open_vol_fd` (x2), `open_inode_fd` (x1)
- Added `test_lookup_nested_nonexistent` regression test to verify nested lookup returns `ENOENT` (not `EIO`) for missing files
- Minor README update: bumped AI Agents section icon height from 13 to 18

## Test Plan

- Run targeted regression tests: `cargo test -p microsandbox-filesystem backends::passthroughfs::tests::test_lookup_inode::test_lookup_nested -- --nocapture`
- Run the new nonexistent lookup test: `cargo test -p microsandbox-filesystem backends::passthroughfs::tests::test_lookup_inode::test_lookup_nested_nonexistent -- --nocapture`
- Run the vol lookup test: `cargo test -p microsandbox-filesystem backends::passthroughfs::tests::test_vol_lookup::test_vol_lookup_nested_subdir -- --nocapture`
- Run full PassthroughFs suite: `cargo test -p microsandbox-filesystem backends::passthroughfs::tests -- --nocapture` (247 tests)
- Verify overlayfs is unaffected: `cargo test -p microsandbox-filesystem backends::overlayfs::tests::test_lookup -- --nocapture`
- End-to-end verification on macOS Tahoe: `msb run python:3.11 -- python -c 'print(1+1)'` should output `2`