### PR TITLE
fix(ci): add GITHUB_ACTIONS fallback for remaining CI env checks

### DIFF
--- a/crates/microsandbox/build.rs
+++ b/crates/microsandbox/build.rs
@@ -133,7 +133,7 @@ fn install_ci_local_bundle(
     lib_dir: &Path,
     libkrunfw_name: &str,
 ) -> io::Result<bool> {
-    if std::env::var_os("CI").is_none() {
+    if std::env::var_os("CI").is_none() && std::env::var_os("GITHUB_ACTIONS").is_none() {
         return Ok(false);
     }
 

--- a/crates/microsandbox/lib/setup/download.rs
+++ b/crates/microsandbox/lib/setup/download.rs
@@ -231,7 +231,7 @@ async fn install_ci_local_bundle(
     lib_dir: &Path,
     libkrunfw_name: &str,
 ) -> MicrosandboxResult<bool> {
-    if std::env::var_os("CI").is_none() {
+    if std::env::var_os("CI").is_none() && std::env::var_os("GITHUB_ACTIONS").is_none() {
         return Ok(false);
     }
 


### PR DESCRIPTION
## Summary
- The previous fix (#556) only patched `crates/filesystem/build.rs` for the `GITHUB_ACTIONS` env var fallback
- The same `CI` env detection issue exists in `crates/microsandbox/build.rs` and `crates/microsandbox/lib/setup/download.rs`, causing the msb + libkrunfw bundle download to 404 inside the maturin Docker container
- This adds the same `GITHUB_ACTIONS` fallback to both remaining `install_ci_local_bundle` functions so locally-built artifacts are used instead of downloading from unreleased GitHub assets

## Verification
- Confirmed from the v0.3.13 release logs that `microsandbox/build.rs:68` panics with `StatusCode(404)` on both linux-x86_64 and linux-aarch64
- The previous fix for `crates/filesystem/build.rs` validated the approach; this applies the same pattern to the remaining two locations
- After merging, re-trigger the v0.3.13 release to verify end-to-end