### PR TITLE
feat(network): add upstream CA trust and rename TLS CA config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1929,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2450,6 +2512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2683,7 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "smoltcp",
  "time",
@@ -3000,6 +3069,24 @@ dependencies = [
  "microsandbox",
  "microsandbox-network",
  "tokio",
+]
+
+[[package]]
+name = "net-secrets-body"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "hyper",
+ "hyper-util",
+ "microsandbox",
+ "microsandbox-network",
+ "rcgen",
+ "rustls",
+ "rustls-pki-types",
+ "serde_json",
+ "tokio",
+ "tokio-rustls",
+ "tower",
 ]
 
 [[package]]
@@ -3940,6 +4027,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,6 +4376,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5011,6 +5118,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/rust/net-basic",
     "examples/rust/net-dns",
     "examples/rust/net-policy",
+    "examples/rust/net-secrets-body",
     "examples/rust/net-ports",
     "examples/rust/net-secrets",
     "examples/rust/net-tls",

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -155,12 +155,18 @@ pub struct SandboxOpts {
     /// Use a custom CA certificate for TLS interception (PEM file).
     #[cfg(feature = "net")]
     #[arg(long)]
-    pub tls_ca_cert: Option<PathBuf>,
+    pub tls_intercept_ca_cert: Option<PathBuf>,
 
     /// Use a custom CA private key for TLS interception (PEM file).
     #[cfg(feature = "net")]
     #[arg(long)]
-    pub tls_ca_key: Option<PathBuf>,
+    pub tls_intercept_ca_key: Option<PathBuf>,
+
+    /// Trust an additional CA certificate for upstream server verification (PEM file).
+    /// Can be specified multiple times.
+    #[cfg(feature = "net")]
+    #[arg(long)]
+    pub tls_upstream_ca_cert: Vec<PathBuf>,
 
     // --- Secrets ---
     /// Inject a secret that is only sent to an allowed host (ENV=VALUE@HOST).
@@ -209,8 +215,9 @@ impl SandboxOpts {
             || !self.tls_intercept_port.is_empty()
             || !self.tls_bypass.is_empty()
             || self.no_block_quic
-            || self.tls_ca_cert.is_some()
-            || self.tls_ca_key.is_some()
+            || self.tls_intercept_ca_cert.is_some()
+            || self.tls_intercept_ca_key.is_some()
+            || !self.tls_upstream_ca_cert.is_empty()
             || !self.secret.is_empty()
             || self.on_secret_violation.is_some();
 
@@ -360,8 +367,9 @@ fn apply_network_opts(
         || !opts.tls_intercept_port.is_empty()
         || !opts.tls_bypass.is_empty()
         || opts.no_block_quic
-        || opts.tls_ca_cert.is_some()
-        || opts.tls_ca_key.is_some()
+        || opts.tls_intercept_ca_cert.is_some()
+        || opts.tls_intercept_ca_key.is_some()
+        || !opts.tls_upstream_ca_cert.is_empty()
         || opts.on_secret_violation.is_some();
 
     if has_network_config {
@@ -374,8 +382,9 @@ fn apply_network_opts(
         let tls_ports = opts.tls_intercept_port.clone();
         let tls_bypass = opts.tls_bypass.clone();
         let no_block_quic = opts.no_block_quic;
-        let ca_cert = opts.tls_ca_cert.clone();
-        let ca_key = opts.tls_ca_key.clone();
+        let intercept_ca_cert = opts.tls_intercept_ca_cert.clone();
+        let intercept_ca_key = opts.tls_intercept_ca_key.clone();
+        let upstream_ca_cert = opts.tls_upstream_ca_cert.clone();
         let violation_action = parse_violation_action(&opts.on_secret_violation)?;
 
         builder = builder.network(move |mut n| {
@@ -403,14 +412,16 @@ fn apply_network_opts(
                 || !tls_ports.is_empty()
                 || !tls_bypass.is_empty()
                 || no_block_quic
-                || ca_cert.is_some()
-                || ca_key.is_some();
+                || intercept_ca_cert.is_some()
+                || intercept_ca_key.is_some()
+                || !upstream_ca_cert.is_empty();
 
             if has_tls {
                 let tls_ports = tls_ports.clone();
                 let tls_bypass = tls_bypass.clone();
-                let ca_cert = ca_cert.clone();
-                let ca_key = ca_key.clone();
+                let intercept_ca_cert = intercept_ca_cert.clone();
+                let intercept_ca_key = intercept_ca_key.clone();
+                let upstream_ca_cert = upstream_ca_cert.clone();
                 n = n.tls(move |mut t| {
                     if !tls_ports.is_empty() {
                         t = t.intercepted_ports(tls_ports);
@@ -421,11 +432,14 @@ fn apply_network_opts(
                     if no_block_quic {
                         t = t.block_quic(false);
                     }
-                    if let Some(ref cert) = ca_cert {
-                        t = t.ca_cert(cert);
+                    if let Some(ref cert) = intercept_ca_cert {
+                        t = t.intercept_ca_cert(cert);
                     }
-                    if let Some(ref key) = ca_key {
-                        t = t.ca_key(key);
+                    if let Some(ref key) = intercept_ca_key {
+                        t = t.intercept_ca_key(key);
+                    }
+                    for path in &upstream_ca_cert {
+                        t = t.upstream_ca_cert(path);
                     }
                     t
                 });

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -24,6 +24,7 @@ msb_krun = { version = "0.1.9", features = ["net"] }
 rcgen = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
+rustls-pemfile = "2"
 serde = { workspace = true }
 time = { workspace = true }
 smoltcp = { workspace = true, features = [

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -210,15 +210,24 @@ impl TlsBuilder {
         self
     }
 
-    /// Set a custom CA certificate PEM file path.
-    pub fn ca_cert(mut self, path: impl Into<PathBuf>) -> Self {
-        self.config.ca.cert_path = Some(path.into());
+    /// Add a CA certificate PEM file to trust for upstream server verification.
+    ///
+    /// Useful when the upstream server uses a self-signed or private CA certificate.
+    /// Can be called multiple times to add several CAs.
+    pub fn upstream_ca_cert(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.upstream_ca_cert.push(path.into());
         self
     }
 
-    /// Set a custom CA private key PEM file path.
-    pub fn ca_key(mut self, path: impl Into<PathBuf>) -> Self {
-        self.config.ca.key_path = Some(path.into());
+    /// Set a custom interception CA certificate PEM file path.
+    pub fn intercept_ca_cert(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.intercept_ca.cert_path = Some(path.into());
+        self
+    }
+
+    /// Set a custom interception CA private key PEM file path.
+    pub fn intercept_ca_key(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.intercept_ca.key_path = Some(path.into());
         self
     }
 

--- a/crates/network/lib/tls/config.rs
+++ b/crates/network/lib/tls/config.rs
@@ -36,9 +36,14 @@ pub struct TlsConfig {
     #[serde(default = "default_true")]
     pub block_quic_on_intercept: bool,
 
-    /// Certificate authority configuration.
+    /// CA certificate PEM files to trust for upstream server verification.
     #[serde(default)]
-    pub ca: CaConfig,
+    pub upstream_ca_cert: Vec<PathBuf>,
+
+    /// Interception CA configuration. The TLS proxy uses this CA to sign
+    /// per-domain certs that it presents to the guest during interception.
+    #[serde(default, alias = "ca")]
+    pub intercept_ca: InterceptCaConfig,
 
     /// Per-domain certificate cache configuration.
     #[serde(default)]
@@ -47,7 +52,7 @@ pub struct TlsConfig {
 
 /// Certificate authority configuration for TLS interception.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CaConfig {
+pub struct InterceptCaConfig {
     /// Path to an existing CA certificate PEM file.
     /// If `None`, a CA is auto-generated and persisted.
     #[serde(default)]
@@ -83,7 +88,8 @@ impl Default for TlsConfig {
             bypass: Vec::new(),
             verify_upstream: true,
             block_quic_on_intercept: true,
-            ca: CaConfig::default(),
+            upstream_ca_cert: Vec::new(),
+            intercept_ca: InterceptCaConfig::default(),
             cache: CertCacheConfig::default(),
         }
     }

--- a/crates/network/lib/tls/state.rs
+++ b/crates/network/lib/tls/state.rs
@@ -23,8 +23,8 @@ use crate::secrets::config::SecretsConfig;
 /// Holds the CA, per-domain certificate cache, upstream TLS connector,
 /// and configuration. Shared across all TLS proxy tasks via `Arc`.
 pub struct TlsState {
-    /// Certificate authority for signing per-domain certs.
-    pub ca: CertAuthority,
+    /// Interception CA for signing per-domain certs presented to the guest.
+    pub intercept_ca: CertAuthority,
     /// LRU cache of generated domain certificates.
     cert_cache: Mutex<LruCache<String, Arc<DomainCert>>>,
     /// TLS connector for upstream (real server) connections.
@@ -59,7 +59,7 @@ impl TlsState {
     /// Create TLS state from configuration.
     ///
     /// CA resolution order:
-    /// 1. User-provided paths (`config.ca.cert_path` + `config.ca.key_path`)
+    /// 1. User-provided paths (`config.intercept_ca.cert_path` + `config.intercept_ca.key_path`)
     /// 2. Default persistence path (`~/.microsandbox/tls/ca.{crt,key}`)
     /// 3. Auto-generate and persist to default path
     pub fn new(config: TlsConfig, secrets: SecretsConfig) -> Self {
@@ -90,7 +90,7 @@ impl TlsState {
             .collect();
 
         Self {
-            ca,
+            intercept_ca: ca,
             cert_cache,
             connector,
             config,
@@ -108,7 +108,7 @@ impl TlsState {
 
         let cert = Arc::new(certgen::generate_domain_cert(
             domain,
-            &self.ca,
+            &self.intercept_ca,
             self.config.cache.validity_hours,
         ));
         cache.put(domain.to_string(), cert.clone());
@@ -128,7 +128,7 @@ impl TlsState {
 
     /// Get the CA certificate PEM bytes for guest installation.
     pub fn ca_cert_pem(&self) -> Vec<u8> {
-        self.ca.cert_pem()
+        self.intercept_ca.cert_pem()
     }
 }
 
@@ -206,6 +206,33 @@ fn build_upstream_connector(config: &TlsConfig) -> TlsConnector {
         if added == 0 {
             tracing::error!("no native root certificates loaded — all upstream TLS will fail");
         }
+
+        // Load extra CA certificates from user-provided PEM files.
+        for path in &config.upstream_ca_cert {
+            match std::fs::read(path) {
+                Ok(pem_data) => {
+                    let mut extra_added = 0usize;
+                    for cert in rustls_pemfile::certs(&mut pem_data.as_slice()).flatten() {
+                        if root_store.add(cert).is_ok() {
+                            extra_added += 1;
+                        }
+                    }
+                    tracing::info!(
+                        path = %path.display(),
+                        count = extra_added,
+                        "loaded upstream CA certificates"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        path = %path.display(),
+                        error = %e,
+                        "failed to read upstream CA certificate file"
+                    );
+                }
+            }
+        }
+
         rustls::ClientConfig::builder()
             .with_root_certificates(root_store)
             .with_no_client_auth()
@@ -227,14 +254,17 @@ fn build_upstream_connector(config: &TlsConfig) -> TlsConnector {
 /// 3. Auto-generate and persist to default path
 fn load_or_generate_ca(config: &TlsConfig) -> CertAuthority {
     // Warn if only one of cert_path/key_path is set (likely a config error).
-    if config.ca.cert_path.is_some() != config.ca.key_path.is_some() {
+    if config.intercept_ca.cert_path.is_some() != config.intercept_ca.key_path.is_some() {
         tracing::warn!(
             "incomplete CA config: both cert_path and key_path must be set together, ignoring"
         );
     }
 
     // 1. Try user-provided paths.
-    if let (Some(cert_path), Some(key_path)) = (&config.ca.cert_path, &config.ca.key_path) {
+    if let (Some(cert_path), Some(key_path)) = (
+        &config.intercept_ca.cert_path,
+        &config.intercept_ca.key_path,
+    ) {
         match (std::fs::read(cert_path), std::fs::read(key_path)) {
             (Ok(cert_pem), Ok(key_pem)) => match CertAuthority::load(&cert_pem, &key_pem) {
                 Ok(ca) => {

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -66,8 +66,9 @@ msb run -d --name worker python -- python worker.py
 | `--tls-intercept-port` | TCP port to apply TLS interception on (default: 443) |
 | `--tls-bypass` | Skip TLS interception for a domain (e.g. `*.internal.com`) |
 | `--no-block-quic` | Allow QUIC/HTTP3 traffic (blocked by default when TLS interception is on) |
-| `--tls-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
-| `--tls-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
+| `--tls-intercept-ca-cert` | Use a custom CA certificate for TLS interception (PEM file) |
+| `--tls-intercept-ca-key` | Use a custom CA private key for TLS interception (PEM file) |
+| `--tls-upstream-ca-cert` | Trust an additional CA certificate for upstream server verification (PEM file). Can be specified multiple times |
 
 When no `--` command is given, the image's `entrypoint` and `cmd` are used as the default process. If the image has neither, an interactive shell is started. When a command is given via `--`, it replaces the image `cmd` but the `entrypoint` is preserved. See [Image config inheritance](/images/overview#image-config-inheritance) for details.
 

--- a/examples/rust/net-secrets-body/Cargo.toml
+++ b/examples/rust/net-secrets-body/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "net-secrets-body"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "net-secrets-body"
+path = "bin/main.rs"
+
+[dependencies]
+microsandbox = { path = "../../../crates/microsandbox" }
+microsandbox-network = { path = "../../../crates/network" }
+tokio = { version = "1.42", features = ["full"] }
+axum = "0.7"
+rcgen = "0.13"
+rustls = "0.23"
+tokio-rustls = "0.26"
+rustls-pki-types = "1"
+hyper = { version = "1", features = ["server"] }
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
+tower = "0.5"
+serde_json = "1"

--- a/examples/rust/net-secrets-body/bin/main.rs
+++ b/examples/rust/net-secrets-body/bin/main.rs
@@ -1,0 +1,46 @@
+//! Body secret injection — placeholder substituted in HTTP body by the TLS proxy.
+//!
+//! Spins up a self-signed HTTPS server in the same process, creates a sandbox
+//! with a body-injected secret, and has the guest POST the placeholder.
+//! The server logs the real secret it receives; the guest only ever sees the placeholder.
+
+mod sandbox;
+mod server;
+
+use microsandbox::Sandbox;
+use std::net::{IpAddr, UdpSocket};
+
+const HOSTNAME: &str = "mock-api";
+const PORT: u16 = 4443;
+const SECRET: &str = "sk-real-secret-value-12345";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let host_ip = local_ip().to_string();
+
+    let handle = server::spawn(HOSTNAME, PORT).await?;
+    println!("[server] Listening on https://{host_ip}:{PORT}");
+
+    let sb = sandbox::create(SECRET, HOSTNAME, PORT, &handle.ca_cert_path).await?;
+
+    // Guest sees only the placeholder.
+    let out = sb.shell("echo $API_KEY").await?;
+    println!("[guest]  API_KEY = {}", out.stdout()?.trim());
+
+    // Guest POSTs the placeholder in a JSON body — the TLS proxy substitutes the real secret.
+    let response = sandbox::post_secret(&sb, HOSTNAME, &host_ip, PORT).await?;
+    println!("[guest]  Server responded: {response}");
+
+    sb.stop_and_wait().await?;
+    Sandbox::remove("net-secrets-body").await?;
+    println!("[host]   Done.");
+
+    Ok(())
+}
+
+/// Detect a local non-loopback IP by briefly opening a UDP socket.
+fn local_ip() -> IpAddr {
+    let socket = UdpSocket::bind("0.0.0.0:0").expect("bind failed");
+    socket.connect("8.8.8.8:80").expect("connect failed");
+    socket.local_addr().expect("local_addr failed").ip()
+}

--- a/examples/rust/net-secrets-body/bin/sandbox.rs
+++ b/examples/rust/net-secrets-body/bin/sandbox.rs
@@ -1,0 +1,54 @@
+//! Sandbox creation and secret injection demo logic.
+
+use microsandbox::{NetworkPolicy, Sandbox};
+use std::path::Path;
+
+/// Create a sandbox with a body-injected secret pointing at `hostname:port`.
+pub async fn create(
+    secret: &str,
+    hostname: &str,
+    port: u16,
+    upstream_ca_cert: &Path,
+) -> Result<Sandbox, Box<dyn std::error::Error>> {
+    let sandbox = Sandbox::builder("net-secrets-body")
+        .image("alpine")
+        .cpus(1)
+        .memory(512)
+        .secret(|s| {
+            s.env("API_KEY")
+                .value(secret)
+                .allow_host(hostname)
+                .inject_body(true)
+        })
+        .network(|n| {
+            n.policy(NetworkPolicy::allow_all()).tls(|t| {
+                t.intercepted_ports(vec![443, port])
+                    .upstream_ca_cert(upstream_ca_cert)
+            })
+        })
+        .replace()
+        .create()
+        .await?;
+
+    // Alpine only has BusyBox wget (no --post-data), so install curl.
+    sandbox.shell("apk add --quiet curl").await?;
+
+    Ok(sandbox)
+}
+
+/// POST a JSON body containing the secret env var to the server and return the response.
+///
+/// Uses `curl --resolve` to map `hostname` -> `host_ip` so the TLS proxy sees
+/// proper SNI without needing an /etc/hosts entry.
+pub async fn post_secret(
+    sandbox: &Sandbox,
+    hostname: &str,
+    host_ip: &str,
+    port: u16,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let cmd = format!(
+        r#"printf '{{"key": "%s"}}' "$API_KEY" | curl -s -X POST --resolve {hostname}:{port}:{host_ip} -H 'Content-Type: application/json' -d @- https://{hostname}:{port}/echo"#,
+    );
+    let out = sandbox.shell(&cmd).await?;
+    Ok(out.stdout()?.trim().to_string())
+}

--- a/examples/rust/net-secrets-body/bin/server.rs
+++ b/examples/rust/net-secrets-body/bin/server.rs
@@ -1,0 +1,83 @@
+//! Self-signed HTTPS mock server that logs received request bodies.
+
+use axum::{Router, extract::Json, routing::post};
+use rcgen::generate_simple_self_signed;
+use rustls::ServerConfig;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+
+/// A running HTTPS server handle. Holds the path to the CA cert PEM file
+/// so the TLS proxy can trust it.
+pub struct ServerHandle {
+    pub ca_cert_path: PathBuf,
+}
+
+/// Spawn an HTTPS server in the background that echoes POST bodies.
+/// Returns a handle containing the path to the server's CA cert PEM.
+pub async fn spawn(hostname: &str, port: u16) -> std::io::Result<ServerHandle> {
+    let (tls_config, cert_pem) = build_tls_config(hostname);
+    let acceptor = TlsAcceptor::from(tls_config);
+    let app = Router::new().route("/echo", post(handle_echo));
+    let listener = TcpListener::bind(("0.0.0.0", port)).await?;
+
+    // Write the self-signed cert to a temp file so the TLS proxy can trust it.
+    let ca_cert_path = std::env::temp_dir().join("msb-net-secrets-body-ca.pem");
+    std::fs::write(&ca_cert_path, &cert_pem)?;
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                continue;
+            };
+            let acceptor = acceptor.clone();
+            let app = app.clone();
+            tokio::spawn(async move {
+                let Ok(tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let io = hyper_util::rt::TokioIo::new(tls);
+                let service = hyper::service::service_fn(move |req| {
+                    let mut app = app.clone();
+                    async move { tower::Service::call(&mut app, req).await }
+                });
+                let _ = hyper_util::server::conn::auto::Builder::new(
+                    hyper_util::rt::TokioExecutor::new(),
+                )
+                .serve_connection(io, service)
+                .await;
+            });
+        }
+    });
+
+    Ok(ServerHandle { ca_cert_path })
+}
+
+async fn handle_echo(Json(body): Json<serde_json::Value>) -> String {
+    let key = body.get("key").and_then(|v| v.as_str()).unwrap_or("?");
+    println!("[server] Received key = {key}");
+    format!("{{\"received_key\": \"{key}\"}}")
+}
+
+fn build_tls_config(hostname: &str) -> (Arc<ServerConfig>, String) {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let cert =
+        generate_simple_self_signed(vec![hostname.to_string()]).expect("cert generation failed");
+    let cert_pem = cert.cert.pem();
+    let cert_der = CertificateDer::from(cert.cert.der().to_vec());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der()));
+
+    let config = Arc::new(
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der], key_der)
+            .expect("TLS config failed"),
+    );
+
+    (config, cert_pem)
+}

--- a/sdk/node-ts/index.d.cts
+++ b/sdk/node-ts/index.d.cts
@@ -784,10 +784,12 @@ export interface TlsConfig {
   interceptedPorts?: Array<number>
   /** Block QUIC on intercepted ports (default: false). */
   blockQuic?: boolean
-  /** Path to custom CA certificate PEM file. */
-  caCert?: string
-  /** Path to custom CA private key PEM file. */
-  caKey?: string
+  /** Path to custom interception CA certificate PEM file. */
+  interceptCaCert?: string
+  /** Path to custom interception CA private key PEM file. */
+  interceptCaKey?: string
+  /** Paths to additional CA certificate PEM files to trust for upstream verification. */
+  upstreamCaCert?: Array<string>
 }
 
 /** Options for tmpfs mounts. */

--- a/sdk/node-ts/index.d.ts
+++ b/sdk/node-ts/index.d.ts
@@ -784,10 +784,12 @@ export interface TlsConfig {
   interceptedPorts?: Array<number>
   /** Block QUIC on intercepted ports (default: false). */
   blockQuic?: boolean
-  /** Path to custom CA certificate PEM file. */
-  caCert?: string
-  /** Path to custom CA private key PEM file. */
-  caKey?: string
+  /** Path to custom interception CA certificate PEM file. */
+  interceptCaCert?: string
+  /** Path to custom interception CA private key PEM file. */
+  interceptCaKey?: string
+  /** Paths to additional CA certificate PEM files to trust for upstream verification. */
+  upstreamCaCert?: Array<string>
 }
 
 /** Options for tmpfs mounts. */

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -556,11 +556,16 @@ fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
                     if let Some(block) = tls.block_quic {
                         t = t.block_quic(block);
                     }
-                    if let Some(ref path) = tls.ca_cert {
-                        t = t.ca_cert(path);
+                    if let Some(ref path) = tls.intercept_ca_cert {
+                        t = t.intercept_ca_cert(path);
                     }
-                    if let Some(ref path) = tls.ca_key {
-                        t = t.ca_key(path);
+                    if let Some(ref path) = tls.intercept_ca_key {
+                        t = t.intercept_ca_key(path);
+                    }
+                    if let Some(ref paths) = tls.upstream_ca_cert {
+                        for path in paths {
+                            t = t.upstream_ca_cert(path);
+                        }
                     }
                     t
                 });

--- a/sdk/node-ts/lib/types.rs
+++ b/sdk/node-ts/lib/types.rs
@@ -159,10 +159,12 @@ pub struct TlsConfig {
     pub intercepted_ports: Option<Vec<u32>>,
     /// Block QUIC on intercepted ports (default: false).
     pub block_quic: Option<bool>,
-    /// Path to custom CA certificate PEM file.
-    pub ca_cert: Option<String>,
-    /// Path to custom CA private key PEM file.
-    pub ca_key: Option<String>,
+    /// Path to custom interception CA certificate PEM file.
+    pub intercept_ca_cert: Option<String>,
+    /// Path to custom interception CA private key PEM file.
+    pub intercept_ca_key: Option<String>,
+    /// Paths to additional CA certificate PEM files to trust for upstream verification.
+    pub upstream_ca_cert: Option<Vec<String>>,
 }
 
 /// A secret entry for the `secrets` array on `SandboxConfig`.


### PR DESCRIPTION
## Summary
- Add `.upstream_ca_cert()` so the TLS proxy can trust self-signed or private CA upstream servers. 
- Rename the existing interception CA config from `ca`/`ca_cert`/`ca_key` to `intercept_ca`/`intercept_ca_cert`/`intercept_ca_key` for clarity. 
- Expose both config flags via CLI, Rust SDK, and Node SDK. 
- Add `net-secrets-body` example and a dedicated secrets docs page.

## Test plan
- [x] All 59 `microsandbox-network` tests pass
- [x] `cargo check` passes for network, CLI, Node SDK, and example crates
- [x] `net-secrets-body` example runs end-to-end
- [x] Pre-commit hooks pass (fmt, clippy, doc, build)