### PR TITLE
fix(cli): download latest version bundle during self update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,6 +357,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: mcp
         run: |
+          rm package-lock.json
           npm install
           npm run build
           npm publish --access public

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -88,6 +88,7 @@ async fn run_update(args: SelfUpdateArgs) -> anyhow::Result<()> {
     let spinner = ui::Spinner::start("Updating", &format!("to {latest}"));
     let result = microsandbox::setup::Setup::builder()
         .base_dir(base_dir)
+        .version(latest_clean.to_string())
         .force(true)
         .build()
         .install()

--- a/crates/microsandbox/lib/setup/download.rs
+++ b/crates/microsandbox/lib/setup/download.rs
@@ -25,6 +25,10 @@ pub struct Setup {
     #[builder(default, setter(strip_option, into))]
     base_dir: Option<PathBuf>,
 
+    /// Target version to download. Defaults to `PREBUILT_VERSION` (compile-time).
+    #[builder(default, setter(strip_option, into))]
+    version: Option<String>,
+
     /// Skip verification after installation.
     #[builder(default = false)]
     skip_verify: bool,
@@ -59,15 +63,16 @@ impl Setup {
     /// Download and extract the microsandbox bundle tarball.
     async fn install_bundle(&self, bin_dir: &Path, lib_dir: &Path) -> MicrosandboxResult<()> {
         let libkrunfw_name = microsandbox_utils::libkrunfw_filename(std::env::consts::OS);
+        let version = self.version.as_deref().unwrap_or(PREBUILT_VERSION);
 
         // Skip if all binaries are already present and the installed msb
-        // version matches this package version.
+        // version matches the target version.
         if !self.force
             && lib_dir.join(&libkrunfw_name).exists()
             && installed_msb_version(&bin_dir.join(MSB_BINARY))
                 .await
                 .as_deref()
-                == Some(PREBUILT_VERSION)
+                == Some(version)
         {
             tracing::debug!("setup: binaries already present, skipping download");
             return Ok(());
@@ -79,13 +84,13 @@ impl Setup {
         }
 
         let url = microsandbox_utils::bundle_download_url(
-            PREBUILT_VERSION,
+            version,
             std::env::consts::ARCH,
             std::env::consts::OS,
         );
 
         tracing::info!(
-            version = PREBUILT_VERSION,
+            version = version,
             url = %url,
             "downloading microsandbox runtime dependencies"
         );


### PR DESCRIPTION
## Summary

- `msb self update` was downloading the bundle matching the compile-time `PREBUILT_VERSION` (the running binary's own version) instead of the fetched latest release version from GitHub
- This meant the command would report a successful update to vX.Y.Z but actually re-install the same version it was already running
- The fix adds a `version` field to the `Setup` builder and passes the fetched latest version from the self-update command

## Changes

- **crates/microsandbox/lib/setup/download.rs**: Added `version: Option<String>` field to `Setup` builder. `install_bundle` now uses this field (falling back to `PREBUILT_VERSION`) for constructing the download URL and for the installed-version skip check.
- **crates/cli/lib/commands/self_cmd.rs**: `run_update` now passes `.version(latest_clean.to_string())` to the `Setup` builder so the download targets the actual latest release.
- **.github/workflows/release.yml**: Added `rm package-lock.json` before `npm install` in the MCP publish job to avoid dependency conflicts during CI.

## Test Plan

- Run `cargo build --release -p microsandbox-cli` to verify compilation
- Run `cargo test` to verify no regressions
- Manual test: install an older `msb` binary, run `msb self update`, then verify `msb -V` shows the latest version