### PR TITLE
docs: fix incorrect code examples across SDK documentation

### DIFF
--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -24,6 +24,8 @@ When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox a
 
 <CodeGroup>
 ```rust Rust
+use microsandbox::size::SizeExt;
+
 // Auto-detect
 let sb = Sandbox::builder("custom-vm")
     .image("./ubuntu-22.04.qcow2")

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -103,7 +103,7 @@ while ((event = await handle.recv()) !== null) {
 
 </CodeGroup>
 
-## Interactive attach <sup><sup>coming soon (TypeScript)</sup></sup>
+## Interactive attach
 
 Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
 

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -103,7 +103,7 @@ while ((event = await handle.recv()) !== null) {
 
 </CodeGroup>
 
-## Interactive attach
+## Interactive attach <sup><sup>coming soon (TypeScript)</sup></sup>
 
 Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
 

--- a/docs/sandboxes/filesystem.mdx
+++ b/docs/sandboxes/filesystem.mdx
@@ -53,7 +53,7 @@ for (const entry of entries) {
 
 </CodeGroup>
 
-## Stream large files <sup><sup>coming soon</sup></sup>
+## Stream large files
 
 For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
 

--- a/docs/sandboxes/networking.mdx
+++ b/docs/sandboxes/networking.mdx
@@ -93,9 +93,8 @@ let sb = Sandbox::builder("safe-agent")
     .image("python")
     .network(|n| n
         .policy(NetworkPolicy::public_only())
-        .dns(DnsMode::Intercepted)
         .block_domain("malware.example.com")
-        .block_domain("*.tracking.com")
+        .block_domain_suffix(".tracking.com")
     )
     .create()
     .await?;
@@ -108,7 +107,7 @@ const sb = await Sandbox.create({
     network: {
         ...NetworkPolicy.publicOnly(),
         blockDomains: ["malware.example.com"],
-        blockDomainSuffixes: ["*.tracking.com"],
+        blockDomainSuffixes: [".tracking.com"],
     },
 })
 ```

--- a/docs/sdk/events.mdx
+++ b/docs/sdk/events.mdx
@@ -4,6 +4,10 @@ description: Bidirectional host-guest communication
 icon: "tower-broadcast"
 ---
 
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
 The events API is for structured communication between host and guest beyond stdin/stdout. The host can subscribe to named events from the guest and emit events back, all through the same channel used by `exec`.
 
 On the guest side, processes just write JSON to `/run/agent.sock`, which is a standard Unix domain socket. No special library needed. Any language that can open a socket and write a newline-delimited JSON message will work.

--- a/docs/sdk/execution.mdx
+++ b/docs/sdk/execution.mdx
@@ -131,7 +131,7 @@ await handle.wait()
 
 </CodeGroup>
 
-## Attach <sup><sup>coming soon (TypeScript)</sup></sup>
+## Attach
 
 Bridge your terminal to a fully interactive PTY session inside the sandbox. Press the detach keys (default `Ctrl+]`) to disconnect without stopping the process. The process keeps running and can be reattached via its session ID.
 

--- a/docs/sdk/execution.mdx
+++ b/docs/sdk/execution.mdx
@@ -57,7 +57,7 @@ let output = sb.exec_with("python", |e| e
     .env("PYTHONPATH", "/app/lib")
     .timeout(Duration::from_secs(30))
     .rlimit(RlimitResource::Nofile, 1024)
-    .rlimit("cpu", 60)
+    .rlimit(RlimitResource::Cpu, 60)
 ).await?;
 ```
 
@@ -131,7 +131,7 @@ await handle.wait()
 
 </CodeGroup>
 
-## Attach
+## Attach <sup><sup>coming soon (TypeScript)</sup></sup>
 
 Bridge your terminal to a fully interactive PTY session inside the sandbox. Press the detach keys (default `Ctrl+]`) to disconnect without stopping the process. The process keeps running and can be reattached via its session ID.
 
@@ -158,7 +158,7 @@ await sb.attach("bash", a => a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"
 
 </CodeGroup>
 
-## Sessions
+## Sessions <sup><sup>coming soon</sup></sup>
 
 Each streaming exec or attach creates a session. You can list active sessions and reattach to them by ID. Up to 16 simultaneous client connections are supported, so multiple sessions can run concurrently without interfering with each other.
 

--- a/docs/sdk/filesystem.mdx
+++ b/docs/sdk/filesystem.mdx
@@ -53,7 +53,7 @@ for (const entry of entries) {
 
 </CodeGroup>
 
-## Stream large files <sup><sup>coming soon</sup></sup>
+## Stream large files
 
 For files too large to fit in memory, stream them in chunks (~3 MiB each).
 

--- a/docs/sdk/metrics.mdx
+++ b/docs/sdk/metrics.mdx
@@ -23,7 +23,7 @@ console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.m
 
 </CodeGroup>
 
-## Streaming <sup><sup>coming soon (TypeScript)</sup></sup>
+## Streaming
 
 Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
 

--- a/docs/sdk/metrics.mdx
+++ b/docs/sdk/metrics.mdx
@@ -23,7 +23,7 @@ console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.m
 
 </CodeGroup>
 
-## Streaming
+## Streaming <sup><sup>coming soon (TypeScript)</sup></sup>
 
 Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
 
@@ -41,7 +41,7 @@ while let Some(m) = stream.next().await {
 
 ```typescript TypeScript
 for await (const m of sb.metricsStream(1000)) {
-    console.log(`[${m.timestamp}] CPU: ${m.cpuPercent.toFixed(1)}%`)
+    console.log(`[${m.timestampMs}] CPU: ${m.cpuPercent.toFixed(1)}%`)
 }
 ```
 

--- a/docs/sdk/networking.mdx
+++ b/docs/sdk/networking.mdx
@@ -70,7 +70,10 @@ Build a policy with explicit egress and ingress rules. Rules are evaluated first
 <CodeGroup>
 ```rust Rust
 use microsandbox::Sandbox;
-use microsandbox_network::policy::*;
+use microsandbox::NetworkPolicy;
+use microsandbox_network::policy::{
+    Action, Destination, DestinationGroup, Direction, PortRange, Protocol, Rule,
+};
 
 let policy = NetworkPolicy {
     default_action: Action::Deny,

--- a/docs/sdk/scripts.mdx
+++ b/docs/sdk/scripts.mdx
@@ -44,8 +44,8 @@ const sb = await Sandbox.create({
     },
 })
 
-await sb.run("setup")
-const output = await sb.run("run")
+await sb.shell("setup")
+const output = await sb.shell("run")
 ```
 
 </CodeGroup>


### PR DESCRIPTION
## Summary
Fix incorrect code examples and add missing "coming soon" notices across SDK documentation.

## Test plan
- [x] Verify docs render correctly
- [x] Confirm code examples match current SDK APIs