### PR TITLE
feat(image): support custom TLS certs and insecure registries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,8 @@ dependencies = [
  "microsandbox-utils",
  "oci-client",
  "oci-spec",
+ "rcgen",
+ "rustls-pemfile",
  "scopeguard",
  "serde",
  "serde_json",

--- a/crates/cli/lib/commands/image.rs
+++ b/crates/cli/lib/commands/image.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use clap::{Args, Subcommand};
 use console::style;
 use microsandbox::image::Image;
+use microsandbox_image::Registry;
 
 use crate::ui;
 
@@ -92,6 +93,8 @@ pub async fn run(args: ImageArgs) -> anyhow::Result<()> {
                 args.reference,
                 args.force,
                 args.quiet,
+                args.insecure,
+                args.ca_certs,
                 microsandbox_image::PullPolicy::IfMissing,
             )
             .await
@@ -108,6 +111,8 @@ pub async fn run_pull(args: pull::PullArgs) -> anyhow::Result<()> {
         args.reference,
         args.force,
         args.quiet,
+        args.insecure,
+        args.ca_certs,
         microsandbox_image::PullPolicy::IfMissing,
     )
     .await
@@ -118,6 +123,8 @@ async fn run_pull_inner(
     reference: String,
     force: bool,
     quiet: bool,
+    insecure: bool,
+    cli_ca_certs: Option<String>,
     pull_policy: microsandbox_image::PullPolicy,
 ) -> anyhow::Result<()> {
     let start = Instant::now();
@@ -180,7 +187,22 @@ async fn run_pull_inner(
     let _ = display_ready_rx.recv();
 
     let auth = global.resolve_registry_auth(image_ref.registry())?;
-    let registry = microsandbox_image::Registry::with_auth(platform, cache, auth)?;
+    let mut ca_certs = global.resolve_ca_certs().await?;
+    if let Some(path) = &cli_ca_certs {
+        let data = tokio::fs::read(path)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to read CA certs from `{path}`: {e}"))?;
+        ca_certs.push(data);
+    }
+    let mut insecure_registries = global.insecure_registries();
+    if insecure {
+        insecure_registries.push(image_ref.registry().to_string());
+    }
+    let registry = Registry::builder(platform, cache)
+        .auth(auth)
+        .extra_ca_certs(ca_certs)
+        .add_insecure_registries(insecure_registries)
+        .build()?;
 
     let task = registry.pull_with_sender(&image_ref, &options, sender);
 
@@ -282,6 +304,8 @@ pub(crate) async fn pull_if_missing(reference: &str, quiet: bool) -> anyhow::Res
         reference.to_string(),
         false,
         quiet,
+        false,
+        None,
         microsandbox_image::PullPolicy::IfMissing,
     )
     .await

--- a/crates/cli/lib/commands/pull.rs
+++ b/crates/cli/lib/commands/pull.rs
@@ -22,4 +22,12 @@ pub struct PullArgs {
     /// Suppress progress output.
     #[arg(short, long)]
     pub quiet: bool,
+
+    /// Connect to the registry over plain HTTP instead of HTTPS.
+    #[arg(long)]
+    pub insecure: bool,
+
+    /// Path to a PEM file containing additional CA root certificates to trust.
+    #[arg(long, value_name = "PATH")]
+    pub ca_certs: Option<String>,
 }

--- a/crates/cli/lib/commands/registry.rs
+++ b/crates/cli/lib/commands/registry.rs
@@ -93,15 +93,17 @@ fn run_login(args: RegistryLoginArgs) -> anyhow::Result<()> {
     })?;
 
     let mut config = load_persisted_config_or_default()?;
-    config.registries.auth.insert(
-        args.registry.clone(),
-        RegistryAuthEntry {
-            username: args.username,
-            store: Some(RegistryCredentialStore::Keyring),
-            password_env: None,
-            secret_name: None,
-        },
-    );
+    config
+        .registries
+        .hosts
+        .entry(args.registry.clone())
+        .or_default()
+        .auth = Some(RegistryAuthEntry {
+        username: args.username,
+        store: Some(RegistryCredentialStore::Keyring),
+        password_env: None,
+        secret_name: None,
+    });
 
     if let Err(error) = save_persisted_config(&config) {
         let restore = match previous_auth {
@@ -130,7 +132,12 @@ fn run_login(args: RegistryLoginArgs) -> anyhow::Result<()> {
 fn run_logout(args: RegistryLogoutArgs) -> anyhow::Result<()> {
     let mut config = load_persisted_config_or_default()?;
     let previous_auth = get_registry_keyring_auth(&args.registry).ok().flatten();
-    let had_config_entry = config.registries.auth.remove(&args.registry).is_some();
+    let had_config_entry = config
+        .registries
+        .hosts
+        .get_mut(&args.registry)
+        .and_then(|e| e.auth.take())
+        .is_some();
     let had_keyring_entry = previous_auth.is_some();
 
     if !had_config_entry && !had_keyring_entry {
@@ -156,12 +163,19 @@ fn run_logout(args: RegistryLogoutArgs) -> anyhow::Result<()> {
 
 fn run_list(_args: RegistryListArgs) -> anyhow::Result<()> {
     let config = load_persisted_config_or_default()?;
-    if config.registries.auth.is_empty() {
+    let auth_entries: Vec<_> = config
+        .registries
+        .hosts
+        .iter()
+        .filter_map(|(hostname, entry)| entry.auth.as_ref().map(|auth| (hostname, auth)))
+        .collect();
+
+    if auth_entries.is_empty() {
         println!("No registries configured.");
         return Ok(());
     }
 
-    let mut entries: Vec<_> = config.registries.auth.iter().collect();
+    let mut entries: Vec<_> = auth_entries;
     entries.sort_by_key(|(name, _)| *name);
 
     let mut table = ui::Table::new(&["REGISTRY", "USERNAME", "SOURCE"]);

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -18,6 +18,7 @@ hex.workspace = true
 libc.workspace = true
 microsandbox-utils = { version = "0.3.14", path = "../utils" }
 oci-client.workspace = true
+rustls-pemfile.workspace = true
 oci-spec.workspace = true
 scopeguard.workspace = true
 serde.workspace = true
@@ -30,5 +31,6 @@ tracing.workspace = true
 xattr.workspace = true
 
 [dev-dependencies]
+rcgen.workspace = true
 tar.workspace = true
 tempfile.workspace = true

--- a/crates/image/lib/auth.rs
+++ b/crates/image/lib/auth.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Authentication credentials for OCI registry access.
 ///
 /// Resolution chain (in [`Registry`](crate::Registry)):
-/// 1. Explicit [`RegistryAuth`] via [`Registry::with_auth()`](crate::Registry::with_auth)
+/// 1. Explicit [`RegistryAuth`] via [`RegistryBuilder::auth()`](crate::RegistryBuilder::auth)
 /// 2. OS keyring / credential store (when configured by the caller)
 /// 3. Global config `registries.auth` (`store`, `password_env`, or `secret_name`)
 /// 4. Docker credential store/config fallback (when enabled by the caller)

--- a/crates/image/lib/error.rs
+++ b/crates/image/lib/error.rs
@@ -74,6 +74,10 @@ pub enum ImageError {
         reference: String,
     },
 
+    /// Invalid PEM certificate data.
+    #[error("invalid PEM certificate: {0}")]
+    InvalidCertificate(String),
+
     /// General I/O error.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/image/lib/lib.rs
+++ b/crates/image/lib/lib.rs
@@ -39,5 +39,5 @@ pub use oci_client::Reference;
 pub use platform::{Arch, Os, Platform};
 pub use progress::{PullProgress, PullProgressHandle, PullProgressSender, progress_channel};
 pub use pull::{PullOptions, PullPolicy, PullResult};
-pub use registry::Registry;
+pub use registry::{Registry, RegistryBuilder};
 pub use store::{CachedImageMetadata, CachedLayerMetadata, GlobalCache};

--- a/crates/image/lib/registry.rs
+++ b/crates/image/lib/registry.rs
@@ -13,7 +13,11 @@ use std::{
     time::Instant,
 };
 
-use oci_client::{Client, client::ClientConfig, manifest::ImageIndexEntry};
+use oci_client::{
+    Client,
+    client::{Certificate, CertificateEncoding, ClientConfig, ClientProtocol},
+    manifest::ImageIndexEntry,
+};
 use tokio::{
     io::{AsyncRead, ReadBuf},
     sync::Semaphore,
@@ -65,6 +69,15 @@ struct LayerDescriptor {
     digest: Digest,
     media_type: Option<String>,
     size: Option<u64>,
+}
+
+/// Builder for constructing a [`Registry`] client with optional auth and TLS settings.
+pub struct RegistryBuilder {
+    platform: Platform,
+    cache: GlobalCache,
+    auth: oci_client::secrets::RegistryAuth,
+    insecure_registries: Vec<String>,
+    extra_ca_certs: Vec<Vec<u8>>,
 }
 
 struct CachedPullInfo {
@@ -122,32 +135,20 @@ impl<R> MaterializeProgressReader<R> {
 }
 
 impl Registry {
-    /// Create a registry client with anonymous authentication.
+    /// Create a registry client with anonymous authentication and default TLS settings.
     pub fn new(platform: Platform, cache: GlobalCache) -> ImageResult<Self> {
-        let client = build_client(&platform);
-
-        Ok(Self {
-            client,
-            auth: oci_client::secrets::RegistryAuth::Anonymous,
-            platform,
-            cache,
-        })
+        Self::builder(platform, cache).build()
     }
 
-    /// Create a registry client with explicit authentication.
-    pub fn with_auth(
-        platform: Platform,
-        cache: GlobalCache,
-        auth: RegistryAuth,
-    ) -> ImageResult<Self> {
-        let client = build_client(&platform);
-
-        Ok(Self {
-            client,
-            auth: (&auth).into(),
+    /// Create a builder for configuring auth, TLS, and other registry options.
+    pub fn builder(platform: Platform, cache: GlobalCache) -> RegistryBuilder {
+        RegistryBuilder {
             platform,
             cache,
-        })
+            auth: oci_client::secrets::RegistryAuth::Anonymous,
+            insecure_registries: Vec::new(),
+            extra_ca_certs: Vec::new(),
+        }
     }
 
     /// Resolve a pull directly from the on-disk cache without building a registry client.
@@ -1263,16 +1264,75 @@ fn detect_manifest_media_type(bytes: &[u8]) -> String {
     "application/vnd.oci.image.manifest.v1+json".to_string()
 }
 
-/// Build an OCI client that resolves multi-platform manifests for the requested target.
-fn build_client(platform: &Platform) -> Client {
-    let platform = platform.clone();
-    Client::new(ClientConfig {
-        protocol: oci_client::client::ClientProtocol::Https,
-        platform_resolver: Some(Box::new(move |manifests| {
-            resolve_platform_digest(manifests, &platform)
-        })),
-        ..Default::default()
-    })
+impl RegistryBuilder {
+    /// Set authentication credentials for the registry.
+    pub fn auth(mut self, auth: RegistryAuth) -> Self {
+        self.auth = (&auth).into();
+        self
+    }
+
+    /// Add registries that should be accessed over plain HTTP instead of HTTPS.
+    pub fn add_insecure_registries(mut self, registries: Vec<String>) -> Self {
+        self.insecure_registries.extend(registries);
+        self
+    }
+
+    /// Add PEM-encoded CA root certificates to trust.
+    pub fn extra_ca_certs(mut self, certs: Vec<Vec<u8>>) -> Self {
+        self.extra_ca_certs = certs;
+        self
+    }
+
+    /// Build the registry client.
+    ///
+    /// Returns [`ImageError::InvalidCertificate`] if any PEM data in
+    /// `extra_ca_certs` cannot be parsed as valid certificates.
+    pub fn build(self) -> ImageResult<Registry> {
+        let protocol = if self.insecure_registries.is_empty() {
+            ClientProtocol::Https
+        } else {
+            ClientProtocol::HttpsExcept(self.insecure_registries)
+        };
+
+        let mut extra_root_certificates = Vec::new();
+        for (i, pem_data) in self.extra_ca_certs.into_iter().enumerate() {
+            let certs: Vec<_> = rustls_pemfile::certs(&mut pem_data.as_slice())
+                .collect::<Result<_, _>>()
+                .map_err(|e| {
+                    ImageError::InvalidCertificate(format!("entry {i}: failed to parse: {e}"))
+                })?;
+
+            if certs.is_empty() {
+                return Err(ImageError::InvalidCertificate(format!(
+                    "entry {i}: no certificates found in PEM data"
+                )));
+            }
+
+            for cert in certs {
+                extra_root_certificates.push(Certificate {
+                    encoding: CertificateEncoding::Der,
+                    data: cert.to_vec(),
+                });
+            }
+        }
+
+        let platform = self.platform.clone();
+        let client = Client::new(ClientConfig {
+            protocol,
+            extra_root_certificates,
+            platform_resolver: Some(Box::new(move |manifests| {
+                resolve_platform_digest(manifests, &platform)
+            })),
+            ..Default::default()
+        });
+
+        Ok(Registry {
+            client,
+            auth: self.auth,
+            platform: self.platform,
+            cache: self.cache,
+        })
+    }
 }
 
 /// Resolve the best matching platform-specific manifest digest.
@@ -1902,5 +1962,134 @@ mod tests {
         cache_root
             .join("manifests")
             .join(format!("{}.json", hex::encode(hasher.finalize())))
+    }
+
+    #[test]
+    fn test_registry_builder_default() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let registry = super::Registry::builder(Platform::default(), cache)
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            registry.auth,
+            oci_client::secrets::RegistryAuth::Anonymous
+        ));
+    }
+
+    #[test]
+    fn test_registry_builder_with_auth() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let registry = super::Registry::builder(Platform::default(), cache)
+            .auth(crate::RegistryAuth::Basic {
+                username: "user".into(),
+                password: "pass".into(),
+            })
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            registry.auth,
+            oci_client::secrets::RegistryAuth::Basic(_, _)
+        ));
+    }
+
+    #[test]
+    fn test_registry_builder_with_insecure_registries() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        // Should build without error — we can't inspect ClientConfig directly,
+        // but we verify it doesn't panic or fail.
+        super::Registry::builder(Platform::default(), cache)
+            .add_insecure_registries(vec!["localhost:5000".into()])
+            .build()
+            .unwrap();
+    }
+
+    /// Generate a self-signed CA certificate and return PEM bytes.
+    fn generate_test_ca_pem() -> Vec<u8> {
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        cert.pem().into_bytes()
+    }
+
+    #[test]
+    fn test_registry_builder_with_valid_ca_cert() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let pem = generate_test_ca_pem();
+        super::Registry::builder(Platform::default(), cache)
+            .extra_ca_certs(vec![pem])
+            .build()
+            .unwrap();
+    }
+
+    /// Helper to extract the error from a builder result.
+    fn build_err(result: Result<super::Registry, crate::ImageError>) -> crate::ImageError {
+        match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected build to fail"),
+        }
+    }
+
+    #[test]
+    fn test_registry_builder_rejects_invalid_pem() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let bad_pem = b"not valid PEM data".to_vec();
+        let err = build_err(
+            super::Registry::builder(Platform::default(), cache)
+                .extra_ca_certs(vec![bad_pem])
+                .build(),
+        );
+
+        assert!(
+            err.to_string().contains("no certificates found"),
+            "expected 'no certificates found', got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_registry_builder_rejects_empty_pem() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let err = build_err(
+            super::Registry::builder(Platform::default(), cache)
+                .extra_ca_certs(vec![Vec::new()])
+                .build(),
+        );
+
+        assert!(
+            err.to_string().contains("no certificates found"),
+            "expected 'no certificates found', got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_registry_builder_all_options() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        let pem = generate_test_ca_pem();
+        super::Registry::builder(Platform::default(), cache)
+            .auth(crate::RegistryAuth::Basic {
+                username: "user".into(),
+                password: "pass".into(),
+            })
+            .add_insecure_registries(vec!["localhost:5000".into()])
+            .extra_ca_certs(vec![pem])
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_registry_new_equals_builder_default() {
+        let temp = tempdir().unwrap();
+        let cache = GlobalCache::new(temp.path()).unwrap();
+        // Registry::new() should succeed just like builder().build()
+        super::Registry::new(Platform::default(), cache).unwrap();
     }
 }

--- a/crates/microsandbox/lib/config/mod.rs
+++ b/crates/microsandbox/lib/config/mod.rs
@@ -14,7 +14,7 @@ use microsandbox_image::RegistryAuth;
 use microsandbox_runtime::logging::LogLevel;
 use serde::{Deserialize, Serialize};
 
-use crate::MicrosandboxResult;
+use crate::{MicrosandboxError, MicrosandboxResult};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -130,28 +130,49 @@ pub struct SandboxDefaults {
     pub workdir: Option<String>,
 }
 
-/// Registry authentication configuration.
+/// Registry configuration.
+///
+/// Example:
+/// ```json
+/// {
+///   "registries": {
+///     "ca_certs": "/path/to/corporate-ca.pem",
+///     "hosts": {
+///       "localhost:5050": { "insecure": true },
+///       "ghcr.io": {
+///         "auth": { "username": "user", "store": "keyring" }
+///       }
+///     }
+///   }
+/// }
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RegistriesConfig {
-    /// Per-registry authentication entries, keyed by registry hostname.
+    /// Path to a PEM file containing additional CA root certificates to trust.
     ///
-    /// Example:
-    /// ```json
-    /// {
-    ///   "registries": {
-    ///     "auth": {
-    ///       "ghcr.io": { "username": "user", "store": "keyring" },
-    ///       "registry.example.com": { "username": "deploy", "password_env": "REGISTRY_TOKEN" },
-    ///       "docker.io": { "username": "user", "secret_name": "dockerhub" }
-    ///     }
-    ///   }
-    /// }
-    /// ```
-    pub auth: HashMap<String, RegistryAuthEntry>,
+    /// Applies globally to all registry connections.
+    pub ca_certs: Option<PathBuf>,
+
+    /// Per-registry settings keyed by hostname.
+    #[serde(default)]
+    pub hosts: HashMap<String, RegistryEntry>,
 }
 
-/// A single registry authentication entry from global config.
+/// Configuration for a single OCI registry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct RegistryEntry {
+    /// Authentication credentials.
+    #[serde(default)]
+    pub auth: Option<RegistryAuthEntry>,
+
+    /// Access this registry over plain HTTP instead of HTTPS.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub insecure: bool,
+}
+
+/// Authentication credentials for a registry entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryAuthEntry {
     /// Registry username.
@@ -233,11 +254,40 @@ impl GlobalConfig {
             .unwrap_or_else(|| self.home().join(microsandbox_utils::SECRETS_SUBDIR))
     }
 
+    /// Resolve registry transport for a given hostname from the global config.
+    /// Load additional CA root certificates from the global `registries.ca_certs` path.
+    ///
+    /// Returns an empty vec if no path is configured.
+    pub async fn resolve_ca_certs(&self) -> MicrosandboxResult<Vec<Vec<u8>>> {
+        match &self.registries.ca_certs {
+            Some(path) => {
+                let data = tokio::fs::read(path).await.map_err(|e| {
+                    MicrosandboxError::InvalidConfig(format!(
+                        "failed to read CA certs from `{}`: {e}",
+                        path.display()
+                    ))
+                })?;
+                Ok(vec![data])
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Return all registry hostnames configured as insecure (plain HTTP).
+    pub fn insecure_registries(&self) -> Vec<String> {
+        self.registries
+            .hosts
+            .iter()
+            .filter(|(_, entry)| entry.insecure)
+            .map(|(hostname, _)| hostname.clone())
+            .collect()
+    }
+
     /// Resolve registry authentication for a given hostname.
     ///
     /// Resolution order:
     /// 1. OS keyring (interactive CLI login, when the `keyring` feature is enabled)
-    /// 2. `registries.auth` in global config
+    /// 2. `registries.<hostname>.auth` in global config
     /// 3. Docker credential store/config
     /// 4. Anonymous
     ///
@@ -269,7 +319,12 @@ impl GlobalConfig {
         &self,
         hostname: &str,
     ) -> MicrosandboxResult<Option<RegistryAuth>> {
-        let entry = match self.registries.auth.get(hostname) {
+        let entry = match self
+            .registries
+            .hosts
+            .get(hostname)
+            .and_then(|e| e.auth.as_ref())
+        {
             Some(entry) => entry,
             None => return Ok(None),
         };
@@ -279,13 +334,13 @@ impl GlobalConfig {
             + usize::from(entry.secret_name.is_some());
 
         if source_count == 0 {
-            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            return Err(MicrosandboxError::InvalidConfig(format!(
                 "registry auth for {hostname}: entry has no credential source"
             )));
         }
 
         if source_count > 1 {
-            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            return Err(MicrosandboxError::InvalidConfig(format!(
                 "registry auth for {hostname}: entry defines multiple credential sources"
             )));
         }
@@ -293,10 +348,10 @@ impl GlobalConfig {
         if entry.store == Some(RegistryCredentialStore::Keyring) {
             return match lookup_registry_keyring_auth(hostname) {
                 Ok(Some(auth)) => Ok(Some(auth)),
-                Ok(None) => Err(crate::MicrosandboxError::InvalidConfig(format!(
+                Ok(None) => Err(MicrosandboxError::InvalidConfig(format!(
                     "registry auth for {hostname}: OS keyring entry is missing"
                 ))),
-                Err(error) => Err(crate::MicrosandboxError::InvalidConfig(format!(
+                Err(error) => Err(MicrosandboxError::InvalidConfig(format!(
                     "registry auth for {hostname}: failed to read OS keyring entry: {error}"
                 ))),
             };
@@ -304,7 +359,7 @@ impl GlobalConfig {
 
         let password = if let Some(ref env_var) = entry.password_env {
             std::env::var(env_var).map_err(|_| {
-                crate::MicrosandboxError::InvalidConfig(format!(
+                MicrosandboxError::InvalidConfig(format!(
                     "registry auth for {hostname}: environment variable `{env_var}` is not set"
                 ))
             })?
@@ -312,7 +367,7 @@ impl GlobalConfig {
             let secret_path = self.secrets_dir().join("registries").join(secret_name);
             std::fs::read_to_string(&secret_path)
                 .map_err(|e| {
-                    crate::MicrosandboxError::InvalidConfig(format!(
+                    MicrosandboxError::InvalidConfig(format!(
                         "registry auth for {hostname}: failed to read secret `{}`: {e}",
                         secret_path.display()
                     ))
@@ -320,7 +375,7 @@ impl GlobalConfig {
                 .trim()
                 .to_string()
         } else {
-            return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            return Err(MicrosandboxError::InvalidConfig(format!(
                 "registry auth for {hostname}: entry has no usable credential source"
             )));
         };
@@ -360,6 +415,10 @@ impl Default for SandboxDefaults {
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+fn is_false(v: &bool) -> bool {
+    !v
+}
 
 fn resolve_docker_registry_auth(hostname: &str) -> Option<RegistryAuth> {
     resolve_registry_auth_with_lookup(hostname, docker_credential::get_credential)
@@ -447,22 +506,18 @@ pub fn save_persisted_config(config: &GlobalConfig) -> MicrosandboxResult<()> {
     let path = config_path();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
-            crate::MicrosandboxError::Custom(format!(
+            MicrosandboxError::Custom(format!(
                 "failed to create config directory `{}`: {e}",
                 parent.display()
             ))
         })?;
     }
 
-    let content = serde_json::to_string_pretty(config).map_err(|e| {
-        crate::MicrosandboxError::Custom(format!("failed to serialize config: {e}"))
-    })?;
+    let content = serde_json::to_string_pretty(config)
+        .map_err(|e| MicrosandboxError::Custom(format!("failed to serialize config: {e}")))?;
 
     std::fs::write(&path, format!("{content}\n")).map_err(|e| {
-        crate::MicrosandboxError::Custom(format!(
-            "failed to write config `{}`: {e}",
-            path.display()
-        ))
+        MicrosandboxError::Custom(format!("failed to write config `{}`: {e}", path.display()))
     })?;
     Ok(())
 }
@@ -473,18 +528,17 @@ pub fn set_registry_keyring_auth(
     username: &str,
     password: &str,
 ) -> MicrosandboxResult<()> {
-    store_registry_keyring_auth(hostname, username, password)
-        .map_err(crate::MicrosandboxError::Custom)
+    store_registry_keyring_auth(hostname, username, password).map_err(MicrosandboxError::Custom)
 }
 
 /// Load registry credentials from the OS keyring, if present.
 pub fn get_registry_keyring_auth(hostname: &str) -> MicrosandboxResult<Option<RegistryAuth>> {
-    lookup_registry_keyring_auth(hostname).map_err(crate::MicrosandboxError::Custom)
+    lookup_registry_keyring_auth(hostname).map_err(MicrosandboxError::Custom)
 }
 
 /// Delete registry credentials from the OS keyring if they exist.
 pub fn delete_registry_keyring_auth(hostname: &str) -> MicrosandboxResult<()> {
-    remove_registry_keyring_auth(hostname).map_err(crate::MicrosandboxError::Custom)
+    remove_registry_keyring_auth(hostname).map_err(MicrosandboxError::Custom)
 }
 
 /// Override the global configuration programmatically.
@@ -547,7 +601,7 @@ pub fn resolve_msb_path() -> MicrosandboxResult<PathBuf> {
     }
 
     let path = which::which(microsandbox_utils::MSB_BINARY).map_err(|_| {
-        crate::MicrosandboxError::Custom(
+        MicrosandboxError::Custom(
             "msb binary not found. Run `cargo clean -p microsandbox && cargo build` to reinstall, \
              or set MSB_PATH to the binary location"
                 .into(),
@@ -569,7 +623,7 @@ pub fn resolve_libkrunfw_path() -> MicrosandboxResult<PathBuf> {
         if path.is_file() {
             return Ok(path.clone());
         }
-        return Err(crate::MicrosandboxError::LibkrunfwNotFound(format!(
+        return Err(MicrosandboxError::LibkrunfwNotFound(format!(
             "configured path does not exist: {}",
             path.display()
         )));
@@ -602,7 +656,7 @@ pub fn resolve_libkrunfw_path() -> MicrosandboxResult<PathBuf> {
         .map(|path| path.display().to_string())
         .collect::<Vec<_>>()
         .join(", ");
-    Err(crate::MicrosandboxError::LibkrunfwNotFound(format!(
+    Err(MicrosandboxError::LibkrunfwNotFound(format!(
         "searched: {searched}"
     )))
 }
@@ -667,11 +721,11 @@ fn dedupe_strings(values: &mut Vec<String>) {
 
 fn read_config_from(path: &Path) -> MicrosandboxResult<GlobalConfig> {
     let content = std::fs::read_to_string(path).map_err(|e| {
-        crate::MicrosandboxError::Custom(format!("failed to read config `{}`: {e}", path.display()))
+        MicrosandboxError::Custom(format!("failed to read config `{}`: {e}", path.display()))
     })?;
 
     serde_json::from_str(&content).map_err(|e| {
-        crate::MicrosandboxError::InvalidConfig(format!(
+        MicrosandboxError::InvalidConfig(format!(
             "failed to parse config `{}`: {e}",
             path.display()
         ))
@@ -893,21 +947,41 @@ mod tests {
         assert!(result.is_none());
     }
 
+    /// Helper to build a `RegistriesConfig` from a list of `(hostname, RegistryEntry)` pairs.
+    fn registries(entries: Vec<(&str, RegistryEntry)>) -> RegistriesConfig {
+        RegistriesConfig {
+            hosts: entries
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn test_deserialize_registry_keyring_store() {
         let json = r#"{
             "registries": {
-                "auth": {
+                "hosts": {
                     "ghcr.io": {
-                        "username": "octocat",
-                        "store": "keyring"
+                        "auth": {
+                            "username": "octocat",
+                            "store": "keyring"
+                        }
                     }
                 }
             }
         }"#;
 
         let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
-        let entry = cfg.registries.auth.get("ghcr.io").unwrap();
+        let entry = cfg
+            .registries
+            .hosts
+            .get("ghcr.io")
+            .unwrap()
+            .auth
+            .as_ref()
+            .unwrap();
         assert_eq!(entry.username, "octocat");
         assert_eq!(entry.store, Some(RegistryCredentialStore::Keyring));
         assert!(entry.password_env.is_none());
@@ -920,17 +994,18 @@ mod tests {
         let path = temp.path().join("config.json");
 
         let cfg = GlobalConfig {
-            registries: RegistriesConfig {
-                auth: HashMap::from([(
-                    "ghcr.io".to_string(),
-                    RegistryAuthEntry {
+            registries: registries(vec![(
+                "ghcr.io",
+                RegistryEntry {
+                    auth: Some(RegistryAuthEntry {
                         username: "octocat".to_string(),
                         store: Some(RegistryCredentialStore::Keyring),
                         password_env: None,
                         secret_name: None,
-                    },
-                )]),
-            },
+                    }),
+                    ..Default::default()
+                },
+            )]),
             ..Default::default()
         };
 
@@ -938,7 +1013,14 @@ mod tests {
         std::fs::write(&path, content).unwrap();
 
         let loaded = read_config_from(&path).unwrap();
-        let entry = loaded.registries.auth.get("ghcr.io").unwrap();
+        let entry = loaded
+            .registries
+            .hosts
+            .get("ghcr.io")
+            .unwrap()
+            .auth
+            .as_ref()
+            .unwrap();
         assert_eq!(entry.username, "octocat");
         assert_eq!(entry.store, Some(RegistryCredentialStore::Keyring));
     }
@@ -989,17 +1071,18 @@ mod tests {
                 secrets: Some(temp.path().to_path_buf()),
                 ..Default::default()
             },
-            registries: RegistriesConfig {
-                auth: HashMap::from([(
-                    "ghcr.io".to_string(),
-                    RegistryAuthEntry {
+            registries: registries(vec![(
+                "ghcr.io",
+                RegistryEntry {
+                    auth: Some(RegistryAuthEntry {
                         username: "user".to_string(),
                         store: None,
                         password_env: None,
                         secret_name: Some("ghcr-token".to_string()),
-                    },
-                )]),
-            },
+                    }),
+                    ..Default::default()
+                },
+            )]),
             ..Default::default()
         };
 
@@ -1016,17 +1099,18 @@ mod tests {
     #[test]
     fn test_resolve_configured_registry_auth_rejects_multiple_sources() {
         let cfg = GlobalConfig {
-            registries: RegistriesConfig {
-                auth: HashMap::from([(
-                    "ghcr.io".to_string(),
-                    RegistryAuthEntry {
+            registries: registries(vec![(
+                "ghcr.io",
+                RegistryEntry {
+                    auth: Some(RegistryAuthEntry {
                         username: "user".to_string(),
                         store: Some(RegistryCredentialStore::Keyring),
                         password_env: Some("GHCR_TOKEN".to_string()),
                         secret_name: None,
-                    },
-                )]),
-            },
+                    }),
+                    ..Default::default()
+                },
+            )]),
             ..Default::default()
         };
 
@@ -1123,5 +1207,139 @@ mod tests {
             }
             other => panic!("expected basic auth, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_deserialize_registry_insecure() {
+        let json = r#"{
+            "registries": {
+                "hosts": {
+                    "localhost:5050": { "insecure": true }
+                }
+            }
+        }"#;
+
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        let entry = cfg.registries.hosts.get("localhost:5050").unwrap();
+        assert!(entry.insecure);
+        assert!(entry.auth.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_registry_ca_certs_global() {
+        let json = r#"{
+            "registries": {
+                "ca_certs": "/path/to/ca.pem"
+            }
+        }"#;
+
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.registries.ca_certs,
+            Some(PathBuf::from("/path/to/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn test_deserialize_registry_full_entry() {
+        let json = r#"{
+            "registries": {
+                "ca_certs": "/path/to/ca.pem",
+                "hosts": {
+                    "localhost:5050": {
+                        "insecure": true,
+                        "auth": {
+                            "username": "user",
+                            "password_env": "TOKEN"
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.registries.ca_certs,
+            Some(PathBuf::from("/path/to/ca.pem"))
+        );
+        let entry = cfg.registries.hosts.get("localhost:5050").unwrap();
+        assert!(entry.insecure);
+        let auth = entry.auth.as_ref().unwrap();
+        assert_eq!(auth.username, "user");
+        assert_eq!(auth.password_env, Some("TOKEN".to_string()));
+    }
+
+    #[test]
+    fn test_deserialize_empty_registries() {
+        let json = r#"{"registries": {}}"#;
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.registries.hosts.is_empty());
+        assert!(cfg.registries.ca_certs.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ca_certs_from_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let pem_path = temp.path().join("ca.pem");
+        let pem_data = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n";
+        std::fs::write(&pem_path, pem_data).unwrap();
+
+        let cfg = GlobalConfig {
+            registries: RegistriesConfig {
+                ca_certs: Some(pem_path),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let certs = cfg.resolve_ca_certs().await.unwrap();
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0], pem_data);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ca_certs_missing_file_errors() {
+        let cfg = GlobalConfig {
+            registries: RegistriesConfig {
+                ca_certs: Some(PathBuf::from("/nonexistent/ca.pem")),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let err = cfg.resolve_ca_certs().await.unwrap_err();
+        assert!(err.to_string().contains("failed to read CA certs"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ca_certs_none_returns_empty() {
+        let cfg = GlobalConfig::default();
+        let certs = cfg.resolve_ca_certs().await.unwrap();
+        assert!(certs.is_empty());
+    }
+
+    #[test]
+    fn test_insecure_registries() {
+        let cfg = GlobalConfig {
+            registries: registries(vec![
+                (
+                    "localhost:5050",
+                    RegistryEntry {
+                        insecure: true,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "ghcr.io",
+                    RegistryEntry {
+                        ..Default::default()
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+
+        let insecure = cfg.insecure_registries();
+        assert_eq!(insecure, vec!["localhost:5050"]);
     }
 }

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -25,6 +25,34 @@ pub struct SandboxBuilder {
     build_error: Option<crate::MicrosandboxError>,
 }
 
+/// Sub-builder for registry connection settings.
+#[derive(Default)]
+pub struct RegistryConfigBuilder {
+    pub(crate) auth: Option<RegistryAuth>,
+    pub(crate) insecure: bool,
+    pub(crate) ca_certs: Vec<Vec<u8>>,
+}
+
+impl RegistryConfigBuilder {
+    /// Set authentication credentials.
+    pub fn auth(mut self, auth: RegistryAuth) -> Self {
+        self.auth = Some(auth);
+        self
+    }
+
+    /// Access the registry over plain HTTP instead of HTTPS.
+    pub fn insecure(mut self) -> Self {
+        self.insecure = true;
+        self
+    }
+
+    /// Add PEM-encoded CA root certificates to trust.
+    pub fn ca_certs(mut self, pem_data: Vec<u8>) -> Self {
+        self.ca_certs.push(pem_data);
+        self
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -134,9 +162,34 @@ impl SandboxBuilder {
         self
     }
 
-    /// Set registry authentication for private OCI registries.
-    pub fn registry_auth(mut self, auth: RegistryAuth) -> Self {
-        self.config.registry_auth = Some(auth);
+    /// Configure registry connection settings (auth, TLS, insecure).
+    ///
+    /// ```rust,ignore
+    /// use microsandbox::{RegistryAuth, sandbox::Sandbox};
+    ///
+    /// let sb = Sandbox::builder("worker")
+    ///     .image("localhost:5050/my-app:latest")
+    ///     .registry(|r| r
+    ///         .auth(RegistryAuth::Basic {
+    ///             username: "user".into(),
+    ///             password: "pass".into(),
+    ///         })
+    ///         .insecure()
+    ///     )
+    ///     .create()
+    ///     .await
+    ///     .unwrap();
+    /// ```
+    pub fn registry(
+        mut self,
+        f: impl FnOnce(RegistryConfigBuilder) -> RegistryConfigBuilder,
+    ) -> Self {
+        let builder = f(RegistryConfigBuilder::default());
+        if let Some(auth) = builder.auth {
+            self.config.registry_auth = Some(auth);
+        }
+        self.config.insecure = builder.insecure;
+        self.config.ca_certs = builder.ca_certs;
         self
     }
 

--- a/crates/microsandbox/lib/sandbox/config.rs
+++ b/crates/microsandbox/lib/sandbox/config.rs
@@ -150,6 +150,14 @@ pub struct SandboxConfig {
     #[serde(default, skip_serializing)]
     pub registry_auth: Option<RegistryAuth>,
 
+    /// Access the registry over plain HTTP (SDK override).
+    #[serde(skip)]
+    pub(crate) insecure: bool,
+
+    /// Additional PEM-encoded CA certs (SDK override).
+    #[serde(skip)]
+    pub(crate) ca_certs: Vec<Vec<u8>>,
+
     /// Replace an existing sandbox with the same name during create.
     ///
     /// If the existing sandbox is still active, microsandbox stops it and
@@ -324,6 +332,8 @@ impl Default for SandboxConfig {
             pull_policy: PullPolicy::default(),
             policy: SandboxPolicy::default(),
             registry_auth: None,
+            insecure: false,
+            ca_certs: Vec::new(),
             replace_existing: false,
             manifest_digest: None,
         }

--- a/crates/microsandbox/lib/sandbox/mod.rs
+++ b/crates/microsandbox/lib/sandbox/mod.rs
@@ -18,6 +18,7 @@ mod types;
 use std::{collections::HashMap, path::Path, process::ExitStatus, sync::Arc};
 
 use bytes::Bytes;
+use microsandbox_image::Registry;
 use microsandbox_protocol::{
     exec::{ExecExited, ExecRequest, ExecRlimit, ExecStarted, ExecStderr, ExecStdin, ExecStdout},
     message::{Message, MessageType},
@@ -29,8 +30,8 @@ use sea_orm::{
 use tokio::sync::{Mutex, mpsc};
 
 use microsandbox_image::{
-    Digest, GlobalCache, PullOptions, PullProgressSender, PullResult, Reference, Registry,
-    RegistryAuth, ext4, filetree, progress_channel,
+    Digest, GlobalCache, PullOptions, PullProgressSender, PullResult, Reference, ext4, filetree,
+    progress_channel,
 };
 
 use crate::{
@@ -51,7 +52,7 @@ use self::exec::{ExecEvent, ExecHandle, ExecOptions, ExecSink, StdinMode};
 
 pub use crate::db::entity::sandbox::SandboxStatus;
 pub use attach::AttachOptionsBuilder;
-pub use builder::SandboxBuilder;
+pub use builder::{RegistryConfigBuilder, SandboxBuilder};
 pub use config::SandboxConfig;
 pub use exec::{ExecOptionsBuilder, ExecOutput, Rlimit, RlimitResource};
 pub use fs::{FsEntry, FsEntryKind, FsMetadata, FsReadStream, FsWriteSink, SandboxFs};
@@ -73,6 +74,13 @@ pub use types::{
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
+
+/// Transient registry overrides from the SDK, merged with global config at pull time.
+pub(crate) struct RegistryOverrides {
+    pub auth: Option<microsandbox_image::RegistryAuth>,
+    pub insecure: bool,
+    pub ca_certs: Vec<Vec<u8>>,
+}
 
 /// A running sandbox.
 ///
@@ -195,13 +203,13 @@ impl Sandbox {
 
         // Resolve OCI images before spawning the sandbox process.
         if let RootfsSource::Oci(reference) = config.image.clone() {
-            let pull_result = pull_oci_image(
-                &reference,
-                config.pull_policy,
-                config.registry_auth.take(),
-                progress,
-            )
-            .await?;
+            let overrides = RegistryOverrides {
+                auth: config.registry_auth.clone(),
+                insecure: config.insecure,
+                ca_certs: config.ca_certs.clone(),
+            };
+            let pull_result =
+                pull_oci_image(&reference, config.pull_policy, overrides, progress).await?;
 
             // Merge image config defaults under user-provided config.
             config.merge_image_defaults(&pull_result.config);
@@ -1439,7 +1447,7 @@ pub(super) fn pid_is_alive(pid: i32) -> bool {
 async fn pull_oci_image(
     reference: &str,
     pull_policy: PullPolicy,
-    explicit_auth: Option<RegistryAuth>,
+    registry_overrides: RegistryOverrides,
     progress: Option<PullProgressSender>,
 ) -> MicrosandboxResult<PullResult> {
     let global = crate::config::config();
@@ -1481,12 +1489,25 @@ async fn pull_oci_image(
         return Ok(result);
     }
 
-    let auth = match explicit_auth {
+    let auth = match registry_overrides.auth {
         Some(auth) => auth,
         None => global.resolve_registry_auth(image_ref.registry())?,
     };
 
-    let registry = Registry::with_auth(platform, cache, auth)?;
+    // Merge global config with SDK overrides.
+    let mut ca_certs = global.resolve_ca_certs().await?;
+    ca_certs.extend(registry_overrides.ca_certs);
+
+    let mut insecure_registries = global.insecure_registries();
+    if registry_overrides.insecure {
+        insecure_registries.push(image_ref.registry().to_string());
+    }
+
+    let registry = Registry::builder(platform, cache)
+        .auth(auth)
+        .extra_ca_certs(ca_certs)
+        .add_insecure_registries(insecure_registries)
+        .build()?;
 
     if let Some(sender) = progress {
         let task = registry.pull_with_sender(&image_ref, &options, sender);

--- a/sdk/node-ts/index.d.ts
+++ b/sdk/node-ts/index.d.ts
@@ -631,7 +631,18 @@ export declare const enum PullPolicy {
 }
 
 /** Registry credentials for pulling private images. */
-export interface RegistryCredentials {
+/** Registry connection settings. */
+export interface RegistryConfig {
+  /** Authentication credentials. */
+  auth?: RegistryAuth
+  /** Access the registry over plain HTTP instead of HTTPS. */
+  insecure?: boolean
+  /** Path to a PEM file containing additional CA root certificates to trust. */
+  caCertsPath?: string
+}
+
+/** Registry authentication credentials. */
+export interface RegistryAuth {
   username: string
   password: string
 }
@@ -680,8 +691,8 @@ export interface SandboxConfig {
   stopSignal?: string
   /** Maximum run duration in seconds. */
   maxDurationSecs?: number
-  /** Registry credentials for pulling private images. */
-  registryAuth?: RegistryCredentials
+  /** Registry connection settings (auth, TLS, insecure). */
+  registry?: RegistryConfig
   /** Port mappings: host_port → guest_port (TCP). */
   ports?: Record<string, number>
   /** Network configuration. */

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use microsandbox::sandbox::{NetworkPolicy, PullPolicy, SandboxConfig as RustSandboxConfig};
-use microsandbox::{LogLevel, RegistryAuth};
+use microsandbox::{LogLevel, RegistryAuth as RustRegistryAuth};
 use microsandbox_network::dns;
 use microsandbox_network::policy::{
     Action, Destination, DestinationGroup, Direction, PortRange, Protocol, Rule,
@@ -68,7 +68,7 @@ impl Sandbox {
     /// Create a sandbox from configuration (attached mode — stops on GC/process exit).
     #[napi(factory)]
     pub async fn create(config: SandboxConfig) -> Result<Sandbox> {
-        let rust_config = convert_config(config)?;
+        let rust_config = convert_config(config).await?;
         let inner = microsandbox::sandbox::Sandbox::create(rust_config)
             .await
             .map_err(to_napi_error)?;
@@ -80,7 +80,7 @@ impl Sandbox {
     /// Create a sandbox that survives the parent process (detached mode).
     #[napi(factory)]
     pub async fn create_detached(config: SandboxConfig) -> Result<Sandbox> {
-        let rust_config = convert_config(config)?;
+        let rust_config = convert_config(config).await?;
         let inner = microsandbox::sandbox::Sandbox::create_detached(rust_config)
             .await
             .map_err(to_napi_error)?;
@@ -441,7 +441,7 @@ impl AsyncGenerator for JsMetricsStream {
 }
 
 /// Convert a JS `SandboxConfig` to the Rust `SandboxConfig` via the builder pattern.
-fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
+async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
     let mut builder =
         microsandbox::sandbox::Sandbox::builder(&config.name).image(config.image.as_str());
 
@@ -511,10 +511,30 @@ fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
     if config.quiet_logs.unwrap_or(false) {
         builder = builder.quiet_logs();
     }
-    if let Some(ref auth) = config.registry_auth {
-        builder = builder.registry_auth(RegistryAuth::Basic {
-            username: auth.username.clone(),
-            password: auth.password.clone(),
+    if let Some(ref registry) = config.registry {
+        let auth = registry.auth.as_ref().map(|a| RustRegistryAuth::Basic {
+            username: a.username.clone(),
+            password: a.password.clone(),
+        });
+        let insecure = registry.insecure.unwrap_or(false);
+        let ca_certs = match &registry.ca_certs_path {
+            Some(path) => Some(tokio::fs::read(path).await.map_err(|e| {
+                napi::Error::from_reason(format!("failed to read CA certs from `{path}`: {e}"))
+            })?),
+            None => None,
+        };
+
+        builder = builder.registry(|mut r| {
+            if let Some(auth) = auth {
+                r = r.auth(auth);
+            }
+            if insecure {
+                r = r.insecure();
+            }
+            if let Some(data) = ca_certs {
+                r = r.ca_certs(data);
+            }
+            r
         });
     }
     if let Some(ref ports) = config.ports {

--- a/sdk/node-ts/lib/types.rs
+++ b/sdk/node-ts/lib/types.rs
@@ -51,8 +51,8 @@ pub struct SandboxConfig {
     pub stop_signal: Option<String>,
     /// Maximum run duration in seconds.
     pub max_duration_secs: Option<f64>,
-    /// Registry credentials for pulling private images.
-    pub registry_auth: Option<RegistryCredentials>,
+    /// Registry connection settings (auth, TLS, insecure).
+    pub registry: Option<RegistryConfig>,
     /// Port mappings: host_port → guest_port (TCP).
     pub ports: Option<HashMap<String, u32>>,
     /// Network configuration.
@@ -205,9 +205,20 @@ pub struct SecretEntry {
     pub on_violation: Option<String>,
 }
 
-/// Registry credentials for pulling private images.
+/// Registry connection settings.
 #[napi(object)]
-pub struct RegistryCredentials {
+pub struct RegistryConfig {
+    /// Authentication credentials.
+    pub auth: Option<RegistryAuth>,
+    /// Access the registry over plain HTTP instead of HTTPS.
+    pub insecure: Option<bool>,
+    /// Path to a PEM file containing additional CA root certificates to trust.
+    pub ca_certs_path: Option<String>,
+}
+
+/// Registry authentication credentials.
+#[napi(object)]
+pub struct RegistryAuth {
     pub username: String,
     pub password: String,
 }

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -161,7 +161,7 @@ pub fn build_config_from_kwargs(
                 pyo3::exceptions::PyValueError::new_err("registry_auth.password required")
             })?
             .extract()?;
-        builder = builder.registry_auth(RegistryAuth::Basic { username, password });
+        builder = builder.registry(|r| r.auth(RegistryAuth::Basic { username, password }));
     }
 
     // Volumes.


### PR DESCRIPTION
## Summary

- Per-registry config in `~/.microsandbox/config.json` with global `ca_certs` and per-host `insecure`/`auth`
- CLI: `--insecure` and `--ca-certs` flags on `msb pull`
- Rust SDK: `.registry(|r| r.auth(..).insecure().ca_certs(..))` sub-builder
- TypeScript SDK: `registry: { auth, insecure, caCertsPath }` config object
- PEM validation via `rustls-pemfile` at build time

```json
{
  "registries": {
    "ca_certs": "/path/to/ca.pem",
    "hosts": {
      "localhost:5050": { "insecure": true },
      "ghcr.io": { "auth": { "username": "user", "store": "keyring" } }
    }
  }
}
```

## Test plan
- [x] Unit tests for config, builder, and PEM validation
- [x] Manual: HTTP registry with `--insecure` and global config
- [x] Manual: HTTPS with self-signed cert via `--ca-certs`