### PR TITLE
ci: add boot and init time enforcement to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -293,7 +293,7 @@ jobs:
           npm run build
 
   # ---------------------------------------------------------------------------
-  # Node.js SDK smoke tests (requires KVM)
+  # Node.js SDK smoke tests and Enforce Boot and Init Time(requires KVM)
   # ---------------------------------------------------------------------------
   node-sdk-test:
     name: Node.js SDK Tests
@@ -344,3 +344,8 @@ jobs:
           export PATH="$HOME/.microsandbox/bin:$PATH"
           export LD_LIBRARY_PATH="${{ github.workspace }}/build:$HOME/.microsandbox/lib"
           npm test
+      - name: Enforce Boot and Init Time
+        run: |
+          chmod +x scripts/check-boot-and-init-performance.sh
+          LD_LIBRARY_PATH="${{ github.workspace }}/build:$HOME/.microsandbox/lib" \
+            ./scripts/check-boot-and-performance.sh

--- a/crates/microsandbox/lib/agent/client.rs
+++ b/crates/microsandbox/lib/agent/client.rs
@@ -84,8 +84,9 @@ impl AgentClient {
             .map_err(|e| crate::MicrosandboxError::Runtime(format!("decode ready payload: {e}")))?;
 
         tracing::info!(
-            "agent client: connected to relay, id_offset={id_offset}, boot_time={}ns",
-            ready.boot_time_ns
+            "agent client: connected to relay, id_offset={id_offset}, boot_time={}ns, init_time={}ns",
+            ready.boot_time_ns,
+            ready.init_time_ns
         );
 
         let pending: Arc<Mutex<HashMap<u32, mpsc::UnboundedSender<Message>>>> =

--- a/scripts/check-boot-and-init-performance.sh
+++ b/scripts/check-boot-and-init-performance.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Defines and enforce max threshold for agentd boot and init sequence useful in CI
+set -e
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BOOT_TIME_THRESHOLD_NS=100000000
+INIT_TIME_THRESHOLD_NS=100000000
+
+echo "Testing boot performance..."
+
+export PATH="$HOME/.microsandbox/bin:$PATH"
+
+trap '
+  echo "Cleaning up timing-test..."
+  msb stop timing-test || true
+  msb remove timing-test || true
+' EXIT
+
+if ! RUST_LOG=info msb create alpine --name timing-test --info 2>&1 | tee /tmp/timing.log; then
+  echo "ERROR: msb create failed"
+  cat /tmp/timing.log
+  exit 1
+fi
+
+BOOT_TIME=$(grep -m1 "agent client: connected to relay" /tmp/timing.log | grep -o 'boot_time=[0-9]*' | cut -d= -f2)
+INIT_TIME=$(grep -m1 "agent client: connected to relay" /tmp/timing.log | grep -o 'init_time=[0-9]*' | cut -d= -f2)
+
+if [ -z "$BOOT_TIME" ] || [ -z "$INIT_TIME" ]; then
+  echo "ERROR: Could not parse timing metrics"
+  cat /tmp/timing.log
+  exit 1
+fi
+
+echo "Boot time: ${BOOT_TIME}ns"
+echo "Init time: ${INIT_TIME}ns"
+
+if [ "$BOOT_TIME" -gt "$BOOT_TIME_THRESHOLD_NS" ]; then
+  echo "ERROR: Boot time exceeded threshold"
+  exit 1
+fi
+
+if [ "$INIT_TIME" -gt "$INIT_TIME_THRESHOLD_NS" ]; then
+  echo "ERROR: Init time exceeded threshold"
+  exit 1
+fi
+
+echo "Boot performance test passed!"


### PR DESCRIPTION
Add automated boot and init time performance testing to prevent regressions.
- Enforces 100ms thresholds for both boot and init times
- Fails CI build if thresholds are exceeded
- Uses existing timing infrastructure from agentd
- Cleans up test sandbox automatically
- Add init_time to agent client connection logs for visibility

---

Fixes #473 