### PR TITLE
Adding Secret Injection options similar to the Rust SDK for node-ts sdk.

### DIFF
--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -49,6 +49,7 @@ Configuration for a secret created via [`Secret.env()`](#secretenv).
 | placeholder? | `string` | `$MSB_<envVar>` | Custom placeholder string. Override when you need a specific format. |
 | requireTls? | `boolean` | `true` | Only substitute on TLS-intercepted connections. Disable only if you know the traffic is safe. |
 | onViolation? | [`ViolationAction`](#violationaction) | `'block'` | Action when the placeholder is sent to a disallowed host |
+| inject? | [`SecretInjection`](#secretinjection) | `{ headers: true, basicAuth: true, queryParams: false, body: false }` | Controls where in the HTTP request the placeholder is substituted. |
 
 ### SecretEntry
 
@@ -63,6 +64,19 @@ The object returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.s
 | placeholder? | `string` | Placeholder string |
 | requireTls? | `boolean` | TLS identity requirement |
 | onViolation? | `string` | Violation action |
+| inject? | [`SecretInjection`](#secretinjection) | Injection scopes (headers, Basic Auth, query params, body) |
+
+### SecretInjection
+
+Controls where the TLS proxy substitutes the placeholder with the real value. Each field is optional; omitted fields use the default.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| headers? | `boolean` | `true` | Replace the placeholder anywhere in the HTTP headers (covers `Authorization: Bearer $MSB_...` and similar). |
+| basicAuth? | `boolean` | `true` | Replace the placeholder specifically in `Authorization` header lines. No-op when `headers` is `true`. |
+| queryParams? | `boolean` | `false` | Replace the placeholder in the URL query string on the request line (e.g. `?key=$MSB_...`). |
+| body? | `boolean` | `false` | Replace the placeholder in the HTTP request body. When enabled, `Content-Length` is rewritten to match the substituted body. |
+
 
 ### ViolationAction
 

--- a/sdk/node-ts/index.d.cts
+++ b/sdk/node-ts/index.d.cts
@@ -654,10 +654,20 @@ export declare const enum PullPolicy {
   Never = 'never'
 }
 
-/** Registry credentials for pulling private images. */
-export interface RegistryCredentials {
+/** Registry authentication credentials. */
+export interface RegistryAuth {
   username: string
   password: string
+}
+
+/** Registry connection settings. */
+export interface RegistryConfig {
+  /** Authentication credentials. */
+  auth?: RegistryAuth
+  /** Access the registry over plain HTTP instead of HTTPS. */
+  insecure?: boolean
+  /** Path to a PEM file containing additional CA root certificates to trust. */
+  caCertsPath?: string
 }
 
 /** Configuration for creating a sandbox. */
@@ -704,8 +714,8 @@ export interface SandboxConfig {
   stopSignal?: string
   /** Maximum run duration in seconds. */
   maxDurationSecs?: number
-  /** Registry credentials for pulling private images. */
-  registryAuth?: RegistryCredentials
+  /** Registry connection settings (auth, TLS, insecure). */
+  registry?: RegistryConfig
   /** Port mappings: host_port → guest_port (TCP). */
   ports?: Record<string, number>
   /** Network configuration. */
@@ -780,6 +790,11 @@ export interface SecretEntry {
   requireTls?: boolean
   /** Violation action: "block", "block-and-log" (default), "block-and-terminate". */
   onViolation?: string
+  /**
+   * Where in the HTTP request the secret can be injected.
+   * Defaults to `{ headers: true, basicAuth: true, queryParams: false, body: false }`.
+   */
+  inject?: SecretInjection
 }
 
 /** Options for `Secret.env()`. */
@@ -796,6 +811,41 @@ export interface SecretEnvOptions {
   requireTls?: boolean
   /** Violation action: "block", "block-and-log" (default), "block-and-terminate". */
   onViolation?: string
+  /**
+   * Where in the HTTP request the secret can be injected. Defaults to
+   * headers + Basic Auth only; enable `queryParams` or `body` to widen scope.
+   */
+  inject?: SecretInjection
+}
+
+/**
+ * Controls where the secret placeholder is substituted by the TLS proxy.
+ *
+ * By default, substitution happens in HTTP headers (including the
+ * `Authorization` header for Basic Auth). Enable `queryParams` or `body`
+ * to expand the scope to the request line query string or the request body.
+ * When `body` is enabled, the proxy also rewrites `Content-Length` to match.
+ *
+ * ```js
+ * Secret.env("API_KEY", {
+ *   value: "sk-...",
+ *   allowHosts: ["api.example.com"],
+ *   inject: { headers: false, body: true },
+ * })
+ * ```
+ */
+export interface SecretInjection {
+  /** Substitute in HTTP headers (default: true). */
+  headers?: boolean
+  /** Substitute in HTTP Basic Auth (default: true). */
+  basicAuth?: boolean
+  /** Substitute in URL query parameters (default: false). */
+  queryParams?: boolean
+  /**
+   * Substitute in request body (default: false).
+   * When enabled, `Content-Length` is rewritten to match the new body size.
+   */
+  body?: boolean
 }
 
 /** TLS interception configuration. */

--- a/sdk/node-ts/lib/helpers.rs
+++ b/sdk/node-ts/lib/helpers.rs
@@ -151,6 +151,9 @@ pub struct SecretEnvOptions {
     pub require_tls: Option<bool>,
     /// Violation action: "block", "block-and-log" (default), "block-and-terminate".
     pub on_violation: Option<String>,
+    /// Where in the HTTP request the secret can be injected. Defaults to
+    /// headers + Basic Auth only; enable `queryParams` or `body` to widen scope.
+    pub inject: Option<SecretInjection>,
 }
 
 /// Options for `Patch.text()` and `Patch.copyFile()`.
@@ -349,6 +352,7 @@ impl Secret {
             placeholder: opts.placeholder,
             require_tls: opts.require_tls,
             on_violation: opts.on_violation,
+            inject: opts.inject,
         }
     }
 }

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -654,6 +654,10 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
             let allow_host_patterns = entry.allow_host_patterns.clone();
             let placeholder = entry.placeholder.clone();
             let require_tls = entry.require_tls;
+            let inject_headers = entry.inject.as_ref().and_then(|i| i.headers);
+            let inject_basic_auth = entry.inject.as_ref().and_then(|i| i.basic_auth);
+            let inject_query = entry.inject.as_ref().and_then(|i| i.query_params);
+            let inject_body = entry.inject.as_ref().and_then(|i| i.body);
             builder = builder.secret(move |mut s| {
                 s = s.env(&env_var).value(value);
                 if let Some(hosts) = allow_hosts {
@@ -671,6 +675,18 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
                 }
                 if let Some(require) = require_tls {
                     s = s.require_tls_identity(require);
+                }
+                if let Some(enabled) = inject_headers {
+                    s = s.inject_headers(enabled);
+                }
+                if let Some(enabled) = inject_basic_auth {
+                    s = s.inject_basic_auth(enabled);
+                }
+                if let Some(enabled) = inject_query {
+                    s = s.inject_query(enabled);
+                }
+                if let Some(enabled) = inject_body {
+                    s = s.inject_body(enabled);
                 }
                 s
             });

--- a/sdk/node-ts/lib/types.rs
+++ b/sdk/node-ts/lib/types.rs
@@ -203,6 +203,36 @@ pub struct SecretEntry {
     pub require_tls: Option<bool>,
     /// Violation action: "block", "block-and-log" (default), "block-and-terminate".
     pub on_violation: Option<String>,
+    /// Where in the HTTP request the secret can be injected.
+    /// Defaults to `{ headers: true, basicAuth: true, queryParams: false, body: false }`.
+    pub inject: Option<SecretInjection>,
+}
+
+/// Controls where the secret placeholder is substituted by the TLS proxy.
+///
+/// By default, substitution happens in HTTP headers (including the
+/// `Authorization` header for Basic Auth). Enable `queryParams` or `body`
+/// to expand the scope to the request line query string or the request body.
+/// When `body` is enabled, the proxy also rewrites `Content-Length` to match.
+///
+/// ```js
+/// Secret.env("API_KEY", {
+///   value: "sk-...",
+///   allowHosts: ["api.example.com"],
+///   inject: { headers: false, body: true },
+/// })
+/// ```
+#[napi(object)]
+pub struct SecretInjection {
+    /// Substitute in HTTP headers (default: true).
+    pub headers: Option<bool>,
+    /// Substitute in HTTP Basic Auth (default: true).
+    pub basic_auth: Option<bool>,
+    /// Substitute in URL query parameters (default: false).
+    pub query_params: Option<bool>,
+    /// Substitute in request body (default: false).
+    /// When enabled, `Content-Length` is rewritten to match the new body size.
+    pub body: Option<bool>,
 }
 
 /// Registry connection settings.


### PR DESCRIPTION
Adding Secret Injection options similar to the Rust SDK for node-ts sdk.

Right now the node-ts SDK does not have options to inject secrets into the body or the query params. This is already built out so this PR is just making the options available in the SDK similar to rust.