### PR TITLE
fix(tls): intermittent CERT_NOT_YET_VALID on fast-booting sandboxes

### DIFF
--- a/crates/network/lib/tls/certgen.rs
+++ b/crates/network/lib/tls/certgen.rs
@@ -42,8 +42,10 @@ pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u6
     params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
 
     // Set certificate validity period.
+    // Backdate not_before by 5 minutes to tolerate clock skew between the
+    // host (which generates the cert) and the guest (which validates it).
     let now = OffsetDateTime::now_utc();
-    params.not_before = now;
+    params.not_before = now - Duration::minutes(5);
     params.not_after = now + Duration::hours(validity_hours as i64);
 
     let key_pair = rcgen::KeyPair::generate().expect("failed to generate domain key pair");

--- a/crates/network/lib/tls/certgen.rs
+++ b/crates/network/lib/tls/certgen.rs
@@ -27,26 +27,8 @@ pub struct DomainCert {
 
 /// Generate a certificate for `domain` signed by the given CA.
 pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u64) -> DomainCert {
-    let mut params = CertificateParams::new(vec![domain.to_string()])
-        .expect("invalid domain for certificate SAN");
-
-    let mut dn = rcgen::DistinguishedName::new();
-    dn.push(rcgen::DnType::CommonName, domain);
-    params.distinguished_name = dn;
-    params.is_ca = IsCa::ExplicitNoCa;
-    params.use_authority_key_identifier_extension = true;
-    params.key_usages = vec![
-        KeyUsagePurpose::DigitalSignature,
-        KeyUsagePurpose::KeyEncipherment,
-    ];
-    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-
-    // Set certificate validity period.
-    // Backdate not_before by 5 minutes to tolerate clock skew between the
-    // host (which generates the cert) and the guest (which validates it).
     let now = OffsetDateTime::now_utc();
-    params.not_before = now - Duration::minutes(5);
-    params.not_after = now + Duration::hours(validity_hours as i64);
+    let params = build_domain_cert_params(domain, validity_hours, now);
 
     let key_pair = rcgen::KeyPair::generate().expect("failed to generate domain key pair");
 
@@ -70,5 +52,51 @@ pub fn generate_domain_cert(domain: &str, ca: &CertAuthority, validity_hours: u6
         chain,
         key,
         server_config: std::sync::Arc::new(server_config),
+    }
+}
+
+fn build_domain_cert_params(
+    domain: &str,
+    validity_hours: u64,
+    now: OffsetDateTime,
+) -> CertificateParams {
+    let mut params = CertificateParams::new(vec![domain.to_string()])
+        .expect("invalid domain for certificate SAN");
+
+    let mut dn = rcgen::DistinguishedName::new();
+    dn.push(rcgen::DnType::CommonName, domain);
+    params.distinguished_name = dn;
+    params.is_ca = IsCa::ExplicitNoCa;
+    params.use_authority_key_identifier_extension = true;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+
+    // Backdate not_before by 2 seconds to tolerate the sub-second clock
+    // offset between the host (which generates the cert) and the guest
+    // (which validates it on the first TLS request to each domain).
+    params.not_before = now - Duration::seconds(2);
+    params.not_after = now + Duration::hours(validity_hours as i64);
+
+    params
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn domain_cert_params_are_backdated_to_absorb_clock_skew() {
+        let now = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let params = build_domain_cert_params("example.com", 24, now);
+
+        assert_eq!(params.not_before, now - Duration::seconds(2));
+        assert_eq!(params.not_after, now + Duration::hours(24));
     }
 }


### PR DESCRIPTION
## Summary

- Per-domain MITM certs had `notBefore` set to the exact host time at generation
- The guest VM clock can be slightly behind the host (even by milliseconds)
- This caused intermittent `CERT_NOT_YET_VALID` errors, especially on fast-booting sandboxes
- Fix: backdate `notBefore` by 2 seconds to absorb clock skew

## Reproduce

Run this 10 times — ~30% will fail with `CERT_NOT_YET_VALID` before the fix:
```bash
msb run --tls-intercept node -- \
  sh -c 'NODE_OPTIONS="--tls-max-v1.2" node -e "
    fetch(\"https://httpbin.org/get\")
      .then(r => console.log(r.status))
      .catch(e => console.error(e.cause?.code || e.message))"'
```

Note: `--tls-max-v1.2` is needed to isolate from the TLS 1.3 deadlock fixed in #542.

## Test plan

- [x] 0/10 failures with fix vs ~3/10 failures on main