### PR TITLE
ci: sync mintlify branch to release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,21 @@ jobs:
             release-artifacts/*
 
   # ---------------------------------------------------------------------------
+  # Sync mintlify branch to the released commit
+  # ---------------------------------------------------------------------------
+  sync-mintlify:
+    name: Sync mintlify branch
+    needs: assemble
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Hard reset mintlify to release commit
+        run: git push --force origin ${{ github.sha }}:refs/heads/mintlify
+
+  # ---------------------------------------------------------------------------
   # Publish Node SDK to npm
   # ---------------------------------------------------------------------------
   npm-publish:


### PR DESCRIPTION
## Summary
- added a `sync-mintlify` job to `release.yml` that runs after the github release is created
- the job force-pushes the tagged commit to `refs/heads/mintlify`, keeping the branch in lockstep with each release

## Test plan
- [ ] cut a test tag and confirm the `mintlify` branch resets to the tag commit