### PR TITLE
build: use vendored dbus

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -121,7 +121,7 @@ jobs:
       # -- Linux build deps --
       - name: Install build deps (Linux)
         if: matrix.os == 'linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y musl-tools libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools
 
       # -- agentd (Linux: native musl) --
       - name: Build agentd (musl)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
           command: build
           args: --release --out dist
           manylinux: ${{ matrix.os == 'linux' && '2_28' || 'off' }}
-          before-script-linux: dnf install -y dbus-devel libcap-ng-devel
+          before-script-linux: dnf install -y libcap-ng-devel
 
       - name: Upload Python SDK wheel
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       # -- Linux build deps --
       - name: Install build deps (Linux)
         if: matrix.os == 'linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y musl-tools libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools
 
       # -- agentd (Linux: native musl) --
       - name: Build agentd (musl)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
       # -- Linux build deps --
       - name: Install build deps (Linux)
         if: matrix.os == 'linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y musl-tools libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools
 
       # -- agentd (Linux: native musl) --
       - name: Build agentd (musl)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -2564,6 +2565,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crossterm",
+ "dbus",
  "dirs",
  "docker_credential",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ clap = { version = "4.5", features = ["color", "derive"] }
 console = "0.16"
 crossbeam-queue = "0.3"
 crossterm = { version = "0.29.0", features = ["events"] }
+dbus = { version = "0.9", features = ["vendored"] }
 dirs = "6.0"
 etherparse = "0.19"
 flate2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ clap = { version = "4.5", features = ["color", "derive"] }
 console = "0.16"
 crossbeam-queue = "0.3"
 crossterm = { version = "0.29.0", features = ["events"] }
-dbus = { version = "0.9", features = ["vendored"] }
 dirs = "6.0"
 etherparse = "0.19"
 flate2 = "1.0"

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -67,5 +67,7 @@ keyring = { version = "3.6.3", features = ["apple-native"] }
 keyring = { version = "3.6.3", features = ["windows-native"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dbus = { version = "0.9.10", features = ["vendored"]}
+# Transitive dep via keyring's Secret Service backend; declared here only to force the `vendored` feature
+# so libdbus is built from source and statically linked (avoids needing libdbus-1-dev at build time).
+dbus = { version = "0.9.10", features = ["vendored"] }
 keyring = { version = "3.6.3", features = ["linux-native-sync-persistent", "crypto-rust"] }

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -67,5 +67,5 @@ keyring = { version = "3.6.3", features = ["apple-native"] }
 keyring = { version = "3.6.3", features = ["windows-native"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dbus = { version = "0.9", features = ["vendored"]}
+dbus = { version = "0.9.10", features = ["vendored"]}
 keyring = { version = "3.6.3", features = ["linux-native-sync-persistent", "crypto-rust"] }

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -24,6 +24,7 @@ net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
 bytes.workspace = true
 chrono.workspace = true
 crossterm.workspace = true
+dbus.workspace = true
 docker_credential = "1.3.2"
 dirs.workspace = true
 flate2.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -24,7 +24,6 @@ net = ["dep:microsandbox-network", "microsandbox-runtime/net"]
 bytes.workspace = true
 chrono.workspace = true
 crossterm.workspace = true
-dbus.workspace = true
 docker_credential = "1.3.2"
 dirs.workspace = true
 flate2.workspace = true
@@ -68,4 +67,5 @@ keyring = { version = "3.6.3", features = ["apple-native"] }
 keyring = { version = "3.6.3", features = ["windows-native"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+dbus = { version = "0.9", features = ["vendored"]}
 keyring = { version = "3.6.3", features = ["linux-native-sync-persistent", "crypto-rust"] }

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ _install-dev-deps:
 
     echo "==> Installing system dependencies..."
     sudo apt install build-essential musl-tools flex bison libelf-dev \
-        python3-pyelftools pkg-config libdbus-1-dev libcap-ng-dev pre-commit
+        python3-pyelftools pkg-config libcap-ng-dev pre-commit
 
     echo "==> Checking Rust toolchain..."
     if ! command -v rustup &>/dev/null; then

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 ARG TARGETARCH
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libdbus-1-3 \
+    && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY build/${TARGETARCH}/msb /usr/local/bin/msb


### PR DESCRIPTION
Explicitly use dbus crate and add the `vendored` feature, so that we do not need to install dbus using system package manager.