### PR TITLE
fix(dns): fetch nameservers via scdynamicstore on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ name = "microsandbox-network"
 version = "0.3.14"
 dependencies = [
  "bytes",
+ "core-foundation 0.9.4",
  "crossbeam-queue",
  "dirs",
  "futures",
@@ -2681,6 +2682,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "smoltcp",
+ "system-configuration",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -350,6 +350,8 @@ fn apply_network_opts(
     mut builder: SandboxBuilder,
     opts: &SandboxOpts,
 ) -> anyhow::Result<SandboxBuilder> {
+    use microsandbox_network::dns::Nameserver;
+
     // Port mappings.
     for port_str in &opts.port {
         let (host, guest, udp) = parse_port(port_str)?;
@@ -395,10 +397,7 @@ fn apply_network_opts(
         let dns_nameservers = opts
             .dns_nameserver
             .iter()
-            .map(|s| {
-                s.parse::<microsandbox_network::dns::Nameserver>()
-                    .map_err(anyhow::Error::from)
-            })
+            .map(|s| s.parse::<Nameserver>().map_err(anyhow::Error::from))
             .collect::<anyhow::Result<Vec<_>>>()?;
         let dns_query_timeout_ms = opts.dns_query_timeout_ms;
         let network_policy = parse_network_policy(opts.network_policy.as_deref())?;

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -395,7 +395,10 @@ fn apply_network_opts(
         let dns_nameservers = opts
             .dns_nameserver
             .iter()
-            .map(|s| microsandbox_network::dns::parse_nameserver(s).map_err(anyhow::Error::from))
+            .map(|s| {
+                s.parse::<microsandbox_network::dns::Nameserver>()
+                    .map_err(anyhow::Error::from)
+            })
             .collect::<anyhow::Result<Vec<_>>>()?;
         let dns_query_timeout_ms = opts.dns_query_timeout_ms;
         let network_policy = parse_network_policy(opts.network_policy.as_deref())?;

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -49,5 +49,7 @@ tracing = { workspace = true }
 # than /etc/resolv.conf. On VPN + split-DNS setups, the file version is
 # stale or incomplete. These deps let us query the live system state.
 [target.'cfg(target_os = "macos")'.dependencies]
+# Pinned to 0.9 to match system-configuration 0.7. Bumping to 0.10 would
+# create two incompatible CFString/CFArray/... types in the build.
 core-foundation = "0.9"
 system-configuration = "0.7"

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -24,23 +24,30 @@ microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = { version = "0.1.10", features = ["net"] }
 rcgen = { workspace = true }
 resolv-conf = { workspace = true }
-thiserror = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pemfile = "2"
 serde = { workspace = true }
-time = { workspace = true }
 smoltcp = { workspace = true, features = [
+    "alloc",
+    "async",
     "medium-ethernet",
     "proto-ipv4",
     "proto-ipv6",
+    "socket-dns",
+    "socket-icmp",
     "socket-tcp",
     "socket-udp",
-    "socket-icmp",
-    "socket-dns",
-    "async",
-    "alloc",
 ] }
+thiserror = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
+
+# macOS reads DNS servers from SystemConfiguration / SCDynamicStore rather
+# than /etc/resolv.conf. On VPN + split-DNS setups, the file version is
+# stale or incomplete. These deps let us query the live system state.
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.9"
+system-configuration = "0.7"

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -6,7 +6,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 
 use crate::config::{DnsConfig, InterfaceOverrides, NetworkConfig, PortProtocol, PublishedPort};
-use crate::dns::NameserverSpec;
+use crate::dns::Nameserver;
 use crate::policy::NetworkPolicy;
 use crate::secrets::config::{HostPattern, SecretEntry, SecretInjection, ViolationAction};
 use crate::tls::TlsConfig;
@@ -103,7 +103,7 @@ impl NetworkBuilder {
     /// .dns(|d| d
     ///     .block_domain("malware.example.com")
     ///     .block_domain_suffix(".tracking.com")
-    ///     .nameservers(["1.1.1.1".parse::<NameserverSpec>()?])
+    ///     .nameservers(["1.1.1.1".parse::<Nameserver>()?])
     /// )
     /// ```
     pub fn dns(mut self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self {
@@ -207,14 +207,14 @@ impl DnsBuilder {
     /// more are set, the interceptor uses these instead of the
     /// nameservers in the host's `/etc/resolv.conf`. Replaces any
     /// previously-set nameservers. Each element is any type convertible
-    /// into [`NameserverSpec`] (`SocketAddr`, `IpAddr`, or a parsed
-    /// string via `"dns.google:53".parse::<NameserverSpec>()?`).
-    pub fn nameservers<I>(mut self, specs: I) -> Self
+    /// into [`Nameserver`] (`SocketAddr`, `IpAddr`, or a parsed
+    /// string via `"dns.google:53".parse::<Nameserver>()?`).
+    pub fn nameservers<I>(mut self, nameservers: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<NameserverSpec>,
+        I::Item: Into<Nameserver>,
     {
-        self.config.nameservers = specs.into_iter().map(Into::into).collect();
+        self.config.nameservers = nameservers.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::dns::NameserverSpec;
+use crate::dns::Nameserver;
 
 use crate::policy::NetworkPolicy;
 use crate::secrets::config::SecretsConfig;
@@ -102,7 +102,7 @@ pub struct DnsConfig {
     /// resolv.conf is incomplete. Accepts IPs, `IP:PORT`, or hostnames
     /// (resolved once at startup via the host's OS resolver).
     #[serde(default)]
-    pub nameservers: Vec<NameserverSpec>,
+    pub nameservers: Vec<Nameserver>,
 
     /// Per-query timeout in milliseconds. Default: 5000.
     #[serde(default = "default_query_timeout_ms")]

--- a/crates/network/lib/dns/filter.rs
+++ b/crates/network/lib/dns/filter.rs
@@ -1,0 +1,114 @@
+//! DNS filter predicates: block-list matching and private-IP detection.
+//!
+//! Pure, synchronous helpers used by the forwarder to decide whether a
+//! query should be refused locally (block list) or whether a response
+//! contains addresses that trip rebind protection.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use super::forwarder::NormalizedDnsConfig;
+
+/// Check if a domain is blocked by the DNS config.
+///
+/// Block lists are pre-lowercased in [`NormalizedDnsConfig`], so only the
+/// queried domain needs lowercasing (once per query instead of per entry).
+pub(super) fn is_domain_blocked(domain: &str, config: &NormalizedDnsConfig) -> bool {
+    let domain_lower = domain.to_lowercase();
+
+    // Check exact domain matches — O(1) via HashSet.
+    if config.blocked_domains.contains(&domain_lower) {
+        return true;
+    }
+
+    // Check suffix matches (already lowercased with pre-computed dot-prefixed forms).
+    for (suffix, dotted) in config
+        .blocked_suffixes
+        .iter()
+        .zip(config.blocked_suffixes_dotted.iter())
+    {
+        if domain_lower == *suffix || domain_lower.ends_with(dotted.as_str()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Check if an IPv4 address is in a private/reserved range (for rebind protection).
+pub(super) fn is_private_ipv4(addr: Ipv4Addr) -> bool {
+    let octets = addr.octets();
+    addr.is_loopback()                                        // 127.0.0.0/8
+        || octets[0] == 10                                    // 10.0.0.0/8
+        || (octets[0] == 172 && (octets[1] & 0xf0) == 16)    // 172.16.0.0/12
+        || (octets[0] == 192 && octets[1] == 168)             // 192.168.0.0/16
+        || (octets[0] == 100 && (octets[1] & 0xc0) == 64)    // 100.64.0.0/10 (CGNAT)
+        || (octets[0] == 169 && octets[1] == 254)             // 169.254.0.0/16 (link-local)
+        || addr.is_unspecified() // 0.0.0.0
+}
+
+/// Check if an IPv6 address is in a private/reserved range (for rebind protection).
+pub(super) fn is_private_ipv6(addr: Ipv6Addr) -> bool {
+    let segments = addr.segments();
+    addr.is_loopback()                       // ::1
+        || (segments[0] & 0xfe00) == 0xfc00  // fc00::/7 (ULA)
+        || (segments[0] & 0xffc0) == 0xfe80  // fe80::/10 (link-local)
+        || addr.is_unspecified() // ::
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::dns::parse::Nameserver;
+
+    fn normalized(domains: Vec<&str>, suffixes: Vec<&str>) -> NormalizedDnsConfig {
+        let blocked_suffixes: Vec<String> = suffixes
+            .iter()
+            .map(|s| s.to_lowercase().trim_start_matches('.').to_string())
+            .collect();
+
+        let blocked_suffixes_dotted = blocked_suffixes.iter().map(|s| format!(".{s}")).collect();
+
+        NormalizedDnsConfig {
+            blocked_domains: domains
+                .iter()
+                .map(|d| d.to_lowercase())
+                .collect::<HashSet<_>>(),
+            blocked_suffixes,
+            blocked_suffixes_dotted,
+            rebind_protection: false,
+            nameservers: Vec::<Nameserver>::new(),
+            query_timeout: Duration::from_millis(5000),
+        }
+    }
+
+    #[test]
+    fn test_exact_domain_blocked() {
+        let config = normalized(vec!["evil.com"], vec![]);
+        assert!(is_domain_blocked("evil.com", &config));
+        assert!(is_domain_blocked("Evil.COM", &config));
+        assert!(!is_domain_blocked("not-evil.com", &config));
+        assert!(!is_domain_blocked("sub.evil.com", &config));
+    }
+
+    #[test]
+    fn test_suffix_domain_blocked() {
+        let config = normalized(vec![], vec![".evil.com"]);
+        assert!(is_domain_blocked("sub.evil.com", &config));
+        assert!(is_domain_blocked("deep.sub.evil.com", &config));
+        assert!(is_domain_blocked("evil.com", &config));
+        assert!(!is_domain_blocked("notevil.com", &config));
+    }
+
+    #[test]
+    fn test_no_blocks_nothing_blocked() {
+        let config = normalized(vec![], vec![]);
+        assert!(!is_domain_blocked("anything.com", &config));
+    }
+}

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -1,0 +1,310 @@
+//! Async DNS forwarder: per-query handling against an upstream resolver.
+//!
+//! The forwarder is the middle of the data flow: the [`DnsInterceptor`]
+//! feeds raw query bytes in via a channel, the forwarder talks to an
+//! upstream resolver over UDP, and the response bytes go back out
+//! through another channel to be written to the smoltcp socket.
+//!
+//! The forwarder is a **forwarder**, not a stub resolver: the guest's OS
+//! already runs its own stub. Queries are forwarded verbatim; upstream
+//! responses are echoed back with their original RCODE, authority
+//! section, EDNS OPT records, and answer records intact. Only the
+//! local-policy cases (block list, rebind protection) synthesize a
+//! response locally (REFUSED); transport failures synthesize SERVFAIL.
+//!
+//! [`DnsInterceptor`]: super::interceptor::DnsInterceptor
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use hickory_client::client::Client;
+use hickory_client::proto::op::{Message, MessageType, ResponseCode};
+use hickory_client::proto::rr::RData;
+use hickory_client::proto::runtime::TokioRuntimeProvider;
+use hickory_client::proto::serialize::binary::{BinDecodable, BinEncodable};
+use hickory_client::proto::udp::UdpClientStream;
+use hickory_client::proto::xfer::{DnsHandle, DnsRequest};
+use tokio::sync::mpsc;
+
+use super::filter::{is_domain_blocked, is_private_ipv4, is_private_ipv6};
+use super::interceptor::{DnsQuery, DnsResponse};
+use super::parse::Nameserver;
+use super::upstream::{read_host_dns_servers, resolve_nameservers};
+use crate::config::DnsConfig;
+use crate::shared::SharedState;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Pre-processed DNS config with lowercased block lists (avoids per-query allocations).
+///
+/// Fields are `pub(super)` so sibling modules (filter, tests) can read
+/// them directly; construction should go through [`Self::from_config`].
+pub(super) struct NormalizedDnsConfig {
+    /// O(1) exact-match lookup for blocked domains.
+    pub(super) blocked_domains: HashSet<String>,
+    /// Lowercased suffixes WITHOUT leading dot (for exact match against the suffix itself).
+    pub(super) blocked_suffixes: Vec<String>,
+    /// Dot-prefixed lowercased suffixes (for `ends_with` matching without per-query `format!`).
+    pub(super) blocked_suffixes_dotted: Vec<String>,
+    pub(super) rebind_protection: bool,
+    /// Explicit nameservers (unresolved specs). Empty means fall back to
+    /// the host's configured resolvers. Hostnames are resolved once at
+    /// forwarder-task startup via the host's own resolver.
+    pub(super) nameservers: Vec<Nameserver>,
+    /// Per-query timeout.
+    pub(super) query_timeout: Duration,
+}
+
+impl NormalizedDnsConfig {
+    /// Build a normalized config from a raw [`DnsConfig`]. Lowercases and
+    /// dot-prefixes the block lists once, up-front, so the query path
+    /// doesn't allocate per match.
+    pub(super) fn from_config(config: DnsConfig) -> Self {
+        let blocked_suffixes: Vec<String> = config
+            .blocked_suffixes
+            .iter()
+            .map(|s| s.to_lowercase().trim_start_matches('.').to_string())
+            .collect();
+        let blocked_suffixes_dotted: Vec<String> =
+            blocked_suffixes.iter().map(|s| format!(".{s}")).collect();
+        Self {
+            blocked_domains: config
+                .blocked_domains
+                .into_iter()
+                .map(|d| d.to_lowercase())
+                .collect(),
+            blocked_suffixes,
+            blocked_suffixes_dotted,
+            rebind_protection: config.rebind_protection,
+            nameservers: config.nameservers,
+            query_timeout: Duration::from_millis(config.query_timeout_ms),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Spawn the forwarder task on the given tokio runtime. Takes ownership
+/// of the query receiver and response sender used by the interceptor.
+pub(super) fn spawn(
+    handle: &tokio::runtime::Handle,
+    query_rx: mpsc::Receiver<DnsQuery>,
+    response_tx: mpsc::Sender<DnsResponse>,
+    config: Arc<NormalizedDnsConfig>,
+    shared: Arc<SharedState>,
+) {
+    handle.spawn(dns_forwarder_task(query_rx, response_tx, config, shared));
+}
+
+/// Background task that forwards DNS queries to the host's upstream
+/// resolver and sends responses back to the guest.
+///
+/// Sets up a single [`Client`] connected to the first configured upstream.
+/// `Client` is cheaply cloneable (it's a handle to a shared multiplexer),
+/// so each incoming query is handled in its own task for concurrency.
+async fn dns_forwarder_task(
+    mut query_rx: mpsc::Receiver<DnsQuery>,
+    response_tx: mpsc::Sender<DnsResponse>,
+    dns_config: Arc<NormalizedDnsConfig>,
+    shared: Arc<SharedState>,
+) {
+    let upstreams = if !dns_config.nameservers.is_empty() {
+        match resolve_nameservers(&dns_config.nameservers).await {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => {
+                tracing::error!("no configured nameservers resolved to an address");
+                return;
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to resolve configured nameservers");
+                return;
+            }
+        }
+    } else {
+        match read_host_dns_servers().await {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => {
+                tracing::error!("no upstream DNS servers discovered from host");
+                return;
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to read host DNS configuration");
+                return;
+            }
+        }
+    };
+
+    // Use the first upstream. If it's unhealthy the guest's stub will
+    // observe SERVFAIL and fall through to its own next nameserver.
+    let upstream = upstreams[0];
+    let stream =
+        UdpClientStream::<TokioRuntimeProvider>::builder(upstream, TokioRuntimeProvider::new())
+            .with_timeout(Some(dns_config.query_timeout))
+            .build();
+    let (client, bg) = match Client::connect(stream).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::error!(upstream = %upstream, error = %e, "failed to connect to upstream DNS");
+            return;
+        }
+    };
+    tokio::spawn(bg);
+
+    while let Some(query) = query_rx.recv().await {
+        let response_tx = response_tx.clone();
+        let dns_config = dns_config.clone();
+        let shared = shared.clone();
+        let client = client.clone();
+
+        // Spawn a task per query for concurrency.
+        tokio::spawn(async move {
+            if let Some(data) = handle_query(&query.data, &dns_config, &client).await {
+                let response = DnsResponse {
+                    data,
+                    dest: query.source,
+                };
+                if response_tx.send(response).await.is_ok() {
+                    shared.proxy_wake.wake();
+                }
+            }
+        });
+    }
+}
+
+/// Handle a single DNS query: parse, apply local policy, forward upstream,
+/// and build the wire response. Returns `None` only when even synthesising
+/// a local error response fails (malformed query bytes).
+async fn handle_query(
+    raw_query: &[u8],
+    dns_config: &NormalizedDnsConfig,
+    client: &Client,
+) -> Option<Bytes> {
+    let query_msg = Message::from_bytes(raw_query).ok()?;
+    let guest_id = query_msg.id();
+
+    let question = query_msg.queries().first()?;
+    let domain = question.name().to_string();
+    let domain = domain.trim_end_matches('.').to_owned();
+
+    // Local policy: block list → synthesize REFUSED.
+    if is_domain_blocked(&domain, dns_config) {
+        tracing::debug!(domain = %domain, "DNS query blocked by policy");
+        return build_status_response(&query_msg, ResponseCode::Refused);
+    }
+
+    // Forward upstream. hickory-client's multiplexer assigns its own
+    // transaction id; we rewrite the response id back to the guest's
+    // below.
+    let mut send = client.send(DnsRequest::from(query_msg.clone()));
+    let response = match send.next().await {
+        Some(Ok(resp)) => resp,
+        Some(Err(e)) => {
+            tracing::warn!(domain = %domain, error = %e, "upstream DNS send failed");
+            return build_status_response(&query_msg, ResponseCode::ServFail);
+        }
+        None => {
+            tracing::warn!(domain = %domain, "upstream DNS closed stream without a response");
+            return build_status_response(&query_msg, ResponseCode::ServFail);
+        }
+    };
+    let mut response_msg: Message = response.into();
+
+    // Rebind protection: reject responses containing private/reserved IPs.
+    if dns_config.rebind_protection {
+        for record in response_msg.answers() {
+            let is_private = match record.data() {
+                RData::A(a) => is_private_ipv4((*a).into()),
+                RData::AAAA(aaaa) => is_private_ipv6((*aaaa).into()),
+                _ => false,
+            };
+            if is_private {
+                tracing::debug!(
+                    domain = %domain,
+                    "DNS rebind protection: response contains private IP"
+                );
+                return build_status_response(&query_msg, ResponseCode::Refused);
+            }
+        }
+    }
+
+    // Preserve the guest's transaction id.
+    response_msg.set_id(guest_id);
+
+    response_msg.to_bytes().ok().map(Bytes::from)
+}
+
+/// Build a status-only response (no answers, no authority) with the given
+/// RCODE. Used for locally-synthesized REFUSED (policy) and SERVFAIL
+/// (upstream unreachable). The guest's transaction id, OPCODE and RD bit
+/// are echoed.
+fn build_status_response(query: &Message, rcode: ResponseCode) -> Option<Bytes> {
+    let mut response = Message::new();
+    response.set_id(query.id());
+    response.set_op_code(query.op_code());
+    response.set_recursion_desired(query.recursion_desired());
+    response.set_message_type(MessageType::Response);
+    response.set_response_code(rcode);
+    response.set_recursion_available(true);
+    if let Some(q) = query.queries().first() {
+        response.add_query(q.clone());
+    }
+    response.to_bytes().ok().map(Bytes::from)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hickory_client::proto::op::{MessageType, OpCode, Query};
+    use hickory_client::proto::rr::{DNSClass, Name, RecordType};
+
+    fn make_query(name: &str, qtype: RecordType) -> Message {
+        let mut msg = Message::new();
+        msg.set_id(0x4242);
+        msg.set_message_type(MessageType::Query);
+        msg.set_op_code(OpCode::Query);
+        msg.set_recursion_desired(true);
+        let parsed = Name::from_ascii(name).expect("valid dns name");
+        let mut q = Query::new();
+        q.set_name(parsed);
+        q.set_query_type(qtype);
+        q.set_query_class(DNSClass::IN);
+        msg.add_query(q);
+        msg
+    }
+
+    #[test]
+    fn build_status_response_preserves_header_and_question() {
+        let query = make_query("slack.com.", RecordType::AAAA);
+        let bytes = build_status_response(&query, ResponseCode::Refused).expect("built");
+        let msg = Message::from_bytes(&bytes).expect("parse response");
+        assert_eq!(msg.id(), 0x4242);
+        assert_eq!(msg.response_code(), ResponseCode::Refused);
+        assert_eq!(msg.message_type(), MessageType::Response);
+        assert_eq!(msg.op_code(), OpCode::Query);
+        assert!(msg.recursion_desired());
+        assert!(msg.recursion_available());
+        assert_eq!(msg.queries().len(), 1);
+        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
+        assert_eq!(msg.answers().len(), 0);
+    }
+
+    #[test]
+    fn build_status_response_servfail_variant() {
+        let query = make_query("example.com.", RecordType::A);
+        let bytes = build_status_response(&query, ResponseCode::ServFail).expect("built");
+        let msg = Message::from_bytes(&bytes).expect("parse response");
+        assert_eq!(msg.response_code(), ResponseCode::ServFail);
+        assert_eq!(msg.answers().len(), 0);
+    }
+}

--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -260,17 +260,14 @@ async fn dns_forwarder_task(
             }
         }
     } else {
-        match read_resolv_conf(Path::new(RESOLV_CONF_PATH)).await {
+        match read_host_dns_servers().await {
             Ok(s) if !s.is_empty() => s,
             Ok(_) => {
-                tracing::error!(
-                    path = RESOLV_CONF_PATH,
-                    "no upstream DNS servers configured"
-                );
+                tracing::error!("no upstream DNS servers discovered from host");
                 return;
             }
             Err(e) => {
-                tracing::error!(path = RESOLV_CONF_PATH, error = %e, "failed to read resolv.conf");
+                tracing::error!(error = %e, "failed to read host DNS configuration");
                 return;
             }
         }
@@ -391,6 +388,43 @@ fn build_status_response(query: &Message, rcode: ResponseCode) -> Option<Bytes> 
         response.add_query(q.clone());
     }
     response.to_bytes().ok().map(Bytes::from)
+}
+
+/// Read the host's configured DNS servers as `SocketAddr`s on port 53.
+///
+/// On macOS the authoritative source is `SystemConfiguration.framework`
+/// (the dynamic store `configd` maintains), not `/etc/resolv.conf` —
+/// VPN + split-DNS setups leave the file either stale or pointing at
+/// only one leg of the resolver table. We query
+/// `State:/Network/Global/DNS` first and only fall back to the file if
+/// the dynamic store is unavailable or reports no servers.
+///
+/// On Linux the file is authoritative.
+async fn read_host_dns_servers() -> std::io::Result<Vec<SocketAddr>> {
+    #[cfg(target_os = "macos")]
+    {
+        match super::scdynamicstore::read_dns_servers() {
+            Ok(servers) if !servers.is_empty() => {
+                tracing::debug!(
+                    count = servers.len(),
+                    "loaded nameservers from SCDynamicStore"
+                );
+                return Ok(servers);
+            }
+            Ok(_) => {
+                tracing::debug!(
+                    "SCDynamicStore returned no nameservers; falling back to /etc/resolv.conf"
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "SCDynamicStore lookup failed; falling back to /etc/resolv.conf"
+                );
+            }
+        }
+    }
+    read_resolv_conf(Path::new(RESOLV_CONF_PATH)).await
 }
 
 /// Parse a `resolv.conf`-format file and return the `nameserver` entries

--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -1,46 +1,26 @@
-//! DNS query interception, filtering, and forwarding.
+//! DNS query interception: the smoltcp ↔ channel bridge.
 //!
-//! The [`DnsInterceptor`] bridges the smoltcp UDP socket (bound to
-//! gateway:53) and the host's upstream DNS servers via [`hickory_client`].
+//! [`DnsInterceptor`] owns the smoltcp UDP socket bound to `gateway:53`
+//! and a pair of channels to the async forwarder task spawned on the
+//! tokio runtime. Each poll-loop iteration, [`DnsInterceptor::process`]
+//! reads pending queries off the smoltcp socket and hands them to the
+//! forwarder, then writes any forwarded responses back to the socket.
 //!
-//! Design: the interceptor is a **forwarder**, not a stub resolver. The
-//! guest's OS already has its own stub (musl, glibc NSS, systemd-resolved)
-//! running its own retry/cache/parallel-A+AAAA logic. This code's job is
-//! to speak DNS on the wire and get out of the way. Queries are forwarded
-//! verbatim upstream; responses are echoed back with their original RCODE,
-//! authority section, EDNS OPT records, and answer records intact. Only
-//! the local-policy cases (block list, rebind protection) synthesize a
-//! response locally (REFUSED); transport failures synthesize SERVFAIL.
-//!
-//! Because resolution is async and the smoltcp poll loop is sync, queries
-//! are sent to a background tokio task via a channel. Responses come back
-//! through another channel and are written to the smoltcp socket on the
-//! next poll iteration.
+//! The DNS wire protocol, upstream client, block-list, and rebind-
+//! protection logic all live under sibling modules and are reached via
+//! the forwarder task.
 
-use std::collections::HashSet;
-use std::net::{IpAddr, SocketAddr};
-use std::path::Path;
 use std::sync::Arc;
-use std::time::Duration;
 
 use bytes::Bytes;
-use futures::StreamExt;
-use hickory_client::client::Client;
-use hickory_client::proto::op::{Message, MessageType, ResponseCode};
-use hickory_client::proto::rr::RData;
-use hickory_client::proto::runtime::TokioRuntimeProvider;
-use hickory_client::proto::serialize::binary::{BinDecodable, BinEncodable};
-use hickory_client::proto::udp::UdpClientStream;
-use hickory_client::proto::xfer::{DnsHandle, DnsRequest};
-use resolv_conf::Config as ResolvConfig;
 use smoltcp::iface::SocketSet;
 use smoltcp::socket::udp;
 use smoltcp::storage::PacketMetadata;
 use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
 use tokio::sync::mpsc;
 
+use super::forwarder::{self, NormalizedDnsConfig};
 use crate::config::DnsConfig;
-use crate::dns::parse::NameserverSpec;
 use crate::shared::SharedState;
 
 //--------------------------------------------------------------------------------------------------
@@ -58,10 +38,6 @@ const DNS_SOCKET_PACKET_SLOTS: usize = 16;
 
 /// Capacity of the query/response channels.
 const CHANNEL_CAPACITY: usize = 64;
-
-/// Path to the host resolver configuration. Used as a fallback when
-/// [`DnsConfig::nameservers`] is empty.
-const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -85,37 +61,20 @@ pub struct DnsInterceptor {
     response_rx: mpsc::Receiver<DnsResponse>,
 }
 
-/// Pre-processed DNS config with lowercased block lists (avoids per-query allocations).
-struct NormalizedDnsConfig {
-    /// O(1) exact-match lookup for blocked domains.
-    blocked_domains: HashSet<String>,
-    /// Lowercased suffixes WITHOUT leading dot (for exact match against the suffix itself).
-    blocked_suffixes: Vec<String>,
-    /// Dot-prefixed lowercased suffixes (for `ends_with` matching without per-query `format!`).
-    blocked_suffixes_dotted: Vec<String>,
-    rebind_protection: bool,
-    /// Explicit nameservers (unresolved specs). Empty means fall back to
-    /// the host's `/etc/resolv.conf`. Hostnames are resolved once at
-    /// forwarder-task startup via the host's own resolver.
-    nameservers: Vec<NameserverSpec>,
-    /// Per-query timeout.
-    query_timeout: Duration,
-}
-
 /// A DNS query extracted from the smoltcp socket.
-struct DnsQuery {
+pub(super) struct DnsQuery {
     /// Raw DNS message bytes.
-    data: Bytes,
+    pub(super) data: Bytes,
     /// Source endpoint (guest IP:port) for routing the response back.
-    source: IpEndpoint,
+    pub(super) source: IpEndpoint,
 }
 
 /// A forwarded DNS response ready to send back to the guest.
-struct DnsResponse {
+pub(super) struct DnsResponse {
     /// Raw DNS response bytes.
-    data: Bytes,
+    pub(super) data: Bytes,
     /// Destination endpoint (guest IP:port).
-    dest: IpEndpoint,
+    pub(super) dest: IpEndpoint,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -156,33 +115,9 @@ impl DnsInterceptor {
         let (query_tx, query_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let (response_tx, response_rx) = mpsc::channel(CHANNEL_CAPACITY);
 
-        // Pre-lowercase block lists once to avoid per-query allocations.
-        let suffixes: Vec<String> = dns_config
-            .blocked_suffixes
-            .iter()
-            .map(|s| s.to_lowercase().trim_start_matches('.').to_string())
-            .collect();
-        let suffixes_dotted: Vec<String> = suffixes.iter().map(|s| format!(".{s}")).collect();
-        let normalized = Arc::new(NormalizedDnsConfig {
-            blocked_domains: dns_config
-                .blocked_domains
-                .iter()
-                .map(|d| d.to_lowercase())
-                .collect(),
-            blocked_suffixes: suffixes,
-            blocked_suffixes_dotted: suffixes_dotted,
-            rebind_protection: dns_config.rebind_protection,
-            nameservers: dns_config.nameservers.clone(),
-            query_timeout: Duration::from_millis(dns_config.query_timeout_ms),
-        });
+        let normalized = Arc::new(NormalizedDnsConfig::from_config(dns_config));
 
-        // Spawn background forwarder task.
-        tokio_handle.spawn(dns_forwarder_task(
-            query_rx,
-            response_tx,
-            normalized,
-            shared,
-        ));
+        forwarder::spawn(tokio_handle, query_rx, response_tx, normalized, shared);
 
         Self {
             socket_handle,
@@ -228,418 +163,5 @@ impl DnsInterceptor {
                 Err(_) => break,
             }
         }
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-// Functions
-//--------------------------------------------------------------------------------------------------
-
-/// Background task that forwards DNS queries to the host's upstream
-/// resolver and sends responses back to the guest.
-///
-/// Sets up a single [`Client`] connected to the first configured upstream.
-/// `Client` is cheaply cloneable (it's a handle to a shared multiplexer),
-/// so each incoming query is handled in its own task for concurrency.
-async fn dns_forwarder_task(
-    mut query_rx: mpsc::Receiver<DnsQuery>,
-    response_tx: mpsc::Sender<DnsResponse>,
-    dns_config: Arc<NormalizedDnsConfig>,
-    shared: Arc<SharedState>,
-) {
-    let upstreams = if !dns_config.nameservers.is_empty() {
-        match resolve_specs(&dns_config.nameservers).await {
-            Ok(s) if !s.is_empty() => s,
-            Ok(_) => {
-                tracing::error!("no configured nameservers resolved to an address");
-                return;
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "failed to resolve configured nameservers");
-                return;
-            }
-        }
-    } else {
-        match read_host_dns_servers().await {
-            Ok(s) if !s.is_empty() => s,
-            Ok(_) => {
-                tracing::error!("no upstream DNS servers discovered from host");
-                return;
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "failed to read host DNS configuration");
-                return;
-            }
-        }
-    };
-
-    // Use the first upstream. If it's unhealthy the guest's stub will
-    // observe SERVFAIL and fall through to its own next nameserver.
-    let upstream = upstreams[0];
-    let stream =
-        UdpClientStream::<TokioRuntimeProvider>::builder(upstream, TokioRuntimeProvider::new())
-            .with_timeout(Some(dns_config.query_timeout))
-            .build();
-    let (client, bg) = match Client::connect(stream).await {
-        Ok(pair) => pair,
-        Err(e) => {
-            tracing::error!(upstream = %upstream, error = %e, "failed to connect to upstream DNS");
-            return;
-        }
-    };
-    tokio::spawn(bg);
-
-    while let Some(query) = query_rx.recv().await {
-        let response_tx = response_tx.clone();
-        let dns_config = dns_config.clone();
-        let shared = shared.clone();
-        let client = client.clone();
-
-        // Spawn a task per query for concurrency.
-        tokio::spawn(async move {
-            if let Some(data) = handle_query(&query.data, &dns_config, &client).await {
-                let response = DnsResponse {
-                    data,
-                    dest: query.source,
-                };
-                if response_tx.send(response).await.is_ok() {
-                    shared.proxy_wake.wake();
-                }
-            }
-        });
-    }
-}
-
-/// Handle a single DNS query: parse, apply local policy, forward upstream,
-/// and build the wire response. Returns `None` only when even synthesising
-/// a local error response fails (malformed query bytes).
-async fn handle_query(
-    raw_query: &[u8],
-    dns_config: &NormalizedDnsConfig,
-    client: &Client,
-) -> Option<Bytes> {
-    let query_msg = Message::from_bytes(raw_query).ok()?;
-    let guest_id = query_msg.id();
-
-    let question = query_msg.queries().first()?;
-    let domain = question.name().to_string();
-    let domain = domain.trim_end_matches('.').to_owned();
-
-    // Local policy: block list → synthesize REFUSED.
-    if is_domain_blocked(&domain, dns_config) {
-        tracing::debug!(domain = %domain, "DNS query blocked by policy");
-        return build_status_response(&query_msg, ResponseCode::Refused);
-    }
-
-    // Forward upstream. hickory-client's multiplexer assigns its own
-    // transaction id; we rewrite the response id back to the guest's
-    // below.
-    let mut send = client.send(DnsRequest::from(query_msg.clone()));
-    let response = match send.next().await {
-        Some(Ok(resp)) => resp,
-        Some(Err(e)) => {
-            tracing::warn!(domain = %domain, error = %e, "upstream DNS send failed");
-            return build_status_response(&query_msg, ResponseCode::ServFail);
-        }
-        None => {
-            tracing::warn!(domain = %domain, "upstream DNS closed stream without a response");
-            return build_status_response(&query_msg, ResponseCode::ServFail);
-        }
-    };
-    let mut response_msg: Message = response.into();
-
-    // Rebind protection: reject responses containing private/reserved IPs.
-    if dns_config.rebind_protection {
-        for record in response_msg.answers() {
-            let is_private = match record.data() {
-                RData::A(a) => is_private_ipv4((*a).into()),
-                RData::AAAA(aaaa) => is_private_ipv6((*aaaa).into()),
-                _ => false,
-            };
-            if is_private {
-                tracing::debug!(
-                    domain = %domain,
-                    "DNS rebind protection: response contains private IP"
-                );
-                return build_status_response(&query_msg, ResponseCode::Refused);
-            }
-        }
-    }
-
-    // Preserve the guest's transaction id.
-    response_msg.set_id(guest_id);
-
-    response_msg.to_bytes().ok().map(Bytes::from)
-}
-
-/// Build a status-only response (no answers, no authority) with the given
-/// RCODE. Used for locally-synthesized REFUSED (policy) and SERVFAIL
-/// (upstream unreachable). The guest's transaction id, OPCODE and RD bit
-/// are echoed.
-fn build_status_response(query: &Message, rcode: ResponseCode) -> Option<Bytes> {
-    let mut response = Message::new();
-    response.set_id(query.id());
-    response.set_op_code(query.op_code());
-    response.set_recursion_desired(query.recursion_desired());
-    response.set_message_type(MessageType::Response);
-    response.set_response_code(rcode);
-    response.set_recursion_available(true);
-    if let Some(q) = query.queries().first() {
-        response.add_query(q.clone());
-    }
-    response.to_bytes().ok().map(Bytes::from)
-}
-
-/// Read the host's configured DNS servers as `SocketAddr`s on port 53.
-///
-/// On macOS the authoritative source is `SystemConfiguration.framework`
-/// (the dynamic store `configd` maintains), not `/etc/resolv.conf` —
-/// VPN + split-DNS setups leave the file either stale or pointing at
-/// only one leg of the resolver table. We query
-/// `State:/Network/Global/DNS` first and only fall back to the file if
-/// the dynamic store is unavailable or reports no servers.
-///
-/// On Linux the file is authoritative.
-async fn read_host_dns_servers() -> std::io::Result<Vec<SocketAddr>> {
-    #[cfg(target_os = "macos")]
-    {
-        match super::scdynamicstore::read_dns_servers() {
-            Ok(servers) if !servers.is_empty() => {
-                tracing::debug!(
-                    count = servers.len(),
-                    "loaded nameservers from SCDynamicStore"
-                );
-                return Ok(servers);
-            }
-            Ok(_) => {
-                tracing::debug!(
-                    "SCDynamicStore returned no nameservers; falling back to /etc/resolv.conf"
-                );
-            }
-            Err(e) => {
-                tracing::debug!(
-                    error = %e,
-                    "SCDynamicStore lookup failed; falling back to /etc/resolv.conf"
-                );
-            }
-        }
-    }
-    read_resolv_conf(Path::new(RESOLV_CONF_PATH)).await
-}
-
-/// Parse a `resolv.conf`-format file and return the `nameserver` entries
-/// as `SocketAddr`s on port 53. Uses the same parser as hickory-resolver
-/// does internally (`resolv-conf` crate), but without pulling hickory's
-/// stub-resolver machinery along with it.
-async fn read_resolv_conf(path: &Path) -> std::io::Result<Vec<SocketAddr>> {
-    let bytes = tokio::fs::read(path).await?;
-    let cfg = ResolvConfig::parse(&bytes)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-    Ok(cfg
-        .nameservers
-        .into_iter()
-        .map(|ns| SocketAddr::new(IpAddr::from(ns), DNS_PORT))
-        .collect())
-}
-
-/// Resolve a list of [`NameserverSpec`]s to concrete `SocketAddr`s.
-///
-/// Hostnames are looked up via the host's OS resolver (via
-/// [`tokio::net::lookup_host`]), never via this interceptor. this
-/// bootstrap path must not depend on us being already running.
-/// Individual lookup failures are logged and skipped; the whole
-/// operation errors only if every entry fails.
-async fn resolve_specs(specs: &[NameserverSpec]) -> std::io::Result<Vec<SocketAddr>> {
-    let mut out = Vec::with_capacity(specs.len());
-    let mut last_err: Option<std::io::Error> = None;
-    for spec in specs {
-        match spec.resolve().await {
-            Ok(sa) => out.push(sa),
-            Err(e) => {
-                tracing::warn!(spec = %spec, error = %e, "failed to resolve nameserver spec");
-                last_err = Some(e);
-            }
-        }
-    }
-    if out.is_empty()
-        && let Some(e) = last_err
-    {
-        return Err(e);
-    }
-    Ok(out)
-}
-
-/// Check if an IPv4 address is in a private/reserved range (for rebind protection).
-fn is_private_ipv4(addr: std::net::Ipv4Addr) -> bool {
-    let octets = addr.octets();
-    addr.is_loopback()                                        // 127.0.0.0/8
-        || octets[0] == 10                                    // 10.0.0.0/8
-        || (octets[0] == 172 && (octets[1] & 0xf0) == 16)    // 172.16.0.0/12
-        || (octets[0] == 192 && octets[1] == 168)             // 192.168.0.0/16
-        || (octets[0] == 100 && (octets[1] & 0xc0) == 64)    // 100.64.0.0/10 (CGNAT)
-        || (octets[0] == 169 && octets[1] == 254)             // 169.254.0.0/16 (link-local)
-        || addr.is_unspecified() // 0.0.0.0
-}
-
-/// Check if an IPv6 address is in a private/reserved range (for rebind protection).
-fn is_private_ipv6(addr: std::net::Ipv6Addr) -> bool {
-    let segments = addr.segments();
-    addr.is_loopback()                       // ::1
-        || (segments[0] & 0xfe00) == 0xfc00  // fc00::/7 (ULA)
-        || (segments[0] & 0xffc0) == 0xfe80  // fe80::/10 (link-local)
-        || addr.is_unspecified() // ::
-}
-
-/// Check if a domain is blocked by the DNS config.
-///
-/// Block lists are pre-lowercased in [`NormalizedDnsConfig`], so only the
-/// queried domain needs lowercasing (once per query instead of per entry).
-fn is_domain_blocked(domain: &str, config: &NormalizedDnsConfig) -> bool {
-    let domain_lower = domain.to_lowercase();
-
-    // Check exact domain matches — O(1) via HashSet.
-    if config.blocked_domains.contains(&domain_lower) {
-        return true;
-    }
-
-    // Check suffix matches (already lowercased with pre-computed dot-prefixed forms).
-    for (suffix, dotted) in config
-        .blocked_suffixes
-        .iter()
-        .zip(config.blocked_suffixes_dotted.iter())
-    {
-        if domain_lower == *suffix || domain_lower.ends_with(dotted.as_str()) {
-            return true;
-        }
-    }
-
-    false
-}
-
-//--------------------------------------------------------------------------------------------------
-// Tests
-//--------------------------------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use hickory_client::proto::op::{MessageType, OpCode, Query};
-    use hickory_client::proto::rr::{DNSClass, Name, RecordType};
-
-    fn normalized(domains: Vec<&str>, suffixes: Vec<&str>) -> NormalizedDnsConfig {
-        let blocked_suffixes: Vec<String> = suffixes
-            .iter()
-            .map(|s| s.to_lowercase().trim_start_matches('.').to_string())
-            .collect();
-        let blocked_suffixes_dotted = blocked_suffixes.iter().map(|s| format!(".{s}")).collect();
-        NormalizedDnsConfig {
-            blocked_domains: domains
-                .iter()
-                .map(|d| d.to_lowercase())
-                .collect::<HashSet<_>>(),
-            blocked_suffixes,
-            blocked_suffixes_dotted,
-            rebind_protection: false,
-            nameservers: Vec::<NameserverSpec>::new(),
-            query_timeout: Duration::from_millis(5000),
-        }
-    }
-
-    fn make_query(name: &str, qtype: RecordType) -> Message {
-        let mut msg = Message::new();
-        msg.set_id(0x4242);
-        msg.set_message_type(MessageType::Query);
-        msg.set_op_code(OpCode::Query);
-        msg.set_recursion_desired(true);
-        let parsed = Name::from_ascii(name).expect("valid dns name");
-        let mut q = Query::new();
-        q.set_name(parsed);
-        q.set_query_type(qtype);
-        q.set_query_class(DNSClass::IN);
-        msg.add_query(q);
-        msg
-    }
-
-    #[test]
-    fn test_exact_domain_blocked() {
-        let config = normalized(vec!["evil.com"], vec![]);
-        assert!(is_domain_blocked("evil.com", &config));
-        assert!(is_domain_blocked("Evil.COM", &config));
-        assert!(!is_domain_blocked("not-evil.com", &config));
-        assert!(!is_domain_blocked("sub.evil.com", &config));
-    }
-
-    #[test]
-    fn test_suffix_domain_blocked() {
-        let config = normalized(vec![], vec![".evil.com"]);
-        assert!(is_domain_blocked("sub.evil.com", &config));
-        assert!(is_domain_blocked("deep.sub.evil.com", &config));
-        assert!(is_domain_blocked("evil.com", &config));
-        assert!(!is_domain_blocked("notevil.com", &config));
-    }
-
-    #[test]
-    fn test_no_blocks_nothing_blocked() {
-        let config = normalized(vec![], vec![]);
-        assert!(!is_domain_blocked("anything.com", &config));
-    }
-
-    #[test]
-    fn build_status_response_preserves_header_and_question() {
-        let query = make_query("slack.com.", RecordType::AAAA);
-        let bytes = build_status_response(&query, ResponseCode::Refused).expect("built");
-        let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.id(), 0x4242);
-        assert_eq!(msg.response_code(), ResponseCode::Refused);
-        assert_eq!(msg.message_type(), MessageType::Response);
-        assert_eq!(msg.op_code(), OpCode::Query);
-        assert!(msg.recursion_desired());
-        assert!(msg.recursion_available());
-        assert_eq!(msg.queries().len(), 1);
-        assert_eq!(msg.queries()[0].query_type(), RecordType::AAAA);
-        assert_eq!(msg.answers().len(), 0);
-    }
-
-    #[test]
-    fn build_status_response_servfail_variant() {
-        let query = make_query("example.com.", RecordType::A);
-        let bytes = build_status_response(&query, ResponseCode::ServFail).expect("built");
-        let msg = Message::from_bytes(&bytes).expect("parse response");
-        assert_eq!(msg.response_code(), ResponseCode::ServFail);
-        assert_eq!(msg.answers().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn read_resolv_conf_parses_nameservers() {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("msb-resolv-{}.conf", std::process::id()));
-        std::fs::write(
-            &path,
-            "# comment line\n\
-             nameserver 1.1.1.1\n\
-             nameserver 8.8.8.8  # inline comment\n\
-             search example.com\n\
-             options ndots:5\n\
-             nameserver 2606:4700:4700::1111\n\
-             \n",
-        )
-        .unwrap();
-
-        let servers = read_resolv_conf(&path).await.expect("read ok");
-        std::fs::remove_file(&path).ok();
-
-        assert_eq!(servers.len(), 3);
-        assert_eq!(servers[0], "1.1.1.1:53".parse().unwrap());
-        assert_eq!(servers[1], "8.8.8.8:53".parse().unwrap());
-        assert_eq!(servers[2], "[2606:4700:4700::1111]:53".parse().unwrap());
-    }
-
-    #[tokio::test]
-    async fn read_resolv_conf_missing_file_errs() {
-        assert!(
-            read_resolv_conf(Path::new("/nonexistent/path/to/resolv.conf"))
-                .await
-                .is_err()
-        );
     }
 }

--- a/crates/network/lib/dns/mod.rs
+++ b/crates/network/lib/dns/mod.rs
@@ -6,8 +6,11 @@
 
 pub mod interceptor;
 pub mod parse;
-
 #[cfg(target_os = "macos")]
 pub(crate) mod scdynamicstore;
 
-pub use parse::{NameserverSpec, ParseNameserverError, parse_nameserver};
+mod filter;
+mod forwarder;
+mod upstream;
+
+pub use parse::{Nameserver, ParseNameserverError};

--- a/crates/network/lib/dns/mod.rs
+++ b/crates/network/lib/dns/mod.rs
@@ -7,4 +7,7 @@
 pub mod interceptor;
 pub mod parse;
 
+#[cfg(target_os = "macos")]
+pub(crate) mod scdynamicstore;
+
 pub use parse::{NameserverSpec, ParseNameserverError, parse_nameserver};

--- a/crates/network/lib/dns/parse.rs
+++ b/crates/network/lib/dns/parse.rs
@@ -159,10 +159,6 @@ impl From<IpAddr> for Nameserver {
 mod tests {
     use super::*;
 
-    fn parse(s: &str) -> Result<Nameserver, ParseNameserverError> {
-        s.parse()
-    }
-
     fn addr(s: &str) -> Nameserver {
         Nameserver::Addr(s.parse().unwrap())
     }
@@ -176,18 +172,21 @@ mod tests {
 
     #[test]
     fn parses_ipv4_bare() {
-        assert_eq!(parse("1.1.1.1").unwrap(), addr("1.1.1.1:53"));
+        assert_eq!("1.1.1.1".parse::<Nameserver>().unwrap(), addr("1.1.1.1:53"));
     }
 
     #[test]
     fn parses_ipv4_with_port() {
-        assert_eq!(parse("8.8.8.8:5353").unwrap(), addr("8.8.8.8:5353"));
+        assert_eq!(
+            "8.8.8.8:5353".parse::<Nameserver>().unwrap(),
+            addr("8.8.8.8:5353")
+        );
     }
 
     #[test]
     fn parses_ipv6_bare() {
         assert_eq!(
-            parse("2606:4700:4700::1111").unwrap(),
+            "2606:4700:4700::1111".parse::<Nameserver>().unwrap(),
             addr("[2606:4700:4700::1111]:53")
         );
     }
@@ -195,62 +194,71 @@ mod tests {
     #[test]
     fn parses_ipv6_bracketed_with_port() {
         assert_eq!(
-            parse("[2606:4700:4700::1111]:53").unwrap(),
+            "[2606:4700:4700::1111]:53".parse::<Nameserver>().unwrap(),
             addr("[2606:4700:4700::1111]:53")
         );
     }
 
     #[test]
     fn parses_hostname_bare() {
-        assert_eq!(parse("dns.google").unwrap(), host("dns.google", 53));
+        assert_eq!(
+            "dns.google".parse::<Nameserver>().unwrap(),
+            host("dns.google", 53)
+        );
     }
 
     #[test]
     fn parses_hostname_with_port() {
-        assert_eq!(parse("dns.google:53").unwrap(), host("dns.google", 53));
         assert_eq!(
-            parse("my-dns.corp.internal:5353").unwrap(),
+            "dns.google:53".parse::<Nameserver>().unwrap(),
+            host("dns.google", 53)
+        );
+        assert_eq!(
+            "my-dns.corp.internal:5353".parse::<Nameserver>().unwrap(),
             host("my-dns.corp.internal", 5353)
         );
     }
 
     #[test]
     fn trims_whitespace() {
-        assert_eq!(parse("  1.1.1.1  ").unwrap(), addr("1.1.1.1:53"));
+        assert_eq!(
+            "  1.1.1.1  ".parse::<Nameserver>().unwrap(),
+            addr("1.1.1.1:53")
+        );
     }
 
     #[test]
     fn rejects_empty() {
-        assert!(parse("").is_err());
-        assert!(parse("   ").is_err());
+        assert!("".parse::<Nameserver>().is_err());
+        assert!("   ".parse::<Nameserver>().is_err());
     }
 
     #[test]
     fn rejects_embedded_whitespace() {
-        assert!(parse("dns google").is_err());
+        assert!("dns google".parse::<Nameserver>().is_err());
     }
 
     #[test]
     fn rejects_bad_port() {
-        assert!(parse("dns.google:notaport").is_err());
-        assert!(parse("1.1.1.1:99999").is_err());
+        assert!("dns.google:notaport".parse::<Nameserver>().is_err());
+        assert!("1.1.1.1:99999".parse::<Nameserver>().is_err());
     }
 
     #[test]
     fn display_roundtrip() {
         for s in ["1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53"] {
-            let spec = parse(s).unwrap();
-            assert_eq!(spec.to_string(), s);
+            let ns: Nameserver = s.parse().unwrap();
+            assert_eq!(ns.to_string(), s);
         }
     }
 
     #[test]
     fn display_feeds_back_into_parse() {
         for s in ["1.1.1.1", "dns.google", "dns.google:53"] {
-            let spec = parse(s).unwrap();
-            // Display output round-trips to the same spec via parse.
-            let reparsed = parse(&spec.to_string()).unwrap();
-            assert_eq!(spec, reparsed);
+            let ns: Nameserver = s.parse().unwrap();
+            // Display output round-trips to the same value via parse.
+            let reparsed: Nameserver = ns.to_string().parse().unwrap();
+            assert_eq!(ns, reparsed);
         }
     }
 }

--- a/crates/network/lib/dns/parse.rs
+++ b/crates/network/lib/dns/parse.rs
@@ -1,4 +1,4 @@
-//! User-facing nameserver specifications and parsing.
+//! User-facing nameserver type and parsing.
 //!
 //! A nameserver can be configured by IP or hostname, with an optional port.
 //! Hostnames are resolved at interceptor startup using the host's own
@@ -14,13 +14,12 @@ use serde::{Deserialize, Serialize};
 /// Default DNS port (used when a spec omits `:PORT`).
 const DEFAULT_DNS_PORT: u16 = 53;
 
-/// A parsed nameserver spec — either a literal address or a hostname to
-/// resolve later.
+/// A nameserver — either a literal address or a hostname to resolve later.
 ///
 /// Serializes as a single string (`"1.1.1.1"`, `"1.1.1.1:53"`,
 /// `"dns.google"`, `"dns.google:53"`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NameserverSpec {
+pub enum Nameserver {
     /// A literal socket address, ready to use.
     Addr(SocketAddr),
     /// A hostname + port to be resolved at startup via the host's resolver.
@@ -32,7 +31,7 @@ pub enum NameserverSpec {
     },
 }
 
-impl NameserverSpec {
+impl Nameserver {
     /// Resolve to a concrete `SocketAddr`. `Addr` returns immediately;
     /// `Host` performs a lookup via the host's OS resolver (not this
     /// interceptor — avoids bootstrap recursion) and returns the first
@@ -53,7 +52,7 @@ impl NameserverSpec {
     }
 }
 
-impl fmt::Display for NameserverSpec {
+impl fmt::Display for Nameserver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Addr(sa) => write!(f, "{sa}"),
@@ -62,20 +61,12 @@ impl fmt::Display for NameserverSpec {
     }
 }
 
-/// Error returned when a user-supplied nameserver spec can't be parsed.
+/// Error returned when a user-supplied nameserver string can't be parsed.
 #[derive(Debug, thiserror::Error)]
 #[error("invalid nameserver {0:?}; expected IP, IP:PORT, HOST, or HOST:PORT")]
 pub struct ParseNameserverError(pub String);
 
-impl FromStr for NameserverSpec {
-    type Err = ParseNameserverError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_nameserver(s)
-    }
-}
-
-/// Parse a user-supplied nameserver spec.
+/// Parse a user-supplied nameserver string.
 ///
 /// Accepted forms:
 /// - `1.1.1.1` — IPv4, port defaults to 53
@@ -84,73 +75,77 @@ impl FromStr for NameserverSpec {
 /// - `[2606:4700:4700::1111]:53` — IPv6 with port (brackets required)
 /// - `dns.google` — hostname, port defaults to 53
 /// - `dns.google:53` — hostname with port
-pub fn parse_nameserver(spec: &str) -> Result<NameserverSpec, ParseNameserverError> {
-    let s = spec.trim();
-    if s.is_empty() {
-        return Err(ParseNameserverError(spec.to_owned()));
-    }
+impl FromStr for Nameserver {
+    type Err = ParseNameserverError;
 
-    // IP:PORT or [IPv6]:PORT.
-    if let Ok(sa) = s.parse::<SocketAddr>() {
-        return Ok(NameserverSpec::Addr(sa));
-    }
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let s = input.trim();
+        if s.is_empty() {
+            return Err(ParseNameserverError(input.to_owned()));
+        }
 
-    // Bare IPv4 / IPv6.
-    if let Ok(ip) = s.parse::<IpAddr>() {
-        return Ok(NameserverSpec::Addr(SocketAddr::new(ip, DEFAULT_DNS_PORT)));
-    }
+        // IP:PORT or [IPv6]:PORT.
+        if let Ok(sa) = s.parse::<SocketAddr>() {
+            return Ok(Self::Addr(sa));
+        }
 
-    // HOST:PORT. `rsplit_once` so we don't get confused by port-less IPv6
-    // forms (those are handled above). Reject when the host segment would
-    // itself parse as an IPv6 address — that means the user wrote a bare
-    // v6 literal without brackets and the `:` is an IPv6 separator.
-    if let Some((host, port)) = s.rsplit_once(':')
-        && !host.is_empty()
-        && !host.contains(':')
-        && host.parse::<IpAddr>().is_err()
-        && let Ok(port) = port.parse::<u16>()
-    {
-        return Ok(NameserverSpec::Host {
-            host: host.to_owned(),
-            port,
-        });
-    }
+        // Bare IPv4 / IPv6.
+        if let Ok(ip) = s.parse::<IpAddr>() {
+            return Ok(Self::Addr(SocketAddr::new(ip, DEFAULT_DNS_PORT)));
+        }
 
-    // Bare hostname. Reject anything with whitespace or characters that
-    // couldn't form a DNS label.
-    if !s.contains(char::is_whitespace) && !s.contains(':') {
-        return Ok(NameserverSpec::Host {
-            host: s.to_owned(),
-            port: DEFAULT_DNS_PORT,
-        });
-    }
+        // HOST:PORT. `rsplit_once` so we don't get confused by port-less IPv6
+        // forms (those are handled above). Reject when the host segment would
+        // itself parse as an IPv6 address — that means the user wrote a bare
+        // v6 literal without brackets and the `:` is an IPv6 separator.
+        if let Some((host, port)) = s.rsplit_once(':')
+            && !host.is_empty()
+            && !host.contains(':')
+            && host.parse::<IpAddr>().is_err()
+            && let Ok(port) = port.parse::<u16>()
+        {
+            return Ok(Self::Host {
+                host: host.to_owned(),
+                port,
+            });
+        }
 
-    Err(ParseNameserverError(spec.to_owned()))
+        // Bare hostname. Reject anything with whitespace or characters that
+        // couldn't form a DNS label.
+        if !s.contains(char::is_whitespace) && !s.contains(':') {
+            return Ok(Self::Host {
+                host: s.to_owned(),
+                port: DEFAULT_DNS_PORT,
+            });
+        }
+
+        Err(ParseNameserverError(input.to_owned()))
+    }
 }
 
 // Serialize as a single string ("1.1.1.1:53" or "dns.google:53") so
 // config files stay flat and readable.
-impl Serialize for NameserverSpec {
+impl Serialize for Nameserver {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.collect_str(self)
     }
 }
 
-impl<'de> Deserialize<'de> for NameserverSpec {
+impl<'de> Deserialize<'de> for Nameserver {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let s = String::deserialize(d)?;
-        parse_nameserver(&s).map_err(serde::de::Error::custom)
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 
 // Ergonomic conversions for Rust builder callers.
-impl From<SocketAddr> for NameserverSpec {
+impl From<SocketAddr> for Nameserver {
     fn from(sa: SocketAddr) -> Self {
         Self::Addr(sa)
     }
 }
 
-impl From<IpAddr> for NameserverSpec {
+impl From<IpAddr> for Nameserver {
     fn from(ip: IpAddr) -> Self {
         Self::Addr(SocketAddr::new(ip, DEFAULT_DNS_PORT))
     }
@@ -164,12 +159,16 @@ impl From<IpAddr> for NameserverSpec {
 mod tests {
     use super::*;
 
-    fn addr(s: &str) -> NameserverSpec {
-        NameserverSpec::Addr(s.parse().unwrap())
+    fn parse(s: &str) -> Result<Nameserver, ParseNameserverError> {
+        s.parse()
     }
 
-    fn host(host: &str, port: u16) -> NameserverSpec {
-        NameserverSpec::Host {
+    fn addr(s: &str) -> Nameserver {
+        Nameserver::Addr(s.parse().unwrap())
+    }
+
+    fn host(host: &str, port: u16) -> Nameserver {
+        Nameserver::Host {
             host: host.to_owned(),
             port,
         }
@@ -177,21 +176,18 @@ mod tests {
 
     #[test]
     fn parses_ipv4_bare() {
-        assert_eq!(parse_nameserver("1.1.1.1").unwrap(), addr("1.1.1.1:53"));
+        assert_eq!(parse("1.1.1.1").unwrap(), addr("1.1.1.1:53"));
     }
 
     #[test]
     fn parses_ipv4_with_port() {
-        assert_eq!(
-            parse_nameserver("8.8.8.8:5353").unwrap(),
-            addr("8.8.8.8:5353")
-        );
+        assert_eq!(parse("8.8.8.8:5353").unwrap(), addr("8.8.8.8:5353"));
     }
 
     #[test]
     fn parses_ipv6_bare() {
         assert_eq!(
-            parse_nameserver("2606:4700:4700::1111").unwrap(),
+            parse("2606:4700:4700::1111").unwrap(),
             addr("[2606:4700:4700::1111]:53")
         );
     }
@@ -199,77 +195,61 @@ mod tests {
     #[test]
     fn parses_ipv6_bracketed_with_port() {
         assert_eq!(
-            parse_nameserver("[2606:4700:4700::1111]:53").unwrap(),
+            parse("[2606:4700:4700::1111]:53").unwrap(),
             addr("[2606:4700:4700::1111]:53")
         );
     }
 
     #[test]
     fn parses_hostname_bare() {
-        assert_eq!(
-            parse_nameserver("dns.google").unwrap(),
-            host("dns.google", 53)
-        );
+        assert_eq!(parse("dns.google").unwrap(), host("dns.google", 53));
     }
 
     #[test]
     fn parses_hostname_with_port() {
+        assert_eq!(parse("dns.google:53").unwrap(), host("dns.google", 53));
         assert_eq!(
-            parse_nameserver("dns.google:53").unwrap(),
-            host("dns.google", 53)
-        );
-        assert_eq!(
-            parse_nameserver("my-dns.corp.internal:5353").unwrap(),
+            parse("my-dns.corp.internal:5353").unwrap(),
             host("my-dns.corp.internal", 5353)
         );
     }
 
     #[test]
     fn trims_whitespace() {
-        assert_eq!(parse_nameserver("  1.1.1.1  ").unwrap(), addr("1.1.1.1:53"));
+        assert_eq!(parse("  1.1.1.1  ").unwrap(), addr("1.1.1.1:53"));
     }
 
     #[test]
     fn rejects_empty() {
-        assert!(parse_nameserver("").is_err());
-        assert!(parse_nameserver("   ").is_err());
+        assert!(parse("").is_err());
+        assert!(parse("   ").is_err());
     }
 
     #[test]
     fn rejects_embedded_whitespace() {
-        assert!(parse_nameserver("dns google").is_err());
+        assert!(parse("dns google").is_err());
     }
 
     #[test]
     fn rejects_bad_port() {
-        assert!(parse_nameserver("dns.google:notaport").is_err());
-        assert!(parse_nameserver("1.1.1.1:99999").is_err());
+        assert!(parse("dns.google:notaport").is_err());
+        assert!(parse("1.1.1.1:99999").is_err());
     }
 
     #[test]
     fn display_roundtrip() {
         for s in ["1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53"] {
-            let spec = parse_nameserver(s).unwrap();
+            let spec = parse(s).unwrap();
             assert_eq!(spec.to_string(), s);
-        }
-    }
-
-    #[test]
-    fn fromstr_matches_parse_nameserver() {
-        for s in ["1.1.1.1", "8.8.8.8:5353", "dns.google", "dns.google:53"] {
-            assert_eq!(
-                s.parse::<NameserverSpec>().unwrap(),
-                parse_nameserver(s).unwrap()
-            );
         }
     }
 
     #[test]
     fn display_feeds_back_into_parse() {
         for s in ["1.1.1.1", "dns.google", "dns.google:53"] {
-            let spec = parse_nameserver(s).unwrap();
+            let spec = parse(s).unwrap();
             // Display output round-trips to the same spec via parse.
-            let reparsed = parse_nameserver(&spec.to_string()).unwrap();
+            let reparsed = parse(&spec.to_string()).unwrap();
             assert_eq!(spec, reparsed);
         }
     }

--- a/crates/network/lib/dns/scdynamicstore.rs
+++ b/crates/network/lib/dns/scdynamicstore.rs
@@ -1,0 +1,90 @@
+//! macOS-specific DNS-server discovery via `SystemConfiguration.framework`.
+//!
+//! Unlike Linux, macOS doesn't treat `/etc/resolv.conf` as authoritative.
+//! The live resolver state is stored in the System Configuration dynamic
+//! store and is managed by `configd`. On VPN + split-DNS setups
+//! `/etc/resolv.conf` is typically either missing, stale, or points at
+//! only one leg of the resolver table — following it there gets us the
+//! wrong answer.
+//!
+//! This module queries `State:/Network/Global/DNS` and returns the
+//! primary nameserver list (the set `configd` tells the system resolver
+//! to use). That's the fix for the most common macOS failure mode: "I
+//! connected to a VPN and DNS stopped working inside the sandbox."
+//!
+//! What this intentionally does *not* handle: per-domain split-DNS
+//! routing (e.g. `*.corp.example.com → 10.0.0.53`, everything else →
+//! `8.8.8.8`). That routing lives in the per-service `Setup:/Network/
+//! Service/<uuid>/DNS` / `State:/Network/Service/<uuid>/DNS` keys and
+//! requires a match engine to implement. Tracked as future work.
+
+use std::io::{self, Error, ErrorKind};
+use std::net::{IpAddr, SocketAddr};
+
+use core_foundation::array::CFArray;
+use core_foundation::base::{CFType, TCFType, ToVoid};
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::propertylist::CFPropertyList;
+use core_foundation::string::CFString;
+use system_configuration::dynamic_store::SCDynamicStoreBuilder;
+use system_configuration::sys::schema_definitions::kSCPropNetDNSServerAddresses;
+
+/// Read the primary DNS servers from the macOS dynamic store.
+///
+/// Returns the list of `SocketAddr`s on port 53 in the order `configd`
+/// has configured them. Returns an empty `Vec` (not `Err`) when the
+/// `Global/DNS` key exists but carries no `ServerAddresses`. Returns
+/// `Err` only when we can't create the store or the key is entirely
+/// absent (rare on a running system, but possible in degenerate
+/// network-off states).
+pub fn read_dns_servers() -> io::Result<Vec<SocketAddr>> {
+    const DNS_PORT: u16 = 53;
+
+    let store = SCDynamicStoreBuilder::new("microsandbox-network")
+        .build()
+        .ok_or_else(|| Error::other("SCDynamicStoreBuilder::build failed"))?;
+
+    let key = CFString::from_static_string("State:/Network/Global/DNS");
+    let dict = match store
+        .get(key)
+        .and_then(CFPropertyList::downcast_into::<CFDictionary>)
+    {
+        Some(d) => d,
+        None => {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                "State:/Network/Global/DNS is absent",
+            ));
+        }
+    };
+
+    let addresses = match dict
+        .find(unsafe { kSCPropNetDNSServerAddresses }.to_void())
+        .map(|ptr| unsafe { CFType::wrap_under_get_rule(*ptr) })
+        .and_then(CFType::downcast_into::<CFArray>)
+    {
+        Some(a) => a,
+        None => return Ok(Vec::new()), // key present, no servers listed
+    };
+
+    let mut out = Vec::with_capacity(addresses.len() as usize);
+    for ptr in &addresses {
+        let Some(cfstr) = unsafe { CFType::wrap_under_get_rule(*ptr) }.downcast_into::<CFString>()
+        else {
+            continue;
+        };
+
+        let s = cfstr.to_string();
+        match s.parse::<IpAddr>() {
+            Ok(ip) => out.push(SocketAddr::new(ip, DNS_PORT)),
+            Err(_) => {
+                tracing::warn!(
+                    address = %s,
+                    "skipping SCDynamicStore nameserver entry that isn't a parseable IP"
+                );
+            }
+        }
+    }
+
+    Ok(out)
+}

--- a/crates/network/lib/dns/upstream.rs
+++ b/crates/network/lib/dns/upstream.rs
@@ -1,0 +1,160 @@
+//! Upstream DNS server discovery.
+//!
+//! Resolves the list of upstream nameservers the forwarder should talk
+//! to. Sources, in order:
+//!
+//! 1. Explicit [`Nameserver`]s from configuration, if any. Hostnames
+//!    are looked up via the host's own OS resolver, never via us —
+//!    bootstrapping cannot depend on the interceptor being up already.
+//! 2. The host's configured resolvers. On macOS this is the
+//!    `SystemConfiguration` dynamic store (`configd`'s view), falling
+//!    back to `/etc/resolv.conf` only if the store is unavailable or
+//!    empty; VPN + split-DNS setups leave the file stale. On Linux
+//!    `/etc/resolv.conf` is authoritative.
+
+use std::net::{IpAddr, SocketAddr};
+use std::path::Path;
+
+use resolv_conf::Config as ResolvConfig;
+
+use super::parse::Nameserver;
+
+/// DNS port.
+const DNS_PORT: u16 = 53;
+
+/// Path to the host resolver configuration. Used as a fallback when
+/// explicit nameservers are not configured and — on macOS — when
+/// SCDynamicStore is unavailable.
+const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
+
+/// Resolve a list of [`Nameserver`]s to concrete `SocketAddr`s.
+///
+/// Individual lookup failures are logged and skipped; the whole operation
+/// errors only if every entry fails.
+pub(super) async fn resolve_nameservers(
+    nameservers: &[Nameserver],
+) -> std::io::Result<Vec<SocketAddr>> {
+    let mut out = Vec::with_capacity(nameservers.len());
+    let mut last_err: Option<std::io::Error> = None;
+    for ns in nameservers {
+        match ns.resolve().await {
+            Ok(sa) => out.push(sa),
+            Err(e) => {
+                tracing::warn!(nameserver = %ns, error = %e, "failed to resolve nameserver");
+                last_err = Some(e);
+            }
+        }
+    }
+    if out.is_empty()
+        && let Some(e) = last_err
+    {
+        return Err(e);
+    }
+    Ok(out)
+}
+
+/// Read the host's configured DNS servers as `SocketAddr`s on port 53.
+///
+/// On macOS the authoritative source is `SystemConfiguration.framework`
+/// (the dynamic store `configd` maintains), not `/etc/resolv.conf` —
+/// VPN + split-DNS setups leave the file either stale or pointing at
+/// only one leg of the resolver table. We query
+/// `State:/Network/Global/DNS` first and only fall back to the file if
+/// the dynamic store is unavailable or reports no servers.
+///
+/// On Linux the file is authoritative.
+pub(super) async fn read_host_dns_servers() -> std::io::Result<Vec<SocketAddr>> {
+    #[cfg(target_os = "macos")]
+    if let Some(servers) = try_read_scdynamicstore() {
+        return Ok(servers);
+    }
+    read_resolv_conf(Path::new(RESOLV_CONF_PATH)).await
+}
+
+/// Try to read nameservers from the macOS SystemConfiguration dynamic
+/// store. Returns `None` (and logs at debug) if the store is
+/// unavailable, reports no servers, or fails — the caller should fall
+/// back to `/etc/resolv.conf` in that case.
+#[cfg(target_os = "macos")]
+fn try_read_scdynamicstore() -> Option<Vec<SocketAddr>> {
+    match super::scdynamicstore::read_dns_servers() {
+        Ok(servers) if !servers.is_empty() => {
+            tracing::debug!(
+                count = servers.len(),
+                "loaded nameservers from SCDynamicStore"
+            );
+            Some(servers)
+        }
+        Ok(_) => {
+            tracing::debug!(
+                "SCDynamicStore returned no nameservers; falling back to /etc/resolv.conf"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "SCDynamicStore lookup failed; falling back to /etc/resolv.conf"
+            );
+            None
+        }
+    }
+}
+
+/// Parse a `resolv.conf`-format file and return the `nameserver` entries
+/// as `SocketAddr`s on port 53. Uses the same parser as hickory-resolver
+/// does internally (`resolv-conf` crate), but without pulling hickory's
+/// stub-resolver machinery along with it.
+async fn read_resolv_conf(path: &Path) -> std::io::Result<Vec<SocketAddr>> {
+    let bytes = tokio::fs::read(path).await?;
+    let cfg = ResolvConfig::parse(&bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    Ok(cfg
+        .nameservers
+        .into_iter()
+        .map(|ns| SocketAddr::new(IpAddr::from(ns), DNS_PORT))
+        .collect())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_resolv_conf_parses_nameservers() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("msb-resolv-{}.conf", std::process::id()));
+        std::fs::write(
+            &path,
+            "# comment line\n\
+             nameserver 1.1.1.1\n\
+             nameserver 8.8.8.8  # inline comment\n\
+             search example.com\n\
+             options ndots:5\n\
+             nameserver 2606:4700:4700::1111\n\
+             \n",
+        )
+        .unwrap();
+
+        let servers = read_resolv_conf(&path).await.expect("read ok");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(servers.len(), 3);
+        assert_eq!(servers[0], "1.1.1.1:53".parse().unwrap());
+        assert_eq!(servers[1], "8.8.8.8:53".parse().unwrap());
+        assert_eq!(servers[2], "[2606:4700:4700::1111]:53".parse().unwrap());
+    }
+
+    #[tokio::test]
+    async fn read_resolv_conf_missing_file_errs() {
+        assert!(
+            read_resolv_conf(Path::new("/nonexistent/path/to/resolv.conf"))
+                .await
+                .is_err()
+        );
+    }
+}

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -263,15 +263,15 @@ By default the sandbox forwards DNS queries to whatever nameservers are listed i
 <CodeGroup>
 
 ```rust Rust
-use microsandbox_network::dns::NameserverSpec;
+use microsandbox_network::dns::Nameserver;
 
 let sb = Sandbox::builder("safe-agent")
     .image("python")
     .network(|n| n
         .dns(|d| d
             .nameservers([
-                "1.1.1.1".parse::<NameserverSpec>()?,
-                "1.0.0.1".parse::<NameserverSpec>()?,
+                "1.1.1.1".parse::<Nameserver>()?,
+                "1.0.0.1".parse::<Nameserver>()?,
             ])
             .query_timeout_ms(3000)
         )

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -61,7 +61,7 @@ Configure DNS interception via a closure. See [`DnsBuilder`](#dnsbuilder) for th
     .dns(|d| d
         .block_domain("malware.example.com")
         .block_domain_suffix(".tracking.com")
-        .nameservers(["1.1.1.1".parse::<NameserverSpec>()?])
+        .nameservers(["1.1.1.1".parse::<Nameserver>()?])
         .query_timeout_ms(3000)
     )
 )
@@ -190,21 +190,21 @@ When enabled, DNS responses that resolve to private IP addresses are blocked. Th
 #### nameservers()
 
 ```rust
-fn nameservers<I>(self, specs: I) -> Self
+fn nameservers<I>(self, nameservers: I) -> Self
 where
     I: IntoIterator,
-    I::Item: Into<NameserverSpec>,
+    I::Item: Into<Nameserver>,
 ```
 
 Set the upstream nameservers to forward DNS queries to. When one or more are set, the interceptor uses these instead of the nameservers in the host's `/etc/resolv.conf`. Replaces any previously-set nameservers. Useful for pinning specific resolvers (e.g. `1.1.1.1:53`) or working around split-DNS / VPN setups.
 
-Each element is any type convertible into `NameserverSpec` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<NameserverSpec>()?`). Hostnames are resolved once at startup via the host's OS resolver.
+Each element is any type convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`). Hostnames are resolved once at startup via the host's OS resolver.
 
 **Parameters**
 
 | Name | Type | Description |
 |------|------|-------------|
-| specs | `IntoIterator<Item: Into<NameserverSpec>>` | Iterable of nameserver specs |
+| nameservers | `IntoIterator<Item: Into<Nameserver>>` | Iterable of nameservers |
 
 ---
 

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use microsandbox::sandbox::{NetworkPolicy, PullPolicy, SandboxConfig as RustSandboxConfig};
 use microsandbox::{LogLevel, RegistryAuth as RustRegistryAuth};
-use microsandbox_network::dns;
+use microsandbox_network::dns::Nameserver;
 use microsandbox_network::policy::{
     Action, Destination, DestinationGroup, Direction, PortRange, Protocol, Rule,
 };
@@ -546,15 +546,10 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
         }
     }
     if let Some(ref network) = config.network {
-        let dns_nameserver_specs: Vec<dns::NameserverSpec> = if let Some(ref dns) = network.dns
+        let dns_nameservers = if let Some(ref dns) = network.dns
             && let Some(ref nameservers) = dns.nameservers
         {
-            nameservers
-                .iter()
-                .map(|s| {
-                    dns::parse_nameserver(s).map_err(|e| napi::Error::from_reason(e.to_string()))
-                })
-                .collect::<Result<Vec<_>, _>>()?
+            parse_nameservers(nameservers)?
         } else {
             Vec::new()
         };
@@ -598,8 +593,8 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
                     if let Some(rebind) = rebind_protection {
                         d = d.rebind_protection(rebind);
                     }
-                    if !dns_nameserver_specs.is_empty() {
-                        d = d.nameservers(dns_nameserver_specs);
+                    if !dns_nameservers.is_empty() {
+                        d = d.nameservers(dns_nameservers);
                     }
                     if let Some(ms) = query_timeout_ms {
                         d = d.query_timeout_ms(u64::from(ms));
@@ -687,6 +682,18 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
     }
 
     builder.build().map_err(to_napi_error)
+}
+
+/// Parse user-supplied nameserver strings into [`Nameserver`]s, wrapping any
+/// parse error in a napi `Error` so it surfaces as a JS exception.
+fn parse_nameservers(nameservers: &[String]) -> Result<Vec<Nameserver>> {
+    nameservers
+        .iter()
+        .map(|s| {
+            s.parse::<Nameserver>()
+                .map_err(|e| napi::Error::from_reason(e.to_string()))
+        })
+        .collect()
 }
 
 fn convert_mount(

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -1,5 +1,6 @@
 use microsandbox::sandbox::{NetworkPolicy, Patch, PullPolicy, SandboxConfig};
 use microsandbox::{LogLevel, RegistryAuth};
+use microsandbox_network::dns::Nameserver;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
@@ -488,10 +489,10 @@ fn apply_network(
         let nameservers_raw = extract_opt::<Vec<String>>(&dns, "nameservers")?;
         let query_timeout_ms = extract_opt::<u64>(&dns, "query_timeout_ms")?;
 
-        let nameserver_specs: Vec<microsandbox_network::dns::NameserverSpec> = nameservers_raw
+        let nameservers: Vec<Nameserver> = nameservers_raw
             .unwrap_or_default()
             .iter()
-            .map(|s| microsandbox_network::dns::parse_nameserver(s))
+            .map(|s| s.parse::<Nameserver>())
             .collect::<Result<_, _>>()
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
@@ -510,8 +511,8 @@ fn apply_network(
                 if let Some(r) = rebind {
                     d = d.rebind_protection(r);
                 }
-                if !nameserver_specs.is_empty() {
-                    d = d.nameservers(nameserver_specs);
+                if !nameservers.is_empty() {
+                    d = d.nameservers(nameservers);
                 }
                 if let Some(ms) = query_timeout_ms {
                     d = d.query_timeout_ms(ms);


### PR DESCRIPTION
## Summary

- on macos, /etc/resolv.conf is often stale under vpn/split-dns. added a scdynamicstore query as the primary nameserver source on macos, with the file kept as fallback. linux unchanged.
- split `dns/interceptor.rs` into `forwarder`, `upstream`, and `filter` submodules. `interceptor.rs` is now the thin smoltcp/channel bridge.
- renamed `NameserverSpec` to `Nameserver` and dropped the `parse_nameserver` free function in favour of `str::parse()`. cli + node/python sdk callers updated.

## Test plan

- [x] `cargo test -p microsandbox-network dns::` (19 tests)
- [x] macos + vpn: `dig @<gateway> <internal-host>` resolves correctly inside a sandbox
- [x] macos without vpn: resolution still works via fallback
- [x] linux: resolv.conf path unchanged