### PR TITLE
fix(runtime): restore VM boot and agentd docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@ sdk/
 **/*.swp
 **/*.swo
 target/
+**/target/
 
 # Specific files that aren't needed
 **/*.log

--- a/crates/microsandbox/lib/runtime/spawn.rs
+++ b/crates/microsandbox/lib/runtime/spawn.rs
@@ -483,7 +483,7 @@ fn sandbox_cli_args(
             args.push(OsString::from(format.as_str()));
 
             // Build MSB_BLOCK_ROOT env var value.
-            let mut block_root_val = String::from("/dev/vda");
+            let mut block_root_val = String::from("kind=disk-image,device=/dev/vda");
             if let Some(ft) = fstype {
                 block_root_val.push_str(&format!(",fstype={ft}"));
             }
@@ -803,7 +803,11 @@ mod tests {
         assert!(rendered.contains(&"/tmp/ubuntu.qcow2".to_string()));
         assert!(rendered.contains(&"--rootfs-disk-format".to_string()));
         assert!(rendered.contains(&"qcow2".to_string()));
-        assert!(rendered.contains(&"MSB_BLOCK_ROOT=/dev/vda,fstype=ext4".to_string()));
+        assert!(
+            rendered.contains(
+                &"MSB_BLOCK_ROOT=kind=disk-image,device=/dev/vda,fstype=ext4".to_string()
+            )
+        );
 
         // Should not contain bind or overlay args.
         assert!(!rendered.contains(&"--rootfs-path".to_string()));
@@ -827,7 +831,7 @@ mod tests {
         assert!(rendered.contains(&"/tmp/alpine.raw".to_string()));
         assert!(rendered.contains(&"--rootfs-disk-format".to_string()));
         assert!(rendered.contains(&"raw".to_string()));
-        assert!(rendered.contains(&"MSB_BLOCK_ROOT=/dev/vda".to_string()));
+        assert!(rendered.contains(&"MSB_BLOCK_ROOT=kind=disk-image,device=/dev/vda".to_string()));
 
         // Should not contain bind or overlay args.
         assert!(!rendered.contains(&"--rootfs-path".to_string()));

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -436,11 +436,7 @@ fn build_vm(
     let vm = &config.vm;
 
     let mut builder = VmBuilder::new()
-        .machine(|m| {
-            m.vcpus(vm.vcpus)
-                .memory_mib(vm.memory_mib as usize)
-                .split_irqchip(true)
-        })
+        .machine(|m| m.vcpus(vm.vcpus).memory_mib(vm.memory_mib as usize))
         .kernel(|k| {
             let k = k.krunfw_path(&vm.libkrunfw_path);
             if let Some(ref init_path) = vm.init_path {


### PR DESCRIPTION
## Summary
- Fix a disk-image boot regression introduced by #548: the host was still emitting `MSB_BLOCK_ROOT=/dev/vda[,fstype=...]` while agentd now parses the `kind=disk-image,device=...` form, so block-backed OCI rootfs sandboxes failed to boot. Test assertions in `spawn.rs` are updated to match.
- Drop `.split_irqchip(true)` from the `VmBuilder` machine config in `crates/runtime/lib/vm.rs`. On Linux the krun IOAPIC path panics with `attempt to shift left with overflow` when split irqchip is requested, which crashed `msb run` before the agentd handshake.
- Add `**/target/` to `.dockerignore` so nested crate target directories no longer balloon the Docker build context from ~1.33 GB to ~208 kB; `just build-agentd` was failing with `no space left on device` on fresh machines.
- Fast-forward the vendored `libkrunfw` submodule to `19dfda5` on `origin/krunfw` (https://github.com/superradcompany/libkrunfw/pull/5), which sets `KBUILD_BUILD_VERSION=1` to silence the missing `.version` warning during kernel build. This invalidates the CI `hashFiles('vendor/libkrunfw/**')` cache key once, then the release caches re-stabilize.

## Test Plan
- [x] `cargo test -p microsandbox-runtime --lib` passes (updated `MSB_BLOCK_ROOT` assertions).
- [x] `just build-agentd` succeeds on a machine where it previously failed with `no space left on device` — expect the Docker build context to be ~200 kB rather than ~1.3 GB.
- [x] On Linux, `./target/debug/msb run --image python:3 -- python -c 'print(1)'` boots cleanly (no `attempt to shift left with overflow` panic from `msb_krun_devices`).
- [x] `./target/debug/msb run` with a block-backed rootfs (qcow2 or raw) boots and reaches the agentd handshake — previously broken because of the old `MSB_BLOCK_ROOT` format.
- [ ] Next CI release run rebuilds `kernel.c` and per-target `libkrunfw` once due to the submodule pointer bump, then caches stabilize on subsequent runs.