### PR TITLE
feat(sdk): add microsandbox CLI entry points for cargo/npx/pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,20 @@
 
 #### <img height="14" src="https://octicons-col.vercel.app/download/A770EF">&nbsp;&nbsp;Install the CLI **(Optional)**
 
+> Boot a  microVM in one command.
+>
+> ```sh
+> npx microsandbox run debian
+> ```
+>
+> Or install the `msb` command globally:
+>
 > ```sh
 > curl -fsSL https://install.microsandbox.dev | sh
+> ```
+>
+> ```sh
+> msb run debian
 > ```
 
 ##

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="https://github.com/superradcompany/microsandbox/releases"><img src="https://img.shields.io/github/v/release/superradcompany/microsandbox?include_prereleases&style=for-the-badge" alt="GitHub release"></a>
   <a href="https://discord.gg/T95Y3XnEAK"><img src="https://img.shields.io/discord/1315784565562019870?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache 2.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License"></a>
+  <a href="https://www.ycombinator.com/"><img src="https://img.shields.io/badge/BACKED%20BY-Y%20COMBINATOR-F26522?style=for-the-badge&logo=ycombinator&logoColor=white" alt="Backed by Y Combinator"></a>
 </div>
 
 <br />

--- a/crates/cli/lib/commands/registry.rs
+++ b/crates/cli/lib/commands/registry.rs
@@ -162,7 +162,7 @@ fn run_list(_args: RegistryListArgs) -> anyhow::Result<()> {
     }
 
     let mut entries: Vec<_> = config.registries.auth.iter().collect();
-    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    entries.sort_by_key(|(name, _)| *name);
 
     let mut table = ui::Table::new(&["REGISTRY", "USERNAME", "SOURCE"]);
     for (registry, entry) in entries {

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -11,6 +11,10 @@ edition.workspace = true
 name = "microsandbox"
 path = "lib/lib.rs"
 
+[[bin]]
+name = "microsandbox"
+path = "bin/main.rs"
+
 [features]
 default = ["prebuilt", "net"]
 prebuilt = ["microsandbox-filesystem/prebuilt", "microsandbox-runtime/prebuilt"]

--- a/crates/microsandbox/bin/main.rs
+++ b/crates/microsandbox/bin/main.rs
@@ -1,0 +1,63 @@
+//! Thin shim that forwards all arguments to the installed `msb` binary.
+//!
+//! Resolution order:
+//! 1. `MSB_PATH` environment variable
+//! 2. `~/.microsandbox/bin/msb` (populated by `build.rs`)
+
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn main() -> ExitCode {
+    let msb = match resolve_msb() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "microsandbox: msb binary not found. Set MSB_PATH or ensure \
+                 ~/.microsandbox/bin/msb exists."
+            );
+            return ExitCode::from(127);
+        }
+    };
+
+    let args: Vec<_> = env::args_os().skip(1).collect();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = Command::new(&msb).args(&args).exec();
+        eprintln!("microsandbox: failed to exec {}: {err}", msb.display());
+        ExitCode::from(127)
+    }
+
+    #[cfg(not(unix))]
+    {
+        match Command::new(&msb).args(&args).status() {
+            Ok(status) => ExitCode::from(status.code().unwrap_or(1) as u8),
+            Err(err) => {
+                eprintln!("microsandbox: failed to run {}: {err}", msb.display());
+                ExitCode::from(127)
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+fn resolve_msb() -> Option<PathBuf> {
+    if let Ok(path) = env::var("MSB_PATH") {
+        return Some(PathBuf::from(path));
+    }
+    let home = env::var("HOME").ok()?;
+    let path = PathBuf::from(home)
+        .join(".microsandbox")
+        .join("bin")
+        .join("msb");
+    path.is_file().then_some(path)
+}

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -72,7 +72,7 @@ sb = await Sandbox.create(
 
 ## The basics
 
-- **Under 100ms boot.** Sandboxes boot in under 100 milliseoconds.
+- **Under 100ms boot.** Sandboxes boot in under 100 milliseconds.
 - **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root, no server, no background service.
 - **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
 - **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -72,8 +72,8 @@ sb = await Sandbox.create(
 
 ## The basics
 
-- **Under 100ms boot.** Sandboxes share the same kernel in memory. No QEMU, no disk images to load.
-- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root process, no socket, no background service.
+- **Under 100ms boot.** Sandboxes boot in under 100 milliseoconds.
+- **No daemon.** The runtime spawns directly as a child process of whatever application creates the sandbox. No root, no server, no background service.
 - **Any OCI image.** Docker Hub, GHCR, ECR, GCR, or any OCI-compatible registry. Shared layers are deduplicated and only stored once.
 - **Cross-platform.** Native on macOS (Apple Silicon) and Linux (KVM). Same CLI, same SDKs.
 - **Multi-language SDKs.** Rust, TypeScript, and Python, all with consistent APIs.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -8,6 +8,14 @@ icon: "bolt"
   microsandbox requires **Linux with KVM** enabled, or **macOS with Apple Silicon** (M-series chip). Both use hardware virtualization.
 </Note>
 
+<Tip>
+  Boot a microVM in one command.
+
+  ```bash
+  npx microsandbox run debian
+  ```
+</Tip>
+
 <Steps>
   <Step title="Install microsandbox">
     The SDK **embeds the runtime directly**, so no separate server process is needed. Only install the `msb` CLI if you want to manage images, volumes, and sandboxes from the terminal.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -402,6 +402,10 @@ main() {
     mkdir -p "$BIN_DIR"
     install -m 755 msb "$BIN_DIR/msb"
 
+    # Also expose the binary as `microsandbox` so users can invoke it under
+    # either name (matches the entry point shipped by the SDK packages).
+    ln -sf msb "$BIN_DIR/microsandbox"
+
     # Install libkrunfw. Use install(1) on Linux (handles running binaries).
     # On macOS, cp+mv for a fresh inode — macOS caches code signatures on the
     # vnode, so overwriting a running library in-place can cause issues.
@@ -416,6 +420,7 @@ main() {
     fi
 
     success "Installed msb to $BIN_DIR/msb"
+    success "Linked microsandbox -> msb in $BIN_DIR/"
     success "Installed libkrunfw to $LIB_DIR/"
 
     # Configure shell environment

--- a/sdk/node-ts/bin/microsandbox.js
+++ b/sdk/node-ts/bin/microsandbox.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// Thin shim that forwards all arguments to the installed msb binary.
+//
+// Resolution order:
+//   1. MSB_PATH environment variable
+//   2. ~/.microsandbox/bin/msb (populated by postinstall.js)
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+function resolveMsb() {
+  if (process.env.MSB_PATH) return process.env.MSB_PATH;
+  const home = os.homedir();
+  if (!home) return null;
+  const p = path.join(home, ".microsandbox", "bin", "msb");
+  return fs.existsSync(p) ? p : null;
+}
+
+const msb = resolveMsb();
+if (!msb) {
+  console.error(
+    "microsandbox: msb binary not found. Set MSB_PATH or ensure ~/.microsandbox/bin/msb exists."
+  );
+  process.exit(127);
+}
+
+const result = spawnSync(msb, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`microsandbox: failed to run ${msb}: ${result.error.message}`);
+  process.exit(127);
+}
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+  process.exit(1);
+}
+process.exit(result.status ?? 0);

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -4,6 +4,9 @@
   "main": "index.cjs",
   "module": "index.mjs",
   "types": "index.d.cts",
+  "bin": {
+    "microsandbox": "bin/microsandbox.js"
+  },
   "napi": {
     "binaryName": "microsandbox",
     "packageName": "@superradcompany/microsandbox",
@@ -38,6 +41,7 @@
     "index.mjs",
     "index.d.cts",
     "postinstall.js",
+    "bin/microsandbox.js",
     "README.md"
   ]
 }

--- a/sdk/python/microsandbox/_cli.py
+++ b/sdk/python/microsandbox/_cli.py
@@ -1,0 +1,26 @@
+"""CLI entry point — execs the bundled msb binary.
+
+Resolution order:
+  1. ``MSB_PATH`` environment variable
+  2. Wheel-bundled ``microsandbox/_bundled/bin/msb``
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    override = os.environ.get("MSB_PATH")
+    msb = override or str(Path(__file__).parent / "_bundled" / "bin" / "msb")
+
+    if not os.path.isfile(msb):
+        sys.stderr.write(
+            f"microsandbox: msb binary not found at {msb}. "
+            "Set MSB_PATH or reinstall the package.\n"
+        )
+        sys.exit(127)
+
+    os.execv(msb, ["msb", *sys.argv[1:]])

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
 ]
 keywords = ["sandbox", "microvm", "isolation", "security", "vm"]
 
+[project.scripts]
+microsandbox = "microsandbox._cli:main"
+
 [project.urls]
 Homepage = "https://github.com/superradcompany/microsandbox"
 Documentation = "https://docs.microsandbox.dev"


### PR DESCRIPTION
## Summary
- Add a thin `microsandbox` executable to each of the three SDK packages (Rust, Node/TS, Python) that forwards all arguments to the installed `msb` binary.
- Makes `cargo install microsandbox`, `npx microsandbox`, `npm install -g microsandbox`, `pipx install microsandbox`, and `uvx microsandbox` all produce a working CLI, without requiring a separate `msb` install via the shell installer.
- Each shim honors `MSB_PATH` as an override, falling back to the location its own SDK already populates: `~/.microsandbox/bin/msb` for Rust/Node (written by `build.rs` / `postinstall.js`), and the wheel-bundled `microsandbox/_bundled/bin/msb` for Python.
- Motivation: users should be able to run the CLI via whichever package manager they already use for the SDK, rather than being told to run a curl-to-shell installer on top.

### Implementation notes
- Rust: adds `[[bin]] name = "microsandbox"` to `crates/microsandbox/Cargo.toml` with `bin/main.rs` that `exec`s the resolved `msb` on Unix (replacing the shim process) and falls back to spawn + exit-code passthrough on non-Unix.
- Node: adds `"bin": { "microsandbox": "bin/microsandbox.js" }` to `sdk/node-ts/package.json` and lists the shim in `files`. The shim uses `spawnSync` with `stdio: "inherit"`, re-raises received signals via `process.kill`, and exits with the child's status.
- Python: adds `[project.scripts] microsandbox = "microsandbox._cli:main"` to `sdk/python/pyproject.toml` with a new `microsandbox/_cli.py` that resolves `msb` via `MSB_PATH` or `Path(__file__).parent / "_bundled" / "bin" / "msb"` and `os.execv`s it.
- All three print a clear error and exit 127 when `msb` cannot be located.

## Test Plan
- [x] Rust: `cargo install --path crates/microsandbox --force` then `microsandbox --version` prints `msb <version>` and exits 0.
- [x] Rust: `microsandbox nonexistent-subcommand` propagates msb's exit code (non-zero).
- [x] Rust: `MSB_PATH=/tmp/does-not-exist microsandbox --version` prints the shim's error and exits 127.
- [x] Node: `cd sdk/node-ts && npm pack && npm install -g ./microsandbox-*.tgz` then `microsandbox --version` prints `msb <version>` and exits 0.
- [x] Node: unknown subcommand propagates exit code; bad `MSB_PATH` exits 127; Ctrl-C during a long-running `microsandbox run ...` terminates cleanly with no orphaned msb process.
- [x] Python: `cd sdk/python && maturin build --release` then `uvx --from ../../target/wheels/microsandbox-*.whl microsandbox --version` prints `msb <version>` and exits 0. Same for `pipx install ./microsandbox-*.whl`.
- [x] Python: unknown subcommand propagates exit code; bad `MSB_PATH` exits 127.
- [x] Library consumers unaffected: `cargo add microsandbox`, `npm install microsandbox`, and `pip install microsandbox` still work as before (no changes to library entry points or public API).