### PR TITLE
refactor(agentd): split BootParams out of AgentdConfig

### DIFF
--- a/crates/agentd/bin/main.rs
+++ b/crates/agentd/bin/main.rs
@@ -6,7 +6,7 @@
 use std::process;
 
 #[cfg(target_os = "linux")]
-use microsandbox_agentd::{AgentdConfig, AgentdError, agent, clock, init};
+use microsandbox_agentd::{AgentdConfig, AgentdError, BootParams, agent, clock, init};
 
 //--------------------------------------------------------------------------------------------------
 // Functions: main
@@ -23,7 +23,16 @@ fn main() {
     // Capture CLOCK_BOOTTIME immediately — this represents kernel boot duration.
     let boot_time_ns = clock::boottime_ns();
 
-    // Read all MSB_* environment variables once at startup and parse.
+    // Read all MSB_* environment variables once at startup. `BootParams`
+    // carries the one-shot init data; `AgentdConfig` carries the runtime
+    // config that outlives init.
+    let boot = match BootParams::from_env() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("agentd: config parse failed: {e}");
+            process::exit(1);
+        }
+    };
     let config = match AgentdConfig::from_env() {
         Ok(c) => c,
         Err(e) => {
@@ -34,7 +43,7 @@ fn main() {
 
     // Phase 1: Synchronous init (mount filesystems, prepare runtime directories).
     let init_start = clock::boottime_ns();
-    if let Err(e) = init::init(&config) {
+    if let Err(e) = init::init(boot) {
         eprintln!("agentd: init failed: {e}");
         process::exit(1);
     }

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -1,9 +1,17 @@
 //! Agentd configuration, read once from environment variables at startup.
 //!
-//! [`AgentdConfig::from_env`] reads all `MSB_*` environment variables and
-//! parses them into their respective types in a single step. Downstream
-//! functions receive the config by reference, avoiding repeated env var reads
-//! and repeated parsing.
+//! Split into two structs with different lifetimes:
+//!
+//! - [`BootParams`] — one-shot MSB_* env vars consumed by [`init::init`] and
+//!   dropped once init completes.
+//! - [`AgentdConfig`] — runtime config that outlives init (currently just
+//!   the default guest user), passed by reference to the agent loop.
+//!
+//! Each struct owns its own [`from_env`](BootParams::from_env) constructor
+//! so reading is centralised and validation failures abort boot with a
+//! single clean error before any side effects begin.
+//!
+//! [`init::init`]: crate::init::init
 
 use std::env;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -20,12 +28,15 @@ use crate::rlimit;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Parsed configuration for agentd.
+/// One-shot MSB_* env vars consumed by [`init::init`] and dropped afterward.
 ///
-/// All `MSB_*` environment variables are read and parsed into their respective
-/// types during construction via [`AgentdConfig::from_env`].
+/// Moved by value into init; owning the data (rather than borrowing) makes
+/// the "consumed once" lifetime explicit in the signature and prevents
+/// accidental reads after init completes.
+///
+/// [`init::init`]: crate::init::init
 #[derive(Debug)]
-pub struct AgentdConfig {
+pub struct BootParams {
     /// Parsed `MSB_BLOCK_ROOT` — block device for rootfs switch.
     pub(crate) block_root: Option<BlockRootSpec>,
 
@@ -50,14 +61,21 @@ pub struct AgentdConfig {
     /// Parsed `MSB_NET_IPV6` — IPv6 config.
     pub(crate) net_ipv6: Option<NetIpv6Spec>,
 
+    /// Parsed `MSB_RLIMITS` — sandbox-wide resource limits applied to PID 1
+    /// so every guest process inherits the raised baseline (empty when unset).
+    pub(crate) rlimits: Vec<ExecRlimit>,
+}
+
+/// Runtime configuration surviving past init; referenced by the agent loop.
+///
+/// Currently holds only the default guest user used when an exec request
+/// does not specify its own.
+#[derive(Debug)]
+pub struct AgentdConfig {
     /// `MSB_USER` — default guest user for exec sessions.
     ///
     /// Captured at startup; changes to `MSB_USER` afterward are not observed.
     pub(crate) user: Option<String>,
-
-    /// Parsed `MSB_RLIMITS` — sandbox-wide resource limits applied to PID 1
-    /// so every guest process inherits the raised baseline (empty when unset).
-    pub(crate) rlimits: Vec<ExecRlimit>,
 }
 
 /// Parsed tmpfs mount specification.
@@ -142,8 +160,8 @@ pub(crate) struct NetConfig<'a> {
 // Implementations
 //--------------------------------------------------------------------------------------------------
 
-impl AgentdConfig {
-    /// Reads all `MSB_*` environment variables and parses them into the config.
+impl BootParams {
+    /// Reads and parses the boot-time `MSB_*` environment variables.
     ///
     /// Empty or whitespace-only values are treated as absent (`None`).
     /// Returns an error if any present value fails to parse.
@@ -172,7 +190,6 @@ impl AgentdConfig {
             net_ipv6: read_env(ENV_NET_IPV6)
                 .map(|v| parse_net_ipv6(&v))
                 .transpose()?,
-            user: read_env(ENV_USER),
             rlimits: read_env(ENV_RLIMITS)
                 .map(|v| parse_rlimits(&v))
                 .transpose()?
@@ -187,6 +204,17 @@ impl AgentdConfig {
             ipv4: self.net_ipv4.as_ref(),
             ipv6: self.net_ipv6.as_ref(),
         }
+    }
+}
+
+impl AgentdConfig {
+    /// Reads the runtime-config `MSB_*` environment variables.
+    ///
+    /// Empty or whitespace-only values are treated as absent (`None`).
+    pub fn from_env() -> AgentdResult<Self> {
+        Ok(Self {
+            user: read_env(ENV_USER),
+        })
     }
 }
 

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -1,6 +1,6 @@
 //! PID 1 init: mount filesystems, apply tmpfs mounts, prepare runtime directories.
 
-use crate::config::AgentdConfig;
+use crate::config::BootParams;
 use crate::error::AgentdResult;
 use crate::{network, rlimit, tls};
 
@@ -12,21 +12,24 @@ use crate::{network, rlimit, tls};
 ///
 /// Applies sandbox-wide resource limits first so every later guest process
 /// inherits the raised baseline, then mounts filesystems, applies directory
-/// mounts, file mounts, and tmpfs mounts from the parsed config. Configures
+/// mounts, file mounts, and tmpfs mounts from the parsed params. Configures
 /// networking and prepares runtime directories.
-pub fn init(config: &AgentdConfig) -> AgentdResult<()> {
-    rlimit::apply_baseline(&config.rlimits)?;
+///
+/// Consumes the [`BootParams`] by value — the data is one-shot and not
+/// needed after init returns.
+pub fn init(params: BootParams) -> AgentdResult<()> {
+    rlimit::apply_baseline(&params.rlimits)?;
     linux::mount_filesystems()?;
     linux::mount_runtime()?;
-    if let Some(spec) = &config.block_root {
+    if let Some(spec) = &params.block_root {
         linux::mount_block_root(spec)?;
     }
-    linux::apply_dir_mounts(&config.dir_mounts)?;
-    linux::apply_file_mounts(&config.file_mounts)?;
-    network::apply_hostname(config.hostname.as_deref())?;
-    linux::apply_tmpfs_mounts(&config.tmpfs)?;
+    linux::apply_dir_mounts(&params.dir_mounts)?;
+    linux::apply_file_mounts(&params.file_mounts)?;
+    network::apply_hostname(params.hostname.as_deref())?;
+    linux::apply_tmpfs_mounts(&params.tmpfs)?;
     linux::ensure_standard_tmp_permissions()?;
-    network::apply_network_config(config.network())?;
+    network::apply_network_config(params.network())?;
     tls::install_ca_cert()?;
     linux::ensure_scripts_path_in_profile()?;
     linux::create_run_dir()?;

--- a/crates/agentd/lib/lib.rs
+++ b/crates/agentd/lib/lib.rs
@@ -24,5 +24,5 @@ pub mod serial;
 pub mod session;
 pub mod tls;
 
-pub use config::AgentdConfig;
+pub use config::{AgentdConfig, BootParams};
 pub use error::*;

--- a/crates/agentd/lib/rlimit.rs
+++ b/crates/agentd/lib/rlimit.rs
@@ -39,7 +39,7 @@ pub(crate) fn to_libc(rlimits: &[ExecRlimit]) -> Vec<(libc::c_int, libc::rlimit)
 /// started through the per-exec API.
 ///
 /// Callers must have validated resource names upfront (e.g. via
-/// [`AgentdConfig::from_env`](crate::config::AgentdConfig::from_env)); unknown
+/// [`BootParams::from_env`](crate::config::BootParams::from_env)); unknown
 /// names here produce an [`AgentdError::Init`] rather than silently skipping.
 pub(crate) fn apply_baseline(rlimits: &[ExecRlimit]) -> AgentdResult<()> {
     for rlimit in rlimits {


### PR DESCRIPTION
## Summary
- Split `AgentdConfig` into `BootParams` (one-shot MSB_* env vars consumed by `init::init`) and a lean `AgentdConfig` (runtime config that outlives init; currently just `user`).
- `init::init` now takes `BootParams` by value and drops it on return — the "consumed once" lifetime is visible in the signature and the data cannot be accidentally referenced after init completes.
- `agent::run` continues to take `&AgentdConfig` but now receives a struct with only the fields it actually reads, removing the dead-weight fields that used to travel through the agent loop's API.
- Each struct owns its own `from_env` constructor; `main.rs` reads both at startup and fails loud on parse errors before init touches any mount or network state.

Motivation: #507's `AgentdConfig` had accumulated two kinds of data with very different lifetimes — one-shot boot params (block_root, dir_mounts, file_mounts, tmpfs, hostname, net*, rlimits) and long-lived runtime config (user) — bundled behind a single `&config` reference passed to both `init::init` and `agent::run`. That made function signatures dishonest (the agent loop received an entire struct by reference to read one field) and left the struct on a path to drift into a kitchen-sink as more MSB_* env vars land. The split makes data lifetimes explicit in the type system and scopes future growth to the right place: new one-shot env vars join `BootParams`, new long-lived runtime config joins `AgentdConfig`.

No behavior change. No protocol or wire-format change. No public-API change beyond the `init::init` signature (host code does not call it; only the agentd binary does).

## Test Plan
- [x] Boot a sandbox end-to-end (`msb run` with an OCI rootfs and some MSB_* env vars set: MSB_HOSTNAME, MSB_NET*, MSB_RLIMITS, MSB_USER) and verify VM boots, agentd handshake succeeds, and an exec request runs with the expected user and rlimits.
- [x] Set a malformed `MSB_RLIMITS` value and confirm boot aborts with `agentd: config parse failed: …` before any mount operation.