### PR TITLE
docs: add Python SDK snippets and reference pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -112,6 +112,20 @@
               "sdk/typescript/snapshots",
               "sdk/typescript/events"
             ]
+          },
+          {
+            "group": "Python SDK",
+            "icon": "python",
+            "pages": [
+              "sdk/python/sandbox",
+              "sdk/python/execution",
+              "sdk/python/filesystem",
+              "sdk/python/volumes",
+              "sdk/python/networking",
+              "sdk/python/secrets",
+              "sdk/python/snapshots",
+              "sdk/python/events"
+            ]
           }
         ]
       },

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -45,6 +45,25 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+import os
+from microsandbox import Network, Sandbox, Secret
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    memory=512,
+    cpus=2,
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+    network=Network.public_only(),
+)
+```
+
 </CodeGroup>
 
 <Callout icon="bolt" color="#7C3AED">
@@ -93,6 +112,19 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    secrets=[
+        Secret.env("OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
 </CodeGroup>
 
 ### Programmable network layer <sup><sup>coming soon</sup></sup>
@@ -119,6 +151,10 @@ const sb = await Sandbox.create({
     image: "python",
     network: NetworkPolicy.allowlist(["api.openai.com", "pypi.org"]),
 })
+```
+
+```python Python
+# Coming soon — allowlist policies for the Python SDK
 ```
 
 </CodeGroup>
@@ -155,6 +191,10 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+# Coming soon — filesystem hooks for the Python SDK
+```
+
 </CodeGroup>
 
 ### Snapshot, fork, restore <sup><sup>coming soon</sup></sup>
@@ -189,6 +229,10 @@ const snapshot = await sb.snapshot()
 const workers = await Promise.all(
     Array.from({ length: 10 }, (_, i) => snapshot.restore(`worker-${i}`))
 )
+```
+
+```python Python
+# Coming soon — snapshots for the Python SDK
 ```
 
 </CodeGroup>
@@ -231,6 +275,10 @@ const sub = sb.onEvent("task.progress", (event: EventData) => {
 
 // Send events to guest
 await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose"] })
+```
+
+```python Python
+# Coming soon — events for the Python SDK
 ```
 
 </CodeGroup>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -154,7 +154,18 @@ const sb = await Sandbox.create({
 ```
 
 ```python Python
-# Coming soon — allowlist policies for the Python SDK
+from microsandbox import Network, NetworkPolicy, Rule, Sandbox
+
+sb = await Sandbox.create(
+    "sandbox",
+    image="python",
+    network=Network(
+        policy=NetworkPolicy(rules=(
+            Rule.allow(destination="api.openai.com"),
+            Rule.allow(destination="pypi.org"),
+        )),
+    ),
+)
 ```
 
 </CodeGroup>
@@ -192,7 +203,19 @@ const sb = await Sandbox.create({
 ```
 
 ```python Python
-# Coming soon — filesystem hooks for the Python SDK
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
 ```
 
 </CodeGroup>
@@ -232,7 +255,18 @@ const workers = await Promise.all(
 ```
 
 ```python Python
-# Coming soon — snapshots for the Python SDK
+import asyncio
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("base", image="python")
+await sb.exec("pip", ["install", "-r", "requirements.txt"])
+
+snapshot = await sb.snapshot()
+
+# Fork 10 workers (skips pip install entirely)
+workers = await asyncio.gather(
+    *(snapshot.restore(f"worker-{i}") for i in range(10))
+)
 ```
 
 </CodeGroup>
@@ -278,7 +312,16 @@ await sb.emit("task.start", { inputFile: "/data/input.txt", options: ["--verbose
 ```
 
 ```python Python
-# Coming soon — events for the Python SDK
+# Receive events from guest
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
+
+# Send events to guest
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
 ```
 
 </CodeGroup>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -21,6 +21,10 @@ icon: "bolt"
     npm install microsandbox
     ```
 
+    ```bash Python
+    pip install microsandbox
+    ```
+
     ```bash CLI
     curl -fsSL https://install.microsandbox.dev | sh
     ```
@@ -64,6 +68,25 @@ icon: "bolt"
     console.log(output.stdout()) // Hello from a microVM!
 
     await sb.stop()
+    ```
+
+    ```python Python
+    import asyncio
+    from microsandbox import Sandbox
+
+    async def main():
+        sb = await Sandbox.create(
+            "hello",
+            image="python",
+            memory=512,
+        )
+
+        output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"])
+        print(output.stdout_text)  # Hello from a microVM!
+
+        await sb.stop()
+
+    asyncio.run(main())
     ```
 
     ```bash CLI

--- a/docs/images/disk-images.mdx
+++ b/docs/images/disk-images.mdx
@@ -60,6 +60,16 @@ const sb2 = await Sandbox.create({
     memoryMib: 512,
 })
 ```
+
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect format from file extension
+sb = await Sandbox.create("custom-vm", image="./ubuntu-22.04.qcow2", cpus=2, memory=2048)
+
+# Explicit filesystem type
+sb2 = await Sandbox.create("custom-vm", image=Image.disk("./alpine.raw", fstype="ext4"), cpus=1, memory=512)
+```
 </CodeGroup>
 
 <Note>

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -36,6 +36,12 @@ const sb = await Sandbox.create({
     pullPolicy: PullPolicy.Always,
 })
 ```
+
+```python Python
+from microsandbox import PullPolicy, Sandbox
+
+sb = await Sandbox.create("worker", image="python", pull_policy=PullPolicy.ALWAYS)
+```
 </CodeGroup>
 
 <Tip>
@@ -66,6 +72,18 @@ const sb = await Sandbox.create({
     registryAuth: { username: "deploy", password: process.env.REGISTRY_TOKEN },
     pullPolicy: PullPolicy.Always,
 })
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="registry.corp.io/team/app:latest",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
 ```
 </CodeGroup>
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -49,6 +49,19 @@ const sb3 = await Sandbox.create({
 })
 ```
 
+```python Python
+from microsandbox import Network, Sandbox
+
+# No network access
+sb1 = await Sandbox.create("isolated", image="python", network=Network.none())
+
+# Public internet only (default, blocks private ranges)
+sb2 = await Sandbox.create("web-agent", image="python", network=Network.public_only())
+
+# Unrestricted access
+sb3 = await Sandbox.create("dev", image="python", network=Network.allow_all())
+```
+
 ```bash CLI
 # No network access
 msb create python --name isolated --no-network
@@ -121,6 +134,26 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+from microsandbox import Action, Network, NetworkPolicy, Protocol, Rule, Sandbox
+
+sb = await Sandbox.create(
+    "secure-agent",
+    image="alpine",
+    network=Network(
+        policy=NetworkPolicy(
+            default_action=Action.DENY,
+            rules=(
+                Rule.allow(protocol=Protocol.TCP, port=443),
+                Rule.allow(protocol=Protocol.UDP, port=53),
+                Rule.deny(destination="metadata"),
+                Rule.deny(destination="private"),
+            ),
+        ),
+    ),
+)
+```
+
 </CodeGroup>
 
 ## Port mapping
@@ -147,6 +180,14 @@ const sb = await Sandbox.create({
     ports: { "8080": 80 },
     network: NetworkPolicy.publicOnly(),
 })
+```
+
+```python Python
+sb = await Sandbox.create(
+    "api",
+    image="python",
+    ports={8080: 80},
+)
 ```
 
 ```bash CLI
@@ -186,6 +227,19 @@ const sb = await Sandbox.create({
         blockDomainSuffixes: [".tracking.com"],
     },
 })
+```
+
+```python Python
+from microsandbox import Network, Sandbox
+
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        block_domains=("malware.example.com",),
+        block_domain_suffixes=(".tracking.com",),
+    ),
+)
 ```
 
 ```bash CLI

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -38,6 +38,18 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+from microsandbox import Network, Sandbox, TlsConfig
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    network=Network(
+        tls=TlsConfig(bypass=("pinned-api.example.com", "*.gov")),
+    ),
+)
+```
+
 ```bash CLI
 msb create python --name agent \
   --tls-intercept \

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -269,7 +269,15 @@ const reattached = await sb.session(sessionId)
 ```
 
 ```python Python
-# Coming soon — sessions for the Python SDK
+# Start a background process and capture its session ID
+handle = await sb.exec_stream("python", ["server.py"])
+session_id = handle.id
+
+# List active sessions
+sessions = await sb.sessions()
+
+# Reattach to a session by ID
+reattached = await sb.session(session_id)
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -26,6 +26,13 @@ console.log(output.success)   // true
 console.log(output.code)      // 0
 ```
 
+```python Python
+output = await sb.exec("python", ["-c", "print('hello')"])
+print(output.stdout_text)     # "hello\n"
+print(output.success)         # True
+print(output.exit_code)       # 0
+```
+
 ```bash CLI
 msb exec worker -- python -c "print('hello')"
 ```
@@ -57,6 +64,18 @@ const output = await sb.execWithConfig({
 })
 ```
 
+```python Python
+from microsandbox import ExecOptions, Rlimit
+
+output = await sb.exec("python", ExecOptions(
+    args=("compute.py",),
+    cwd="/app",
+    env={"PYTHONPATH": "/app/lib"},
+    timeout=30.0,
+    rlimits=(Rlimit.nofile(1024),),
+))
+```
+
 ```bash CLI
 msb exec worker \
   -w /app \
@@ -79,6 +98,10 @@ let output = sb.shell("ls -la /app && echo done").await?;
 
 ```typescript TypeScript
 const output = await sb.shell("ls -la /app && echo done")
+```
+
+```python Python
+output = await sb.shell("ls -la /app && echo done")
 ```
 
 ```bash CLI
@@ -118,6 +141,16 @@ while ((event = await handle.recv()) !== null) {
 }
 ```
 
+```python Python
+handle = await sb.exec_stream("tail", ["-f", "/var/log/app.log"])
+
+async for event in handle:
+    match event.event_type:
+        case "stdout": print(event.data.decode(), end="")
+        case "stderr": print(event.data.decode(), end="", file=sys.stderr)
+        case "exited": print(f"Exited: {event.code}")
+```
+
 </CodeGroup>
 
 ## Interactive attach
@@ -141,6 +174,20 @@ const exitCode = await sb.attach()
 
 // Attach to a specific command with custom detach keys
 await sb.attach("bash", a => a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"))
+```
+
+```python Python
+from microsandbox import AttachOptions
+
+# Attach to the default shell
+exit_code = await sb.attach_shell()
+
+# Attach to a specific command with custom detach keys
+exit_code = await sb.attach("python", AttachOptions(
+    env={"DEBUG": "1"},
+    cwd="/app",
+    detach_keys="ctrl-q",
+))
 ```
 
 ```bash CLI
@@ -179,6 +226,17 @@ await stdin.close()
 await handle.wait()
 ```
 
+```python Python
+from microsandbox import ExecOptions, Stdin
+
+handle = await sb.exec_stream("python", ExecOptions(stdin=Stdin.pipe(), tty=True))
+stdin = handle.take_stdin()
+await stdin.write(b"print('hello')\n")
+await stdin.write(b"exit()\n")
+await stdin.close()
+await handle.wait()
+```
+
 </CodeGroup>
 
 ## Sessions <sup><sup>coming soon</sup></sup>
@@ -208,6 +266,10 @@ const sessions = await sb.sessions()
 
 // Reattach to a session by ID
 const reattached = await sb.session(sessionId)
+```
+
+```python Python
+# Coming soon — sessions for the Python SDK
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/customization.mdx
+++ b/docs/sandboxes/customization.mdx
@@ -50,6 +50,22 @@ await sb.shell("setup")
 const output = await sb.shell("run")
 ```
 
+```python Python
+from microsandbox import Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="ubuntu",
+    scripts={
+        "setup": "#!/bin/bash\napt-get update && apt-get install -y python3 curl",
+        "start": "#!/bin/bash\nexec python3 /app/main.py",
+    },
+)
+
+await sb.shell("setup")
+output = await sb.shell("start")
+```
+
 </CodeGroup>
 
 ## Patches
@@ -95,6 +111,23 @@ const sb = await Sandbox.create({
         Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
     ],
 })
+```
+
+```python Python
+from microsandbox import Patch, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    patches=[
+        Patch.text("/etc/greeting.txt", "Hello from a patched rootfs!\n"),
+        Patch.text("/etc/motd", "Custom message of the day.\n", replace=True),
+        Patch.mkdir("/app", mode=0o755),
+        Patch.text("/app/config.json", '{"debug": true}', mode=0o644),
+        Patch.copy_file("./cert.pem", "/etc/ssl/cert.pem"),
+        Patch.append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    ],
+)
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/events.mdx
+++ b/docs/sandboxes/events.mdx
@@ -44,6 +44,10 @@ const sub = sb.onEvent("task.progress", (event: EventData) => {
 })
 ```
 
+```python Python
+# Coming soon — events for the Python SDK
+```
+
 </CodeGroup>
 
 ## Send events to guest
@@ -69,6 +73,10 @@ await sb.emit("task.start", {
     inputFile: "/data/input.txt",
     options: ["--verbose"],
 })
+```
+
+```python Python
+# Coming soon — events for the Python SDK
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/events.mdx
+++ b/docs/sandboxes/events.mdx
@@ -45,7 +45,13 @@ const sub = sb.onEvent("task.progress", (event: EventData) => {
 ```
 
 ```python Python
-# Coming soon — events for the Python SDK
+from microsandbox import Sandbox
+
+sb = await (await Sandbox.get("worker")).start()
+
+sub = sb.on_event("task.progress", lambda event: (
+    print(f"[{event.data['percent']}%] {event.data['message']}")
+))
 ```
 
 </CodeGroup>
@@ -76,7 +82,10 @@ await sb.emit("task.start", {
 ```
 
 ```python Python
-# Coming soon — events for the Python SDK
+await sb.emit("task.start", {
+    "input_file": "/data/input.txt",
+    "output_dir": "/data/output",
+})
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/filesystem.mdx
+++ b/docs/sandboxes/filesystem.mdx
@@ -19,6 +19,10 @@ sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
 await sb.fs().write("/app/config.json", '{"debug": true}')
 ```
 
+```python Python
+await sb.fs.write("/app/config.json", b'{"debug": true}')
+```
+
 </CodeGroup>
 
 ## Read a file
@@ -30,6 +34,10 @@ let content = sb.fs().read_to_string("/app/config.json").await?;
 
 ```typescript TypeScript
 const content = await sb.fs().readString("/app/config.json")
+```
+
+```python Python
+content = await sb.fs.read_text("/app/config.json")
 ```
 
 </CodeGroup>
@@ -49,6 +57,12 @@ const entries = await sb.fs().list("/app")
 for (const entry of entries) {
     console.log(`${entry.path}: ${entry.kind}`)
 }
+```
+
+```python Python
+entries = await sb.fs.list("/app")
+for entry in entries:
+    print(f"{entry.path}: {entry.kind}")
 ```
 
 </CodeGroup>
@@ -72,6 +86,12 @@ for await (const chunk of stream) {
 }
 ```
 
+```python Python
+stream = await sb.fs.read_stream("/app/data.bin")
+async for chunk in stream:
+    process(chunk)
+```
+
 </CodeGroup>
 
 ## Copy from host
@@ -85,6 +105,10 @@ sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
 
 ```typescript TypeScript
 await sb.fs().copyFromHost("./local-file.txt", "/app/remote-file.txt")
+```
+
+```python Python
+await sb.fs.copy_from_host("./local-file.txt", "/app/remote-file.txt")
 ```
 
 </CodeGroup>
@@ -131,6 +155,10 @@ const sb = await Sandbox.create({
         }),
     },
 })
+```
+
+```python Python
+# Coming soon — filesystem hooks for the Python SDK
 ```
 
 </CodeGroup>
@@ -180,6 +208,10 @@ const sb = await Sandbox.create({
         "/secrets": Mount.backend(new EncryptedFs(key, "/data")),
     },
 })
+```
+
+```python Python
+# Coming soon — custom filesystem backends for the Python SDK
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/filesystem.mdx
+++ b/docs/sandboxes/filesystem.mdx
@@ -158,7 +158,19 @@ const sb = await Sandbox.create({
 ```
 
 ```python Python
-# Coming soon — filesystem hooks for the Python SDK
+from microsandbox import Sandbox, Volume
+
+key = get_encryption_key()
+sb = await Sandbox.create(
+    "encrypted",
+    image="python",
+    volumes={
+        "/secrets": Volume.bind("/data/secrets",
+            on_read=lambda path, data: decrypt(data, key),
+            on_write=lambda path, data: encrypt(data, key),
+        ),
+    },
+)
 ```
 
 </CodeGroup>
@@ -211,7 +223,19 @@ const sb = await Sandbox.create({
 ```
 
 ```python Python
-# Coming soon — custom filesystem backends for the Python SDK
+from microsandbox import FsBackend, Sandbox, Volume
+
+# Implement the FsBackend interface
+class EncryptedFs(FsBackend):
+    # ... implement read, write, and other required methods
+    pass
+
+sb = await Sandbox.create(
+    "custom",
+    volumes={
+        "/secrets": Volume.backend(EncryptedFs(key, "/data")),
+    },
+)
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -55,6 +55,14 @@ const sb = await Sandbox.create({ name: "worker", image: "python" })
 const sb = await Sandbox.createDetached({ name: "worker", image: "python" })
 ```
 
+```python Python
+# Attached: sandbox stops when your process exits
+sb = await Sandbox.create("worker", image="python")
+
+# Detached: sandbox survives after your process exits
+sb = await Sandbox.create("worker", image="python", detached=True)
+```
+
 ```bash CLI
 # Attached
 msb create python --name worker
@@ -83,6 +91,13 @@ await sb.stop()
 const sb = await Sandbox.start("worker")
 ```
 
+```python Python
+await sb.stop()
+
+# Later, resume where you left off
+sb = await Sandbox.start("worker")
+```
+
 ```bash CLI
 msb stop worker
 
@@ -102,6 +117,10 @@ sb.kill().await?;
 ```
 
 ```typescript TypeScript
+await sb.kill()
+```
+
+```python Python
 await sb.kill()
 ```
 
@@ -126,6 +145,10 @@ await sb.pause()
 await sb.resume()
 ```
 
+```python Python
+# Coming soon — pause/resume for the Python SDK
+```
+
 </CodeGroup>
 
 ## Detach
@@ -138,6 +161,10 @@ sb.detach().await;
 ```
 
 ```typescript TypeScript
+await sb.detach()
+```
+
+```python Python
 await sb.detach()
 ```
 
@@ -160,6 +187,10 @@ sb.drain().await?;
 await sb.drain()
 ```
 
+```python Python
+await sb.drain()
+```
+
 </CodeGroup>
 
 ## Wait
@@ -175,6 +206,10 @@ let exit_status = sb.wait().await?;
 const exitStatus = await sb.wait()
 ```
 
+```python Python
+code, success = await sb.wait()
+```
+
 </CodeGroup>
 
 ## Remove
@@ -187,6 +222,10 @@ Sandbox::remove("worker").await?;
 ```
 
 ```typescript TypeScript
+await Sandbox.remove("worker")
+```
+
+```python Python
 await Sandbox.remove("worker")
 ```
 
@@ -213,6 +252,14 @@ for (const info of sandboxes) {
 
 const handle = await Sandbox.get("worker")
 console.log(handle.status) // "Running" | "Stopped" | ...
+```
+
+```python Python
+for handle in await Sandbox.list():
+    print(f"{handle.name}: {handle.status}")
+
+handle = await Sandbox.get("worker")
+print(handle.status)  # "running" | "stopped" | ...
 ```
 
 ```bash CLI
@@ -290,6 +337,18 @@ try {
 }
 ```
 
+```python Python
+import asyncio
+from microsandbox import Sandbox
+
+handle = await Sandbox.get("worker")
+sb = await handle.connect()
+try:
+    await asyncio.wait_for(sb.stop(), timeout=30)
+except asyncio.TimeoutError:
+    await sb.kill()
+```
+
 </CodeGroup>
 
 ## Sandbox Process Policies
@@ -312,6 +371,15 @@ const sb = await Sandbox.create({
     image: "python",
     maxDurationSecs: 3600,  // maximum sandbox lifetime in seconds
 })
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    max_duration=3600,
+    idle_timeout=300,
+)
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -146,7 +146,8 @@ await sb.resume()
 ```
 
 ```python Python
-# Coming soon — pause/resume for the Python SDK
+await sb.pause()
+await sb.resume()
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/metrics.mdx
+++ b/docs/sandboxes/metrics.mdx
@@ -21,6 +21,11 @@ const metrics = await sb.metrics()
 console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`)
 ```
 
+```python Python
+m = await sb.metrics()
+print(f"CPU: {m.cpu_percent:.1f}%, Mem: {m.memory_bytes // 1024 // 1024} MB")
+```
+
 </CodeGroup>
 
 ## Streaming
@@ -45,6 +50,11 @@ for await (const m of sb.metricsStream(1000)) {
 }
 ```
 
+```python Python
+async for m in await sb.metrics_stream(interval=1.0):
+    print(f"[{m.timestamp_ms}] CPU: {m.cpu_percent:.1f}%")
+```
+
 </CodeGroup>
 
 ## Fleet-wide metrics
@@ -62,6 +72,12 @@ let all = all_sandbox_metrics().await?;
 import { allSandboxMetrics } from 'microsandbox'
 
 const all = await allSandboxMetrics()
+```
+
+```python Python
+from microsandbox import all_sandbox_metrics
+
+all_metrics = await all_sandbox_metrics()
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -338,7 +338,17 @@ const sb = await Sandbox.create(config)
 ```
 
 ```python Python
-# Coming soon — config inspection for the Python SDK
+import json
+from microsandbox import Sandbox
+
+config = Sandbox.build_config(
+    "preview",
+    image="python",
+    memory=1024,
+)
+
+print(json.dumps(config, indent=2))
+sb = await Sandbox.create(config)
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -27,6 +27,10 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+sb = await Sandbox.create("worker", image="python")
+```
+
 ```bash CLI
 msb create python --name worker
 ```
@@ -67,6 +71,24 @@ const sb = await Sandbox.create({
         "/tmp/scratch": Mount.tmpfs({ sizeMib: 100 }),
     },
 })
+```
+
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    memory=1024,
+    cpus=2,
+
+    env={"DEBUG": "true", "API_PORT": "8000"},
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/data": Volume.named("my-data"),
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
 ```
 
 ```bash CLI
@@ -115,6 +137,10 @@ Sandbox::builder("worker").image("python").create().await?;
 await Sandbox.create({ name: "worker", image: "python" })
 ```
 
+```python Python
+await Sandbox.create("worker", image="python")
+```
+
 ```bash CLI
 msb create python --name worker
 ```
@@ -132,6 +158,10 @@ Sandbox::builder("worker").image("./my-rootfs").create().await?;
 
 ```typescript TypeScript
 await Sandbox.create({ name: "worker", image: "./my-rootfs" })
+```
+
+```python Python
+await Sandbox.create("worker", image="./my-rootfs")
 ```
 
 ```bash CLI
@@ -170,6 +200,16 @@ await Sandbox.create({
 })
 ```
 
+```python Python
+from microsandbox import Image, Sandbox
+
+# Auto-detect filesystem
+await Sandbox.create("worker", image="./ubuntu-22.04.qcow2")
+
+# Explicit filesystem type
+await Sandbox.create("worker", image=Image.disk("./alpine.raw", fstype="ext4"))
+```
+
 ```bash CLI
 msb create ./alpine.qcow2 --name worker
 ```
@@ -199,6 +239,10 @@ const sb = await Sandbox.create({
     image: "python",
     replace: true,
 })
+```
+
+```python Python
+sb = await Sandbox.create("worker", image="python", replace=True)
 ```
 
 ```bash CLI
@@ -235,6 +279,18 @@ const sb = await Sandbox.create({
     registryAuth: { username: "deploy", password: process.env.REGISTRY_TOKEN! },
     pullPolicy: PullPolicy.Always,
 })
+```
+
+```python Python
+import os
+from microsandbox import PullPolicy, RegistryAuth, Sandbox
+
+sb = await Sandbox.create(
+    "worker",
+    image="private.registry.io/org/app:v1",
+    registry_auth=RegistryAuth.basic("deploy", os.environ["REGISTRY_PASSWORD"]),
+    pull_policy=PullPolicy.ALWAYS,
+)
 ```
 
 ```bash CLI
@@ -279,6 +335,10 @@ const config = Sandbox.buildConfig({
 
 console.log(JSON.stringify(config, null, 2))
 const sb = await Sandbox.create(config)
+```
+
+```python Python
+# Coming soon — config inspection for the Python SDK
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -47,6 +47,29 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+import os
+from microsandbox import Sandbox, Secret
+
+sb = await Sandbox.create(
+    "agent",
+    image="python",
+    secrets=[
+        Secret.env(
+            "GITHUB_TOKEN",
+            value=os.environ["GITHUB_TOKEN"],
+            allow_hosts=["api.github.com"],
+            allow_host_patterns=["*.githubusercontent.com"],
+        ),
+        Secret.env(
+            "OPENAI_API_KEY",
+            value=os.environ["OPENAI_API_KEY"],
+            allow_hosts=["api.openai.com"],
+        ),
+    ],
+)
+```
+
 ```bash CLI
 msb create python --name agent \
   --secret "GITHUB_TOKEN=$GITHUB_TOKEN@api.github.com" \
@@ -55,4 +78,4 @@ msb create python --name agent \
 
 </CodeGroup>
 
-See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets).
+See the SDK Reference for the full API: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets).

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -39,6 +39,10 @@ const snapshot = await sb.snapshot()
 await sb.resume()
 ```
 
+```python Python
+# Coming soon — snapshots for the Python SDK
+```
+
 </CodeGroup>
 
 ## Save and load named snapshots
@@ -68,6 +72,10 @@ await snapshot.saveNamed("after-pip-install")
 const saved = await Snapshot.get("after-pip-install")
 ```
 
+```python Python
+# Coming soon — snapshots for the Python SDK
+```
+
 </CodeGroup>
 
 ## Fork workers
@@ -93,6 +101,10 @@ const saved = await Snapshot.get("after-pip-install")
 const workers = await Promise.all(
     Array.from({ length: 10 }, (_, i) => saved.restore(`worker-${i}`))
 )
+```
+
+```python Python
+# Coming soon — snapshots for the Python SDK
 ```
 
 </CodeGroup>
@@ -125,6 +137,10 @@ const custom = await saved.restore("custom", {
 })
 ```
 
+```python Python
+# Coming soon — snapshots for the Python SDK
+```
+
 </CodeGroup>
 
 ## List and delete snapshots
@@ -142,6 +158,10 @@ import { Snapshot } from 'microsandbox'
 
 const snapshots = await Snapshot.list()
 await Snapshot.delete("old-snapshot")
+```
+
+```python Python
+# Coming soon — snapshots for the Python SDK
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -40,7 +40,13 @@ await sb.resume()
 ```
 
 ```python Python
-# Coming soon — snapshots for the Python SDK
+from microsandbox import Sandbox
+
+sb = await Sandbox.create("base", image="python")
+await sb.exec("pip", ["install", "-r", "requirements.txt"])
+
+snapshot = await sb.snapshot()
+await sb.resume()
 ```
 
 </CodeGroup>
@@ -73,7 +79,14 @@ const saved = await Snapshot.get("after-pip-install")
 ```
 
 ```python Python
-# Coming soon — snapshots for the Python SDK
+from microsandbox import Snapshot
+
+# Save
+snapshot = await sb.snapshot()
+await snapshot.save_named("after-pip-install")
+
+# Load by name
+saved = await Snapshot.get("after-pip-install")
 ```
 
 </CodeGroup>
@@ -104,7 +117,14 @@ const workers = await Promise.all(
 ```
 
 ```python Python
-# Coming soon — snapshots for the Python SDK
+import asyncio
+from microsandbox import Snapshot
+
+saved = await Snapshot.get("after-pip-install")
+
+workers = await asyncio.gather(
+    *(saved.restore(f"worker-{i}") for i in range(10))
+)
 ```
 
 </CodeGroup>
@@ -138,7 +158,16 @@ const custom = await saved.restore("custom", {
 ```
 
 ```python Python
-# Coming soon — snapshots for the Python SDK
+from microsandbox import Snapshot
+
+saved = await Snapshot.get("after-pip-install")
+
+custom = await saved.restore(
+    "custom",
+    memory=1024,
+    cpus=4,
+    env={"WORKER_ID": "42"},
+)
 ```
 
 </CodeGroup>
@@ -161,7 +190,10 @@ await Snapshot.delete("old-snapshot")
 ```
 
 ```python Python
-# Coming soon — snapshots for the Python SDK
+from microsandbox import Snapshot
+
+snapshots = await Snapshot.list()
+await Snapshot.delete("old-snapshot")
 ```
 
 </CodeGroup>

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -35,6 +35,19 @@ const sb = await Sandbox.create({
 })
 ```
 
+```python Python
+from microsandbox import Sandbox, Volume
+
+sb = await Sandbox.create(
+    "dev",
+    image="python",
+    volumes={
+        "/app/src": Volume.bind("./src", readonly=True),
+        "/app/data": Volume.bind("./data"),
+    },
+)
+```
+
 ```bash CLI
 msb create python --name dev \
   -v ./src:/app/src:ro \
@@ -59,6 +72,10 @@ let cache = Volume::builder("pip-cache")
 
 ```typescript TypeScript
 const cache = await Volume.create({ name: "pip-cache", quotaMib: 1024 })
+```
+
+```python Python
+cache = await Volume.create("pip-cache", quota_mib=1024)
 ```
 
 ```bash CLI
@@ -86,6 +103,16 @@ const sb = await Sandbox.create({
         "/root/.cache/pip": Mount.named(cache.name),
     },
 })
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="python",
+    volumes={
+        "/root/.cache/pip": Volume.named(cache.name),
+    },
+)
 ```
 
 ```bash CLI
@@ -138,6 +165,25 @@ const output = await reader.exec("cat", ["/data/message.txt"])
 // => "hello"
 ```
 
+```python Python
+# Writer
+writer = await Sandbox.create(
+    "writer",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data")},
+)
+await writer.shell("echo 'hello' > /data/message.txt")
+
+# Reader (read-only)
+reader = await Sandbox.create(
+    "reader",
+    image="alpine",
+    volumes={"/data": Volume.named("shared-data", readonly=True)},
+)
+output = await reader.exec("cat", ["/data/message.txt"])
+# => "hello"
+```
+
 </CodeGroup>
 
 <Tip>
@@ -158,6 +204,11 @@ vol.fs().write("/requirements.txt", "requests==2.28.0").await?;
 // Coming soon — host-side filesystem access for volumes
 ```
 
+```python Python
+vol = await Volume.get("pip-cache")
+await vol.fs.write("/requirements.txt", b"requests==2.28.0")
+```
+
 </CodeGroup>
 
 ### Manage volumes
@@ -170,6 +221,11 @@ Volume::remove("old-cache").await?;
 
 ```typescript TypeScript
 const volumes = await Volume.list()
+await Volume.remove("old-cache")
+```
+
+```python Python
+volumes = await Volume.list()
 await Volume.remove("old-cache")
 ```
 
@@ -201,6 +257,16 @@ const sb = await Sandbox.create({
         "/tmp/scratch": Mount.tmpfs({ sizeMib: 100 }),
     },
 })
+```
+
+```python Python
+sb = await Sandbox.create(
+    "worker",
+    image="alpine",
+    volumes={
+        "/tmp/scratch": Volume.tmpfs(size_mib=100),
+    },
+)
 ```
 
 ```bash CLI

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -4,7 +4,7 @@ description: Typed errors and resource cleanup patterns
 icon: "triangle-exclamation"
 ---
 
-Both SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum and TypeScript errors carry a type tag prefix (e.g. `[ExecTimeout]`, `[Runtime]`) in the error message.
+All SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript errors carry a type tag prefix (e.g. `[ExecTimeout]`, `[Runtime]`) in the error message, and Python provides dedicated exception classes.
 
 ## Matching errors
 
@@ -59,6 +59,26 @@ try {
 }
 ```
 
+```python Python
+from microsandbox import (
+    ExecTimeoutError, Sandbox, SandboxNotFoundError
+)
+
+async def get_or_create(name: str):
+    try:
+        handle = await Sandbox.get(name)
+        return await handle.start()
+    except SandboxNotFoundError:
+        return await Sandbox.create(name, image="python")
+
+try:
+    output = await sb.exec("python", ["script.py"])
+    if not output.success:
+        print(f"Exit {output.exit_code}: {output.stderr_text}")
+except ExecTimeoutError:
+    print("Timed out")
+```
+
 </CodeGroup>
 
 ## Resource cleanup
@@ -92,6 +112,13 @@ async function runTemporary(): Promise<string> {
         await Sandbox.remove("temp").catch(() => {})
     }
 }
+```
+
+```python Python
+# Use async context manager — auto-kills and removes on exit.
+async with await Sandbox.create("temp", image="python") as sb:
+    output = await sb.exec("python", ["-c", "print('hello')"])
+    print(output.stdout_text)
 ```
 
 </CodeGroup>

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -16,6 +16,10 @@ cargo add microsandbox
 ```bash TypeScript
 npm install microsandbox
 ```
+
+```bash Python
+pip install microsandbox
+```
 </CodeGroup>
 
 ## Quick start
@@ -67,6 +71,31 @@ console.log("Output:", output.stdout())
 await sb.stop()
 ```
 
+```python Python
+import asyncio
+from microsandbox import Network, Sandbox, Volume
+
+async def main():
+    sb = await Sandbox.create(
+        "my-sandbox",
+        image="python",
+        memory=512,
+        cpus=2,
+        env={"PYTHONDONTWRITEBYTECODE": "1"},
+        volumes={
+            "/app/src": Volume.bind("./src", readonly=True),
+        },
+        network=Network.public_only(),
+    )
+
+    output = await sb.exec("python", ["-c", "print('Hello, World!')"])
+    print("Output:", output.stdout_text)
+
+    await sb.stop()
+
+asyncio.run(main())
+```
+
 </CodeGroup>
 
-The SDK reference is split by language - choose [Rust SDK](/sdk/rust/sandbox) or [TypeScript SDK](/sdk/typescript/sandbox) for the full API. See also [error handling](/sdk/errors).
+The SDK reference is split by language - choose [Rust SDK](/sdk/rust/sandbox), [TypeScript SDK](/sdk/typescript/sandbox), or [Python SDK](/sdk/python/sandbox) for the full API. See also [error handling](/sdk/errors).

--- a/docs/sdk/python/events.mdx
+++ b/docs/sdk/python/events.mdx
@@ -1,0 +1,11 @@
+---
+title: Events
+description: Python SDK - Events API reference
+icon: "tower-broadcast"
+---
+
+<Note>
+  Events are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Events](/sandboxes/events) for a preview of event concepts and planned API.

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -1,0 +1,212 @@
+---
+title: Execution
+description: Python SDK - Command execution API reference
+icon: "terminal"
+---
+
+See [Commands](/sandboxes/commands) for usage examples.
+
+## Types
+
+### ExecOutput
+
+The result of a completed command execution.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| exit_code | `int` | Exit code |
+| success | `bool` | `True` if exit_code is `0` |
+| stdout_text | `str` | Collected stdout decoded as UTF-8. Raises on invalid encoding. |
+| stderr_text | `str` | Collected stderr decoded as UTF-8 |
+| stdout_bytes | `bytes` | Raw stdout bytes |
+| stderr_bytes | `bytes` | Raw stderr bytes |
+
+---
+
+### ExecHandle
+
+A handle to a running streaming execution. Supports `async for event in handle:` to iterate over events until the stream ends.
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| id | `str` | Correlation ID for this execution |
+| take_stdin() | [`ExecSink`](#execsink) ` \| None` | Take the stdin writer. Returns `None` after first call. |
+| recv() | `ExecEvent \| None` | *(async)* Receive the next event. Returns `None` when done. |
+| wait() | `tuple[int, bool]` | *(async)* Wait for the process to exit. Returns `(code, success)`. |
+| collect() | [`ExecOutput`](#execoutput) | *(async)* Wait and collect all remaining output |
+| signal(sig) | `None` | *(async)* Send a POSIX signal to the process |
+| kill() | `None` | *(async)* Send SIGKILL |
+
+---
+
+### ExecSink
+
+Writer for sending data to a running process's stdin.
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| write() | `data: bytes` | *(async)* Write bytes to the process's stdin |
+| close() | - | *(async)* Close stdin. The process sees EOF. |
+
+---
+
+### ExecEvent
+
+Low-level event from PyO3 bindings.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| event_type | `str` | `"started"`, `"stdout"`, `"stderr"`, or `"exited"` |
+| pid | `int \| None` | Guest PID (on `"started"`) |
+| data | `bytes \| None` | Output data (on `"stdout"` / `"stderr"`) |
+| code | `int \| None` | Exit code (on `"exited"`) |
+
+Python dataclass variants are also available for pattern matching:
+
+| Class | Fields | Description |
+|-------|--------|-------------|
+| `StartedEvent` | `pid: int` | The process has started |
+| `StdoutEvent` | `data: bytes` | A chunk of stdout data |
+| `StderrEvent` | `data: bytes` | A chunk of stderr data |
+| `ExitedEvent` | `code: int` | The process has exited |
+
+The union type `ExecEvent = StartedEvent | StdoutEvent | StderrEvent | ExitedEvent` is available from `events.py`.
+
+---
+
+### ExecOptions
+
+```python
+ExecOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    timeout: float | None = None,  # seconds
+    stdin: Stdin = Stdin.null(),
+    tty: bool = False,
+    rlimits: tuple[Rlimit, ...] = (),
+)
+```
+
+Frozen dataclass for per-execution overrides.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| timeout | `float \| None` | `None` | Kill the process after this many seconds |
+| stdin | [`Stdin`](#stdin) | `Stdin.null()` | Stdin source |
+| tty | `bool` | `False` | Allocate a pseudo-terminal |
+| rlimits | `tuple[`[`Rlimit`](#rlimit)`, ...]` | `()` | Resource limits |
+
+---
+
+### AttachOptions
+
+```python
+AttachOptions(
+    args: tuple[str, ...] = (),
+    cwd: str | None = None,
+    user: str | None = None,
+    env: Mapping[str, str] = {},
+    detach_keys: str | None = None,
+)
+```
+
+Frozen dataclass for interactive PTY attach configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| args | `tuple[str, ...]` | `()` | Command arguments |
+| cwd | `str \| None` | `None` | Working directory |
+| user | `str \| None` | `None` | Guest user |
+| env | `Mapping[str, str]` | `{}` | Environment variables |
+| detach_keys | `str \| None` | `None` | Key sequence to detach without stopping |
+
+---
+
+### Stdin
+
+Frozen dataclass with factory methods for configuring process stdin.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Stdin.null() | - | `/dev/null` (default) |
+| Stdin.pipe() | - | Piped stdin. Use [`take_stdin()`](#exechandle) on the handle to write. |
+| Stdin.bytes() | `data: bytes` | Inline data sent before the process starts |
+
+---
+
+### Rlimit
+
+Frozen dataclass with factory methods for POSIX resource limits.
+
+| Factory | Parameters | Description |
+|---------|-----------|-------------|
+| Rlimit.nofile(limit) | `limit: int` | Max open file descriptors |
+| Rlimit.cpu(secs) | `secs: int` | CPU time limit in seconds |
+| Rlimit.as_(*, soft, hard) | `soft: int, hard: int` | Virtual memory size |
+| Rlimit.nproc(limit) | `limit: int` | Max number of processes |
+| Rlimit.fsize(limit) | `limit: int` | Max file size |
+| Rlimit.memlock(limit) | `limit: int` | Max locked memory |
+| Rlimit.stack(limit) | `limit: int` | Max stack size |
+
+**Properties**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| resource | [`RlimitResource`](#rlimitresource) | Resource type |
+| soft | `int` | Soft limit |
+| hard | `int` | Hard limit |
+
+---
+
+### RlimitResource
+
+Enum of POSIX resource types.
+
+| Value | Description |
+|-------|-------------|
+| `cpu` | CPU time |
+| `fsize` | File size |
+| `data` | Data segment size |
+| `stack` | Stack size |
+| `core` | Core file size |
+| `rss` | Resident set size |
+| `nproc` | Number of processes |
+| `nofile` | Open file descriptors |
+| `memlock` | Locked memory |
+| `as` | Virtual memory |
+| `locks` | File locks |
+| `sigpending` | Pending signals |
+| `msgqueue` | Message queue size |
+| `nice` | Nice priority ceiling |
+| `rtprio` | Real-time priority ceiling |
+| `rttime` | Real-time CPU time |
+
+---
+
+### SandboxMetrics
+
+Metrics snapshot for a running sandbox.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| cpu_percent | `float` | CPU utilization percentage |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| disk_read_bytes | `int` | Total bytes read from disk |
+| disk_write_bytes | `int` | Total bytes written to disk |
+| net_rx_bytes | `int` | Total bytes received over the network |
+| net_tx_bytes | `int` | Total bytes sent over the network |
+| uptime_ms | `int` | Sandbox uptime in milliseconds |
+| timestamp_ms | `float` | Timestamp of the snapshot in milliseconds |
+
+---
+
+### MetricsStream
+
+Async iterator yielding [`SandboxMetrics`](#sandboxmetrics). Use `async for metrics in stream:` to consume.

--- a/docs/sdk/python/filesystem.mdx
+++ b/docs/sdk/python/filesystem.mdx
@@ -1,0 +1,357 @@
+---
+title: Filesystem
+description: Python SDK - Filesystem API reference
+icon: "folder-open"
+---
+
+See [Filesystem](/sandboxes/filesystem) for usage examples and extensible backends.
+
+## SandboxFs
+
+Filesystem handle for a running sandbox. Obtained via the `sandbox.fs` property. All operations go through the same host-guest channel as command execution - no SSH, no network involved. For bulk file operations, consider using [volumes](/sandboxes/volumes) instead.
+
+---
+
+#### copy()
+
+```python
+async def copy(src: str, dst: str) -> None
+```
+
+Copy a file within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Source path |
+| dst | `str` | Destination path |
+
+---
+
+#### copy_from_host()
+
+```python
+async def copy_from_host(host_path: str, guest_path: str) -> None
+```
+
+Copy a file from the host machine into the sandbox. For transferring many files, consider a [bind-mounted volume](/sandboxes/volumes) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host_path | `str` | Path on the host filesystem |
+| guest_path | `str` | Destination path inside the sandbox |
+
+---
+
+#### copy_to_host()
+
+```python
+async def copy_to_host(guest_path: str, host_path: str) -> None
+```
+
+Copy a file from the sandbox to the host machine.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guest_path | `str` | Path inside the sandbox |
+| host_path | `str` | Destination path on the host |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists inside the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest (e.g. `"/app/config.json"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_stream()
+
+```python
+async def read_stream(path: str) -> FsReadStream
+```
+
+Open a streaming reader for a file. Data is transferred in chunks of approximately 3 MiB each. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsReadStream`](#fsreadstream) | Async iterator that yields chunks of file data |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### remove()
+
+```python
+async def remove(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute file path |
+
+---
+
+#### remove_dir()
+
+```python
+async def remove_dir(path: str) -> None
+```
+
+Remove a directory recursively.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute directory path |
+
+---
+
+#### rename()
+
+```python
+async def rename(src: str, dst: str) -> None
+```
+
+Rename or move a file or directory within the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `str` | Current path |
+| dst | `str` | New path |
+
+---
+
+#### stat()
+
+```python
+async def stat(path: str) -> FsMetadata
+```
+
+Get detailed metadata for a file or directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsMetadata`](#fsmetadata) | File metadata |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+| data | `bytes` | File content |
+
+---
+
+#### write_stream()
+
+```python
+async def write_stream(path: str) -> FsWriteSink
+```
+
+Open a streaming writer for a file. Use this for files too large to fit in memory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Absolute path inside the guest |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`FsWriteSink`](#fswritesink) | Async writer that accepts chunks of data |
+
+---
+
+## Types
+
+### FsEntry
+
+Metadata for a single directory entry, returned by [`list()`](#list).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| path | `str` | File path |
+| size | `int` | File size in bytes |
+
+### FsEntryKind
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) representing the type of a filesystem entry.
+
+| Value | Description |
+|-------|-------------|
+| `"directory"` | Directory |
+| `"file"` | Regular file |
+| `"other"` | Other entry type |
+| `"symlink"` | Symbolic link |
+
+### FsMetadata
+
+Detailed file metadata, returned by [`stat()`](#stat).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| created | `float \| None` | Creation timestamp (ms since epoch) |
+| kind | `str` | Type of entry (`"file"`, `"directory"`, `"symlink"`, `"other"`) |
+| mode | `int` | Unix permission bits |
+| modified | `float \| None` | Last modified timestamp (ms since epoch) |
+| readonly | `bool` | Whether the file is read-only |
+| size | `int` | File size in bytes |
+
+### FsReadStream
+
+Async stream for reading a file in chunks. Obtained via [`read_stream()`](#read_stream).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `__aiter__` / `__anext__` | `bytes` | Async iterator - use with `async for chunk in stream:` |
+| `collect()` | `bytes` | Collect all remaining data into a single `bytes` object |
+
+### FsWriteSink
+
+Async writer for streaming data into a file. Obtained via [`write_stream()`](#write_stream). Supports the async context manager protocol (`async with`).
+
+| Method / Protocol | Returns | Description |
+|-------------------|---------|-------------|
+| `write(data)` | `None` | Write a chunk of `bytes` to the file |
+| `close()` | `None` | Send EOF and finalize the file |
+| `__aenter__` / `__aexit__` | `FsWriteSink` | Use with `async with` for automatic close on exit |

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -1,0 +1,280 @@
+---
+title: Networking
+description: Python SDK - Network API reference
+icon: "network-wired"
+---
+
+See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
+
+## Network
+
+Frozen dataclass for sandbox network configuration. Use the class method presets for common cases, or construct directly with custom options.
+
+```python
+Network(
+    policy: str | NetworkPolicy | None = None,
+    ports: Mapping[int, int] = {},
+    block_domains: tuple[str, ...] = (),
+    block_domain_suffixes: tuple[str, ...] = (),
+    dns_rebind_protection: bool = True,
+    tls: TlsConfig | None = None,
+    max_connections: int | None = None,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| policy | `str \| NetworkPolicy \| None` | `None` | Preset name or custom [`NetworkPolicy`](#networkpolicy) |
+| ports | `Mapping[int, int]` | `{}` | Port mappings from host to guest |
+| block_domains | `tuple[str, ...]` | `()` | Block DNS for exact domains (returns NXDOMAIN) |
+| block_domain_suffixes | `tuple[str, ...]` | `()` | Block DNS for all subdomains of a suffix |
+| dns_rebind_protection | `bool` | `True` | Block DNS responses resolving to private IPs |
+| tls | [`TlsConfig`](#tlsconfig) ` \| None` | `None` | TLS interception configuration |
+| max_connections | `int \| None` | `None` | Maximum concurrent connections |
+
+---
+
+#### Network.none()
+
+```python
+@classmethod
+def none() -> Network
+```
+
+Deny all traffic. No network interface is created -- the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Fully airgapped network configuration |
+
+---
+
+#### Network.public_only()
+
+```python
+@classmethod
+def public_only() -> Network
+```
+
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Public-only network configuration |
+
+---
+
+#### Network.allow_all()
+
+```python
+@classmethod
+def allow_all() -> Network
+```
+
+Unrestricted network access, including to private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Unrestricted network configuration |
+
+---
+
+## Types
+
+### NetworkPolicy
+
+Frozen dataclass for a custom network policy with rules.
+
+```python
+NetworkPolicy(
+    default_action: Action = Action.ALLOW,
+    rules: tuple[Rule, ...] = (),
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| default_action | [`Action`](#action) | `Action.ALLOW` | Action when no rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | `()` | Custom rules evaluated first-match-wins |
+
+---
+
+### Rule
+
+Frozen dataclass for a single network policy rule.
+
+```python
+Rule(
+    action: Action,
+    direction: Direction = Direction.EGRESS,
+    destination: str | None = None,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| action | [`Action`](#action) | - | What to do when this rule matches |
+| direction | [`Direction`](#direction) | `Direction.EGRESS` | Traffic direction |
+| destination | `str \| None` | `None` | Target filter: a [`DestGroup`](#destgroup) value, domain, CIDR range, domain suffix (prefixed with `"."`), or `"*"` for any |
+| protocol | [`Protocol`](#protocol) ` \| None` | `None` | Protocol filter |
+| port | `int \| str \| None` | `None` | Single port (`443`) or range (`"8000-9000"`) |
+
+---
+
+#### Rule.allow()
+
+```python
+@classmethod
+def allow(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that permits matching traffic.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| direction | [`Direction`](#direction) | `Direction.EGRESS` | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | `None` | Protocol filter |
+| port | `int \| str \| None` | `None` | Port or port range |
+| destination | `str \| None` | `None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | An allow rule |
+
+---
+
+#### Rule.deny()
+
+```python
+@classmethod
+def deny(
+    *,
+    direction: Direction = Direction.EGRESS,
+    protocol: Protocol | None = None,
+    port: int | str | None = None,
+    destination: str | None = None,
+) -> Rule
+```
+
+Create a rule that blocks matching traffic.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| direction | [`Direction`](#direction) | `Direction.EGRESS` | Traffic direction |
+| protocol | [`Protocol`](#protocol) ` \| None` | `None` | Protocol filter |
+| port | `int \| str \| None` | `None` | Port or port range |
+| destination | `str \| None` | `None` | Destination filter |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | A deny rule |
+
+---
+
+### TlsConfig
+
+Frozen dataclass for TLS interception settings within [`Network`](#network).
+
+```python
+TlsConfig(
+    bypass: tuple[str, ...] = (),
+    verify_upstream: bool = True,
+    intercepted_ports: tuple[int, ...] = (443,),
+    block_quic: bool = False,
+    ca_cert: str | None = None,
+    ca_key: str | None = None,
+    ca_cn: str | None = None,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| bypass | `tuple[str, ...]` | `()` | Domains to skip interception. Use for domains with certificate pinning. |
+| verify_upstream | `bool` | `True` | Verify upstream server certificates. Set to `False` only for self-signed servers. |
+| intercepted_ports | `tuple[int, ...]` | `(443,)` | TCP ports where TLS interception is active |
+| block_quic | `bool` | `False` | Block QUIC/HTTP3 (UDP) on intercepted ports, forcing TCP/TLS fallback |
+| ca_cert | `str \| None` | `None` | Path to a custom interception CA certificate PEM file |
+| ca_key | `str \| None` | `None` | Path to a custom interception CA private key PEM file |
+| ca_cn | `str \| None` | `None` | Common name for the generated interception CA |
+
+---
+
+### Action
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) for policy actions.
+
+| Value | Description |
+|-------|-------------|
+| `"allow"` | Permit the traffic |
+| `"deny"` | Drop the traffic silently |
+
+---
+
+### Direction
+
+String enum for traffic direction.
+
+| Value | Description |
+|-------|-------------|
+| `"egress"` | Traffic leaving the sandbox |
+| `"ingress"` | Traffic entering the sandbox (via published ports) |
+
+---
+
+### Protocol
+
+String enum for network protocols in policy rules.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP traffic |
+| `"udp"` | UDP traffic |
+| `"icmpv4"` | ICMPv4 traffic |
+| `"icmpv6"` | ICMPv6 traffic |
+
+---
+
+### PortProtocol
+
+String enum for port-level protocol selection.
+
+| Value | Description |
+|-------|-------------|
+| `"tcp"` | TCP port |
+| `"udp"` | UDP port |
+
+---
+
+### DestGroup
+
+String enum for well-known destination groups used in [`Rule.destination`](#rule).
+
+| Value | Description |
+|-------|-------------|
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`) |
+| `"private"` | Private/RFC 1918 addresses (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) |
+| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) |
+| `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -1,0 +1,589 @@
+---
+title: Sandbox
+description: Python SDK - Sandbox API reference
+icon: "cube"
+---
+
+See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
+
+## Static methods
+
+---
+
+#### Sandbox.create()
+
+```python
+@staticmethod
+async def create(name_or_config: str | dict, **kwargs) -> Sandbox
+```
+
+Create and boot a sandbox. The first argument is either a name (`str`) or a full config (`dict`). Keyword arguments provide individual config fields. Pulls the image if needed, boots the VM, starts the guest agent, and waits until it is ready to accept commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name_or_config | `str \| dict` | Sandbox name or full configuration dict |
+| image | `str \| ImageSource` | OCI image, local path, or disk image (required) |
+| cpus | `int` | Virtual CPUs (default `1`) |
+| memory | `int` | Guest memory in MiB (default `512`) |
+| workdir | `str` | Default working directory for commands |
+| shell | `str` | Shell for `shell()` calls (default `"/bin/sh"`) |
+| hostname | `str` | Guest hostname |
+| user | `str` | Default guest user |
+| entrypoint | `list[str]` | Override image entrypoint |
+| replace | `bool` | Replace existing sandbox with same name |
+| max_duration | `float` | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | Idle timeout in seconds |
+| env | `dict[str, str]` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | Image pull behavior |
+| log_level | `str \| LogLevel` | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | Private registry credentials |
+| volumes | `dict[str, dict]` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | Secret injection |
+| detached | `bool` | If `True`, sandbox survives after your process exits |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.create_with_progress()
+
+```python
+@staticmethod
+def create_with_progress(name_or_config: str | dict, **kwargs) -> PullSession
+```
+
+Same parameters as [`Sandbox.create()`](#sandboxcreate) but returns a [`PullSession`](#pullsession) that lets you track image pull progress before the sandbox is ready. This method is synchronous (not awaitable) -- the async work happens through the `PullSession`.
+
+**Parameters**
+
+Same as [`Sandbox.create()`](#sandboxcreate).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PullSession`](#pullsession) | Session for tracking pull progress and obtaining the final sandbox |
+
+---
+
+#### Sandbox.start()
+
+```python
+@staticmethod
+async def start(name: str, *, detached: bool = False) -> Sandbox
+```
+
+Restart a previously stopped sandbox. The VM reboots using the persisted configuration.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Name of a stopped sandbox |
+| detached | `bool` | If `True`, sandbox survives after your process exits (default `False`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Sandbox`](#instance-methods) | Running sandbox |
+
+---
+
+#### Sandbox.get()
+
+```python
+@staticmethod
+async def get(name: str) -> SandboxHandle
+```
+
+Get a handle to an existing sandbox (running or stopped). The handle provides status, configuration, and lifecycle control.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxHandle`](#sandboxhandle) | Handle with status and lifecycle control |
+
+---
+
+#### Sandbox.list()
+
+```python
+@staticmethod
+async def list() -> list[SandboxHandle]
+```
+
+List all sandboxes (running, stopped, and crashed).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`SandboxHandle`](#sandboxhandle)`]` | All sandboxes |
+
+---
+
+#### Sandbox.remove()
+
+```python
+@staticmethod
+async def remove(name: str) -> None
+```
+
+Delete a stopped sandbox and all its state from disk. Fails if the sandbox is still running.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Sandbox name |
+
+---
+
+## Instance properties
+
+---
+
+#### name
+
+```python
+@property
+async def name(self) -> str
+```
+
+Sandbox name. This is an async property -- use `await sb.name`.
+
+---
+
+#### owns_lifecycle
+
+```python
+@property
+async def owns_lifecycle(self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `True` in attached mode, `False` in detached mode. This is an async property -- use `await sb.owns_lifecycle`.
+
+---
+
+#### fs
+
+```python
+@property
+def fs(self) -> SandboxFs
+```
+
+Get a filesystem handle for reading and writing files inside the running sandbox. This is a synchronous property -- use `sb.fs` (no `await`). See [Filesystem](/sdk/python/filesystem) for the full API.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxFs`](/sdk/python/filesystem) | Filesystem handle |
+
+---
+
+## Instance methods
+
+---
+
+#### attach()
+
+```python
+async def attach(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> int
+```
+
+Bridge your terminal directly to a process inside the sandbox for a fully interactive PTY session.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to run |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or execution options |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code of the process |
+
+---
+
+#### attach_shell()
+
+```python
+async def attach_shell() -> int
+```
+
+Attach to the sandbox's default shell.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `int` | Exit code |
+
+---
+
+#### detach()
+
+```python
+async def detach() -> None
+```
+
+Release the handle without stopping the sandbox. Reconnect later with [`Sandbox.get()`](#sandboxget).
+
+---
+
+#### drain()
+
+```python
+async def drain() -> None
+```
+
+Start a graceful drain (SIGUSR1). Existing commands run to completion, new `exec` calls are rejected.
+
+---
+
+#### exec()
+
+```python
+async def exec(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecOutput
+```
+
+Run a command inside the sandbox and wait for it to complete. Collects all stdout and stderr into memory and returns them along with the exit code. For long-running processes or large output, use [`exec_stream()`](#exec_stream) instead.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute (e.g. `"python"`, `"/usr/bin/node"`) |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments (e.g. `["-c", "print('hello')"]`) or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### exec_stream()
+
+```python
+async def exec_stream(cmd: str, args_or_options: list[str] | ExecOptions | None = None) -> ExecHandle
+```
+
+Run a command with streaming output. Returns a handle that emits stdout, stderr, and exit events as they happen, rather than buffering everything.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `str` | Command to execute |
+| args_or_options | `list[str] \| ExecOptions \| None` | Command arguments or [`ExecOptions`](/sdk/python/execution#execoptions) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle for receiving events and controlling the process |
+
+---
+
+#### kill()
+
+```python
+async def kill() -> None
+```
+
+Force-terminate the sandbox immediately (SIGKILL). No graceful shutdown.
+
+---
+
+#### metrics()
+
+```python
+async def metrics() -> SandboxMetrics
+```
+
+Get a point-in-time snapshot of the sandbox's resource usage.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxMetrics`](#sandboxmetrics) | CPU, memory, disk, network metrics |
+
+---
+
+#### metrics_stream()
+
+```python
+async def metrics_stream(interval: float = 1.0) -> MetricsStream
+```
+
+Stream resource metrics at a regular interval. The returned stream supports both `recv()` and `async for`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| interval | `float` | Seconds between metric snapshots (default `1.0`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`MetricsStream`](#metricsstream) | Async stream of metrics |
+
+---
+
+#### remove_persisted()
+
+```python
+async def remove_persisted() -> None
+```
+
+Remove the sandbox and all its persisted state from disk.
+
+---
+
+#### shell()
+
+```python
+async def shell(script: str) -> ExecOutput
+```
+
+Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Shell syntax like pipes, redirects, and `&&` chains works.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string (e.g. `"ls -la /app && echo done"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecOutput`](/sdk/python/execution#execoutput) | Collected stdout, stderr, and exit status |
+
+---
+
+#### shell_stream()
+
+```python
+async def shell_stream(script: str) -> ExecHandle
+```
+
+Shell command with streaming output.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| script | `str` | Shell command string |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`ExecHandle`](/sdk/python/execution#exechandle) | Streaming handle |
+
+---
+
+#### stop()
+
+```python
+async def stop() -> None
+```
+
+Gracefully shut down the sandbox (SIGTERM).
+
+---
+
+#### stop_and_wait()
+
+```python
+async def stop_and_wait() -> tuple[int, bool]
+```
+
+Stop the sandbox and wait for the exit status.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+#### wait()
+
+```python
+async def wait() -> tuple[int, bool]
+```
+
+Block until the sandbox exits on its own.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `tuple[int, bool]` | `(exit_code, success)` -- `success` is `True` if exit code is `0` |
+
+---
+
+## Context manager
+
+```python
+async with await Sandbox.create("my-sandbox", image="alpine") as sb:
+    output = await sb.shell("echo hello")
+    print(output.stdout_text)
+# sandbox is automatically killed and removed on exit
+```
+
+Use `Sandbox` as an async context manager to ensure cleanup. On exit, the sandbox is killed and its persisted state is removed.
+
+---
+
+## Types
+
+### LogLevel
+
+Sandbox process log verbosity.
+
+| Value | Description |
+|-------|-------------|
+| `"debug"` | Debug and higher |
+| `"error"` | Errors only |
+| `"info"` | Info and higher |
+| `"trace"` | Most verbose -- all diagnostic output |
+| `"warn"` | Warnings and errors only |
+
+### MetricsStream
+
+Async stream for receiving periodic metrics snapshots.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `__aiter__` | `AsyncIterator[`[`SandboxMetrics`](#sandboxmetrics)`]` | Use with `async for` |
+| `recv()` | [`SandboxMetrics`](#sandboxmetrics) `\| None` | Receive next snapshot. Returns `None` when the stream ends. |
+
+### PullPolicy
+
+Controls when the SDK fetches an OCI image from the registry.
+
+| Value | Description |
+|-------|-------------|
+| `"always"` | Pull the image every time, even if cached locally |
+| `"if-missing"` | Pull only if the image is not already cached. This is the default. |
+| `"never"` | Never pull; fail if the image is not cached locally |
+
+### PullSession
+
+Returned by [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress). Use as an async context manager to track image pull progress.
+
+```python
+session = Sandbox.create_with_progress("my-sandbox", image="ubuntu:latest")
+async with session:
+    async for event in session.progress:
+        print(event)
+    sb = await session.result()
+```
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| progress | `AsyncIterator[PullProgress]` | Async iterator of pull progress events |
+| result() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Await to get the final running sandbox |
+
+### RegistryAuth
+
+Private registry credentials.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| username | `str` | Registry username |
+| password | `str` | Registry password |
+
+### SandboxConfig
+
+The keyword arguments accepted by [`Sandbox.create()`](#sandboxcreate) and [`Sandbox.create_with_progress()`](#sandboxcreate_with_progress).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| image | `str \| ImageSource` | - | OCI image, local path, or disk image (required) |
+| cpus | `int` | `1` | Virtual CPUs |
+| memory | `int` | `512` | Guest memory in MiB. This is a limit, not a reservation. |
+| workdir | `str` | - | Default working directory for commands |
+| shell | `str` | `"/bin/sh"` | Shell for `shell()` calls |
+| hostname | `str` | - | Guest hostname |
+| user | `str` | - | Default guest user |
+| entrypoint | `list[str]` | - | Override image entrypoint |
+| replace | `bool` | `False` | Replace existing sandbox with same name |
+| max_duration | `float` | - | Maximum sandbox lifetime in seconds |
+| idle_timeout | `float` | - | Idle timeout in seconds |
+| env | `dict[str, str]` | `{}` | Environment variables visible to all commands |
+| scripts | `dict[str, str]` | `{}` | Named scripts mounted at `/.msb/scripts/` |
+| pull_policy | `str \| PullPolicy` | `"if-missing"` | Image pull behavior |
+| log_level | `str \| LogLevel` | - | Override log verbosity |
+| registry_auth | [`RegistryAuth`](#registryauth) | - | Private registry credentials |
+| volumes | `dict[str, dict]` | `{}` | Volume mounts. See [Volumes](/sdk/python/volumes). |
+| patches | `list[PatchConfig]` | `[]` | Rootfs modifications applied before boot |
+| ports | `dict[int, int]` | `{}` | Port mappings (`host_port: guest_port`) |
+| network | [`Network`](/sdk/python/networking#network) | `public_only` | Network policy and configuration |
+| secrets | `list[`[`SecretEntry`](/sdk/python/secrets#secretentry)`]` | `[]` | Secret injection |
+| detached | `bool` | `False` | If `True`, sandbox survives after your process exits |
+
+### SandboxHandle
+
+A lightweight handle to an existing sandbox (running or stopped). Obtained via [`Sandbox.get()`](#sandboxget) or [`Sandbox.list()`](#sandboxlist). Provides status, configuration, and lifecycle control **without** an active connection to the guest agent. Call `.start()` or `.connect()` to upgrade to a full [`Sandbox`](#instance-methods).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Sandbox name |
+| status | `str` | Current status (`"running"`, `"stopped"`, `"crashed"`, `"draining"`, `"paused"`) |
+| config_json | `str` | Raw JSON configuration |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| updated_at | `float \| None` | Last update timestamp (ms since epoch) |
+| connect() | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox |
+| start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
+| stop() | `Awaitable[None]` | Graceful shutdown |
+| kill() | `Awaitable[None]` | Force terminate |
+| remove() | `Awaitable[None]` | Delete sandbox and state |
+| metrics() | `Awaitable[`[`SandboxMetrics`](#sandboxmetrics)`]` | Point-in-time resource metrics |
+
+### SandboxMetrics
+
+Point-in-time resource usage snapshot.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cpu_percent | `float` | CPU usage as a percentage |
+| disk_read_bytes | `int` | Total bytes read from disk since boot |
+| disk_write_bytes | `int` | Total bytes written to disk since boot |
+| memory_bytes | `int` | Current memory usage in bytes |
+| memory_limit_bytes | `int` | Memory limit in bytes |
+| net_rx_bytes | `int` | Total bytes received over the network since boot |
+| net_tx_bytes | `int` | Total bytes sent over the network since boot |
+| timestamp_ms | `float` | When this measurement was taken (ms since epoch) |
+| uptime_ms | `int` | Time since the sandbox was created (ms) |

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -1,0 +1,77 @@
+---
+title: Secrets
+description: Python SDK - Secret injection API reference
+icon: "key"
+---
+
+See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
+
+## Secret
+
+Static factory for creating secret entries used in `SandboxConfig.secrets`.
+
+---
+
+#### Secret.env()
+
+```python
+@staticmethod
+def env(
+    env_var: str,
+    *,
+    value: str,
+    allow_hosts: Sequence[str] = (),
+    allow_host_patterns: Sequence[str] = (),
+    placeholder: str | None = None,
+    require_tls: bool = True,
+    on_violation: ViolationAction = ViolationAction.BLOCK_AND_LOG,
+) -> SecretEntry
+```
+
+Create a secret entry that maps an environment variable to a real value. The guest sees a placeholder - the real value is only substituted by the TLS proxy when traffic goes to an allowed host.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| env_var | `str` | - | Environment variable name (e.g. `"OPENAI_API_KEY"`) |
+| value | `str` | - | The real secret value. Never enters the guest VM. **Required.** |
+| allow_hosts | `Sequence[str]` | `()` | Hosts allowed to receive the real value (exact match). The TLS proxy matches against the SNI. |
+| allow_host_patterns | `Sequence[str]` | `()` | Wildcard host patterns (e.g. `"*.googleapis.com"`) |
+| placeholder | `str \| None` | `None` | Custom placeholder string. Auto-generated as `$MSB_<env_var>` if not set. |
+| require_tls | `bool` | `True` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
+| on_violation | [`ViolationAction`](#violationaction) | `BLOCK_AND_LOG` | Action when the placeholder is sent to a disallowed host |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SecretEntry`](#secretentry) | Secret entry for `SandboxConfig.secrets` |
+
+---
+
+## Types
+
+### SecretEntry
+
+Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| env_var | `str` | Environment variable name |
+| value | `str` | Secret value |
+| allow_hosts | `tuple[str, ...]` | Allowed hosts (exact match) |
+| allow_host_patterns | `tuple[str, ...]` | Wildcard patterns |
+| placeholder | `str \| None` | Placeholder string |
+| require_tls | `bool` | TLS requirement |
+| on_violation | [`ViolationAction`](#violationaction) | Violation action |
+
+### ViolationAction
+
+String enum ([`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)) defining the action taken when a secret placeholder is sent to a disallowed host.
+
+| Value | Description |
+|-------|-------------|
+| `"block"` | Silently drop the request. The guest sees a connection reset. |
+| `"block-and-log"` | Drop the request and emit a warning log on the host side. This is the default. |
+| `"block-and-terminate"` | Drop the request, log an error, and shut down the entire sandbox. |

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -1,0 +1,11 @@
+---
+title: Snapshots
+description: Python SDK - Snapshot API reference
+icon: "code-branch"
+---
+
+<Note>
+  Snapshots are coming soon and not yet available in the current SDK.
+</Note>
+
+See [Snapshots](/sandboxes/snapshots) for a preview of snapshot concepts and planned API.

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -1,0 +1,375 @@
+---
+title: Volumes
+description: Python SDK - Volume API reference
+icon: "hard-drive"
+---
+
+See [Volumes](/sandboxes/volumes) for usage examples and patterns.
+
+## Volume
+
+Named volumes are managed by microsandbox and stored at `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox.
+
+## Static methods
+
+---
+
+#### Volume.create()
+
+```python
+async def Volume.create(
+    name: str,
+    *,
+    quota_mib: int | None = None,
+    labels: dict[str, str] | None = None,
+) -> Volume
+```
+
+Create a new named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name (required) |
+| quota_mib | `int \| None` | Maximum storage size in MiB |
+| labels | `dict[str, str] \| None` | Metadata labels |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Volume` | Created volume with `name` and `path` properties |
+
+---
+
+#### Volume.get()
+
+```python
+async def Volume.get(name: str) -> VolumeHandle
+```
+
+Get a handle to an existing named volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeHandle`](#volumehandle) | Volume handle |
+
+---
+
+#### Volume.list()
+
+```python
+async def Volume.list() -> list[VolumeHandle]
+```
+
+List all named volumes.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`VolumeHandle`](#volumehandle)`]` | All volumes |
+
+---
+
+#### Volume.remove()
+
+```python
+async def Volume.remove(name: str) -> None
+```
+
+Delete a named volume and its contents. Fails if the volume is currently mounted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+
+---
+
+## Volume instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | `str` | Volume name |
+| path | `str` | Host path to the volume directory |
+
+---
+
+## Mount config factories
+
+Static factory methods on `Volume` for creating mount configurations used in sandbox volume config.
+
+---
+
+#### Volume.bind()
+
+```python
+def Volume.bind(path: str, *, readonly: bool = False) -> dict
+```
+
+Mount a host directory into the sandbox. Changes in the guest are reflected on the host and vice versa.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Directory path on the host |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.named()
+
+```python
+def Volume.named(name: str, *, readonly: bool = False) -> dict
+```
+
+Mount a named volume. The volume must already exist (create it with [`Volume.create()`](#volumecreate)).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `str` | Volume name |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+#### Volume.tmpfs()
+
+```python
+def Volume.tmpfs(*, size_mib: int | None = None, readonly: bool = False) -> dict
+```
+
+Use an in-memory filesystem. Contents are discarded when the sandbox stops.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size_mib | `int \| None` | Maximum size in MiB |
+| readonly | `bool` | Mount as read-only |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `dict` | Mount configuration dictionary |
+
+---
+
+## VolumeHandle
+
+Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Volume name |
+| quota_mib | `int \| None` | Storage quota in MiB |
+| used_bytes | `int` | Current disk usage in bytes |
+| labels | `dict[str, str]` | Metadata labels |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| remove() | *(async)* `None` | Delete this volume |
+
+---
+
+## VolumeFs
+
+Host-side filesystem operations on a named volume. Obtained via the `fs` property on [`VolumeHandle`](#volumehandle). These operations run directly on the host filesystem - no running sandbox is required.
+
+---
+
+#### read()
+
+```python
+async def read(path: str) -> bytes
+```
+
+Read the entire contents of a file as raw bytes.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bytes` | File contents as raw bytes |
+
+---
+
+#### read_text()
+
+```python
+async def read_text(path: str) -> str
+```
+
+Read the entire contents of a file and decode as UTF-8.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `str` | File contents as a string |
+
+---
+
+#### write()
+
+```python
+async def write(path: str, data: bytes) -> None
+```
+
+Write content to a file, creating it if it doesn't exist and overwriting if it does.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+| data | `bytes` | File content |
+
+---
+
+#### list()
+
+```python
+async def list(path: str) -> list[FsEntry]
+```
+
+List the entries in a directory.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `list[`[`FsEntry`](/sdk/python/filesystem#fsentry)`]` | Directory entries |
+
+---
+
+#### mkdir()
+
+```python
+async def mkdir(path: str) -> None
+```
+
+Create a directory and all parent directories.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### remove_file()
+
+```python
+async def remove_file(path: str) -> None
+```
+
+Remove a file.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+---
+
+#### exists()
+
+```python
+async def exists(path: str) -> bool
+```
+
+Check whether a path exists within the volume.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `str` | Path relative to the volume root |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the path exists |
+
+---
+
+## Types
+
+### MountConfig
+
+Frozen dataclass representing a mount configuration.
+
+```python
+MountConfig(
+    kind: MountKind,
+    bind: str | None = None,
+    named: str | None = None,
+    size_mib: int | None = None,
+    readonly: bool = False,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| kind | [`MountKind`](#mountkind) | - | Type of mount (required) |
+| bind | `str \| None` | `None` | Host path for bind mounts |
+| named | `str \| None` | `None` | Volume name for named mounts |
+| size_mib | `int \| None` | `None` | Size limit for tmpfs mounts |
+| readonly | `bool` | `False` | Whether the mount is read-only |
+
+### MountKind
+
+String enum representing the type of mount.
+
+| Value | Description |
+|-------|-------------|
+| `"bind"` | Host bind mount |
+| `"named"` | Named volume mount |
+| `"tmpfs"` | In-memory filesystem |


### PR DESCRIPTION
## Summary
- Add Python code examples alongside Rust and TypeScript in all 73 CodeGroup blocks across 18 documentation guide pages (quickstart, sandboxes, networking, images, SDK overview, errors)
- Create 8 new Python SDK API reference pages under `docs/sdk/python/` covering Sandbox, Execution, Filesystem, Volumes, Networking, Secrets, Snapshots, and Events
- Update `docs.json` navigation to include the Python SDK group in the SDK Reference tab
- Update cross-reference links in secrets and SDK overview pages to include links to the new Python SDK reference

All Python snippets were verified against the actual PyO3 bindings in `sdk/python/src/*.rs`, the Python type definitions in `sdk/python/microsandbox/types.py`, and the working examples in `examples/python/`. Features marked "coming soon" (snapshots, events, filesystem hooks, custom backends) use placeholder stubs consistent with the existing Rust and TypeScript patterns.

## Test Plan
- [x] Verify all 8 new Python SDK reference pages are reachable in the Mintlify navigation under SDK Reference > Python SDK
- [x] Spot-check Python code snippets against actual SDK usage in `examples/python/` (e.g., `root-oci/main.py`, `net-secrets/main.py`, `volume-named/main.py`)
- [x] Verify CodeGroup tabs render correctly with Rust, TypeScript, Python, and CLI tabs where applicable
- [x] Confirm `docs.json` is valid JSON and all referenced page paths resolve to existing `.mdx` files
- [x] Check that cross-reference links from guide pages to Python SDK reference pages resolve correctly (e.g., `/sdk/python/secrets`, `/sdk/python/sandbox`)