### PR TITLE
refactor(filesystem): extract shared dir snapshot and add inject_init config

### DIFF
--- a/crates/filesystem/lib/backends/dualfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/dualfs/dir_ops.rs
@@ -16,7 +16,10 @@ use super::{
 };
 use crate::{
     Context, DirEntry, Entry, OpenOptions,
-    backends::shared::{init_binary, platform},
+    backends::shared::{
+        dir_snapshot::{self, SnapshotEntry},
+        init_binary, platform,
+    },
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -203,6 +206,28 @@ pub(crate) fn do_releasedir(
 ) -> io::Result<()> {
     fs.state.dir_handles.write().unwrap().remove(&handle);
     Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl SnapshotEntry for MergedDirEntry {
+    fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn file_type(&self) -> u32 {
+        self.file_type
+    }
+
+    fn name(&self) -> &[u8] {
+        &self.name
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -499,46 +524,10 @@ fn collect_dentry_entries(
 
 /// Serve readdir results from a snapshot starting at the given offset.
 fn serve_readdir(snapshot: &DirSnapshot, offset: u64) -> io::Result<Vec<DirEntry<'static>>> {
-    let start = snapshot
-        .entries
-        .iter()
-        .position(|e| e.offset > offset)
-        .unwrap_or(snapshot.entries.len());
-
-    let result_entries = &snapshot.entries[start..];
-    if result_entries.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Bounded-leak: collect all names into one contiguous buffer.
-    let mut names_buf = Vec::new();
-    let mut offsets_vec = Vec::new();
-
-    for entry in result_entries {
-        let name_start = names_buf.len();
-        names_buf.extend_from_slice(&entry.name);
-        offsets_vec.push((
-            name_start,
-            entry.name.len(),
-            entry.inode,
-            entry.offset,
-            entry.file_type,
-        ));
-    }
-
-    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
-
-    let result: Vec<DirEntry<'static>> = offsets_vec
-        .into_iter()
-        .map(|(name_start, name_len, ino, offset, file_type)| DirEntry {
-            ino,
-            offset,
-            type_: file_type,
-            name: &leaked[name_start..name_start + name_len],
-        })
-        .collect();
-
-    Ok(result)
+    Ok(dir_snapshot::serve_snapshot_entries(
+        &snapshot.entries,
+        offset,
+    ))
 }
 
 /// Get a directory handle by guest handle ID.

--- a/crates/filesystem/lib/backends/memfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/memfs/dir_ops.rs
@@ -15,7 +15,10 @@ use super::{
 };
 use crate::{
     Context, DirEntry, Entry, OpenOptions,
-    backends::shared::{init_binary, platform},
+    backends::shared::{
+        dir_snapshot::{self, SnapshotEntry},
+        init_binary, platform,
+    },
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -109,6 +112,28 @@ pub(crate) fn do_releasedir(
 }
 
 //--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl SnapshotEntry for MemDirEntry {
+    fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn file_type(&self) -> u32 {
+        self.file_type
+    }
+
+    fn name(&self) -> &[u8] {
+        &self.name
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
@@ -129,57 +154,10 @@ fn serve_snapshot_entries(
     }
     let snapshot = snapshot_lock.as_ref().unwrap();
 
-    // Serve entries from offset.
-    let start = if offset == 0 {
-        0
-    } else {
-        snapshot
-            .entries
-            .iter()
-            .position(|e| e.offset > offset)
-            .unwrap_or(snapshot.entries.len())
-    };
-
-    if start >= snapshot.entries.len() {
-        return Ok(Vec::new());
-    }
-
-    let slice = &snapshot.entries[start..];
-
-    // Collect names into a contiguous buffer for bounded leak.
-    let mut names_buf: Vec<u8> = Vec::new();
-    let mut raw_entries: Vec<(u64, u64, u32, usize, usize)> = Vec::new();
-
-    for entry in slice {
-        let name_offset = names_buf.len();
-        names_buf.extend_from_slice(&entry.name);
-        raw_entries.push((
-            entry.inode,
-            entry.offset,
-            entry.file_type,
-            name_offset,
-            entry.name.len(),
-        ));
-    }
-
-    if raw_entries.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Leak one contiguous buffer (bounded: one per readdir call).
-    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
-
-    let entries = raw_entries
-        .into_iter()
-        .map(|(ino, off, typ, start, len)| DirEntry {
-            ino,
-            offset: off,
-            type_: typ,
-            name: &leaked[start..start + len],
-        })
-        .collect();
-
-    Ok(entries)
+    Ok(dir_snapshot::serve_snapshot_entries(
+        &snapshot.entries,
+        offset,
+    ))
 }
 
 /// Build a point-in-time snapshot of a directory's entries.

--- a/crates/filesystem/lib/backends/overlayfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/overlayfs/dir_ops.rs
@@ -24,7 +24,10 @@ use super::{
 };
 use crate::{
     Context, DirEntry, Entry, OpenOptions,
-    backends::shared::{init_binary, platform},
+    backends::shared::{
+        dir_snapshot::{self, SnapshotEntry},
+        init_binary, platform,
+    },
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -131,6 +134,28 @@ pub(crate) fn do_releasedir(
 }
 
 //--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl SnapshotEntry for MergedDirEntry {
+    fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn file_type(&self) -> u32 {
+        self.file_type
+    }
+
+    fn name(&self) -> &[u8] {
+        &self.name
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
@@ -166,57 +191,10 @@ fn serve_snapshot_entries(
     }
     let snapshot = snapshot_lock.as_ref().unwrap();
 
-    // Serve entries from offset.
-    let start = if offset == 0 {
-        0
-    } else {
-        snapshot
-            .entries
-            .iter()
-            .position(|e| e.offset > offset)
-            .unwrap_or(snapshot.entries.len())
-    };
-
-    if start >= snapshot.entries.len() {
-        return Ok(Vec::new());
-    }
-
-    let slice = &snapshot.entries[start..];
-
-    // Collect names into a contiguous buffer for bounded leak.
-    let mut names_buf: Vec<u8> = Vec::new();
-    let mut raw_entries: Vec<(u64, u64, u32, usize, usize)> = Vec::new();
-
-    for entry in slice {
-        let name_offset = names_buf.len();
-        names_buf.extend_from_slice(&entry.name);
-        raw_entries.push((
-            entry.inode,
-            entry.offset,
-            entry.file_type,
-            name_offset,
-            entry.name.len(),
-        ));
-    }
-
-    if raw_entries.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Leak one contiguous buffer (bounded: one per readdir call).
-    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
-
-    let entries = raw_entries
-        .into_iter()
-        .map(|(ino, off, typ, start, len)| DirEntry {
-            ino,
-            offset: off,
-            type_: typ,
-            name: &leaked[start..start + len],
-        })
-        .collect();
-
-    Ok(entries)
+    Ok(dir_snapshot::serve_snapshot_entries(
+        &snapshot.entries,
+        offset,
+    ))
 }
 
 /// Build a merged directory snapshot across all layers.

--- a/crates/filesystem/lib/backends/passthroughfs/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/builder.rs
@@ -39,6 +39,7 @@ pub struct PassthroughFsBuilder {
     attr_timeout: Duration,
     cache_policy: CachePolicy,
     writeback: bool,
+    inject_init: bool,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -56,6 +57,7 @@ impl PassthroughFsBuilder {
             attr_timeout: Duration::from_secs(5),
             cache_policy: CachePolicy::Auto,
             writeback: false,
+            inject_init: true,
         }
     }
 
@@ -98,6 +100,12 @@ impl PassthroughFsBuilder {
     /// Enable or disable writeback caching.
     pub fn writeback(mut self, enabled: bool) -> Self {
         self.writeback = enabled;
+        self
+    }
+
+    /// Enable or disable exposing the synthetic init binary at mount root.
+    pub fn inject_init(mut self, enabled: bool) -> Self {
+        self.inject_init = enabled;
         self
     }
 
@@ -160,6 +168,7 @@ impl PassthroughFsBuilder {
             attr_timeout: self.attr_timeout,
             cache_policy: self.cache_policy,
             writeback: self.writeback,
+            inject_init: self.inject_init,
         };
 
         Ok(PassthroughFs {
@@ -168,6 +177,7 @@ impl PassthroughFsBuilder {
             inodes: RwLock::new(MultikeyBTreeMap::new()),
             next_inode: AtomicU64::new(3), // 1=root, 2=init
             handles: RwLock::new(BTreeMap::new()),
+            dir_handles: RwLock::new(BTreeMap::new()),
             next_handle: AtomicU64::new(1), // 0=init handle
             writeback: AtomicBool::new(false),
             init_file,

--- a/crates/filesystem/lib/backends/passthroughfs/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/create_ops.rs
@@ -28,9 +28,7 @@ use std::{
 use super::{PassthroughFs, inode};
 use crate::{
     Context, Entry, Extensions, OpenOptions,
-    backends::shared::{
-        handle_table::HandleData, init_binary, name_validation, platform, stat_override,
-    },
+    backends::shared::{handle_table::HandleData, name_validation, platform, stat_override},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -56,7 +54,7 @@ pub(crate) fn do_create(
 ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
     name_validation::validate_name(name)?;
 
-    if init_binary::is_init_name(name.to_bytes()) {
+    if fs.is_reserved_init_name(parent, name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -131,7 +129,7 @@ pub(crate) fn do_mkdir(
 ) -> io::Result<Entry> {
     name_validation::validate_name(name)?;
 
-    if init_binary::is_init_name(name.to_bytes()) {
+    if fs.is_reserved_init_name(parent, name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -178,7 +176,7 @@ pub(crate) fn do_mknod(
 ) -> io::Result<Entry> {
     name_validation::validate_name(name)?;
 
-    if init_binary::is_init_name(name.to_bytes()) {
+    if fs.is_reserved_init_name(parent, name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -226,7 +224,7 @@ pub(crate) fn do_symlink(
 ) -> io::Result<Entry> {
     name_validation::validate_name(name)?;
 
-    if init_binary::is_init_name(name.to_bytes()) {
+    if fs.is_reserved_init_name(parent, name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -321,11 +319,11 @@ pub(crate) fn do_link(
 ) -> io::Result<Entry> {
     name_validation::validate_name(newname)?;
 
-    if init_binary::is_init_name(newname.to_bytes()) {
+    if fs.is_reserved_init_name(newparent, newname.to_bytes()) {
         return Err(platform::eacces());
     }
 
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Err(platform::eacces());
     }
 
@@ -383,7 +381,7 @@ pub(crate) fn do_link(
 /// On macOS, verifies the inode is actually a symlink via `stat_inode` (which applies
 /// xattr patching) before calling readlinkat.
 pub(crate) fn do_readlink(fs: &PassthroughFs, _ctx: Context, ino: u64) -> io::Result<Vec<u8>> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         return Err(platform::einval());
     }
 

--- a/crates/filesystem/lib/backends/passthroughfs/dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/dir_ops.rs
@@ -1,20 +1,9 @@
 //! Directory operations: opendir, readdir, readdirplus, releasedir.
 //!
-//! ## Memory Strategy: Bounded Leak
-//!
-//! `DynFileSystem::readdir` returns `Vec<DirEntry<'static>>` where names are `&'static [u8]`.
-//! Since the trait requires `'static` lifetimes, we cannot return borrowed data. Instead, we
-//! collect all entry names into a single contiguous `Vec<u8>`, leak it once per readdir call,
-//! and slice `&'static [u8]` references from it. This bounds the leak to one allocation per
-//! readdir call (not per entry), which is acceptable for the FUSE usage pattern.
-//!
-//! ## d_type Correction
-//!
-//! File-backed symlinks and virtual device nodes report `DT_REG` from the kernel's `getdents64`.
-//! Correcting d_type in plain `readdir` would require opening every `DT_REG` entry to check its
-//! override xattr (3 syscalls per entry). Instead, correction is deferred to `readdirplus`, where
-//! each entry already gets a full `do_lookup` that reads the override xattr — making d_type
-//! correction free.
+//! Passthrough directory handles build a point-in-time snapshot on the first
+//! `readdir`/`readdirplus` call. This avoids backend-specific cookie semantics
+//! such as macOS `telldir`/`seekdir` values leaking into guest-visible offsets,
+//! and gives every handle stable, monotonic offsets for its lifetime.
 
 use std::{
     io,
@@ -22,10 +11,13 @@ use std::{
     sync::{Arc, RwLock, atomic::Ordering},
 };
 
-use super::{PassthroughFs, inode};
+use super::{DirSnapshot, PassthroughDirEntry, PassthroughDirHandle, PassthroughFs, inode};
 use crate::{
     Context, DirEntry, Entry, OpenOptions,
-    backends::shared::{handle_table::HandleData, init_binary, platform},
+    backends::shared::{
+        dir_snapshot::{self, SnapshotEntry},
+        init_binary, platform,
+    },
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -43,57 +35,43 @@ pub(crate) fn do_opendir(
     let file = unsafe { std::fs::File::from_raw_fd(fd) };
 
     let handle = fs.next_handle.fetch_add(1, Ordering::Relaxed);
-    let data = Arc::new(HandleData {
+    let data = Arc::new(PassthroughDirHandle {
         file: RwLock::new(file),
+        snapshot: std::sync::Mutex::new(None),
     });
 
-    fs.handles.write().unwrap().insert(handle, data);
+    fs.dir_handles.write().unwrap().insert(handle, data);
     Ok((Some(handle), fs.cache_dir_options()))
 }
 
-/// Read directory entries.
-///
-/// On Linux, uses raw `getdents64` syscall with buffer sized by the FUSE
-/// `size` parameter (clamped to 1KB–64KB). This avoids reading the entire
-/// directory when the kernel only needs a small response.
-///
-/// Names are collected into a single contiguous buffer that is leaked once
-/// per call (bounded leak) rather than leaking individual allocations per entry.
-///
-/// d_type correction for file-backed symlinks is NOT done here — it's
-/// deferred to [`do_readdirplus`] where the lookup already provides the
-/// correct stat, making the correction free (see module-level doc).
+/// Read directory entries from a point-in-time snapshot.
 pub(crate) fn do_readdir(
     fs: &PassthroughFs,
     _ctx: Context,
     inode: u64,
     handle: u64,
-    size: u32,
+    _size: u32,
     offset: u64,
 ) -> io::Result<Vec<DirEntry<'static>>> {
-    let handles = fs.handles.read().unwrap();
+    let handles = fs.dir_handles.read().unwrap();
     let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
-    // Write lock: lseek in read_dir_entries modifies fd seek position.
-    #[allow(clippy::readonly_write_lock)]
-    let f = data.file.write().unwrap();
-    let fd = f.as_raw_fd();
 
-    let mut entries = read_dir_entries(fd, offset, size)?;
-
-    // Inject init.krun into root directory listing.
-    if inode == 1 {
-        inject_init_entry(&mut entries);
+    let mut snapshot_lock = data.snapshot.lock().unwrap();
+    if snapshot_lock.is_none() {
+        #[allow(clippy::readonly_write_lock)]
+        let file = data.file.write().unwrap();
+        let inject_init = fs.injects_init() && inode == 1;
+        *snapshot_lock = Some(build_snapshot(file.as_raw_fd(), inject_init)?);
     }
 
-    Ok(entries)
+    let snapshot = snapshot_lock.as_ref().unwrap();
+    Ok(dir_snapshot::serve_snapshot_entries(
+        &snapshot.entries,
+        offset,
+    ))
 }
 
 /// Read directory entries with attributes (readdirplus).
-///
-/// d_type is corrected from the lookup result's `st_mode`, which catches
-/// file-backed symlinks and virtual device nodes at zero extra cost (the
-/// lookup already reads the override xattr). `.` and `..` are filtered out
-/// entirely — the kernel handles them itself.
 pub(crate) fn do_readdirplus(
     fs: &PassthroughFs,
     ctx: Context,
@@ -107,32 +85,28 @@ pub(crate) fn do_readdirplus(
 
     for de in dir_entries {
         let name_bytes = de.name;
-        // Skip . and .. — the kernel handles these itself.
         if name_bytes == b"." || name_bytes == b".." {
             continue;
         }
 
-        // For init.krun, return the synthetic entry.
         if name_bytes == init_binary::INIT_FILENAME {
             let entry = init_binary::init_entry(fs.cfg.entry_timeout, fs.cfg.attr_timeout);
             result.push((de, entry));
             continue;
         }
 
-        // Look up the entry to get full attributes.
         let name_cstr = match std::ffi::CString::new(name_bytes.to_vec()) {
             Ok(c) => c,
             Err(_) => continue,
         };
         match inode::do_lookup(fs, inode, &name_cstr) {
             Ok(entry) => {
-                // Correct d_type from the lookup's stat (free: no extra syscalls).
                 let mut de = de;
                 let file_type = platform::mode_file_type(entry.attr.st_mode);
                 de.type_ = mode_to_dtype(file_type);
                 result.push((de, entry));
             }
-            Err(_) => continue, // Entry may have been removed between readdir and lookup.
+            Err(_) => continue,
         }
     }
 
@@ -147,57 +121,75 @@ pub(crate) fn do_releasedir(
     _flags: u32,
     handle: u64,
 ) -> io::Result<()> {
-    fs.handles.write().unwrap().remove(&handle);
+    fs.dir_handles.write().unwrap().remove(&handle);
     Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl SnapshotEntry for PassthroughDirEntry {
+    fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn file_type(&self) -> u32 {
+        self.file_type
+    }
+
+    fn name(&self) -> &[u8] {
+        &self.name
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
-/// Inject the init.krun entry into a directory listing if not already present.
-fn inject_init_entry(entries: &mut Vec<DirEntry<'static>>) {
-    let already_present = entries.iter().any(|e| e.name == init_binary::INIT_FILENAME);
-
-    if !already_present {
-        let next_offset = entries.last().map(|e| e.offset + 1).unwrap_or(1);
-        let name: &'static [u8] = init_binary::INIT_FILENAME;
-        entries.push(DirEntry {
-            ino: init_binary::INIT_INODE,
-            offset: next_offset,
-            type_: platform::DIRENT_REG,
-            name,
-        });
-    }
-}
-
 /// Convert a file mode type to a directory entry type.
 fn mode_to_dtype(mode_type: u32) -> u32 {
     platform::dirent_type_from_mode(mode_type)
 }
 
-/// Read directory entries using `getdents64` with FUSE size as buffer hint.
-///
-/// Names are collected into a single contiguous buffer, leaked once, and
-/// sliced into `&'static [u8]` references. This replaces the previous
-/// approach of leaking N individual `Box<[u8]>` allocations.
-#[cfg(target_os = "linux")]
-fn read_dir_entries(fd: i32, offset: u64, size: u32) -> io::Result<Vec<DirEntry<'static>>> {
-    // Seek to the requested offset.
-    if offset > 0 {
-        let ret = unsafe { libc::lseek64(fd, offset as i64, libc::SEEK_SET) };
-        if ret < 0 {
-            return Err(platform::linux_error(io::Error::last_os_error()));
-        }
+/// Build a point-in-time directory snapshot with stable synthetic offsets.
+fn build_snapshot(fd: i32, inject_init: bool) -> io::Result<DirSnapshot> {
+    let mut entries = read_dir_entries(fd)?;
+
+    if inject_init
+        && !entries
+            .iter()
+            .any(|entry| entry.name == init_binary::INIT_FILENAME)
+    {
+        entries.push(PassthroughDirEntry {
+            inode: init_binary::INIT_INODE,
+            name: init_binary::INIT_FILENAME.to_vec(),
+            offset: 0,
+            file_type: platform::DIRENT_REG,
+        });
     }
 
-    // Use FUSE size as a hint for the getdents buffer.
-    let buf_size = (size as usize).clamp(1024, 65536);
-    let mut buf = vec![0u8; buf_size];
+    for (index, entry) in entries.iter_mut().enumerate() {
+        entry.offset = (index + 1) as u64;
+    }
 
-    // Collect raw entry data and names into a contiguous buffer.
-    let mut raw_entries: Vec<(u64, u64, u8, usize, usize)> = Vec::new();
-    let mut names_buf: Vec<u8> = Vec::new();
+    Ok(DirSnapshot { entries })
+}
+
+/// Read all directory entries from a file descriptor on Linux.
+#[cfg(target_os = "linux")]
+fn read_dir_entries(fd: i32) -> io::Result<Vec<PassthroughDirEntry>> {
+    let ret = unsafe { libc::lseek64(fd, 0, libc::SEEK_SET) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    let mut buf = vec![0u8; 65536];
+    let mut entries = Vec::new();
 
     loop {
         let nread = unsafe { libc::syscall(libc::SYS_getdents64, fd, buf.as_mut_ptr(), buf.len()) };
@@ -211,13 +203,10 @@ fn read_dir_entries(fd: i32, offset: u64, size: u32) -> io::Result<Vec<DirEntry<
 
         let mut pos = 0usize;
         while pos < nread as usize {
-            // SAFETY: getdents64 returns properly aligned linux_dirent64 structs.
             let d_ino = u64::from_ne_bytes(buf[pos..pos + 8].try_into().unwrap());
-            let d_off = u64::from_ne_bytes(buf[pos + 8..pos + 16].try_into().unwrap());
             let d_reclen = u16::from_ne_bytes(buf[pos + 16..pos + 18].try_into().unwrap());
-            let d_type = buf[pos + 18];
+            let d_type = buf[pos + 18] as u32;
 
-            // Name starts at offset 19, null-terminated.
             let name_start = pos + 19;
             let name_end = pos + d_reclen as usize;
             let name_slice = &buf[name_start..name_end];
@@ -225,43 +214,29 @@ fn read_dir_entries(fd: i32, offset: u64, size: u32) -> io::Result<Vec<DirEntry<
                 .iter()
                 .position(|&b| b == 0)
                 .unwrap_or(name_slice.len());
-            let name_bytes = &name_slice[..name_len];
 
-            let name_offset = names_buf.len();
-            names_buf.extend_from_slice(name_bytes);
-
-            raw_entries.push((d_ino, d_off, d_type, name_offset, name_len));
+            entries.push(PassthroughDirEntry {
+                inode: d_ino,
+                name: name_slice[..name_len].to_vec(),
+                offset: 0,
+                file_type: d_type,
+            });
 
             pos += d_reclen as usize;
         }
     }
 
-    if raw_entries.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Leak one contiguous buffer for all names (bounded: one per readdir call).
-    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
-
-    let entries = raw_entries
-        .into_iter()
-        .map(|(ino, off, typ, start, len)| DirEntry {
-            ino,
-            offset: off,
-            type_: typ as u32,
-            name: &leaked[start..start + len],
-        })
-        .collect();
-
     Ok(entries)
 }
 
-/// Read directory entries from a file descriptor using readdir on macOS.
-///
-/// Names are collected into a single contiguous buffer, leaked once.
+/// Read all directory entries from a file descriptor on macOS.
 #[cfg(target_os = "macos")]
-fn read_dir_entries(fd: i32, offset: u64, _size: u32) -> io::Result<Vec<DirEntry<'static>>> {
-    // Duplicate the fd so fdopendir can take ownership without closing ours.
+fn read_dir_entries(fd: i32) -> io::Result<Vec<PassthroughDirEntry>> {
+    let ret = unsafe { libc::lseek(fd, 0, libc::SEEK_SET) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
     let dup_fd = unsafe { libc::dup(fd) };
     if dup_fd < 0 {
         return Err(platform::linux_error(io::Error::last_os_error()));
@@ -273,16 +248,9 @@ fn read_dir_entries(fd: i32, offset: u64, _size: u32) -> io::Result<Vec<DirEntry
         return Err(platform::linux_error(io::Error::last_os_error()));
     }
 
-    // Seek to offset if needed.
-    if offset > 0 {
-        unsafe { libc::seekdir(dirp, offset as libc::c_long) };
-    }
-
-    let mut raw_entries: Vec<(u64, u64, u32, usize, usize)> = Vec::new();
-    let mut names_buf: Vec<u8> = Vec::new();
+    let mut entries = Vec::new();
 
     loop {
-        // Clear errno before readdir to distinguish EOF from error.
         unsafe { *libc::__error() = 0 };
 
         let ent = unsafe { libc::readdir(dirp) };
@@ -292,46 +260,23 @@ fn read_dir_entries(fd: i32, offset: u64, _size: u32) -> io::Result<Vec<DirEntry
                 unsafe { libc::closedir(dirp) };
                 return Err(platform::linux_error(io::Error::from_raw_os_error(errno)));
             }
-            break; // EOF
+            break;
         }
 
-        let d = unsafe { &*ent };
-        let name_len = d.d_namlen as usize;
-        let name_bytes =
-            unsafe { std::slice::from_raw_parts(d.d_name.as_ptr() as *const u8, name_len) };
+        let entry = unsafe { &*ent };
+        let name_len = entry.d_namlen as usize;
+        let name =
+            unsafe { std::slice::from_raw_parts(entry.d_name.as_ptr() as *const u8, name_len) };
 
-        let name_offset = names_buf.len();
-        names_buf.extend_from_slice(name_bytes);
-
-        let tell_offset = unsafe { libc::telldir(dirp) };
-
-        raw_entries.push((
-            d.d_ino,
-            tell_offset as u64,
-            d.d_type as u32,
-            name_offset,
-            name_len,
-        ));
+        entries.push(PassthroughDirEntry {
+            inode: entry.d_ino,
+            name: name.to_vec(),
+            offset: 0,
+            file_type: entry.d_type as u32,
+        });
     }
 
     unsafe { libc::closedir(dirp) };
-
-    if raw_entries.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Leak one contiguous buffer for all names (bounded: one per readdir call).
-    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
-
-    let entries = raw_entries
-        .into_iter()
-        .map(|(ino, off, typ, start, len)| DirEntry {
-            ino,
-            offset: off,
-            type_: typ,
-            name: &leaked[start..start + len],
-        })
-        .collect();
 
     Ok(entries)
 }

--- a/crates/filesystem/lib/backends/passthroughfs/file_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/file_ops.rs
@@ -40,7 +40,7 @@ pub(crate) fn do_open(
     kill_priv: bool,
     flags: u32,
 ) -> io::Result<(Option<u64>, OpenOptions)> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Ok((Some(init_binary::INIT_HANDLE), OpenOptions::KEEP_CACHE));
     }
 
@@ -92,7 +92,7 @@ pub(crate) fn do_read(
     offset: u64,
 ) -> io::Result<usize> {
     // Virtual init.krun binary.
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return init_binary::read_init(w, &fs.init_file, size, offset);
     }
 
@@ -118,7 +118,7 @@ pub(crate) fn do_write(
     offset: u64,
     kill_priv: bool,
 ) -> io::Result<usize> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Err(platform::eacces());
     }
 
@@ -149,7 +149,7 @@ pub(crate) fn do_flush(
     inode: u64,
     handle: u64,
 ) -> io::Result<()> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Ok(());
     }
 
@@ -175,7 +175,7 @@ pub(crate) fn do_release(
     inode: u64,
     handle: u64,
 ) -> io::Result<()> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Ok(());
     }
 

--- a/crates/filesystem/lib/backends/passthroughfs/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/metadata.rs
@@ -31,7 +31,7 @@ pub(crate) fn do_getattr(
     ino: u64,
     handle: Option<u64>,
 ) -> io::Result<(stat64, Duration)> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         return Ok((init_binary::init_stat(), fs.cfg.attr_timeout));
     }
 
@@ -51,7 +51,7 @@ pub(crate) fn do_setattr(
     _handle: Option<u64>,
     valid: SetattrValid,
 ) -> io::Result<(stat64, Duration)> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         return Err(platform::eacces());
     }
 
@@ -172,7 +172,7 @@ pub(crate) fn do_setattr(
 /// the guest-visible ownership and mode bits, not the real host file permissions.
 /// Root (uid 0) bypasses read/write checks but still needs at least one execute bit.
 pub(crate) fn do_access(fs: &PassthroughFs, ctx: Context, ino: u64, mask: u32) -> io::Result<()> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         // init.krun is always readable and executable.
         return Ok(());
     }

--- a/crates/filesystem/lib/backends/passthroughfs/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/mod.rs
@@ -22,7 +22,7 @@ use std::{
     os::fd::{AsRawFd, FromRawFd},
     path::PathBuf,
     sync::{
-        Arc, RwLock,
+        Arc, Mutex, RwLock,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
@@ -78,6 +78,9 @@ pub struct PassthroughConfig {
 
     /// Whether to enable writeback caching.
     pub writeback: bool,
+
+    /// Whether to expose the synthetic `init.krun` entry at the mount root.
+    pub inject_init: bool,
 }
 
 /// Passthrough filesystem backend.
@@ -100,6 +103,9 @@ pub struct PassthroughFs {
     /// Open file handle table.
     pub(crate) handles: RwLock<BTreeMap<u64, Arc<HandleData>>>,
 
+    /// Open directory handle table.
+    pub(crate) dir_handles: RwLock<BTreeMap<u64, Arc<PassthroughDirHandle>>>,
+
     /// Next file handle number to allocate (starts at 1, after init_handle=0).
     pub(crate) next_handle: AtomicU64,
 
@@ -119,6 +125,36 @@ pub struct PassthroughFs {
     /// after first rejecting real host symlinks on the pinned inode.
     #[cfg(target_os = "linux")]
     pub(crate) proc_self_fd: File,
+}
+
+/// Open directory handle with a lazy point-in-time snapshot.
+pub(crate) struct PassthroughDirHandle {
+    /// Real open fd for directory operations.
+    pub file: RwLock<File>,
+
+    /// Snapshot built on the first readdir call.
+    pub snapshot: Mutex<Option<DirSnapshot>>,
+}
+
+/// Snapshot of one directory handle's entries.
+pub(crate) struct DirSnapshot {
+    /// Guest-visible entries for this handle.
+    pub entries: Vec<PassthroughDirEntry>,
+}
+
+/// One passthrough directory entry in a snapshot.
+pub(crate) struct PassthroughDirEntry {
+    /// Guest-visible inode number.
+    pub inode: u64,
+
+    /// Entry name bytes.
+    pub name: Vec<u8>,
+
+    /// Stable synthetic offset cookie.
+    pub offset: u64,
+
+    /// Guest-visible directory entry type.
+    pub file_type: u32,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -190,6 +226,7 @@ impl PassthroughFs {
             inodes: RwLock::new(MultikeyBTreeMap::new()),
             next_inode: AtomicU64::new(3), // 1=root, 2=init
             handles: RwLock::new(BTreeMap::new()),
+            dir_handles: RwLock::new(BTreeMap::new()),
             next_handle: AtomicU64::new(1), // 0=init handle
             writeback: AtomicBool::new(false),
             init_file,
@@ -281,6 +318,21 @@ impl PassthroughFs {
             CachePolicy::Always => OpenOptions::CACHE_DIR,
         }
     }
+
+    /// Whether this mount exposes the synthetic init binary.
+    pub(crate) fn injects_init(&self) -> bool {
+        self.cfg.inject_init
+    }
+
+    /// Whether a root entry name is reserved for the synthetic init binary.
+    pub(crate) fn is_reserved_init_name(&self, parent: u64, name: &[u8]) -> bool {
+        self.injects_init() && parent == 1 && init_binary::is_init_name(name)
+    }
+
+    /// Whether the given inode refers to the synthetic init binary.
+    pub(crate) fn is_virtual_init_inode(&self, inode: u64) -> bool {
+        self.injects_init() && inode == init_binary::INIT_INODE
+    }
 }
 
 impl Default for PassthroughConfig {
@@ -293,6 +345,7 @@ impl Default for PassthroughConfig {
             attr_timeout: Duration::from_secs(5),
             cache_policy: CachePolicy::Auto,
             writeback: false,
+            inject_init: true,
         }
     }
 }
@@ -349,12 +402,13 @@ impl DynFileSystem for PassthroughFs {
 
     fn destroy(&self) {
         self.handles.write().unwrap().clear();
+        self.dir_handles.write().unwrap().clear();
         self.inodes.write().unwrap().clear();
     }
 
     fn lookup(&self, _ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
         // Handle init.krun lookup in root directory.
-        if parent == 1 && init_binary::is_init_name(name.to_bytes()) {
+        if self.is_reserved_init_name(parent, name.to_bytes()) {
             return Ok(init_binary::init_entry(
                 self.cfg.entry_timeout,
                 self.cfg.attr_timeout,
@@ -364,7 +418,7 @@ impl DynFileSystem for PassthroughFs {
     }
 
     fn forget(&self, _ctx: Context, ino: u64, count: u64) {
-        if ino == init_binary::INIT_INODE {
+        if self.is_virtual_init_inode(ino) {
             return;
         }
         inode::forget_one(self, ino, count);
@@ -375,7 +429,7 @@ impl DynFileSystem for PassthroughFs {
         // batch_forget is called with hundreds of entries after directory traversals.
         let mut inodes = self.inodes.write().unwrap();
         for (ino, count) in requests {
-            if ino == init_binary::INIT_INODE {
+            if self.is_virtual_init_inode(ino) {
                 continue;
             }
             inode::forget_one_locked(&mut inodes, ino, count);

--- a/crates/filesystem/lib/backends/passthroughfs/remove_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/remove_ops.rs
@@ -9,7 +9,7 @@ use std::{ffi::CStr, io};
 use super::{PassthroughFs, inode};
 use crate::{
     Context,
-    backends::shared::{init_binary, name_validation, platform},
+    backends::shared::{name_validation, platform},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -30,7 +30,7 @@ pub(crate) fn do_unlink(
     name_validation::validate_name(name)?;
 
     // Protect init.krun from deletion.
-    if init_binary::is_init_name(name.to_bytes()) {
+    if fs.is_reserved_init_name(parent, name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -92,7 +92,7 @@ pub(crate) fn do_rmdir(
 ) -> io::Result<()> {
     name_validation::validate_name(name)?;
 
-    if init_binary::is_init_name(name.to_bytes()) {
+    if fs.is_reserved_init_name(parent, name.to_bytes()) {
         return Err(platform::eacces());
     }
 
@@ -118,8 +118,8 @@ pub(crate) fn do_rename(
     name_validation::validate_name(newname)?;
 
     // Protect init.krun from being renamed or overwritten.
-    if init_binary::is_init_name(oldname.to_bytes())
-        || init_binary::is_init_name(newname.to_bytes())
+    if fs.is_reserved_init_name(olddir, oldname.to_bytes())
+        || fs.is_reserved_init_name(newdir, newname.to_bytes())
     {
         return Err(platform::eacces());
     }

--- a/crates/filesystem/lib/backends/passthroughfs/special.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/special.rs
@@ -14,11 +14,7 @@
 use std::{io, os::fd::AsRawFd};
 
 use super::PassthroughFs;
-use crate::{
-    Context,
-    backends::shared::{init_binary, platform},
-    statvfs64,
-};
+use crate::{Context, backends::shared::platform, statvfs64};
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -32,7 +28,7 @@ pub(crate) fn do_fsync(
     datasync: bool,
     handle: u64,
 ) -> io::Result<()> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Ok(());
     }
 
@@ -65,12 +61,26 @@ pub(crate) fn do_fsync(
 /// Synchronize directory contents.
 pub(crate) fn do_fsyncdir(
     fs: &PassthroughFs,
-    ctx: Context,
+    _ctx: Context,
     inode: u64,
-    datasync: bool,
+    _datasync: bool,
     handle: u64,
 ) -> io::Result<()> {
-    do_fsync(fs, ctx, inode, datasync, handle)
+    if fs.is_virtual_init_inode(inode) {
+        return Ok(());
+    }
+
+    let handles = fs.dir_handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    #[allow(clippy::readonly_write_lock)]
+    let file = data.file.write().unwrap();
+
+    let ret = unsafe { libc::fsync(file.as_raw_fd()) };
+    if ret < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+
+    Ok(())
 }
 
 /// Allocate space for a file.
@@ -83,7 +93,7 @@ pub(crate) fn do_fallocate(
     offset: u64,
     length: u64,
 ) -> io::Result<()> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Err(platform::eacces());
     }
 
@@ -159,7 +169,7 @@ pub(crate) fn do_lseek(
     offset: u64,
     whence: u32,
 ) -> io::Result<u64> {
-    if inode == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode) {
         return Err(platform::enosys());
     }
 
@@ -195,7 +205,7 @@ pub(crate) fn do_copyfilerange(
     len: u64,
     flags: u64,
 ) -> io::Result<usize> {
-    if inode_in == init_binary::INIT_INODE || inode_out == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(inode_in) || fs.is_virtual_init_inode(inode_out) {
         return Err(platform::enosys());
     }
 
@@ -239,7 +249,7 @@ pub(crate) fn do_copyfilerange(
 pub(crate) fn do_statfs(fs: &PassthroughFs, _ctx: Context, inode: u64) -> io::Result<statvfs64> {
     // Keep InodeFd guard alive so the fd isn't closed before fstatvfs uses it.
     let inode_fd;
-    let fd = if inode == init_binary::INIT_INODE || inode == 1 {
+    let fd = if fs.is_virtual_init_inode(inode) || inode == 1 {
         fs.root_fd.as_raw_fd()
     } else {
         inode_fd = super::inode::get_inode_fd(fs, inode)?;

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_bootstrap.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_bootstrap.rs
@@ -120,6 +120,7 @@ fn test_default_config_values() {
     assert_eq!(cfg.attr_timeout, Duration::from_secs(5));
     assert_eq!(cfg.cache_policy, CachePolicy::Auto);
     assert!(!cfg.writeback);
+    assert!(cfg.inject_init);
 }
 
 #[test]

--- a/crates/filesystem/lib/backends/passthroughfs/tests/test_dir_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/tests/test_dir_ops.rs
@@ -163,6 +163,101 @@ fn test_readdir_large_dir() {
 }
 
 #[test]
+fn test_readdir_offset_resume() {
+    let sb = TestSandbox::new();
+    sb.fuse_create_root("a.txt").unwrap();
+    sb.fuse_create_root("b.txt").unwrap();
+    sb.fuse_create_root("c.txt").unwrap();
+
+    let handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let all_entries = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+    assert!(all_entries.len() >= 4, "expected . .. init.krun and files");
+
+    let resume_after = all_entries[2].offset;
+    let resumed = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, handle, 65536, resume_after)
+        .unwrap();
+
+    let expected_names: Vec<&[u8]> = all_entries
+        .iter()
+        .filter(|entry| entry.offset > resume_after)
+        .map(|entry| entry.name)
+        .collect();
+    let resumed_names: Vec<&[u8]> = resumed.iter().map(|entry| entry.name).collect();
+
+    assert_eq!(resumed_names, expected_names);
+}
+
+#[test]
+fn test_readdir_snapshot_is_handle_local() {
+    let sb = TestSandbox::new();
+    sb.fuse_create_root("before.txt").unwrap();
+
+    let handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let before = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+    assert!(before.iter().any(|entry| entry.name == b"before.txt"));
+
+    sb.host_create_file("after.txt", b"new");
+
+    let same_handle = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+    assert!(!same_handle.iter().any(|entry| entry.name == b"after.txt"));
+
+    let next_handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let next_handle_entries = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, next_handle, 65536, 0)
+        .unwrap();
+    assert!(
+        next_handle_entries
+            .iter()
+            .any(|entry| entry.name == b"after.txt")
+    );
+}
+
+#[test]
+fn test_readdir_root_without_init_when_disabled() {
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.inject_init = false;
+        cfg
+    });
+
+    let handle = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let entries = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, handle, 65536, 0)
+        .unwrap();
+
+    assert!(!entries.iter().any(|entry| entry.name == b"init.krun"));
+}
+
+#[test]
+fn test_root_init_name_is_not_reserved_when_disabled() {
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.inject_init = false;
+        cfg
+    });
+
+    let (entry, handle) = sb.fuse_create_root("init.krun").unwrap();
+    assert_ne!(entry.inode, INIT_INODE);
+    sb.fs
+        .release(sb.ctx(), entry.inode, 0, handle, false, false, None)
+        .unwrap();
+
+    let looked_up = sb.lookup_root("init.krun").unwrap();
+    assert_eq!(looked_up.inode, entry.inode);
+}
+
+#[test]
 fn test_readdirplus_skips_dot_dotdot() {
     let sb = TestSandbox::new();
     let handle = sb.fuse_opendir(ROOT_INODE).unwrap();

--- a/crates/filesystem/lib/backends/passthroughfs/xattr_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/xattr_ops.rs
@@ -24,7 +24,7 @@ use super::metadata;
 use super::{PassthroughFs, inode};
 use crate::{
     Context, GetxattrReply, ListxattrReply,
-    backends::shared::{init_binary, platform, stat_override},
+    backends::shared::{platform, stat_override},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -40,7 +40,7 @@ pub(crate) fn do_setxattr(
     value: &[u8],
     flags: u32,
 ) -> io::Result<()> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         return Err(platform::eacces());
     }
 
@@ -102,7 +102,7 @@ pub(crate) fn do_getxattr(
     name: &CStr,
     size: u32,
 ) -> io::Result<GetxattrReply> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         return Err(platform::enodata());
     }
 
@@ -186,7 +186,7 @@ pub(crate) fn do_listxattr(
     ino: u64,
     size: u32,
 ) -> io::Result<ListxattrReply> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         if size == 0 {
             return Ok(ListxattrReply::Count(0));
         }
@@ -296,7 +296,7 @@ pub(crate) fn do_removexattr(
     ino: u64,
     name: &CStr,
 ) -> io::Result<()> {
-    if ino == init_binary::INIT_INODE {
+    if fs.is_virtual_init_inode(ino) {
         return Err(platform::eacces());
     }
 

--- a/crates/filesystem/lib/backends/shared/dir_snapshot.rs
+++ b/crates/filesystem/lib/backends/shared/dir_snapshot.rs
@@ -1,0 +1,69 @@
+//! Shared helpers for serving snapshot-backed directory entries.
+
+use crate::DirEntry;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// View over a backend-owned directory snapshot entry.
+pub(crate) trait SnapshotEntry {
+    /// Guest-visible inode number.
+    fn inode(&self) -> u64;
+
+    /// Stable offset cookie.
+    fn offset(&self) -> u64;
+
+    /// Guest-visible directory entry type.
+    fn file_type(&self) -> u32;
+
+    /// Entry name bytes.
+    fn name(&self) -> &[u8];
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Serve directory entries from a snapshot starting strictly after `offset`.
+pub(crate) fn serve_snapshot_entries<T: SnapshotEntry>(
+    entries: &[T],
+    offset: u64,
+) -> Vec<DirEntry<'static>> {
+    let start = entries
+        .iter()
+        .position(|entry| entry.offset() > offset)
+        .unwrap_or(entries.len());
+
+    let slice = &entries[start..];
+    if slice.is_empty() {
+        return Vec::new();
+    }
+
+    let mut names_buf = Vec::new();
+    let mut raw_entries = Vec::with_capacity(slice.len());
+
+    for entry in slice {
+        let name_offset = names_buf.len();
+        names_buf.extend_from_slice(entry.name());
+        raw_entries.push((
+            entry.inode(),
+            entry.offset(),
+            entry.file_type(),
+            name_offset,
+            entry.name().len(),
+        ));
+    }
+
+    let leaked: &'static [u8] = Box::leak(names_buf.into_boxed_slice());
+
+    raw_entries
+        .into_iter()
+        .map(|(ino, off, typ, start, len)| DirEntry {
+            ino,
+            offset: off,
+            type_: typ,
+            name: &leaked[start..start + len],
+        })
+        .collect()
+}

--- a/crates/filesystem/lib/backends/shared/mod.rs
+++ b/crates/filesystem/lib/backends/shared/mod.rs
@@ -3,6 +3,7 @@
 //! Contains data structures and utilities used by both [`PassthroughFs`](super::passthrough)
 //! and the future `OverlayFs`.
 
+pub(crate) mod dir_snapshot;
 pub(crate) mod handle_table;
 pub(crate) mod init_binary;
 pub(crate) mod inode_table;

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -488,6 +488,7 @@ fn build_vm(
         let runtime_tag = microsandbox_protocol::RUNTIME_FS_TAG.to_string();
         let cfg = PassthroughConfig {
             root_dir: config.runtime_dir.clone(),
+            inject_init: false,
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg)
@@ -506,6 +507,7 @@ fn build_vm(
             let tag = tag.to_string();
             let cfg = PassthroughConfig {
                 root_dir: PathBuf::from(path),
+                inject_init: false,
                 ..Default::default()
             };
             let backend = PassthroughFs::new(cfg)


### PR DESCRIPTION
## Summary

- Extract duplicated readdir snapshot-serving logic from all four filesystem backends (passthroughfs, memfs, overlayfs, dualfs) into a shared `dir_snapshot` module with a `SnapshotEntry` trait and generic `serve_snapshot_entries` function
- Refactor passthroughfs directory operations to use point-in-time snapshots with stable synthetic offsets, replacing the previous per-call getdents64 streaming approach that leaked platform-specific offset cookies into guest-visible values
- Add `inject_init` configuration flag to `PassthroughConfig` so non-rootfs passthrough mounts (runtime directory, bind mounts) can disable init.krun injection, and gate all init binary checks behind `is_virtual_init_inode()` and `is_reserved_init_name()` helpers
- Add comprehensive directory operation tests for passthroughfs covering readdir, readdirplus, offset resumption, snapshot isolation, init injection, and edge cases

## Test Plan

- Run `cargo test -p microsandbox-filesystem` to verify all filesystem tests pass, including the 15 new directory operation tests
- Run `cargo clippy --workspace` to verify no new warnings
- Run `cargo build -p msb` to verify the CLI builds successfully with the vm.rs changes
- Verify readdir offset resumption works correctly by checking `test_readdir_offset_resume`
- Verify snapshot isolation (new files don't appear in existing handles) via `test_readdir_snapshot_is_handle_local`
- Verify init.krun is not injected when `inject_init = false` via `test_readdir_root_without_init_when_disabled`
- Verify init.krun name is not reserved when disabled via `test_root_init_name_is_not_reserved_when_disabled`