### PR TITLE
fix(ci): install libcap-ng-devel in maturin container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
           command: build
           args: --release --out dist
           manylinux: ${{ matrix.os == 'linux' && '2_28' || 'off' }}
-          before-script-linux: dnf install -y dbus-devel
+          before-script-linux: dnf install -y dbus-devel libcap-ng-devel
 
       - name: Upload Python SDK wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- The Python wheel link step fails with `unable to find library -lcap-ng` on both linux-x86_64 and linux-aarch64
- The `libcap-ng` development library is installed on the host runner but not inside the manylinux_2_28 Docker container where maturin runs `cargo build`
- Add `libcap-ng-devel` to the `before-script-linux` alongside `dbus-devel` so linking succeeds inside the container

## Verification
- Confirmed the linker error from the latest v0.3.13 release run logs: `rust-lld: error: unable to find library -lcap-ng`
- The manylinux_2_28 container is AlmaLinux-based, so `libcap-ng-devel` is the correct package name
- After merging, re-trigger the v0.3.13 release to verify end-to-end