### PR TITLE
chore: bump version to 0.3.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "bytes",
  "chrono",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2625,14 +2625,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2670,14 +2670,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "bytes",
  "crossbeam-queue",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "bytes",
  "chrono",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "futures",
  "ipnetwork",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "bytes",
  "chrono",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "crc32c",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.3.13"
+version = "0.3.14"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.3.13"
+version = "0.3.14"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.3.13", path = "../protocol" }
+microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,11 +28,11 @@ console.workspace = true
 dirs.workspace = true
 indicatif.workspace = true
 libc.workspace = true
-microsandbox = { version = "0.3.13", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.3.13", path = "../image" }
-microsandbox-network = { version = "0.3.13", path = "../network", optional = true }
-microsandbox-runtime = { version = "0.3.13", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox = { version = "0.3.14", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.3.14", path = "../image" }
+microsandbox-network = { version = "0.3.14", path = "../network", optional = true }
+microsandbox-runtime = { version = "0.3.14", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 rand.workspace = true
 reqwest.workspace = true
 rpassword.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = "0.1.9"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 oci-client.workspace = true
 oci-spec.workspace = true
 scopeguard.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -29,14 +29,14 @@ dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.3.13", path = "../db" }
-microsandbox-filesystem = { version = "0.3.13", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.3.13", path = "../image" }
-microsandbox-migration = { version = "0.3.13", path = "../migration" }
-microsandbox-network = { version = "0.3.13", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.13", path = "../protocol" }
-microsandbox-runtime = { version = "0.3.13", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox-db = { version = "0.3.14", path = "../db" }
+microsandbox-filesystem = { version = "0.3.14", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.3.14", path = "../image" }
+microsandbox-migration = { version = "0.3.14", path = "../migration" }
+microsandbox-network = { version = "0.3.14", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
+microsandbox-runtime = { version = "0.3.14", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -19,7 +19,7 @@ hickory-resolver = { workspace = true }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = { version = "0.1.9", features = ["net"] }
 rcgen = { workspace = true }
 rustls = { workspace = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.3.13", path = "../db" }
-microsandbox-filesystem = { version = "0.3.13", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.3.13", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.13", path = "../protocol" }
-microsandbox-utils = { version = "0.3.13", path = "../utils" }
+microsandbox-db = { version = "0.3.14", path = "../db" }
+microsandbox-filesystem = { version = "0.3.14", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.3.14", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
+microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = { version = "0.1.9", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/docs/recipes/docker.mdx
+++ b/docs/recipes/docker.mdx
@@ -24,7 +24,7 @@ docker pull ghcr.io/superradcompany/microsandbox:latest
 Or pin to a specific version:
 
 ```bash
-docker pull ghcr.io/superradcompany/microsandbox:0.3.13
+docker pull ghcr.io/superradcompany/microsandbox:0.3.14
 ```
 
 ## Run a sandbox
@@ -53,5 +53,5 @@ docker run --privileged --device /dev/kvm \
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest release |
-| `x.y.z` (e.g. `0.3.13`) | Specific version |
+| `x.y.z` (e.g. `0.3.14`) | Specific version |
 | `x.y` (e.g. `0.3`) | Latest patch of a minor version |

--- a/examples/typescript/fs-read-stream/package-lock.json
+++ b/examples/typescript/fs-read-stream/package-lock.json
@@ -17,7 +17,7 @@
     "../../..": {},
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -27,9 +27,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.3.13",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.13",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.13"
+        "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/metrics-stream/package-lock.json
+++ b/examples/typescript/metrics-stream/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -26,9 +26,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.3.13",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.13",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.13"
+        "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -26,9 +26,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.3.13",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.13",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.13"
+        "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.13"
+    "microsandbox": "0.3.14"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "lib/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.3.13", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.3.13", path = "../../crates/network" }
+microsandbox = { version = "0.3.14", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.3.14", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/index.cjs
+++ b/sdk/node-ts/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.3.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "microsandbox.darwin-arm64.node",

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "microsandbox.linux-arm64-gnu.node",

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "microsandbox.linux-x64-gnu.node",

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -18,9 +18,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.3.13",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.13",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.13"
+        "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1845,8 +1845,8 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.3.13.tgz",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.3.14.tgz",
       "integrity": "sha512-RSOhkzmfXHTvm8+R2qcRihTGv5kRSL164rfs4q3gAigHFtTfYAUI2c+R6oX01b0V6/HBfvdrJKzihRpkrxQIWA==",
       "cpu": [
         "arm64"
@@ -1861,8 +1861,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.3.13.tgz",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.3.14.tgz",
       "integrity": "sha512-i5EiP8ZrNgOjNghBsvRqk5bZNKyaMFIGd/AvN/7tDKDYcffMdj/lAtQlwjIxHojlyeBzK3qor4idUG+GCVqyHA==",
       "cpu": [
         "arm64"
@@ -1877,8 +1877,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.3.13.tgz",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.3.14.tgz",
       "integrity": "sha512-v34c42HhltWI/jNp9ciDO3y+fqIh7KLg4XZ4o+X/h2aL+1n7dEHwx/LGBDuLsRxq6pt78pdZrMT54AdazK6A0g==",
       "cpu": [
         "x64"

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "main": "index.cjs",
   "module": "index.mjs",
   "types": "index.d.cts",
@@ -32,9 +32,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.3.13",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.13",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.3.13"
+    "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
   },
   "files": [
     "index.cjs",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.3.13", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.3.13", path = "../../crates/network" }
+microsandbox = { version = "0.3.14", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.3.14", path = "../../crates/network" }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "microsandbox"
-version = "0.3.13"
+version = "0.3.14"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bump the workspace patch version from `0.3.13` to `0.3.14` across every publishable surface so the next release cuts cleanly.
- Motivation: prepare the next patch release that carries the new `microsandbox` CLI entry points (Rust/Node/Python), the shell installer's `microsandbox -> msb` symlink, and the clippy/typo/doc fixes from #570 (already merged into `main`).
- Single commit, 35 files, +140/-140 (symmetric version string replacements). Cross-validated via `cargo metadata --locked` for both the main workspace and `crates/agentd/`.

### Scope of the bump
- Workspace: root `Cargo.toml` (`workspace.package.version`), all `crates/*/Cargo.toml` inter-crate dependency pins, `Cargo.lock`, and the standalone `crates/agentd/Cargo.{toml,lock}`.
- Node SDK: `sdk/node-ts/package.json` (root version + `optionalDependencies` pins), `sdk/node-ts/package-lock.json`, `sdk/node-ts/Cargo.toml`, `sdk/node-ts/index.cjs` version-check strings, and per-platform packages under `sdk/node-ts/npm/{darwin-arm64,linux-arm64-gnu,linux-x64-gnu}/package.json`.
- Python SDK: `sdk/python/Cargo.toml` and `sdk/python/uv.lock`.
- mcp submodule: bumped `package.json` and `src/index.ts` inside the submodule (upstream commit `4f8a927` on `superradcompany/microsandbox-mcp@main`, already pushed); the parent repo's tracked submodule pointer is updated to match.
- TypeScript examples: every `examples/typescript/*/package.json` (13 packages) plus the three that track `package-lock.json` (`fs-read-stream`, `metrics-stream`, `shell-attach`).
- Docs: `docs/recipes/docker.mdx` version reference.

## Test Plan
- [x] `cargo metadata --format-version 1 --locked` succeeds in the workspace root (no Cargo.lock drift).
- [x] `cargo metadata --format-version 1 --locked` succeeds in `crates/agentd/`.
- [x] `cargo build -p microsandbox-cli` produces an `msb` reporting `0.3.14` via `--version`.
- [x] `rg '0\.3\.13' -g '!.git' -g '!target' -g '!node_modules' -g '!.venv' -g '!vendor' -g '!*/rootfs-alpine/*' -g '!*/qcow2-alpine/*'` returns no matches.
- [x] mcp submodule pointer in the parent repo resolves to `4f8a927` on `superradcompany/microsandbox-mcp`.
- [x] After merge: the release pipeline picks up `0.3.14` and publishes the Rust crates, npm package (+ per-platform natives), Python wheels, and Docker image under the new tag.