### PR TITLE
fix(ci): install dbus-devel in manylinux container for Python wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
           command: build
           args: --release --out dist
           manylinux: ${{ matrix.os == 'linux' && '2_28' || 'off' }}
+          before-script-linux: dnf install -y dbus-devel
 
       - name: Upload Python SDK wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- The v0.3.13 release CI fails on both linux-x86_64 and linux-aarch64 when building the Python SDK wheel
- The `libdbus-sys` crate (pulled in via `keyring -> dbus-secret-service -> dbus`) requires the `dbus-1` system library headers at compile time
- The host runner installs `libdbus-1-dev`, but maturin builds Python wheels inside an isolated manylinux_2_28 Docker container that lacks this dependency
- Add `before-script-linux: dnf install -y dbus-devel` to the maturin-action step so the library is available inside the container during compilation

## Verification
- Reproduced the failure locally by running `cargo build` for `sdk/python` inside a `quay.io/pypa/manylinux_2_28_aarch64` container without `dbus-devel` — same `libdbus-sys` panic as CI
- Confirmed the build gets past `libdbus-sys` after running `dnf install -y dbus-devel` in the same container
- After merging, re-trigger the v0.3.13 release to confirm end-to-end