### PR TITLE
feat(network): trust host CAs inside sandbox guests (opt-in)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "lru",
  "microsandbox-utils",
  "msb_krun",
+ "pem",
  "rcgen",
  "resolv-conf",
  "rustls",

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -31,6 +31,7 @@ pub fn init(params: BootParams) -> AgentdResult<()> {
     linux::ensure_standard_tmp_permissions()?;
     network::apply_network_config(params.network())?;
     tls::install_ca_cert()?;
+    tls::install_host_cas()?;
     linux::ensure_scripts_path_in_profile()?;
     linux::create_run_dir()?;
     Ok(())

--- a/crates/agentd/lib/tls.rs
+++ b/crates/agentd/lib/tls.rs
@@ -36,9 +36,12 @@ const CA_BUNDLE_PATHS: &[&str] = &[
 /// Fallback path to create if no existing bundle is found.
 const FALLBACK_BUNDLE_PATH: &str = "/etc/ssl/certs/ca-certificates.crt";
 
-/// Filenames for the CA cert when copied to distro trust directories.
+/// Filenames for the microsandbox MITM CA when copied to distro trust directories.
 /// Both extensions for broad tool compatibility (`.crt` for `update-ca-certificates`).
 const CA_CERT_FILENAMES: &[&str] = &["microsandbox-ca.pem", "microsandbox-ca.crt"];
+
+/// Filenames for the host-CA bundle when copied to distro trust directories.
+const HOST_CAS_FILENAMES: &[&str] = &["microsandbox-host-cas.pem", "microsandbox-host-cas.crt"];
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -60,7 +63,7 @@ pub fn install_ca_cert() -> AgentdResult<()> {
     );
 
     // Copy to distro-specific trust directories (if they exist).
-    copy_to_trust_dirs(&ca_pem);
+    copy_to_trust_dirs(&ca_pem, CA_CERT_FILENAMES);
 
     // Append to the system CA bundle.
     let bundle_path = append_to_bundle(&ca_pem)?;
@@ -82,16 +85,49 @@ pub fn install_ca_cert() -> AgentdResult<()> {
     Ok(())
 }
 
-/// Copies the CA PEM to distro-specific trust directories that exist.
+/// Installs the host's extra trusted CAs into the guest trust store so
+/// outbound TLS works behind corporate MITM proxies (Warp Zero Trust,
+/// Zscaler, etc.) whose gateway CA is trusted on the host but not in the
+/// guest's Mozilla root bundle.
+///
+/// No-op if `/.msb/tls/host-cas.pem` does not exist (host-CA shipping
+/// disabled or host store empty).
+pub fn install_host_cas() -> AgentdResult<()> {
+    let path = Path::new(microsandbox_protocol::GUEST_TLS_HOST_CAS_PATH);
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let pem = fs::read_to_string(path)?;
+    let count = pem.matches("-----BEGIN CERTIFICATE-----").count();
+    eprintln!(
+        "tls: host CA bundle found at {} ({count} cert{}), installing into guest trust store",
+        path.display(),
+        if count == 1 { "" } else { "s" },
+    );
+
+    copy_to_trust_dirs(&pem, HOST_CAS_FILENAMES);
+    let bundle_path = append_to_bundle(&pem)?;
+
+    eprintln!(
+        "tls: installed {count} host CA cert{} into {bundle_path}",
+        if count == 1 { "" } else { "s" }
+    );
+    Ok(())
+}
+
+/// Copies a PEM to distro-specific trust directories that exist, under
+/// each of the given filenames. Both `.pem` and `.crt` are typically
+/// passed so tools that scan by extension pick one up.
 ///
 /// Best-effort: logs warnings on failure but does not abort.
-fn copy_to_trust_dirs(ca_pem: &str) {
+fn copy_to_trust_dirs(pem: &str, filenames: &[&str]) {
     for &dir in CA_TRUST_DIRS {
         let dir_path = Path::new(dir);
         if dir_path.is_dir() {
-            for &filename in CA_CERT_FILENAMES {
+            for &filename in filenames {
                 let dest = dir_path.join(filename);
-                match fs::write(&dest, ca_pem) {
+                match fs::write(&dest, pem) {
                     Ok(()) => eprintln!("tls: copied CA cert to {}", dest.display()),
                     Err(e) => eprintln!("tls: failed to copy CA cert to {}: {e}", dest.display()),
                 }

--- a/crates/agentd/lib/tls.rs
+++ b/crates/agentd/lib/tls.rs
@@ -99,20 +99,15 @@ pub fn install_host_cas() -> AgentdResult<()> {
     }
 
     let pem = fs::read_to_string(path)?;
-    let count = pem.matches("-----BEGIN CERTIFICATE-----").count();
     eprintln!(
-        "tls: host CA bundle found at {} ({count} cert{}), installing into guest trust store",
-        path.display(),
-        if count == 1 { "" } else { "s" },
+        "tls: host CA bundle found at {}, installing into guest trust store",
+        path.display()
     );
 
     copy_to_trust_dirs(&pem, HOST_CAS_FILENAMES);
     let bundle_path = append_to_bundle(&pem)?;
 
-    eprintln!(
-        "tls: installed {count} host CA cert{} into {bundle_path}",
-        if count == 1 { "" } else { "s" }
-    );
+    eprintln!("tls: host CA bundle installed, bundle={bundle_path}");
     Ok(())
 }
 

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -143,12 +143,13 @@ pub struct SandboxOpts {
     #[arg(long)]
     pub max_connections: Option<usize>,
 
-    /// Don't ship the host's trusted root CAs into the guest. By default the
-    /// host's trust store is copied into the guest so outbound TLS works
-    /// behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.).
+    /// Ship the host's trusted root CAs into the guest. Opt in to make
+    /// outbound TLS work behind corporate MITM proxies (Warp Zero
+    /// Trust, Zscaler, etc.) whose gateway CA is installed on the host
+    /// but unknown to the guest's stock Mozilla bundle.
     #[cfg(feature = "net")]
     #[arg(long)]
-    pub no_trust_host_cas: bool,
+    pub trust_host_cas: bool,
 
     // --- TLS interception ---
     /// Intercept and inspect HTTPS traffic via a built-in TLS proxy.
@@ -232,7 +233,7 @@ impl SandboxOpts {
             || self.dns_query_timeout_ms.is_some()
             || self.network_policy.is_some()
             || self.max_connections.is_some()
-            || self.no_trust_host_cas
+            || self.trust_host_cas
             || self.tls_intercept
             || !self.tls_intercept_port.is_empty()
             || !self.tls_bypass.is_empty()
@@ -387,7 +388,7 @@ fn apply_network_opts(
         || opts.dns_query_timeout_ms.is_some()
         || opts.network_policy.is_some()
         || opts.max_connections.is_some()
-        || opts.no_trust_host_cas
+        || opts.trust_host_cas
         || opts.tls_intercept
         || !opts.tls_intercept_port.is_empty()
         || !opts.tls_bypass.is_empty()
@@ -409,7 +410,7 @@ fn apply_network_opts(
         let dns_query_timeout_ms = opts.dns_query_timeout_ms;
         let network_policy = parse_network_policy(opts.network_policy.as_deref())?;
         let max_conn = opts.max_connections;
-        let trust_host_cas = !opts.no_trust_host_cas;
+        let trust_host_cas = opts.trust_host_cas;
         let tls_intercept = opts.tls_intercept;
         let tls_ports = opts.tls_intercept_port.clone();
         let tls_bypass = opts.tls_bypass.clone();
@@ -451,8 +452,8 @@ fn apply_network_opts(
             if let Some(max) = max_conn {
                 n = n.max_connections(max);
             }
-            if !trust_host_cas {
-                n = n.trust_host_cas(false);
+            if trust_host_cas {
+                n = n.trust_host_cas(true);
             }
             if let Some(action) = violation_action {
                 n = n.on_secret_violation(action);

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -143,6 +143,13 @@ pub struct SandboxOpts {
     #[arg(long)]
     pub max_connections: Option<usize>,
 
+    /// Don't ship the host's trusted root CAs into the guest. By default the
+    /// host's trust store is copied into the guest so outbound TLS works
+    /// behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.).
+    #[cfg(feature = "net")]
+    #[arg(long)]
+    pub no_trust_host_cas: bool,
+
     // --- TLS interception ---
     /// Intercept and inspect HTTPS traffic via a built-in TLS proxy.
     #[cfg(feature = "net")]
@@ -225,6 +232,7 @@ impl SandboxOpts {
             || self.dns_query_timeout_ms.is_some()
             || self.network_policy.is_some()
             || self.max_connections.is_some()
+            || self.no_trust_host_cas
             || self.tls_intercept
             || !self.tls_intercept_port.is_empty()
             || !self.tls_bypass.is_empty()
@@ -379,6 +387,7 @@ fn apply_network_opts(
         || opts.dns_query_timeout_ms.is_some()
         || opts.network_policy.is_some()
         || opts.max_connections.is_some()
+        || opts.no_trust_host_cas
         || opts.tls_intercept
         || !opts.tls_intercept_port.is_empty()
         || !opts.tls_bypass.is_empty()
@@ -400,6 +409,7 @@ fn apply_network_opts(
         let dns_query_timeout_ms = opts.dns_query_timeout_ms;
         let network_policy = parse_network_policy(opts.network_policy.as_deref())?;
         let max_conn = opts.max_connections;
+        let trust_host_cas = !opts.no_trust_host_cas;
         let tls_intercept = opts.tls_intercept;
         let tls_ports = opts.tls_intercept_port.clone();
         let tls_bypass = opts.tls_bypass.clone();
@@ -440,6 +450,9 @@ fn apply_network_opts(
             }
             if let Some(max) = max_conn {
                 n = n.max_connections(max);
+            }
+            if !trust_host_cas {
+                n = n.trust_host_cas(false);
             }
             if let Some(action) = violation_action {
                 n = n.on_secret_violation(action);

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -22,6 +22,7 @@ libc = { workspace = true }
 lru = { workspace = true }
 microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = { version = "0.1.10", features = ["net"] }
+pem = "3"
 rcgen = { workspace = true }
 resolv-conf = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -171,6 +171,15 @@ impl NetworkBuilder {
         self
     }
 
+    /// Whether to ship the host's trusted root CAs into the guest at
+    /// boot. Default: true. Disable to force the guest to rely on its
+    /// stock Mozilla bundle only; useful in strict reproducible-build
+    /// scenarios where host trust should not leak in.
+    pub fn trust_host_cas(mut self, enabled: bool) -> Self {
+        self.config.trust_host_cas = enabled;
+        self
+    }
+
     /// Consume the builder and return the configuration.
     pub fn build(self) -> NetworkConfig {
         self.config

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -172,9 +172,10 @@ impl NetworkBuilder {
     }
 
     /// Whether to ship the host's trusted root CAs into the guest at
-    /// boot. Default: true. Disable to force the guest to rely on its
-    /// stock Mozilla bundle only; useful in strict reproducible-build
-    /// scenarios where host trust should not leak in.
+    /// boot. Default: false. Opt in when running behind a corporate
+    /// TLS-inspecting proxy (Cloudflare Warp Zero Trust, Zscaler,
+    /// Netskope, ...) whose gateway CA is trusted on the host but
+    /// unknown to the guest's stock Mozilla bundle.
     pub fn trust_host_cas(mut self, enabled: bool) -> Self {
         self.config.trust_host_cas = enabled;
         self

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -61,8 +61,9 @@ pub struct NetworkConfig {
     /// TLS works behind corporate MITM proxies (Cloudflare Warp Zero
     /// Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on
     /// the host but not shipped in the Mozilla root bundle the guest OS
-    /// uses. Default: true.
-    #[serde(default = "default_true")]
+    /// uses. Opt-in: host trust is not copied into the guest unless
+    /// this is explicitly enabled. Default: false.
+    #[serde(default)]
     pub trust_host_cas: bool,
 }
 
@@ -161,7 +162,7 @@ impl Default for NetworkConfig {
             tls: TlsConfig::default(),
             secrets: SecretsConfig::default(),
             max_connections: None,
-            trust_host_cas: true,
+            trust_host_cas: false,
         }
     }
 }

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -56,6 +56,14 @@ pub struct NetworkConfig {
     /// Max concurrent guest connections. Default: 256.
     #[serde(default)]
     pub max_connections: Option<usize>,
+
+    /// Ship the host's trusted root CAs into the guest at boot so outbound
+    /// TLS works behind corporate MITM proxies (Cloudflare Warp Zero
+    /// Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on
+    /// the host but not shipped in the Mozilla root bundle the guest OS
+    /// uses. Default: true.
+    #[serde(default = "default_true")]
+    pub trust_host_cas: bool,
 }
 
 /// Optional overrides for the guest interface.
@@ -153,6 +161,7 @@ impl Default for NetworkConfig {
             tls: TlsConfig::default(),
             secrets: SecretsConfig::default(),
             max_connections: None,
+            trust_host_cas: true,
         }
     }
 }

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -228,6 +228,20 @@ impl SmoltcpNetwork {
         self.tls_state.as_ref().map(|s| s.ca_cert_pem())
     }
 
+    /// Host-trusted CA bundle to ship into the guest, if
+    /// [`NetworkConfig::trust_host_cas`] is enabled.
+    ///
+    /// Returned PEM may concatenate CAs that the Mozilla root bundle in
+    /// the guest already trusts; duplicates are harmless and saved the
+    /// cost of computing a delta. Returns `None` when the host store is
+    /// empty or the feature is disabled.
+    pub fn host_cas_cert_pem(&self) -> Option<Vec<u8>> {
+        if !self.config.trust_host_cas {
+            return None;
+        }
+        crate::tls::host_cas::collect_host_cas()
+    }
+
     /// Create a handle for wiring runtime termination into the network stack.
     pub fn termination_handle(&self) -> TerminationHandle {
         TerminationHandle {

--- a/crates/network/lib/tls/host_cas.rs
+++ b/crates/network/lib/tls/host_cas.rs
@@ -1,0 +1,99 @@
+//! Collect the host's trusted root CAs as a PEM bundle.
+//!
+//! Used by [`SmoltcpNetwork::host_cas_cert_pem`] to ship the host's extra
+//! CAs into the guest so outbound TLS works behind corporate MITM proxies
+//! (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA
+//! is trusted on the host but unknown to the guest.
+//!
+//! What this ships: only trust roots from the host's keychain / system
+//! trust store, deduplicated by DER. `rustls_native_certs` is a
+//! roots-only API — it reads certificates marked trusted for SSL
+//! (macOS System/SystemRoots/login keychains; `/etc/ssl/certs` on
+//! Linux) and never returns private keys or end-entity certs.
+//!
+//! We ship *everything* the host trusts, not a delta against Mozilla's
+//! root bundle. The guest already trusts the Mozilla set natively;
+//! appending duplicates is harmless (trust is a set, not a list). Skipping
+//! the delta avoids pulling `webpki-roots` and keeps the code trivial.
+//!
+//! [`SmoltcpNetwork::host_cas_cert_pem`]: super::super::network::SmoltcpNetwork::host_cas_cert_pem
+
+use std::collections::HashSet;
+
+use pem::{EncodeConfig, LineEnding, Pem};
+
+/// PEM block tag for a trust-root certificate. We only ever emit this
+/// tag; the bundle is constrained to public certs by both the input API
+/// (`rustls_native_certs` returns DER-encoded certs only) and by the
+/// encoder here, so no private-key material can leak into the guest.
+const CERTIFICATE_TAG: &str = "CERTIFICATE";
+
+/// Collect the host's trusted root CAs as a concatenated PEM bundle.
+///
+/// Deduplicates by DER bytes so macOS hosts, where the same root may
+/// appear in multiple keychains (System, SystemRoots, login), don't ship
+/// duplicated entries to the guest. Returns `None` if the host store has
+/// no usable certs. Loader errors are logged (not returned) so one bad
+/// entry does not fail the whole collection.
+pub(crate) fn collect_host_cas() -> Option<Vec<u8>> {
+    let result = rustls_native_certs::load_native_certs();
+    let error_count = result.errors.len();
+
+    let mut seen: HashSet<Vec<u8>> = HashSet::with_capacity(result.certs.len());
+    let mut pems: Vec<Pem> = Vec::with_capacity(result.certs.len());
+    for cert in result.certs {
+        let der = cert.as_ref().to_vec();
+        if seen.insert(der.clone()) {
+            pems.push(Pem::new(CERTIFICATE_TAG, der));
+        }
+    }
+
+    tracing::info!(
+        imported = pems.len(),
+        errors = error_count,
+        "collected host CAs for guest trust store"
+    );
+
+    if pems.is_empty() {
+        return None;
+    }
+
+    let encoded =
+        pem::encode_many_config(&pems, EncodeConfig::new().set_line_ending(LineEnding::LF));
+    Some(encoded.into_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_host_cas_returns_parseable_bundle() {
+        // The host running this test has *some* trust store — any modern
+        // macOS / Linux dev machine does. If this returns `None`, the test
+        // is uninformative, not wrong; skip.
+        let Some(bundle) = collect_host_cas() else {
+            eprintln!("host has no trusted CAs; skipping roundtrip check");
+            return;
+        };
+
+        let parsed = pem::parse_many(&bundle).expect("bundle parses");
+        assert!(!parsed.is_empty(), "bundle contains at least one cert");
+
+        // Every block must be a CERTIFICATE — no private keys allowed to
+        // slip through under any tag.
+        for p in &parsed {
+            assert_eq!(p.tag(), CERTIFICATE_TAG);
+            assert!(!p.contents().is_empty(), "cert body is non-empty");
+        }
+
+        // DER dedup: no two entries should share the same body bytes.
+        let mut seen = HashSet::new();
+        for p in &parsed {
+            assert!(
+                seen.insert(p.contents().to_vec()),
+                "bundle contains a duplicated cert"
+            );
+        }
+    }
+}

--- a/crates/network/lib/tls/mod.rs
+++ b/crates/network/lib/tls/mod.rs
@@ -8,6 +8,7 @@
 pub(crate) mod ca;
 pub(crate) mod certgen;
 pub mod config;
+pub(crate) mod host_cas;
 pub(crate) mod proxy;
 pub(crate) mod sni;
 pub mod state;

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -184,6 +184,15 @@ pub const ENV_RLIMITS: &str = "MSB_RLIMITS";
 /// trust store.
 pub const GUEST_TLS_CA_PATH: &str = "/.msb/tls/ca.pem";
 
+/// Guest-side path to a PEM bundle of the host's extra trusted CAs.
+///
+/// Placed by the sandbox process via the runtime virtiofs mount when
+/// host-CA trust is enabled (default). agentd checks for this file during
+/// init and appends it to the guest's trust bundle, so outbound TLS works
+/// even behind a corporate MITM proxy whose gateway CA is installed on
+/// the host but unknown to the guest.
+pub const GUEST_TLS_HOST_CAS_PATH: &str = "/.msb/tls/host-cas.pem";
+
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -558,10 +558,15 @@ fn build_vm(
         let guest_mac = network.guest_mac();
         let net_backend = network.take_backend();
 
-        if let Some(ca_pem) = network.ca_cert_pem() {
+        {
             let tls_dir = config.runtime_dir.join("tls");
             let _ = std::fs::create_dir_all(&tls_dir);
-            let _ = std::fs::write(tls_dir.join("ca.pem"), &ca_pem);
+            if let Some(ca_pem) = network.ca_cert_pem() {
+                let _ = std::fs::write(tls_dir.join("ca.pem"), &ca_pem);
+            }
+            if let Some(host_cas_pem) = network.host_cas_cert_pem() {
+                let _ = std::fs::write(tls_dir.join("host-cas.pem"), &host_cas_pem);
+            }
         }
 
         for (key, value) in network.guest_env_vars() {

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -62,7 +62,7 @@ msb run -d --name worker python -- python worker.py
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
 | `--max-connections` | Limit the number of concurrent network connections |
-| `--no-trust-host-cas` | Don't ship the host's trusted root CAs into the guest. Default behaviour is to copy the host trust store into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is unknown to the guest's stock bundle |
+| `--trust-host-cas` | Ship the host's trusted root CAs into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is installed on the host but unknown to the guest's stock bundle. Opt-in; by default the guest validates against its stock Mozilla bundle only |
 | `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
 | `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`) |
 | `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -62,6 +62,7 @@ msb run -d --name worker python -- python worker.py
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |
 | `--max-connections` | Limit the number of concurrent network connections |
+| `--no-trust-host-cas` | Don't ship the host's trusted root CAs into the guest. Default behaviour is to copy the host trust store into the guest so outbound TLS works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, etc.) whose gateway CA is unknown to the guest's stock bundle |
 | `--secret` | Inject a secret that is only sent to an allowed host (`ENV=VALUE@HOST`) |
 | `--on-secret-violation` | Action when a secret is sent to a disallowed host (`block`, `block-and-log`, `block-and-terminate`) |
 | `--tls-intercept` | Intercept and inspect HTTPS traffic via a built-in TLS proxy |

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -314,6 +314,61 @@ msb create python --name safe-agent \
 
 </CodeGroup>
 
+## Trusting host CAs
+
+Sandbox guests boot with their distro's stock Mozilla root bundle. That works for ordinary public TLS, but fails the moment outbound HTTPS is intercepted by a corporate proxy (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, etc.) whose gateway CA is trusted on the host but unknown to the guest. The symptom is `apk update`, `pip install`, `curl https://...`, or any HTTPS client failing with `server certificate not trusted`.
+
+By default, microsandbox copies the host's trusted root CAs into every sandbox at boot, so anything that already works on the host also works inside the sandbox. No per-sandbox configuration is needed.
+
+Disable it when you want the guest to rely strictly on its stock Mozilla bundle (for example, in reproducible-build setups where host trust should not leak in):
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("strict")
+    .image("alpine")
+    .network(|n| n.trust_host_cas(false))
+    .build()?;
+```
+
+```typescript TypeScript
+const sb = await Sandbox.create({
+  name: "strict",
+  image: "alpine",
+  network: { trustHostCas: false },
+});
+```
+
+```python Python
+sb = await Sandbox.create(
+    "strict",
+    image="alpine",
+    network=Network(trust_host_cas=False),
+)
+```
+
+```bash CLI
+msb run alpine --no-trust-host-cas -- apk update
+```
+
+</CodeGroup>
+
+<Note>
+**Security:** this feature extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. This matches the existing threat model — an attacker with host access already owns the sandbox — but worth noting before disabling default-on behaviour or running on a host with an unfamiliar trust store.
+</Note>
+
+### Interaction with TLS interception
+
+[TLS interception](/networking/tls) and host-CA trust are independent settings that compose cleanly. With interception enabled, the host proxy terminates the guest's TLS, validates the upstream certificate against the host's trust store (any gateway CA like Warp's is already there), and re-signs with a microsandbox CA the guest already trusts. That handles MITM-proxy environments for the flows interception covers.
+
+Interception is scoped:
+
+- It only applies to `intercepted_ports` (default `[443]`); HTTPS on other ports (gRPC, Postgres / Redis / Mongo TLS, custom 8443, etc.) bypasses the proxy.
+- Domains listed in `bypass` skip interception on purpose.
+- QUIC / HTTP/3, when allowed, never reaches the TCP proxy.
+
+Host-CA trust covers those flows, so leaving `trust_host_cas` on (the default) is safe even when interception is enabled: interception provides richer inspection on the ports it covers, and host-CA trust is the blanket fallback for everything else. Turning `trust_host_cas` off while interception is on means port 443 still works via the proxy, but non-intercepted TLS under a MITM proxy will break with `server certificate not trusted`.
+
 ## How it works
 
 Policy rules are evaluated first-match-wins. Allowed traffic goes to the real network; everything else is dropped.

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -316,11 +316,15 @@ msb create python --name safe-agent \
 
 ## Trusting host CAs
 
-Sandbox guests boot with their distro's stock Mozilla root bundle. That works for ordinary public TLS, but fails the moment outbound HTTPS is intercepted by a corporate proxy (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, etc.) whose gateway CA is trusted on the host but unknown to the guest. The symptom is `apk update`, `pip install`, `curl https://...`, or any HTTPS client failing with `server certificate not trusted`.
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
 
-By default, microsandbox copies the host's trusted root CAs into every sandbox at boot, so anything that already works on the host also works inside the sandbox. No per-sandbox configuration is needed.
+Microsandbox fixes this by default. At sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle, so the guest trusts whatever the host trusts. No per-sandbox configuration, no custom image.
 
-Disable it when you want the guest to rely strictly on its stock Mozilla bundle (for example, in reproducible-build setups where host trust should not leak in):
+<Note>
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before running on a host with an unfamiliar trust store.
+</Note>
+
+Disable it when you want the guest to rely strictly on its stock Mozilla bundle, for example in reproducible-build setups where host trust should not leak in:
 
 <CodeGroup>
 
@@ -353,21 +357,13 @@ msb run alpine --no-trust-host-cas -- apk update
 
 </CodeGroup>
 
-<Note>
-**Security:** this feature extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. This matches the existing threat model — an attacker with host access already owns the sandbox — but worth noting before disabling default-on behaviour or running on a host with an unfamiliar trust store.
-</Note>
+### With TLS interception enabled
 
-### Interaction with TLS interception
+Microsandbox also ships an opt-in [TLS interception](/networking/tls) feature. When enabled on a port, it terminates the guest's TLS at a host-side proxy, validates the upstream certificate against the host's trust store (the corporate gateway CA is already there), and re-signs with a CA the guest already trusts. For that port, TLS interception handles the corporate-proxy case on its own.
 
-[TLS interception](/networking/tls) and host-CA trust are independent settings that compose cleanly. With interception enabled, the host proxy terminates the guest's TLS, validates the upstream certificate against the host's trust store (any gateway CA like Warp's is already there), and re-signs with a microsandbox CA the guest already trusts. That handles MITM-proxy environments for the flows interception covers.
+But interception is scoped. It only applies to `intercepted_ports` (default `[443]`), respects `bypass` domains, and does not touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
 
-Interception is scoped:
-
-- It only applies to `intercepted_ports` (default `[443]`); HTTPS on other ports (gRPC, Postgres / Redis / Mongo TLS, custom 8443, etc.) bypasses the proxy.
-- Domains listed in `bypass` skip interception on purpose.
-- QUIC / HTTP/3, when allowed, never reaches the TCP proxy.
-
-Host-CA trust covers those flows, so leaving `trust_host_cas` on (the default) is safe even when interception is enabled: interception provides richer inspection on the ports it covers, and host-CA trust is the blanket fallback for everything else. Turning `trust_host_cas` off while interception is on means port 443 still works via the proxy, but non-intercepted TLS under a MITM proxy will break with `server certificate not trusted`.
+The two features compose. Leave `trust_host_cas` on (the default) when you also enable TLS interception: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Turn it off only when you want the guest's TLS stack to validate strictly against its stock Mozilla bundle.
 
 ## How it works
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -318,41 +318,39 @@ msb create python --name safe-agent \
 
 Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
 
-Microsandbox fixes this by default. At sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle, so the guest trusts whatever the host trusts. No per-sandbox configuration, no custom image.
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
 
 <Note>
-**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before running on a host with an unfamiliar trust store.
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
 </Note>
-
-Disable it when you want the guest to rely strictly on its stock Mozilla bundle, for example in reproducible-build setups where host trust should not leak in:
 
 <CodeGroup>
 
 ```rust Rust
-let sb = Sandbox::builder("strict")
+let sb = Sandbox::builder("agent")
     .image("alpine")
-    .network(|n| n.trust_host_cas(false))
+    .network(|n| n.trust_host_cas(true))
     .build()?;
 ```
 
 ```typescript TypeScript
 const sb = await Sandbox.create({
-  name: "strict",
+  name: "agent",
   image: "alpine",
-  network: { trustHostCas: false },
+  network: { trustHostCas: true },
 });
 ```
 
 ```python Python
 sb = await Sandbox.create(
-    "strict",
+    "agent",
     image="alpine",
-    network=Network(trust_host_cas=False),
+    network=Network(trust_host_cas=True),
 )
 ```
 
 ```bash CLI
-msb run alpine --no-trust-host-cas -- apk update
+msb run alpine --trust-host-cas -- apk update
 ```
 
 </CodeGroup>
@@ -363,7 +361,7 @@ Microsandbox also ships an opt-in [TLS interception](/networking/tls) feature. W
 
 But interception is scoped. It only applies to `intercepted_ports` (default `[443]`), respects `bypass` domains, and does not touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
 
-The two features compose. Leave `trust_host_cas` on (the default) when you also enable TLS interception: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Turn it off only when you want the guest's TLS stack to validate strictly against its stock Mozilla bundle.
+The two features compose. Turn on `trust_host_cas` alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
 
 ## How it works
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -28,7 +28,7 @@ Network(
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | `None` | DNS interception configuration |
 | tls | [`TlsConfig`](#tlsconfig) ` \| None` | `None` | TLS interception configuration |
 | max_connections | `int \| None` | `None` | Maximum concurrent connections |
-| trust_host_cas | `bool \| None` | `True` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.) |
+| trust_host_cas | `bool \| None` | `False` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.). Opt-in |
 
 ### DnsConfig
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -17,6 +17,7 @@ Network(
     dns: DnsConfig | None = None,
     tls: TlsConfig | None = None,
     max_connections: int | None = None,
+    trust_host_cas: bool | None = None,
 )
 ```
 
@@ -27,6 +28,7 @@ Network(
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | `None` | DNS interception configuration |
 | tls | [`TlsConfig`](#tlsconfig) ` \| None` | `None` | TLS interception configuration |
 | max_connections | `int \| None` | `None` | Maximum concurrent connections |
+| trust_host_cas | `bool \| None` | `True` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.) |
 
 ### DnsConfig
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -91,7 +91,7 @@ Limit the maximum number of concurrent network connections from the sandbox.
 fn trust_host_cas(self, enabled: bool) -> Self
 ```
 
-Whether to ship the host's trusted root CAs into the guest at boot. Default: `true`. With this enabled, outbound HTTPS inside the sandbox works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle. Disable when you want the guest to rely strictly on its native trust store.
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when outbound HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle. Leave off to keep the guest validating strictly against its native trust store.
 
 **Parameters**
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -85,6 +85,22 @@ Limit the maximum number of concurrent network connections from the sandbox.
 
 ---
 
+#### trust_host_cas()
+
+```rust
+fn trust_host_cas(self, enabled: bool) -> Self
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `true`. With this enabled, outbound HTTPS inside the sandbox works behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle. Disable when you want the guest to rely strictly on its native trust store.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | `true` to copy the host trust store into the guest, `false` to disable |
+
+---
+
 #### on_secret_violation()
 
 ```rust

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -74,6 +74,7 @@ Network configuration object passed as [`SandboxConfig.network`](/sdk/typescript
 | policy? | `string` | - | Preset name (set automatically by `NetworkPolicy.*()`) |
 | rules? | `Array<`[`PolicyRule`](#policyrule)`>` | `[]` | Custom rules evaluated first-match-wins |
 | tls? | [`TlsConfig`](#tlsconfig) | - | TLS interception configuration |
+| trustHostCas? | `boolean` | `true` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.) |
 
 ### DnsConfig
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -74,7 +74,7 @@ Network configuration object passed as [`SandboxConfig.network`](/sdk/typescript
 | policy? | `string` | - | Preset name (set automatically by `NetworkPolicy.*()`) |
 | rules? | `Array<`[`PolicyRule`](#policyrule)`>` | `[]` | Custom rules evaluated first-match-wins |
 | tls? | [`TlsConfig`](#tlsconfig) | - | TLS interception configuration |
-| trustHostCas? | `boolean` | `true` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.) |
+| trustHostCas? | `boolean` | `false` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.). Opt-in |
 
 ### DnsConfig
 

--- a/sdk/node-ts/index.d.ts
+++ b/sdk/node-ts/index.d.ts
@@ -544,6 +544,8 @@ export interface NetworkConfig {
   tls?: TlsConfig
   /** Max concurrent connections (default: 256). */
   maxConnections?: number
+  /** Ship the host's trusted CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.). Default: true. */
+  trustHostCas?: boolean
 }
 
 /** Rootfs patch applied before VM startup. */

--- a/sdk/node-ts/index.d.ts
+++ b/sdk/node-ts/index.d.ts
@@ -544,7 +544,7 @@ export interface NetworkConfig {
   tls?: TlsConfig
   /** Max concurrent connections (default: 256). */
   maxConnections?: number
-  /** Ship the host's trusted CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.). Default: true. */
+  /** Ship the host's trusted CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.). Opt-in. Default: false. */
   trustHostCas?: boolean
 }
 

--- a/sdk/node-ts/lib/helpers.rs
+++ b/sdk/node-ts/lib/helpers.rs
@@ -306,6 +306,7 @@ impl JsNetworkPolicy {
             dns: None,
             tls: None,
             max_connections: None,
+            trust_host_cas: None,
         }
     }
 
@@ -319,6 +320,7 @@ impl JsNetworkPolicy {
             dns: None,
             tls: None,
             max_connections: None,
+            trust_host_cas: None,
         }
     }
 
@@ -332,6 +334,7 @@ impl JsNetworkPolicy {
             dns: None,
             tls: None,
             max_connections: None,
+            trust_host_cas: None,
         }
     }
 }

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -642,6 +642,9 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
             if let Some(max) = network.max_connections {
                 n = n.max_connections(max as usize);
             }
+            if let Some(trust) = network.trust_host_cas {
+                n = n.trust_host_cas(trust);
+            }
             n
         });
     }

--- a/sdk/node-ts/lib/types.rs
+++ b/sdk/node-ts/lib/types.rs
@@ -124,7 +124,7 @@ pub struct NetworkConfig {
     pub max_connections: Option<u32>,
     /// Ship the host's trusted CAs into the guest at boot so outbound TLS
     /// works behind corporate MITM proxies (Warp Zero Trust, Zscaler,
-    /// etc.). Default: true.
+    /// etc.). Opt-in. Default: false.
     pub trust_host_cas: Option<bool>,
 }
 

--- a/sdk/node-ts/lib/types.rs
+++ b/sdk/node-ts/lib/types.rs
@@ -122,6 +122,10 @@ pub struct NetworkConfig {
     pub tls: Option<TlsConfig>,
     /// Max concurrent connections (default: 256).
     pub max_connections: Option<u32>,
+    /// Ship the host's trusted CAs into the guest at boot so outbound TLS
+    /// works behind corporate MITM proxies (Warp Zero Trust, Zscaler,
+    /// etc.). Default: true.
+    pub trust_host_cas: Option<bool>,
 }
 
 /// DNS interception configuration.

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -526,6 +526,11 @@ fn apply_network(
         builder = builder.network(|n| n.max_connections(max));
     }
 
+    // Host-CA trust (ship host's extra CAs into the guest at boot).
+    if let Some(trust) = extract_opt::<bool>(net, "trust_host_cas")? {
+        builder = builder.network(move |n| n.trust_host_cas(trust));
+    }
+
     // Secret violation action (sandbox-level, not per-secret).
     if let Some(violation) = extract_opt::<String>(net, "on_secret_violation")? {
         let action = parse_violation_action(&violation)?;


### PR DESCRIPTION
## summary

- outbound https inside a sandbox fails whenever the host is behind a tls-inspecting proxy (warp zero trust, zscaler, netskope, etc.) because the proxy's ca is trusted on the host but not in the guest.
- added an opt-in path that copies the host's trusted roots into the guest at boot, so the guest trusts whatever the host trusts.
- off by default. enable via `.trust_host_cas(true)` in rust, `trustHostCas: true` in the node sdk, `trust_host_cas=True` in the python sdk, or `--trust-host-cas` on the cli.

## test plan

- [x] `cargo test -p microsandbox-network tls::host_cas`
- [x] `cargo check --workspace` clean
- [x] macos + warp on + `--trust-host-cas`: `msb run alpine -- apk update` succeeds
- [x] macos + warp on, no flag: original failure reproduces
- [x] linux: apk/curl unchanged