### PR TITLE
docs: add AI Agents page and reorganize Getting Started

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,10 +43,10 @@
               "sandboxes/filesystem",
               "sandboxes/volumes",
               "sandboxes/secrets",
+              "sandboxes/customization",
+              "sandboxes/metrics",
               "sandboxes/snapshots",
-              "sandboxes/events",
-              "sandboxes/scripts",
-              "sandboxes/metrics"
+              "sandboxes/events"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,8 +28,9 @@
             "group": "Getting Started",
             "icon": "rocket",
             "pages": [
-              "introduction",
-              "quickstart"
+              "getting-started/introduction",
+              "getting-started/quickstart",
+              "getting-started/agents"
             ]
           },
           {

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -76,6 +76,19 @@ claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
 }
 ```
 
+```json Open Code
+// .opencode.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
 ```json Zed
 // Zed settings
 {

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -28,16 +28,63 @@ The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mc
 claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
 ```
 
-```bash Cursor
-npx -y microsandbox-mcp --stdio
-```
-
-```json Claude Desktop (claude_desktop_config.json)
+```json Cursor
+// ~/.cursor/mcp.json
 {
   "mcpServers": {
     "microsandbox": {
       "command": "npx",
       "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json VS Code
+// .vscode/mcp.json
+{
+  "servers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Claude Desktop
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Windsurf
+// ~/.codeium/windsurf/mcp_config.json
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+```json Zed
+// Zed settings
+{
+  "context_servers": {
+    "microsandbox": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "microsandbox-mcp"]
+      }
     }
   }
 }

--- a/docs/getting-started/agents.mdx
+++ b/docs/getting-started/agents.mdx
@@ -1,0 +1,48 @@
+---
+title: AI Agents
+description: Give AI agents the ability to create and manage their own sandboxes
+icon: "robot"
+---
+
+microsandbox is built for AI agents. The SDK and CLI give you full programmatic control, but there are two additional ways to connect agents directly: **Agent Skills** for coding assistants and an **MCP server** for any MCP-compatible client.
+
+## Agent Skills
+
+[Agent Skills](https://github.com/superradcompany/skills) teach AI coding agents how to use microsandbox without any custom integration code. Once installed, the agent can create sandboxes, run commands, manage files, and control the full sandbox lifecycle through natural language.
+
+Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and other agents that support the skills format.
+
+```bash
+npx skills add superradcompany/skills
+```
+
+This installs a set of skill files into your project that the agent reads as context. No server process, no configuration, just files that describe how to use microsandbox.
+
+## MCP Server
+
+The [microsandbox MCP server](https://github.com/superradcompany/microsandbox-mcp) exposes microsandbox as a set of structured tool calls over the [Model Context Protocol](https://modelcontextprotocol.io). Any MCP-compatible client can use it to manage sandbox lifecycle, execute commands, access the filesystem, work with volumes, and monitor sandbox state.
+
+<CodeGroup>
+
+```bash Claude Code
+claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+```
+
+```bash Cursor
+npx -y microsandbox-mcp --stdio
+```
+
+```json Claude Desktop (claude_desktop_config.json)
+{
+  "mcpServers": {
+    "microsandbox": {
+      "command": "npx",
+      "args": ["-y", "microsandbox-mcp"]
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+Once connected, the agent gets access to tools for creating sandboxes, running commands inside them, reading and writing files, and managing the sandbox lifecycle, all through the MCP protocol.

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -51,6 +51,15 @@ const sb = await Sandbox.create({
   microsandbox spins up lightweight VMs in **under a second**, right from your code on your machine. **No servers, no daemons**, no infrastructure to manage.
 </Callout>
 
+## The basics
+
+- **Under 100ms boot.** Sandboxes share the same kernel in memory. No QEMU, no disk images to load.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root process, no socket, no background service.
+- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
+- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
+- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
+- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
+
 ## What makes it different
 
 ### Secrets that can't leak
@@ -225,15 +234,6 @@ await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose
 ```
 
 </CodeGroup>
-
-## The basics
-
-- **Under 100ms boot.** Sandboxes share the same kernel in memory. No QEMU, no disk images to load.
-- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root process, no socket, no background service.
-- **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
-- **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
-- **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.
-- **Programmable.** Network policies, filesystem hooks, secret bindings, and TLS interception are all configured from the host side through the SDK.
 
 ## Next steps
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -238,7 +238,7 @@ await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="bolt" href="/quickstart">
+  <Card title="Quickstart" icon="bolt" href="/getting-started/quickstart">
     Get a sandbox running in under 5 minutes
   </Card>
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -51,6 +51,10 @@ icon: "bolt"
     }
     ```
 
+    ```bash CLI
+    msb run python -- python3 -c "print('Hello from a microVM!')"
+    ```
+
     ```typescript TypeScript
     import { Sandbox } from 'microsandbox'
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -51,10 +51,6 @@ icon: "bolt"
     }
     ```
 
-    ```bash CLI
-    msb run python -- python3 -c "print('Hello from a microVM!')"
-    ```
-
     ```typescript TypeScript
     import { Sandbox } from 'microsandbox'
 
@@ -68,6 +64,10 @@ icon: "bolt"
     console.log(output.stdout()) // Hello from a microVM!
 
     await sb.stop()
+    ```
+
+    ```bash CLI
+    msb run python -- python3 -c "print('Hello from a microVM!')"
     ```
 
     </CodeGroup>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -4,8 +4,14 @@ description: Get a sandbox running in under 5 minutes
 icon: "bolt"
 ---
 
+<Note>
+  microsandbox requires **Linux with KVM** enabled, or **macOS with Apple Silicon** (M-series chip). Both use hardware virtualization.
+</Note>
+
 <Steps>
-  <Step title="Install the SDK">
+  <Step title="Install microsandbox">
+    The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.
+
     <CodeGroup>
     ```bash Rust
     cargo add microsandbox
@@ -15,23 +21,11 @@ icon: "bolt"
     npm install microsandbox
     ```
 
-    </CodeGroup>
-
-    <Tip>
-      There are SDKs for many other languages as well. Check the [SDK reference](/sdk/rust) for the full list.
-    </Tip>
-  </Step>
-
-  <Step title="Install the CLI">
-    The SDK embeds the runtime directly, so no separate server process is needed. Install the `msb` CLI to manage images, volumes, and sandboxes from the terminal.
-
-    ```bash
+    ```bash CLI
     curl -fsSL https://install.microsandbox.dev | sh
     ```
 
-    <Note>
-      microsandbox requires Linux with KVM enabled, or macOS with Apple Silicon (M-series chip). Both use hardware virtualization.
-    </Note>
+    </CodeGroup>
   </Step>
 
   <Step title="Run code in a sandbox">

--- a/docs/sandboxes/customization.mdx
+++ b/docs/sandboxes/customization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pre-init
+title: Customization
 description: Inject scripts and modify the rootfs before boot
 icon: "scroll"
 ---

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -287,5 +287,5 @@ const sb = await Sandbox.create(config)
 
 If you need to run setup logic, install packages, or inject files before a sandbox starts doing real work, there are two ways to do it without building a custom image:
 
-- **[Scripts](/sandboxes/scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
-- **[Patches](/sandboxes/scripts#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.
+- **[Scripts](/sandboxes/customization#scripts)** are files mounted into the sandbox at `/.msb/scripts/` and added to `PATH`. Define them at creation time and call them by name with `exec()` or `shell()`. Good for multi-step setup procedures or named entry points.
+- **[Patches](/sandboxes/customization#patches)** modify the rootfs before the VM boots: write config files, copy directories from the host, create symlinks, append to existing files, etc. The base image stays untouched since patches go into the writable layer.

--- a/docs/sandboxes/scripts.mdx
+++ b/docs/sandboxes/scripts.mdx
@@ -1,8 +1,10 @@
 ---
-title: Scripts & Patches
+title: Pre-init
 description: Inject scripts and modify the rootfs before boot
 icon: "scroll"
 ---
+
+Before a sandbox starts doing real work, you can prepare it in two ways: **scripts** that bundle reusable commands, and **patches** that modify the rootfs before the VM boots. Both are defined at creation time and keep the base image untouched.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary
- Add new **AI Agents** docs page covering Agent Skills and MCP server setup
- Move Getting Started pages (`introduction`, `quickstart`) into a dedicated `getting-started/` directory for consistency with the rest of the docs
- Streamline quickstart install into a single tabbed step (Rust / TypeScript / CLI)
- Surface platform requirements note at the top of the quickstart page

## Test plan
- [x] Verify docs build locally with `mintlify dev`
- [x] Confirm all internal links resolve (introduction → quickstart)
- [x] Check AI Agents page renders correctly with CodeGroup tabs
- [x] Verify navigation sidebar shows the new page under Getting Started