### PR TITLE
fix(tls): Node.js TLS 1.3 connections hang through MITM proxy

### DIFF
--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -199,6 +199,19 @@ async fn intercept_relay(
     let mut server_buf = vec![0u8; RELAY_BUF_SIZE];
     let mut plaintext_buf = vec![0u8; RELAY_BUF_SIZE];
 
+    // Drain any application data already buffered during the TLS handshake.
+    // In TLS 1.3, the client sends Finished + application data in the same
+    // flight, so process_new_packets() during the handshake loop may have
+    // already decrypted the first HTTP request into the plaintext buffer.
+    forward_plaintext(
+        &mut guest_tls,
+        &mut server_tls,
+        &secrets_handler,
+        &shared,
+        &mut plaintext_buf,
+    )
+    .await?;
+
     loop {
         tokio::select! {
             // Guest → server: receive encrypted, decrypt, forward plaintext.
@@ -218,36 +231,14 @@ async fn intercept_relay(
                         .map_err(io::Error::other)?;
                 }
 
-                // Read all available decrypted plaintext and substitute secrets.
-                loop {
-                    match guest_tls.reader().read(&mut plaintext_buf) {
-                        Ok(0) => break,
-                        Ok(n) => {
-                            if secrets_handler.is_empty() {
-                                server_tls.write_all(&plaintext_buf[..n]).await?;
-                            } else {
-                                match secrets_handler.substitute(&plaintext_buf[..n]) {
-                                    Some(substituted) => {
-                                        server_tls.write_all(&substituted).await?;
-                                    }
-                                    None => {
-                                        // Violation: placeholder going to disallowed host.
-                                        if secrets_handler.terminates_on_violation() {
-                                            shared.trigger_termination();
-                                        }
-                                        // Drop the connection.
-                                        return Err(io::Error::new(
-                                            io::ErrorKind::PermissionDenied,
-                                            "secret violation: placeholder sent to disallowed host",
-                                        ));
-                                    }
-                                }
-                            }
-                        }
-                        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
-                        Err(e) => return Err(e),
-                    }
-                }
+                forward_plaintext(
+                    &mut guest_tls,
+                    &mut server_tls,
+                    &secrets_handler,
+                    &shared,
+                    &mut plaintext_buf,
+                )
+                .await?;
             }
 
             // Server → guest: read plaintext, encrypt, send via channel.
@@ -292,6 +283,47 @@ async fn extract_sni_from_channel(
             ));
         }
     }
+}
+
+/// Read all available decrypted plaintext from the guest-facing TLS
+/// connection and forward it to the upstream server, applying secret
+/// substitution when configured.
+async fn forward_plaintext(
+    guest_tls: &mut rustls::ServerConnection,
+    server_tls: &mut tokio_rustls::client::TlsStream<TcpStream>,
+    secrets_handler: &SecretsHandler,
+    shared: &SharedState,
+    buf: &mut [u8],
+) -> io::Result<()> {
+    loop {
+        let n = match guest_tls.reader().read(buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
+            Err(e) => return Err(e),
+        };
+
+        if secrets_handler.is_empty() {
+            server_tls.write_all(&buf[..n]).await?;
+            continue;
+        }
+
+        let substituted = secrets_handler.substitute(&buf[..n]);
+        if let Some(data) = substituted {
+            server_tls.write_all(&data).await?;
+            continue;
+        }
+
+        // Violation: placeholder going to disallowed host. Drop the connection.
+        if secrets_handler.terminates_on_violation() {
+            shared.trigger_termination();
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "secret violation: placeholder sent to disallowed host",
+        ));
+    }
+    Ok(())
 }
 
 /// Flush pending TLS output from the guest-facing rustls connection


### PR DESCRIPTION
## Summary

Reported when trying to log into Claude Code from inside a sandbox with `--tls-intercept` — the connection would hang indefinitely unless `NODE_OPTIONS=--tls-max-v1.2` was set.

- TLS 1.3 clients (notably Node.js) send `Finished` + application data in the same flight
- The handshake loop called `process_new_packets()` which decrypted this data into rustls's internal plaintext buffer
- The relay loop only read from `from_smoltcp.recv()` — it never drained what was already buffered
- Result: deadlock — proxy waiting for new guest data, guest waiting for HTTP response
- TLS 1.2 was unaffected because application data arrives in a separate flight after the handshake

## Reproduce

Hangs indefinitely:
```bash
msb run --tls-intercept node -- \
  node -e "fetch('https://api.anthropic.com').then(r => console.log(r.status)).catch(e => console.error(e.message))"
```

Workaround (forcing TLS 1.2):
```bash
msb run --tls-intercept node -- \
  sh -c 'NODE_OPTIONS="--tls-max-v1.2" node -e "fetch(\"https://api.anthropic.com\").then(r => console.log(r.status)).catch(e => console.error(e.message))"'
```

## Fix

- After the handshake completes and the upstream connection is established, drain `guest_tls.reader()` and forward any buffered plaintext before entering the relay loop
- Extracted the plaintext forwarding logic into `forward_plaintext()` to share between the drain and the relay loop

## Test plan

- [x] Node.js `fetch()` to `api.anthropic.com` works over TLS 1.3 with `--tls-intercept` (5/5 attempts)
- [x] TLS 1.2 still works (regression check)
- [x] curl and Python TLS 1.3 still work through the proxy