### PR TITLE
fix: apply run execution options only with --tty attach mode

### DIFF
--- a/crates/cli/lib/commands/run.rs
+++ b/crates/cli/lib/commands/run.rs
@@ -112,7 +112,7 @@ async fn run_existing(name: String, args: RunArgs) -> anyhow::Result<()> {
     }
 
     let exec_opts = ExecOpts::parse(&args)?;
-    let interactive = args.tty && std::io::stdin().is_terminal();
+    let interactive = std::io::stdin().is_terminal();
 
     let result: anyhow::Result<i32> = async {
         let (cmd, cmd_args) = resolve_command(sandbox.config(), args.command, interactive)?;
@@ -167,7 +167,7 @@ async fn run_new(name: String, is_named: bool, args: RunArgs) -> anyhow::Result<
     }
 
     let exec_opts = ExecOpts::parse(&args)?;
-    let interactive = args.tty && std::io::stdin().is_terminal();
+    let interactive = std::io::stdin().is_terminal();
 
     let (cmd, cmd_args) = resolve_command(sandbox.config(), args.command, interactive)?;
     let (cmd, cmd_args) = match (cmd, cmd_args) {
@@ -241,22 +241,34 @@ async fn exec_in_sandbox(
     if interactive {
         let rlimits = opts.rlimits.clone();
         let detach_keys = opts.detach_keys.clone();
+        let timeout = opts.timeout;
         let has_opts = !rlimits.is_empty() || detach_keys.is_some();
-        if has_opts {
-            Ok(sandbox
-                .attach_with(cmd, |a| {
-                    let mut a = a.args(cmd_args);
-                    for (resource, soft, hard) in rlimits {
-                        a = a.rlimit_range(resource, soft, hard);
-                    }
-                    if let Some(keys) = detach_keys {
-                        a = a.detach_keys(keys);
-                    }
-                    a
-                })
-                .await?)
-        } else {
-            Ok(sandbox.attach(cmd, cmd_args).await?)
+
+        let attach_fut = async {
+            if has_opts {
+                Ok(sandbox
+                    .attach_with(cmd, |a| {
+                        let mut a = a.args(cmd_args);
+                        for (resource, soft, hard) in rlimits {
+                            a = a.rlimit_range(resource, soft, hard);
+                        }
+                        if let Some(keys) = detach_keys {
+                            a = a.detach_keys(keys);
+                        }
+                        a
+                    })
+                    .await?)
+            } else {
+                Ok(sandbox.attach(cmd, cmd_args).await?)
+            }
+        };
+
+        match timeout {
+            Some(duration) => match tokio::time::timeout(duration, attach_fut).await {
+                Ok(result) => result,
+                Err(_) => anyhow::bail!("command timed out after {duration:?}"),
+            },
+            None => attach_fut.await,
         }
     } else {
         let rlimits = opts.rlimits.clone();

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -38,7 +38,11 @@ msb run -d --name worker python -- python worker.py
 | `-e`, `--env` | Set an environment variable (`KEY=VALUE`) |
 | `-w`, `--workdir` | Working directory inside the sandbox |
 | `--shell` | Default shell for interactive sessions |
+| `-t`, `--tty` | Allocate a pseudo-terminal (enables colors, line editing) |
 | `-d`, `--detach` | Run in background and print the sandbox name |
+| `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`). Per-command; the sandbox stays alive |
+| `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`, `as=1073741824`) |
+| `--detach-keys` | Key sequence to detach from interactive session (default: `ctrl-]`) |
 | `--replace` | Replace an existing sandbox with the same name |
 | `-q`, `--quiet` | Suppress progress output |
 | `--entrypoint` | Override the image's default entrypoint command |
@@ -48,7 +52,7 @@ msb run -d --name worker python -- python worker.py
 | `--log-level` | Log verbosity for the sandbox runtime (`error`, `warn`, `info`, `debug`, `trace`) |
 | `--tmpfs` | Mount a temporary in-memory filesystem (`PATH` or `PATH:SIZE`) |
 | `--script` | Mount a host file as a named script (`NAME:PATH`) |
-| `--max-duration` | Kill the sandbox after this duration (e.g. `30s`, `5m`, `1h`) |
+| `--max-duration` | Kill the entire sandbox after this duration (e.g. `30s`, `5m`, `1h`). Sandbox-level lifetime limit |
 | `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
 | `--no-network` | Disable all network access |
 | `--dns-block-domain` | Block DNS lookups for a domain (returns NXDOMAIN) |


### PR DESCRIPTION
Fixes #494

msb run was entering attach mode whenever stdin was a TTY, even without --tty. In that path, timeout/max-duration behavior was bypassed and rlimit behavior differed from exec_with.

This change gates interactive attach mode behind --tty so non-tty runs use the exec path where timeout and resource limits are enforced consistently.

Greetings, saschabuehrle
