### PR TITLE
docs(networking): split into overview, dns, tls, security-model

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,31 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Detect whether the diff touches anything outside docs/. When it doesn't,
+  # every downstream job is gated off and posts as "skipped", which satisfies
+  # the required status checks on main without burning CI minutes.
+  # ---------------------------------------------------------------------------
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+
+  # ---------------------------------------------------------------------------
   # Build kernel.c on Linux for macOS libkrunfw linking
   # ---------------------------------------------------------------------------
   build-kernel:
     name: Build kernel.c (aarch64)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +75,8 @@ jobs:
   # ---------------------------------------------------------------------------
   build-agentd-aarch64:
     name: Build agentd (aarch64-linux-musl)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -85,8 +108,8 @@ jobs:
   # ---------------------------------------------------------------------------
   check:
     name: Check (${{ matrix.target }})
-    needs: [build-kernel, build-agentd-aarch64]
-    if: always()
+    needs: [build-kernel, build-agentd-aarch64, changes]
+    if: always() && needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -300,7 +323,8 @@ jobs:
   # ---------------------------------------------------------------------------
   integration-test:
     name: Integration Tests
-    needs: check
+    needs: [check, changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
     steps:
       - name: Clean workspace
@@ -362,7 +386,8 @@ jobs:
   # ---------------------------------------------------------------------------
   node-sdk-test:
     name: Node.js SDK Tests
-    needs: check
+    needs: [check, changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: self-hosted-ubuntu-2404-x64
     steps:
       - name: Clean workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,31 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Detect whether the diff touches anything outside docs/. When it doesn't,
+  # every downstream job is gated off and posts as "skipped", which satisfies
+  # the required status checks on main without burning CI minutes.
+  # ---------------------------------------------------------------------------
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+
+  # ---------------------------------------------------------------------------
   # Build kernel.c on Linux for macOS libkrunfw linking
   # ---------------------------------------------------------------------------
   build-kernel:
     name: Build kernel.c (aarch64)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +72,8 @@ jobs:
   # ---------------------------------------------------------------------------
   build-agentd-aarch64:
     name: Build agentd (aarch64-linux-musl)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -82,8 +105,8 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     name: Test (${{ matrix.target }})
-    needs: [build-kernel, build-agentd-aarch64]
-    if: always()
+    needs: [build-kernel, build-agentd-aarch64, changes]
+    if: always() && needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,7 +54,9 @@
             "icon": "network-wired",
             "pages": [
               "networking/overview",
-              "networking/tls"
+              "networking/dns",
+              "networking/tls",
+              "networking/security-model"
             ]
           },
           {

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -15,7 +15,7 @@ The knobs below cover the day-to-day controls. For the rebinding and TOCTOU prot
 
 ## Blocking domains
 
-Block lookups by exact match or suffix (e.g. `*.tracking.com`). Blocked queries get a local `REFUSED` response — the upstream resolver never sees them.
+Block lookups by exact match or suffix (e.g. `*.tracking.com`). Blocked queries get a local `REFUSED` response, so the upstream resolver never sees them.
 
 <CodeGroup>
 ```rust Rust
@@ -130,11 +130,11 @@ msb create python --name safe-agent \
 
 ## Domain-based policy rules
 
-Network policy rules can target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Matching works by observing DNS responses as they flow through the interceptor and tracking which IPs belong to which domains — a connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+Network policy rules can target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Matching works by observing DNS responses as they flow through the interceptor and tracking which IPs belong to which domains. A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
 
 Because of this, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
 
 ## See also
 
-- [Security model](/networking/security-model) — rebinding protection and DNS-to-IP binding (TOCTOU defense)
-- [TLS interception](/networking/tls) — domains that get intercepted also go through TLS inspection
+- [Security model](/networking/security-model): rebinding protection and DNS-to-IP binding (TOCTOU defense)
+- [TLS interception](/networking/tls): domains that get intercepted also go through TLS inspection

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -1,0 +1,140 @@
+---
+title: DNS
+description: Domain blocking, pinned resolvers, and query timeouts
+icon: "magnifying-glass"
+---
+
+DNS queries from the sandbox are intercepted on the host. Rather than letting the guest talk to a resolver directly, microsandbox proxies each query, which lets you:
+
+- block lookups by domain or suffix,
+- pin which upstream resolvers get used,
+- tune the query timeout,
+- power domain-based policy rules (by mapping responses back to IPs).
+
+The knobs below cover the day-to-day controls. For the rebinding and TOCTOU protections that also ride on the interceptor, see the [security model](/networking/security-model).
+
+## Blocking domains
+
+Block lookups by exact match or suffix (e.g. `*.tracking.com`). Blocked queries get a local `REFUSED` response — the upstream resolver never sees them.
+
+<CodeGroup>
+```rust Rust
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n
+        .policy(NetworkPolicy::public_only())
+        .dns(|d| d
+            .block_domain("malware.example.com")
+            .block_domain_suffix(".tracking.com")
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const sb = await Sandbox.create({
+    name: "safe-agent",
+    image: "python",
+    network: {
+        ...NetworkPolicy.publicOnly(),
+        dns: {
+            blockDomains: ["malware.example.com"],
+            blockDomainSuffixes: [".tracking.com"],
+        },
+    },
+})
+```
+
+```python Python
+from microsandbox import DnsConfig, Network, Sandbox
+
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        dns=DnsConfig(
+            block_domains=("malware.example.com",),
+            block_domain_suffixes=(".tracking.com",),
+        ),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --dns-block-domain malware.example.com \
+  --dns-block-suffix .tracking.com
+```
+
+</CodeGroup>
+
+## Pinning nameservers
+
+By default the sandbox forwards DNS queries to whatever nameservers are listed in the host's `/etc/resolv.conf`. Override this with `nameservers` to pin specific resolvers (e.g. `1.1.1.1`, `dns.google`) or to work around split-DNS setups on VPNs where `/etc/resolv.conf` doesn't reflect the real resolver table.
+
+Accepts IPs, `IP:PORT`, hostnames, and `HOST:PORT`. Hostnames are resolved once at startup via the host's OS resolver.
+
+<CodeGroup>
+```rust Rust
+use microsandbox_network::dns::NameserverSpec;
+
+let sb = Sandbox::builder("safe-agent")
+    .image("python")
+    .network(|n| n
+        .dns(|d| d
+            .nameservers([
+                "1.1.1.1".parse::<NameserverSpec>()?,
+                "1.0.0.1".parse::<NameserverSpec>()?,
+            ])
+            .query_timeout_ms(3000)
+        )
+    )
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const sb = await Sandbox.create("safe-agent", {
+    image: "python",
+    network: {
+        dns: {
+            nameservers: ["1.1.1.1", "1.0.0.1"],
+            queryTimeoutMs: 3000,
+        },
+    },
+})
+```
+
+```python Python
+sb = await Sandbox.create(
+    "safe-agent",
+    image="python",
+    network=Network(
+        dns=DnsConfig(
+            nameservers=("1.1.1.1", "1.0.0.1"),
+            query_timeout_ms=3000,
+        ),
+    ),
+)
+```
+
+```bash CLI
+msb create python --name safe-agent \
+  --dns-nameserver 1.1.1.1 \
+  --dns-nameserver 1.0.0.1 \
+  --dns-query-timeout-ms 3000
+```
+
+</CodeGroup>
+
+## Domain-based policy rules
+
+Network policy rules can target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Matching works by observing DNS responses as they flow through the interceptor and tracking which IPs belong to which domains — a connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+
+Because of this, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
+
+## See also
+
+- [Security model](/networking/security-model) — rebinding protection and DNS-to-IP binding (TOCTOU defense)
+- [TLS interception](/networking/tls) — domains that get intercepted also go through TLS inspection

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -1,6 +1,6 @@
 ---
 title: DNS
-description: Domain blocking, pinned resolvers, and query timeouts
+description: How the sandbox resolves DNS queries
 icon: "magnifying-glass"
 ---
 
@@ -71,9 +71,14 @@ msb create python --name safe-agent \
 
 ## Pinning nameservers
 
-By default the sandbox picks up the host's resolver list automatically: on macOS this comes from `State:/Network/Global/DNS` in the system configuration store, with `/etc/resolv.conf` as a fallback; on Linux `/etc/resolv.conf` is authoritative. Override this with `nameservers` to pin specific resolvers (e.g. `1.1.1.1`, `dns.google`) or to work around setups where auto-discovery picks the wrong upstream.
+By default the sandbox picks up the host's resolver list automatically:
 
-Accepts IPs, `IP:PORT`, hostnames, and `HOST:PORT`. Hostnames are resolved once at startup via the host's OS resolver.
+- **macOS**: reads `State:/Network/Global/DNS` from the system configuration store, with `/etc/resolv.conf` as a fallback when the store isn't available.
+- **Linux**: reads `/etc/resolv.conf` directly.
+
+You can override this by setting `nameservers` to pin the exact resolvers you want (e.g. `1.1.1.1`, `dns.google`), which is useful when auto-discovery picks the wrong ones.
+
+Values can be plain IPs, `IP:PORT`, hostnames, or `HOST:PORT`. Hostnames are resolved once at sandbox startup using the host's OS resolver.
 
 <CodeGroup>
 ```rust Rust
@@ -128,15 +133,13 @@ msb create python --name safe-agent \
 
 </CodeGroup>
 
-## Per-query upstream routing
-
-A guest that targets a specific resolver (`dig @1.1.1.1`, an explicit `/etc/resolv.conf` entry, or a library that takes a resolver IP) reaches that resolver directly instead of being silently rewritten to the pinned upstream. The interceptor preserves the original destination IP so the guest's reply comes back from the address it aimed at. Egress policy still applies: if the destination IP isn't allowed by the network policy, the query is refused.
+If the guest aims a query at a specific resolver (`dig @1.1.1.1`, an `/etc/resolv.conf` entry inside the guest, or a library call that takes a resolver IP), the interceptor forwards the query to that resolver directly instead of redirecting it to the pinned defaults. The network policy still applies: the query only goes through if the destination IP is allowed.
 
 ## DNS over alternative transports
 
 The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
 
-**Intercepted** (block list + rebind + per-query upstream selection apply):
+**Intercepted** (block list and rebind protection apply):
 - DNS over UDP (UDP/53)
 - DNS over TCP (TCP/53)
 - DNS over TLS (DoT, TCP/853): requires [TLS interception](/networking/tls)
@@ -152,9 +155,11 @@ For strict DNS integrity, combine DoT interception with a network policy denying
 
 ## Domain-based policy rules
 
-Network policy rules can target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Matching works by observing DNS responses as they flow through the interceptor and tracking which IPs belong to which domains. A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+Network policy rules can match a destination by exact domain or by suffix. The interceptor watches DNS responses as they flow back to the guest and keeps track of which IP addresses belong to which domain.
 
-Because of this, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
+A connection to `93.184.216.34` is only allowed by a rule targeting `example.com` if that IP actually came back as an answer to a lookup for `example.com` from this sandbox.
+
+Because of that, domain rules only take effect on connections that are preceded by a DNS lookup from inside the sandbox. An application that connects to a hard-coded IP it didn't resolve through the interceptor won't match any domain rule.
 
 ## See also
 

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -71,21 +71,21 @@ msb create python --name safe-agent \
 
 ## Pinning nameservers
 
-By default the sandbox forwards DNS queries to whatever nameservers are listed in the host's `/etc/resolv.conf`. Override this with `nameservers` to pin specific resolvers (e.g. `1.1.1.1`, `dns.google`) or to work around split-DNS setups on VPNs where `/etc/resolv.conf` doesn't reflect the real resolver table.
+By default the sandbox picks up the host's resolver list automatically: on macOS this comes from `State:/Network/Global/DNS` in the system configuration store, with `/etc/resolv.conf` as a fallback; on Linux `/etc/resolv.conf` is authoritative. Override this with `nameservers` to pin specific resolvers (e.g. `1.1.1.1`, `dns.google`) or to work around setups where auto-discovery picks the wrong upstream.
 
 Accepts IPs, `IP:PORT`, hostnames, and `HOST:PORT`. Hostnames are resolved once at startup via the host's OS resolver.
 
 <CodeGroup>
 ```rust Rust
-use microsandbox_network::dns::NameserverSpec;
+use microsandbox_network::dns::Nameserver;
 
 let sb = Sandbox::builder("safe-agent")
     .image("python")
     .network(|n| n
         .dns(|d| d
             .nameservers([
-                "1.1.1.1".parse::<NameserverSpec>()?,
-                "1.0.0.1".parse::<NameserverSpec>()?,
+                "1.1.1.1".parse::<Nameserver>()?,
+                "1.0.0.1".parse::<Nameserver>()?,
             ])
             .query_timeout_ms(3000)
         )
@@ -127,6 +127,28 @@ msb create python --name safe-agent \
 ```
 
 </CodeGroup>
+
+## Per-query upstream routing
+
+A guest that targets a specific resolver (`dig @1.1.1.1`, an explicit `/etc/resolv.conf` entry, or a library that takes a resolver IP) reaches that resolver directly instead of being silently rewritten to the pinned upstream. The interceptor preserves the original destination IP so the guest's reply comes back from the address it aimed at. Egress policy still applies: if the destination IP isn't allowed by the network policy, the query is refused.
+
+## DNS over alternative transports
+
+The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
+
+**Intercepted** (block list + rebind + per-query upstream selection apply):
+- DNS over UDP (UDP/53)
+- DNS over TCP (TCP/53)
+- DNS over TLS (DoT, TCP/853): requires [TLS interception](/networking/tls)
+
+**Refused** (guest's stub falls back to plain DNS):
+- DNS over QUIC (DoQ, UDP/853)
+- mDNS (UDP/5353), LLMNR (UDP/5355), NetBIOS-NS (UDP/137)
+
+**Not distinguishable from regular traffic** (operator must filter via network policy):
+- DNS over HTTPS (DoH, TCP/443)
+
+For strict DNS integrity, combine DoT interception with a network policy denying outbound `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
 
 ## Domain-based policy rules
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -10,8 +10,8 @@ All network traffic from a sandbox flows through a host-controlled networking st
 
 Three presets cover most cases. `public_only` is the default.
 
-- **`none`**: no network interface at all. The guest is fully offline, though `exec` and `fs` still work since they don't use the network.
-- **`public_only`**: blocks private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) and only allows routable public addresses.
+- **`none`**: no network interface at all. The guest is fully offline.
+- **`public_only`**: blocks private, loopback, and link-local addresses so only routable public destinations are reachable. The blocked ranges are `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918 private), `127.0.0.0/8` (loopback), and `169.254.0.0/16` (link-local).
 - **`allow_all`**: no filtering, including access to the host machine and local network.
 
 <CodeGroup>

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -4,13 +4,15 @@ description: Control network access and isolation
 icon: "network-wired"
 ---
 
-All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere.
-
-The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
+All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere. The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
 
 ## Network presets
 
-The simplest way to configure networking. `public_only` is the default.
+Three presets cover most cases. `public_only` is the default.
+
+- **`none`**: no network interface at all. The guest is fully offline, though `exec` and `fs` still work since they don't use the network.
+- **`public_only`**: blocks private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) and only allows routable public addresses.
+- **`allow_all`**: no filtering, including access to the host machine and local network.
 
 <CodeGroup>
 ```rust Rust
@@ -68,16 +70,13 @@ msb create python --name isolated --no-network
 
 # Public internet only (default)
 msb create python --name web-agent
-
-# With TLS interception
-msb create python --name agent --tls-intercept
 ```
 
 </CodeGroup>
 
 ## Custom policies
 
-Build a policy with explicit egress and ingress rules. Rules are evaluated first-match-wins.
+When a preset isn't the right shape, build a policy with explicit egress and ingress rules. Rules are evaluated first-match-wins and anything that doesn't match falls through to `default_action`.
 
 <CodeGroup>
 ```rust Rust
@@ -156,9 +155,11 @@ sb = await Sandbox.create(
 
 </CodeGroup>
 
+Rules can also target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Those rely on DNS pinning so the sandbox can map a connection's destination IP back to the domain that resolved to it — see [DNS](/networking/dns) and the [security model](/networking/security-model) for how that works.
+
 ## Port mapping
 
-Expose ports from the sandbox to the host so services running inside the VM are accessible from your machine.
+Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
 
 In Rust, `SandboxBuilder::port()` and `port_udp()` are top-level shorthands, so you can publish ports without nesting everything inside `.network(...)`.
 
@@ -196,210 +197,20 @@ msb create python --name api -p 8080:80
 
 </CodeGroup>
 
-## DNS interception
-
-DNS queries from the guest are intercepted and resolved on the host side, which opens up a few useful controls:
-
-- **Domain blocking** by exact match or suffix (e.g. `*.tracking.com`).
-- **Rebinding protection**: if a DNS response resolves to a private IP (`10.x`, `172.16.x`, `192.168.x`, `127.x`, link-local), the query is blocked. This prevents the trick where an attacker registers a public domain that points to an internal service.
-- **DNS-to-IP binding**: when secrets are configured, domains can be pinned to the IPs they resolved to, preventing TOCTOU attacks where DNS changes between the policy check and the actual connection.
-
-<CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("safe-agent")
-    .image("python")
-    .network(|n| n
-        .policy(NetworkPolicy::public_only())
-        .dns(|d| d
-            .block_domain("malware.example.com")
-            .block_domain_suffix(".tracking.com")
-        )
-    )
-    .create()
-    .await?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.create({
-    name: "safe-agent",
-    image: "python",
-    network: {
-        ...NetworkPolicy.publicOnly(),
-        dns: {
-            blockDomains: ["malware.example.com"],
-            blockDomainSuffixes: [".tracking.com"],
-        },
-    },
-})
-```
-
-```python Python
-from microsandbox import DnsConfig, Network, Sandbox
-
-sb = await Sandbox.create(
-    "safe-agent",
-    image="python",
-    network=Network(
-        dns=DnsConfig(
-            block_domains=("malware.example.com",),
-            block_domain_suffixes=(".tracking.com",),
-        ),
-    ),
-)
-```
-
-```bash CLI
-msb create python --name safe-agent \
-  --dns-block-domain malware.example.com \
-  --dns-block-suffix .tracking.com
-```
-
-</CodeGroup>
-
-### Pinning DNS nameservers
-
-By default the sandbox forwards DNS queries to whatever nameservers are listed in the host's `/etc/resolv.conf`. Override this with `nameservers` to pin specific resolvers (e.g. `1.1.1.1`, `dns.google`) or to work around split-DNS setups on VPNs where `/etc/resolv.conf` doesn't reflect the real resolver table. Accepts IPs, `IP:PORT`, hostnames, and `HOST:PORT` — hostnames are resolved once at startup via the host's OS resolver.
-
-<CodeGroup>
-
-```rust Rust
-use microsandbox_network::dns::Nameserver;
-
-let sb = Sandbox::builder("safe-agent")
-    .image("python")
-    .network(|n| n
-        .dns(|d| d
-            .nameservers([
-                "1.1.1.1".parse::<Nameserver>()?,
-                "1.0.0.1".parse::<Nameserver>()?,
-            ])
-            .query_timeout_ms(3000)
-        )
-    )
-    .create()
-    .await?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.create("safe-agent", {
-    image: "python",
-    network: {
-        dns: {
-            nameservers: ["1.1.1.1", "1.0.0.1"],
-            queryTimeoutMs: 3000,
-        },
-    },
-})
-```
-
-```python Python
-sb = await Sandbox.create(
-    "safe-agent",
-    image="python",
-    network=Network(
-        dns=DnsConfig(
-            nameservers=("1.1.1.1", "1.0.0.1"),
-            query_timeout_ms=3000,
-        ),
-    ),
-)
-```
-
-```bash CLI
-msb create python --name safe-agent \
-  --dns-nameserver 1.1.1.1 \
-  --dns-nameserver 1.0.0.1 \
-  --dns-query-timeout-ms 3000
-```
-
-</CodeGroup>
-
-### DNS over alternative transports
-
-The block list and rebind protection only apply to queries the gateway can see. A guest that routes DNS through an encrypted or non-DNS protocol bypasses both unless the gateway intercepts or refuses it.
-
-**Intercepted** — block list + rebind + per-query upstream selection apply:
-- DNS over UDP (UDP/53)
-- DNS over TCP (TCP/53)
-- DNS over TLS (DoT, TCP/853) — requires [TLS interception](/networking/tls)
-
-**Refused** — guest's stub falls back to plain DNS:
-- DNS over QUIC (DoQ, UDP/853)
-- mDNS (UDP/5353), LLMNR (UDP/5355), NetBIOS-NS (UDP/137)
-
-**Not distinguishable from regular traffic** — operator must filter via network policy:
-- DNS over HTTPS (DoH, TCP/443)
-
-For strict DNS integrity, combine DoT interception with a network policy denying outbound `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
-
-## Trusting host CAs
-
-Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
-
-By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
-
-<Note>
-**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
-</Note>
-
-<CodeGroup>
-
-```rust Rust
-let sb = Sandbox::builder("agent")
-    .image("alpine")
-    .network(|n| n.trust_host_cas(true))
-    .build()?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.create({
-  name: "agent",
-  image: "alpine",
-  network: { trustHostCas: true },
-});
-```
-
-```python Python
-sb = await Sandbox.create(
-    "agent",
-    image="alpine",
-    network=Network(trust_host_cas=True),
-)
-```
-
-```bash CLI
-msb run alpine --trust-host-cas -- apk update
-```
-
-</CodeGroup>
-
-### With TLS interception enabled
-
-Microsandbox also ships an opt-in [TLS interception](/networking/tls) feature. When enabled on a port, it terminates the guest's TLS at a host-side proxy, validates the upstream certificate against the host's trust store (the corporate gateway CA is already there), and re-signs with a CA the guest already trusts. For that port, TLS interception handles the corporate-proxy case on its own.
-
-But interception is scoped. It only applies to `intercepted_ports` (default `[443]`), respects `bypass` domains, and does not touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
-
-The two features compose. Turn on `trust_host_cas` alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
-
-## How it works
-
-Policy rules are evaluated first-match-wins. Allowed traffic goes to the real network; everything else is dropped.
-
-- **`none`**: no network interface at all. The guest is fully offline, though `exec` and `fs` still work since they don't use the network.
-- **`public_only`**: blocks private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) and only allows routable public addresses. This is the default.
-- **`allow_all`**: no filtering, including access to the host machine and local network.
-- **`allowlist`** / **`denylist`** (coming soon): fine-grained per-host control.
-
 ## Protocol support
 
 For most sandboxed workloads, networking behaves the way you'd expect:
 
 - Normal outbound **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
-- **DNS** is intercepted on the host side, which is what enables domain blocking, rebinding protection, and secret-aware policy checks.
-- **ICMP echo** is supported: Pinging external hosts works on systems that support unprivileged ICMP echo sockets.
+- **DNS** queries are intercepted on the host side. See [DNS](/networking/dns) for blocking, pinned resolvers, and query timeouts.
+- **ICMP echo** is supported: pinging external hosts works on systems that support unprivileged ICMP echo sockets.
 
 <Note>
 **Raw sockets** and **full ICMP forwarding** are not supported because they require elevated privileges on the host. Tools that depend on richer ICMP behavior, such as `traceroute`, are outside the current scope.
 </Note>
 
-In practice, web requests, APIs, package installs, service-to-service calls, and published ports are the primary use case, and those work independently of these ICMP caveats.
+## Next
+
+- [DNS](/networking/dns) — domain blocking, pinned nameservers, query timeouts
+- [TLS interception](/networking/tls) — HTTPS inspection with an auto-generated CA
+- [Security model](/networking/security-model) — how the stack defends against SSRF, rebinding, and metadata exfiltration

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Networking
+title: Overview
 description: Control network access and isolation
 icon: "network-wired"
 ---
@@ -155,7 +155,7 @@ sb = await Sandbox.create(
 
 </CodeGroup>
 
-Rules can also target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Those rely on DNS pinning so the sandbox can map a connection's destination IP back to the domain that resolved to it — see [DNS](/networking/dns) and the [security model](/networking/security-model) for how that works.
+Rules can also target domains directly (`Destination::Domain`, `Destination::DomainSuffix`). Those rely on DNS pinning so the sandbox can map a connection's destination IP back to the domain that resolved to it. See [DNS](/networking/dns) and the [security model](/networking/security-model) for how that works.
 
 ## Port mapping
 
@@ -211,6 +211,6 @@ For most sandboxed workloads, networking behaves the way you'd expect:
 
 ## Next
 
-- [DNS](/networking/dns) — domain blocking, pinned nameservers, query timeouts
-- [TLS interception](/networking/tls) — HTTPS inspection with an auto-generated CA
-- [Security model](/networking/security-model) — how the stack defends against SSRF, rebinding, and metadata exfiltration
+- [DNS](/networking/dns): domain blocking, pinned nameservers, query timeouts
+- [TLS interception](/networking/tls): HTTPS inspection with an auto-generated CA
+- [Security model](/networking/security-model): how the stack defends against SSRF, rebinding, and metadata exfiltration

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -10,15 +10,15 @@ microsandbox's networking defaults are shaped around giving an AI agent, a scrap
 
 The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The `public_only` preset (the default) addresses this by dropping any packet whose destination falls in:
 
-- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — RFC1918 private ranges
-- `127.0.0.0/8` — loopback
-- `169.254.0.0/16` — link-local
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC1918 private ranges)
+- `127.0.0.0/8` (loopback)
+- `169.254.0.0/16` (link-local)
 
 If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Use `allow_all` only when the workload genuinely needs to reach local services, and `none` when it doesn't need network at all.
 
 ## Cloud metadata endpoints
 
-On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service — a well-known SSRF target because it hands out temporary credentials to anything that can connect. Because it sits in link-local space, the `public_only` preset already blocks it. For custom policies that start from `allow_all`, `DestinationGroup::Metadata` lets you deny it explicitly:
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. Because it sits in link-local space, the `public_only` preset already blocks it. For custom policies that start from `allow_all`, `DestinationGroup::Metadata` lets you deny it explicitly:
 
 ```rust
 Rule::deny_outbound(Destination::Group(DestinationGroup::Metadata)),
@@ -68,5 +68,5 @@ The networking stack doesn't try to defend against:
 
 ## See also
 
-- [DNS](/networking/dns) — the controls that ride on the DNS interceptor
-- [TLS interception](/networking/tls) — plaintext visibility for per-host policy and secret injection
+- [DNS](/networking/dns): the controls that ride on the DNS interceptor
+- [TLS interception](/networking/tls): plaintext visibility for per-host policy and secret injection

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -1,0 +1,72 @@
+---
+title: Security model
+description: What the networking stack defends against
+icon: "shield-halved"
+---
+
+microsandbox's networking defaults are shaped around giving an AI agent, a scraper, or some other untrusted workload access to the internet without letting it pivot into your internal infrastructure. This page walks through the specific threats the stack is designed to handle and where each defense lives.
+
+## Private IPs and the host's local network
+
+The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The `public_only` preset (the default) addresses this by dropping any packet whose destination falls in:
+
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — RFC1918 private ranges
+- `127.0.0.0/8` — loopback
+- `169.254.0.0/16` — link-local
+
+If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Use `allow_all` only when the workload genuinely needs to reach local services, and `none` when it doesn't need network at all.
+
+## Cloud metadata endpoints
+
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service — a well-known SSRF target because it hands out temporary credentials to anything that can connect. Because it sits in link-local space, the `public_only` preset already blocks it. For custom policies that start from `allow_all`, `DestinationGroup::Metadata` lets you deny it explicitly:
+
+```rust
+Rule::deny_outbound(Destination::Group(DestinationGroup::Metadata)),
+```
+
+## DNS rebinding
+
+An attacker who controls a domain can set up records that resolve to a public IP during the initial allowlist check and then flip to a private IP on a subsequent lookup. The guest ends up making a request that *looked* like it was going to `evil.example.com` and actually lands on `192.168.1.10`.
+
+Rebind protection catches this at the response level: when the DNS interceptor sees an answer resolving a domain to a private, loopback, or link-local IP, the response is rewritten to `REFUSED` and the connection never gets made. This is on by default. You can turn it off when you genuinely need domains to resolve to internal hosts (local development, split-horizon DNS):
+
+<CodeGroup>
+```rust Rust
+.network(|n| n.dns(|d| d.rebind_protection(false)))
+```
+
+```typescript TypeScript
+network: { dns: { rebindProtection: false } }
+```
+
+```python Python
+network=Network(dns=DnsConfig(rebind_protection=False))
+```
+
+```bash CLI
+msb create python --name dev --no-dns-rebind-protection
+```
+
+</CodeGroup>
+
+## DNS-to-IP binding (TOCTOU)
+
+Even without rebinding tricks, a classic time-of-check/time-of-use race exists: an allowlisted domain resolves to an allowed IP when the policy is checked, then the guest looks it up again at connect time and reaches a different IP.
+
+Domain-based policy rules (`Destination::Domain`, `Destination::DomainSuffix`) close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
+
+The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
+
+## Out of scope
+
+The networking stack doesn't try to defend against:
+
+- **Kernel exploits inside the guest.** The microVM boundary is what keeps a compromised guest contained.
+- **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
+- **Host tampering.** If a workload can modify host-side config, it's already past this layer.
+- **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
+
+## See also
+
+- [DNS](/networking/dns) — the controls that ride on the DNS interceptor
+- [TLS interception](/networking/tls) — plaintext visibility for per-host policy and secret injection

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -57,6 +57,12 @@ Domain-based policy rules (`Destination::Domain`, `Destination::DomainSuffix`) c
 
 The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
 
+## DNS bypass surface
+
+DNS-based defenses (block list, rebind protection, domain pinning) only work on queries the interceptor sees. The gateway intercepts UDP/53 and TCP/53 directly, and DoT (TCP/853) when TLS interception is enabled. Alternative transports are either refused at the port layer (DoQ, mDNS, LLMNR, NetBIOS-NS) or indistinguishable from regular traffic (DoH on TCP/443), and tunneled DNS (VPN, SOCKS5 hostname mode, HTTP `CONNECT`) is carried inside the outer encrypted flow and never reaches the forwarder.
+
+For workloads where DNS integrity matters, pair DoT interception with a network policy that denies outbound `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
+
 ## Out of scope
 
 The networking stack doesn't try to defend against:
@@ -65,6 +71,7 @@ The networking stack doesn't try to defend against:
 - **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
 - **Host tampering.** If a workload can modify host-side config, it's already past this layer.
 - **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
+- **Host trust store integrity.** When `trust_host_cas` is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
 
 ## See also
 

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -53,7 +53,7 @@ msb create python --name dev --no-dns-rebind-protection
 
 Even without rebinding tricks, a classic time-of-check/time-of-use race exists: an allowlisted domain resolves to an allowed IP when the policy is checked, then the guest looks it up again at connect time and reaches a different IP.
 
-Domain-based policy rules (`Destination::Domain`, `Destination::DomainSuffix`) close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
+Domain-based policy rules close this by maintaining a pin set of observed DNS answers. A connection only matches a domain rule if its destination IP was actually returned as an answer to a DNS query for that domain from this sandbox. A guest that hard-codes an IP it didn't resolve through the interceptor can't slip past a domain-based allowlist.
 
 The same mechanism gates host-scoped secret injection. When a `SecretEntry` is restricted via `allowed_hosts`, the secret is only injected into outbound requests whose destination IP the interceptor tied to one of those hosts. An exfiltration attempt that POSTs the secret to an arbitrary IP won't receive the injection in the first place.
 
@@ -71,7 +71,7 @@ The networking stack doesn't try to defend against:
 - **Raw packet crafting from outside the sandbox.** Host-side privileged processes aren't in this threat model.
 - **Host tampering.** If a workload can modify host-side config, it's already past this layer.
 - **Deep ICMP behavior.** Supported ICMP is limited to unprivileged echo; `traceroute`-style flows are not proxied.
-- **Host trust store integrity.** When `trust_host_cas` is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
+- **Host trust store integrity.** When [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) is opted into, an attacker who can plant a CA on the host has that trust inside every sandbox. Off by default for exactly this reason.
 
 ## See also
 

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -10,7 +10,7 @@ Enable HTTPS traffic inspection so policy rules, logging, and other controls can
 
 When you enable TLS interception:
 
-1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox — it's not shared across sandboxes or with the host.
+1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox: it's not shared across sandboxes or with the host.
 2. The guest's trust store is updated to trust this CA.
 3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
 4. The proxy opens its own TLS connection to the upstream server and bridges the two.
@@ -72,17 +72,17 @@ msb create python --name agent \
 
 ## Bypass patterns
 
-Some domains don't play well with interception — typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Mobile apps talking to their vendor's backend (Apple, Google services) and software update endpoints are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Mobile apps talking to their vendor's backend (Apple, Google services) and software update endpoints are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
 
 Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
 
 ## Limits
 
-- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key — rather than trusting the system CA — will fail TLS interception and needs to be bypassed explicitly.
+- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key (rather than trusting the system CA) will fail TLS interception and needs to be bypassed explicitly.
 - **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
 - **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
 
 ## See also
 
-- [DNS](/networking/dns) — the DNS interceptor is what makes per-host rules possible
-- [Security model](/networking/security-model) — how TLS interception interacts with secret injection and SSRF defenses
+- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible
+- [Security model](/networking/security-model): how TLS interception interacts with secret injection and SSRF defenses

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -82,7 +82,55 @@ Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`,
 - **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
 - **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
 
+## Trusting host CAs
+
+Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, Palo Alto, ...) terminate outbound HTTPS at the host and re-sign it with a gateway CA. That CA is installed in your macOS Keychain or Linux trust store as part of the corporate rollout, so HTTPS works silently on the host. Inside a sandbox it doesn't: the guest's stock Mozilla bundle has never seen the gateway CA, so `apk update`, `pip install`, `curl`, and any SDK fetch fail with `server certificate not trusted`.
+
+By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
+
+<Note>
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
+</Note>
+
+<CodeGroup>
+
+```rust Rust
+let sb = Sandbox::builder("agent")
+    .image("alpine")
+    .network(|n| n.trust_host_cas(true))
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const sb = await Sandbox.create({
+  name: "agent",
+  image: "alpine",
+  network: { trustHostCas: true },
+});
+```
+
+```python Python
+sb = await Sandbox.create(
+    "agent",
+    image="alpine",
+    network=Network(trust_host_cas=True),
+)
+```
+
+```bash CLI
+msb run alpine --trust-host-cas -- apk update
+```
+
+</CodeGroup>
+
+### Interaction with TLS interception
+
+TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
+
+The two features compose. Turn on `trust_host_cas` alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
+
 ## See also
 
-- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible
+- [DNS](/networking/dns): the DNS interceptor is what makes per-host rules possible, and DoT interception reuses this TLS path
 - [Security model](/networking/security-model): how TLS interception interacts with secret injection and SSRF defenses

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -72,7 +72,7 @@ msb create python --name agent \
 
 ## Bypass patterns
 
-Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Mobile apps talking to their vendor's backend (Apple, Google services) and software update endpoints are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+Some domains don't play well with interception, typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Software update channels (browser autoupdate, macOS `softwareupdate`, package-manager mirrors that ship a pinned signing CA) and vendor SDKs that bundle their own pinned CA are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
 
 Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
 
@@ -89,7 +89,9 @@ Corporate TLS-inspecting proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope,
 By default the sandbox does not extend host trust into the guest, so the guest validates TLS strictly against its stock Mozilla bundle. Opt in when you need the guest to trust whatever the host trusts: at sandbox boot the host's trusted root CAs are copied into the guest and appended to the system CA bundle.
 
 <Note>
-**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox. It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
+**Security:** this extends the guest's trust to whatever the host trusts. That's the point for MITM-proxy environments, but it also means an attacker who can plant a CA on the host now has that trust inside every sandbox.
+
+It matches the existing threat model (a host-access attacker already owns the sandbox), but worth knowing before enabling on a host with an unfamiliar trust store.
 </Note>
 
 <CodeGroup>
@@ -128,7 +130,7 @@ msb run alpine --trust-host-cas -- apk update
 
 TLS interception also covers the corporate-proxy case, but only on the ports it's configured for (default `[443]`), and only for non-bypassed domains. It doesn't touch QUIC / HTTP/3 flows. Everything outside that scope (gRPC, Postgres / Redis / Mongo TLS, custom 8443, non-intercepted ports, bypassed domains) goes over raw TLS from the guest, where host-CA trust is what makes certificate validation succeed.
 
-The two features compose. Turn on `trust_host_cas` alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
+The two features compose. Turn on [`trust_host_cas`](/sdk/rust/networking#trust_host_cas) alongside TLS interception when you need both: interception provides richer inspection on the ports it covers, host-CA trust covers everything else. Leave it off to keep the guest's TLS stack validating strictly against its stock Mozilla bundle.
 
 ## See also
 

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -1,12 +1,23 @@
 ---
-title: TLS Interception
-description: HTTPS inspection and certificate management
+title: TLS interception
+description: HTTPS inspection with an auto-generated CA
 icon: "lock"
 ---
 
-## TLS interception
+Enable HTTPS traffic inspection so policy rules, logging, and other controls can see plaintext request data. microsandbox terminates TLS on the host side and re-encrypts to the upstream server, which is how features like per-host secret injection and URL-level policy checks are able to see inside what would otherwise be an opaque stream.
 
-Enable HTTPS traffic inspection with an auto-generated CA certificate. microsandbox generates a per-sandbox CA during creation, installs it in the guest's trust store, and generates per-domain certificates on first connection. Domains that use certificate pinning (or that you don't want to intercept) can be bypassed.
+## How it works
+
+When you enable TLS interception:
+
+1. A CA key and certificate are generated for the sandbox at creation time. The CA is scoped to that sandbox — it's not shared across sandboxes or with the host.
+2. The guest's trust store is updated to trust this CA.
+3. When the guest opens an HTTPS connection, the host-side proxy intercepts the handshake, generates a leaf certificate for the target domain on the fly, and signs it with the per-sandbox CA.
+4. The proxy opens its own TLS connection to the upstream server and bridges the two.
+
+Because the CA lives only for the sandbox's lifetime, nothing signed by it is trusted anywhere else.
+
+## Enabling interception
 
 <CodeGroup>
 ```rust Rust
@@ -58,3 +69,20 @@ msb create python --name agent \
 ```
 
 </CodeGroup>
+
+## Bypass patterns
+
+Some domains don't play well with interception — typically ones whose clients pin a specific certificate or public key instead of trusting the system CA store. Mobile apps talking to their vendor's backend (Apple, Google services) and software update endpoints are the usual suspects. Add them to the bypass list and their traffic flows through as-is, encrypted end-to-end between the guest and the upstream server.
+
+Bypass patterns accept exact matches (`api.example.com`) and wildcards (`*.gov`, `*.apple.com`).
+
+## Limits
+
+- **Pinned clients bypass the trust store.** Any client that pins the server's certificate or public key — rather than trusting the system CA — will fail TLS interception and needs to be bypassed explicitly.
+- **Bypassed traffic is opaque.** Policy checks that depend on inspecting request content (URL-based rules, secret injection with `require_tls_identity`) don't apply on bypassed domains.
+- **Client certificates are not proxied.** mTLS flows where the guest is the one presenting a client certificate aren't supported through interception; add those hosts to the bypass list.
+
+## See also
+
+- [DNS](/networking/dns) — the DNS interceptor is what makes per-host rules possible
+- [Security model](/networking/security-model) — how TLS interception interacts with secret injection and SSRF defenses


### PR DESCRIPTION
## Summary

- split `networking/overview` into four pages: `overview`, `dns`, `tls`, `security-model`
- folded in recent networking work from main: macos scdynamicstore as the resolver source, per-query resolver routing, dot/tcp-53 interception, and `trust_host_cas`

## Test plan

- [x] render docs locally and read the networking section end to end
- [x] verify cross-links resolve