### PR TITLE
fix(ci): detect CI env inside maturin Docker containers

### DIFF
--- a/crates/filesystem/build.rs
+++ b/crates/filesystem/build.rs
@@ -30,7 +30,9 @@ fn build_agentd(workspace_root: &Path, out_dir: &Path) {
         }
 
         // In CI, prefer the locally-built agentd from workspace build/.
-        if std::env::var_os("CI").is_some() {
+        // Check both CI (standard) and GITHUB_ACTIONS (set inside maturin Docker containers
+        // where CI is not forwarded).
+        if std::env::var_os("CI").is_some() || std::env::var_os("GITHUB_ACTIONS").is_some() {
             let local = workspace_root.join("build").join(AGENTD_BINARY);
             if local.is_file() {
                 std::fs::copy(&local, &dest).expect("failed to copy agentd from build/");


### PR DESCRIPTION
## Summary
- The `microsandbox-filesystem` build script checks the `CI` env var to decide whether to use a locally-built `agentd` binary or download it from a GitHub release
- The maturin-action runs `cargo build` inside a manylinux_2_28 Docker container that forwards `GITHUB_ACTIONS` but not `CI`, causing the local file check to be skipped
- This results in the build attempting to download `agentd` from a release URL that doesn't exist yet during the release workflow, failing with a 404
- The fix adds `GITHUB_ACTIONS` as a fallback check alongside `CI` in `crates/filesystem/build.rs`

## Verification
- Confirmed `CI` is absent from the env vars forwarded to the maturin Docker container by inspecting the `docker run` command in the failed release workflow logs
- Confirmed `GITHUB_ACTIONS` is present in the forwarded env vars
- After merging, re-trigger the v0.3.13 release to verify end-to-end