### PR TITLE
feat(network): add host.microsandbox.internal alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "lru",
+ "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",
  "parking_lot",

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -17,8 +17,8 @@ use std::env;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use microsandbox_protocol::{
-    ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_FILE_MOUNTS, ENV_HOSTNAME, ENV_NET, ENV_NET_IPV4,
-    ENV_NET_IPV6, ENV_RLIMITS, ENV_TMPFS, ENV_USER, exec::ExecRlimit,
+    ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_FILE_MOUNTS, ENV_HOST_ALIAS, ENV_HOSTNAME, ENV_NET,
+    ENV_NET_IPV4, ENV_NET_IPV6, ENV_RLIMITS, ENV_TMPFS, ENV_USER, exec::ExecRlimit,
 };
 
 use crate::error::{AgentdError, AgentdResult};
@@ -51,6 +51,11 @@ pub struct BootParams {
 
     /// `MSB_HOSTNAME` — guest hostname.
     pub(crate) hostname: Option<String>,
+
+    /// `MSB_HOST_ALIAS` — DNS name (e.g. `host.microsandbox.internal`)
+    /// the guest uses to reach the sandbox host. Written into
+    /// `/etc/hosts` pointing at the gateway IPs.
+    pub(crate) host_alias: Option<String>,
 
     /// Parsed `MSB_NET` — network interface config.
     pub(crate) net: Option<NetSpec>,
@@ -183,6 +188,7 @@ impl BootParams {
                 .transpose()?
                 .unwrap_or_default(),
             hostname: read_env(ENV_HOSTNAME),
+            host_alias: read_env(ENV_HOST_ALIAS),
             net: read_env(ENV_NET).map(|v| parse_net(&v)).transpose()?,
             net_ipv4: read_env(ENV_NET_IPV4)
                 .map(|v| parse_net_ipv4(&v))

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -26,7 +26,12 @@ pub fn init(params: BootParams) -> AgentdResult<()> {
     }
     linux::apply_dir_mounts(&params.dir_mounts)?;
     linux::apply_file_mounts(&params.file_mounts)?;
-    network::apply_hostname(params.hostname.as_deref())?;
+    network::apply_hostname(
+        params.hostname.as_deref(),
+        params.host_alias.as_deref(),
+        params.net_ipv4.as_ref().map(|v4| v4.gateway),
+        params.net_ipv6.as_ref().map(|v6| v6.gateway),
+    )?;
     linux::apply_tmpfs_mounts(&params.tmpfs)?;
     linux::ensure_standard_tmp_permissions()?;
     network::apply_network_config(params.network())?;

--- a/crates/agentd/lib/network.rs
+++ b/crates/agentd/lib/network.rs
@@ -3,6 +3,8 @@
 //! Configures the guest network interface using ioctls and netlink, following
 //! the parameters from host.
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use crate::config::NetConfig;
 use crate::error::AgentdResult;
 
@@ -10,12 +12,31 @@ use crate::error::AgentdResult;
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Sets the guest hostname.
+/// Set the guest hostname and provision `/etc/hosts`. Each argument is
+/// optional; omitted pieces are skipped.
 ///
-/// Calls `sethostname()`, writes `/etc/hostname`, and provisions
-/// `/etc/hosts` with localhost aliases and the hostname entry.
-pub(crate) fn apply_hostname(hostname: Option<&str>) -> AgentdResult<()> {
-    linux::write_hosts_file(hostname)?;
+/// # Arguments
+///
+/// * `hostname` - Guest hostname. When set, calls `sethostname()` and writes
+///   `/etc/hostname`.
+/// * `host_alias` - DNS name the guest uses to reach the sandbox host
+///   (typically `host.microsandbox.internal`). Written to `/etc/hosts`
+///   alongside whichever gateway IPs are present.
+/// * `gateway_ipv4` - Gateway IPv4 the alias points at.
+/// * `gateway_ipv6` - Gateway IPv6 the alias points at.
+///
+/// # Errors
+///
+/// Returns [`AgentdError::Init`][crate::error::AgentdError::Init] when `/etc`
+/// cannot be created, `/etc/hosts` or `/etc/hostname` cannot be written, or
+/// `sethostname(2)` fails.
+pub(crate) fn apply_hostname(
+    hostname: Option<&str>,
+    host_alias: Option<&str>,
+    gateway_ipv4: Option<Ipv4Addr>,
+    gateway_ipv6: Option<Ipv6Addr>,
+) -> AgentdResult<()> {
+    linux::write_hosts_file(hostname, host_alias, gateway_ipv4, gateway_ipv6)?;
 
     if let Some(name) = hostname {
         linux::set_hostname(name)?;
@@ -24,10 +45,23 @@ pub(crate) fn apply_hostname(hostname: Option<&str>) -> AgentdResult<()> {
     Ok(())
 }
 
-/// Applies network configuration.
+/// Apply the guest-side network configuration.
 ///
-/// Always provisions loopback, even when no external network interface is
-/// requested. Missing `net` is not an error (no networking requested).
+/// Always provisions loopback first so the guest has a working `lo` interface
+/// even when the sandbox was booted with networking disabled. When `cfg.net`
+/// is `None`, nothing further is configured.
+///
+/// # Arguments
+///
+/// * `cfg` - Parsed `MSB_NET*` specs bundled by
+///   [`BootParams::network`][crate::config::BootParams::network]: interface
+///   name/MAC/MTU plus optional IPv4 and IPv6 addressing.
+///
+/// # Errors
+///
+/// Returns [`AgentdError::Init`][crate::error::AgentdError::Init] when bringing
+/// up `lo` fails, or any of the interface ioctls / netlink messages for the
+/// main interface fail.
 pub(crate) fn apply_network_config(cfg: NetConfig<'_>) -> AgentdResult<()> {
     linux::configure_loopback()?;
 
@@ -38,7 +72,24 @@ pub(crate) fn apply_network_config(cfg: NetConfig<'_>) -> AgentdResult<()> {
     linux::configure_interface(net, cfg.ipv4, cfg.ipv6)
 }
 
-fn hosts_file_contents(hostname: Option<&str>) -> String {
+/// Render the `/etc/hosts` contents.
+///
+/// # Arguments
+///
+/// * `hostname` - Guest hostname; when `Some`, appended as an alias on the
+///   `127.0.0.1` and `::1` lines.
+/// * `host_alias` - Name like `host.microsandbox.internal`; when `Some` and a
+///   gateway IP is set for the matching family, emits `<gw>\t<alias>` lines.
+/// * `gateway_ipv4` - IPv4 the alias resolves to. The IPv4 alias line is
+///   skipped when `None` (or when `host_alias` is `None`).
+/// * `gateway_ipv6` - IPv6 the alias resolves to. The IPv6 alias line is
+///   skipped when `None` (or when `host_alias` is `None`).
+fn hosts_file_contents(
+    hostname: Option<&str>,
+    host_alias: Option<&str>,
+    gateway_ipv4: Option<Ipv4Addr>,
+    gateway_ipv6: Option<Ipv6Addr>,
+) -> String {
     let mut s = String::new();
 
     // Localhost entries — always include hostname aliases when set.
@@ -50,6 +101,17 @@ fn hosts_file_contents(hostname: Option<&str>) -> String {
     } else {
         s.push_str("127.0.0.1\tlocalhost\n");
         s.push_str("::1\tlocalhost ip6-localhost ip6-loopback\n");
+    }
+
+    // `<host_alias>` → gateway IP mapping. Emits both address families
+    // so v4-only and v6-only resolvers find the alias.
+    if let Some(alias) = host_alias {
+        if let Some(gw_v4) = gateway_ipv4 {
+            s.push_str(&format!("{gw_v4}\t{alias}\n"));
+        }
+        if let Some(gw_v6) = gateway_ipv6 {
+            s.push_str(&format!("{gw_v6}\t{alias}\n"));
+        }
     }
 
     s.push_str("fe00::\tip6-localnet\n");
@@ -475,11 +537,19 @@ mod linux {
     }
 
     /// Writes `/etc/hosts` with localhost aliases and an optional hostname entry.
-    pub fn write_hosts_file(hostname: Option<&str>) -> AgentdResult<()> {
+    pub fn write_hosts_file(
+        hostname: Option<&str>,
+        host_alias: Option<&str>,
+        gateway_ipv4: Option<Ipv4Addr>,
+        gateway_ipv6: Option<Ipv6Addr>,
+    ) -> AgentdResult<()> {
         fs::create_dir_all("/etc")
             .map_err(|e| AgentdError::Init(format!("failed to create /etc: {e}")))?;
-        fs::write("/etc/hosts", super::hosts_file_contents(hostname))
-            .map_err(|e| AgentdError::Init(format!("failed to write /etc/hosts: {e}")))?;
+        fs::write(
+            "/etc/hosts",
+            super::hosts_file_contents(hostname, host_alias, gateway_ipv4, gateway_ipv6),
+        )
+        .map_err(|e| AgentdError::Init(format!("failed to write /etc/hosts: {e}")))?;
         Ok(())
     }
 
@@ -575,7 +645,7 @@ mod tests {
     #[test]
     fn test_hosts_file_without_hostname() {
         assert_eq!(
-            hosts_file_contents(None),
+            hosts_file_contents(None, None, None, None),
             concat!(
                 "127.0.0.1\tlocalhost\n",
                 "::1\tlocalhost ip6-localhost ip6-loopback\n",
@@ -590,7 +660,7 @@ mod tests {
     #[test]
     fn test_hosts_file_with_hostname() {
         assert_eq!(
-            hosts_file_contents(Some("worker-01")),
+            hosts_file_contents(Some("worker-01"), None, None, None),
             concat!(
                 "127.0.0.1\tlocalhost worker-01\n",
                 "::1\tlocalhost ip6-localhost ip6-loopback worker-01\n",
@@ -600,5 +670,52 @@ mod tests {
                 "ff02::2\tip6-allrouters\n",
             )
         );
+    }
+
+    #[test]
+    fn test_hosts_file_with_host_alias_both_families() {
+        assert_eq!(
+            hosts_file_contents(
+                Some("worker-01"),
+                Some("host.microsandbox.internal"),
+                Some(Ipv4Addr::new(100, 96, 0, 1)),
+                Some("fd42:6d73:62::1".parse().unwrap()),
+            ),
+            concat!(
+                "127.0.0.1\tlocalhost worker-01\n",
+                "::1\tlocalhost ip6-localhost ip6-loopback worker-01\n",
+                "100.96.0.1\thost.microsandbox.internal\n",
+                "fd42:6d73:62::1\thost.microsandbox.internal\n",
+                "fe00::\tip6-localnet\n",
+                "ff00::\tip6-mcastprefix\n",
+                "ff02::1\tip6-allnodes\n",
+                "ff02::2\tip6-allrouters\n",
+            )
+        );
+    }
+
+    #[test]
+    fn test_hosts_file_with_host_alias_v4_only() {
+        let out = hosts_file_contents(
+            None,
+            Some("host.microsandbox.internal"),
+            Some(Ipv4Addr::new(100, 96, 0, 1)),
+            None,
+        );
+        assert!(out.contains("100.96.0.1\thost.microsandbox.internal\n"));
+        assert!(!out.contains("fd42"));
+    }
+
+    #[test]
+    fn test_hosts_file_omits_alias_when_name_missing() {
+        let out = hosts_file_contents(
+            None,
+            None,
+            Some(Ipv4Addr::new(100, 96, 0, 1)),
+            Some("fd42:6d73:62::1".parse().unwrap()),
+        );
+        assert!(!out.contains("host.microsandbox.internal"));
+        assert!(!out.contains("100.96.0.1"));
+        assert!(!out.contains("fd42"));
     }
 }

--- a/crates/microsandbox/tests/host_access.rs
+++ b/crates/microsandbox/tests/host_access.rs
@@ -1,0 +1,357 @@
+//! Integration tests for the `host.microsandbox.internal` alias.
+
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use ipnetwork::{IpNetwork, Ipv4Network};
+use microsandbox::{NetworkPolicy, Sandbox};
+use microsandbox_network::policy::{Action, Destination, DestinationGroup, Rule};
+use test_utils::msb_test;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+//--------------------------------------------------------------------------------------------------
+// Host HTTP fixture
+//--------------------------------------------------------------------------------------------------
+
+/// Minimal HTTP server bound to `127.0.0.1` and `::1` on the same port. Dual-family avoids
+/// flakes when the guest's happy-eyeballs picks v6 and the listener only lives on v4.
+struct HostHttp {
+    port: u16,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl HostHttp {
+    async fn start(body: &'static str) -> io::Result<Self> {
+        let v4_listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
+        let port = v4_listener.local_addr()?.port();
+        let v6_listener = TcpListener::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, port))).await?;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let body = Arc::new(body.to_owned());
+
+        let handle = tokio::spawn(async move {
+            let mut shutdown_rx = shutdown_rx;
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    accept = v4_listener.accept() => Self::handle_accept(accept, &body),
+                    accept = v6_listener.accept() => Self::handle_accept(accept, &body),
+                }
+            }
+        });
+
+        Ok(Self {
+            port,
+            shutdown: Some(shutdown_tx),
+            handle: Some(handle),
+        })
+    }
+
+    fn handle_accept(accept: io::Result<(tokio::net::TcpStream, SocketAddr)>, body: &Arc<String>) {
+        let Ok((mut stream, _)) = accept else { return };
+        let body = body.clone();
+        tokio::spawn(async move {
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        });
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Drop for HostHttp {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Boot an alpine sandbox with the given policy (or the default when `None`).
+async fn spawn_sandbox(name: &str, policy: Option<NetworkPolicy>) -> Sandbox {
+    let builder = Sandbox::builder(name)
+        .image("alpine")
+        .cpus(1)
+        .memory(256)
+        .replace();
+    match policy {
+        Some(p) => builder.network(|n| n.policy(p)).create(),
+        None => builder.create(),
+    }
+    .await
+    .expect("create sandbox")
+}
+
+/// Stop the sandbox and remove it.
+async fn teardown(sb: Sandbox, name: &str) {
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}
+
+/// Read the sandbox gateway IPv4 from the guest's `/etc/resolv.conf`.
+async fn read_gateway_ip(sb: &Sandbox) -> String {
+    let out = sb
+        .shell("awk '/^nameserver /{print $2; exit}' /etc/resolv.conf")
+        .await
+        .expect("read resolv.conf");
+    out.stdout().expect("utf8").trim().to_owned()
+}
+
+/// Allow host only; deny everything else.
+fn allow_host_only_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        default_action: Action::Deny,
+        rules: vec![Rule::allow_outbound(Destination::Group(
+            DestinationGroup::Host,
+        ))],
+    }
+}
+
+/// Deny host only; allow everything else.
+fn deny_host_group_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        default_action: Action::Allow,
+        rules: vec![Rule::deny_outbound(Destination::Group(
+            DestinationGroup::Host,
+        ))],
+    }
+}
+
+/// Deny the given gateway IPv4 `/32`; allow everything else.
+fn deny_gateway_cidr_policy(gateway_ip: &str) -> NetworkPolicy {
+    let addr: Ipv4Addr = gateway_ip.parse().expect("valid gateway ipv4");
+    NetworkPolicy {
+        default_action: Action::Allow,
+        rules: vec![Rule::deny_outbound(Destination::Cidr(IpNetwork::V4(
+            Ipv4Network::new(addr, 32).expect("valid /32"),
+        )))],
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+/// Baseline reachability by hostname and by raw gateway IPv4, plus `/etc/hosts` entry.
+#[msb_test]
+async fn host_alias_reachable_by_hostname_and_gateway_ip() {
+    let server = HostHttp::start("hello from host")
+        .await
+        .expect("http fixture");
+    let port = server.port();
+
+    let name = "host-alias-baseline";
+    let sb = spawn_sandbox(name, Some(NetworkPolicy::allow_all())).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=10 http://host.microsandbox.internal:{port}/"
+        ))
+        .await
+        .expect("wget hostname");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "hello from host",
+        "hostname path body mismatch (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let gw = read_gateway_ip(&sb).await;
+    let out = sb
+        .shell(format!("wget -qO- --timeout=10 http://{gw}:{port}/"))
+        .await
+        .expect("wget gateway");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "hello from host",
+        "gateway-IP path body mismatch (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let hosts = sb
+        .shell("cat /etc/hosts")
+        .await
+        .expect("cat /etc/hosts")
+        .stdout()
+        .unwrap()
+        .to_owned();
+    assert!(
+        hosts.contains("host.microsandbox.internal"),
+        "expected host.microsandbox.internal in /etc/hosts, got:\n{hosts}"
+    );
+    assert!(
+        hosts.contains(&gw),
+        "expected gateway IPv4 {gw} in /etc/hosts, got:\n{hosts}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// `dig` skips `/etc/hosts`, so a successful answer proves the forwarder synthesises the alias.
+#[msb_test]
+async fn host_alias_dns_synth_bypasses_hosts_file() {
+    let name = "host-alias-dns-synth";
+    let sb = spawn_sandbox(name, None).await;
+
+    sb.shell("apk add --quiet --no-progress bind-tools >/dev/null 2>&1")
+        .await
+        .expect("install bind-tools");
+
+    let gw = read_gateway_ip(&sb).await;
+    let out = sb
+        .shell("dig +short +time=3 +tries=1 host.microsandbox.internal A")
+        .await
+        .expect("dig alias");
+    let answer = out.stdout().unwrap().trim().to_owned();
+    assert_eq!(
+        answer,
+        gw,
+        "expected DNS synth to return gateway {gw}, got {answer:?} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    teardown(sb, name).await;
+}
+
+/// CIDR deny on the gateway `/32` blocks host access (policy fires before the proxy rewrite).
+#[msb_test]
+async fn host_alias_denied_by_gateway_cidr_policy() {
+    let server = HostHttp::start("should not see")
+        .await
+        .expect("http fixture");
+    let port = server.port();
+
+    // Boot once to read the gateway, tear down, then boot again with the CIDR policy.
+    let probe_name = "host-alias-policy-probe";
+    let probe = spawn_sandbox(probe_name, None).await;
+    let gw = read_gateway_ip(&probe).await;
+    teardown(probe, probe_name).await;
+
+    let name = "host-alias-policy-deny";
+    let sb = spawn_sandbox(name, Some(deny_gateway_cidr_policy(&gw))).await;
+
+    // Dial v4 directly; via the hostname, happy-eyeballs could pick the v6 entry (not covered).
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://{gw}:{port}/; echo status=$?"
+        ))
+        .await
+        .expect("wget");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        stdout.contains("status=") && !stdout.trim_end().ends_with("status=0"),
+        "expected wget to fail when gateway denied by policy; got: {stdout:?} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    teardown(sb, name).await;
+}
+
+/// Default `public_only` must block host access; users opt in explicitly.
+#[msb_test]
+async fn host_alias_denied_by_default_policy() {
+    let server = HostHttp::start("should not see")
+        .await
+        .expect("http fixture");
+    let port = server.port();
+
+    let name = "host-alias-default-deny";
+    let sb = spawn_sandbox(name, None).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://host.microsandbox.internal:{port}/; echo status=$?"
+        ))
+        .await
+        .expect("wget");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        stdout.contains("status=") && !stdout.trim_end().ends_with("status=0"),
+        "expected wget to fail under default public_only policy; got: {stdout:?} (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+    assert!(
+        !stdout.contains("should not see"),
+        "host body leaked through default-denied policy: {stdout:?}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// `Group::Host` allow on a deny-all base: host reachable, everything else denied.
+#[msb_test]
+async fn group_host_allow_narrows_to_gateway() {
+    let server = HostHttp::start("host ok").await.expect("http fixture");
+    let port = server.port();
+
+    let name = "group-host-allow";
+    let sb = spawn_sandbox(name, Some(allow_host_only_policy())).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://host.microsandbox.internal:{port}/"
+        ))
+        .await
+        .expect("wget host");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "host ok",
+        "group host allow should let guest reach the host (stderr: {})",
+        out.stderr().unwrap_or_default()
+    );
+
+    let out = sb
+        .shell("wget -qO- --timeout=5 http://8.8.8.8/ ; echo status=$?")
+        .await
+        .expect("wget external");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        !stdout.trim_end().ends_with("status=0"),
+        "non-host traffic should be denied under allow-host-only policy; got: {stdout:?}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// `Group::Host` deny on an allow-all base: host blocked, rest still works.
+#[msb_test]
+async fn group_host_deny_blocks_host_only() {
+    let server = HostHttp::start("unreachable").await.expect("http fixture");
+    let port = server.port();
+
+    let name = "group-host-deny";
+    let sb = spawn_sandbox(name, Some(deny_host_group_policy())).await;
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=5 http://host.microsandbox.internal:{port}/ ; echo status=$?"
+        ))
+        .await
+        .expect("wget host");
+    let stdout = out.stdout().unwrap();
+    assert!(
+        !stdout.trim_end().ends_with("status=0"),
+        "host should be denied by group-host deny rule; got: {stdout:?}"
+    );
+
+    teardown(sb, name).await;
+}

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,6 +23,7 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
+microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
 microsandbox-utils = { version = "0.3.14", path = "../utils" }
 msb_krun = { version = "0.1.10", features = ["net"] }
 parking_lot = { workspace = true }

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -33,7 +33,8 @@ use bytes::Bytes;
 use futures::StreamExt;
 use hickory_client::client::Client;
 use hickory_client::proto::op::{Message, MessageType, ResponseCode};
-use hickory_client::proto::rr::{RData, RecordType};
+use hickory_client::proto::rr::rdata::{A, AAAA};
+use hickory_client::proto::rr::{RData, Record, RecordType};
 use hickory_client::proto::serialize::binary::{BinDecodable, BinEncodable};
 use hickory_client::proto::xfer::{DnsHandle, DnsRequest};
 use tokio::sync::{OnceCell, watch};
@@ -45,6 +46,7 @@ use super::common::transport::Transport;
 use super::nameserver::{read_host_dns_servers, resolve_nameservers};
 use crate::policy::NetworkPolicy;
 use crate::shared::{ResolvedHostnameFamily, SharedState};
+use crate::stack::GatewayIps;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -58,6 +60,11 @@ use crate::shared::{ResolvedHostnameFamily, SharedState};
 /// immediate connect following a successful DNS lookup does not fail
 /// closed before the guest can use the answer.
 const RESOLVED_HOSTNAME_MIN_TTL_SECS: u32 = 1;
+
+/// TTL for locally-synthesized `host.microsandbox.internal` answers. Short
+/// enough that the guest re-resolves often, long enough to avoid hammering
+/// the forwarder on each connection.
+const HOST_ALIAS_TTL_SECS: u32 = 60;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -99,6 +106,9 @@ pub(crate) struct DnsForwarder {
     /// from upstream answers so Domain rules can match on subsequent
     /// guest connects.
     shared: Arc<SharedState>,
+    /// Gateway IPs returned as A / AAAA answers when the guest asks for
+    /// `host.microsandbox.internal`.
+    gateway: GatewayIps,
     config: Arc<NormalizedDnsConfig>,
 }
 
@@ -154,6 +164,15 @@ impl DnsForwarder {
         if is_domain_blocked(&domain, &self.config) {
             tracing::debug!(domain = %domain, "DNS query blocked by domain policy");
             return build_status_response(&query_msg, ResponseCode::Refused);
+        }
+
+        // Locally synthesize answers for the host alias; MX / TXT / etc.
+        // fall through to upstream.
+        if is_host_alias_query(&domain)
+            && let Some(response) =
+                synthesize_host_alias_response(&query_msg, self.gateway, query_type)
+        {
+            return Some(response);
         }
 
         // Pick upstream client based on where the guest aimed and the
@@ -307,16 +326,19 @@ impl DnsForwarder {
     /// TCP/53 proxy ([`super::proxies::tcp::TcpProxy`]) clone the
     /// handle and [`Self::wait`] before serving any query, so they
     /// share one configured upstream + policy across transports.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn spawn(
         handle: &tokio::runtime::Handle,
         config: Arc<NormalizedDnsConfig>,
         gateway_ips: Arc<HashSet<IpAddr>>,
         network_policy: Arc<NetworkPolicy>,
         shared: Arc<SharedState>,
+        gateway: GatewayIps,
     ) -> DnsForwarderHandle {
         let (forwarder_tx, forwarder_rx) = watch::channel(None);
         handle.spawn(async move {
-            let Some(forwarder) = Self::build(config, gateway_ips, network_policy, shared).await
+            let Some(forwarder) =
+                Self::build(config, gateway_ips, network_policy, shared, gateway).await
             else {
                 // Drop forwarder_tx by returning; waiters observe init
                 // failure as `Self::wait().await == None`.
@@ -335,6 +357,7 @@ impl DnsForwarder {
         gateway_ips: Arc<HashSet<IpAddr>>,
         network_policy: Arc<NetworkPolicy>,
         shared: Arc<SharedState>,
+        gateway: GatewayIps,
     ) -> Option<Arc<Self>> {
         let upstreams = if !config.nameservers.is_empty() {
             match resolve_nameservers(&config.nameservers).await {
@@ -375,6 +398,7 @@ impl DnsForwarder {
             gateway_ips,
             network_policy,
             shared,
+            gateway,
             config,
         }))
     }
@@ -483,6 +507,43 @@ fn extract_addrs_and_ttl(
     }
 
     ttl.map(|ttl| (addrs, ttl))
+}
+
+/// Case-insensitive match against [`crate::HOST_ALIAS`] with trailing-dot tolerance.
+fn is_host_alias_query(query_name: &str) -> bool {
+    query_name
+        .trim_end_matches('.')
+        .eq_ignore_ascii_case(crate::HOST_ALIAS)
+}
+
+/// Synthesize an A/AAAA response for `host.microsandbox.internal`. Returns
+/// `None` for non-A/AAAA queries so the caller keeps forwarding upstream.
+fn synthesize_host_alias_response(
+    query: &Message,
+    gateway: GatewayIps,
+    qtype: RecordType,
+) -> Option<Bytes> {
+    let question = query.queries().first()?;
+    let name = question.name().clone();
+
+    let rdata = match qtype {
+        RecordType::A => RData::A(A::from(gateway.ipv4)),
+        RecordType::AAAA => RData::AAAA(AAAA::from(gateway.ipv6)),
+        _ => return None,
+    };
+
+    let mut response = Message::new();
+    response.set_id(query.id());
+    response.set_op_code(query.op_code());
+    response.set_recursion_desired(query.recursion_desired());
+    response.set_message_type(MessageType::Response);
+    response.set_response_code(ResponseCode::NoError);
+    response.set_recursion_available(true);
+    response.set_authoritative(true);
+    response.add_query(question.clone());
+    response.add_answer(Record::from_rdata(name, HOST_ALIAS_TTL_SECS, rdata));
+
+    response.to_bytes().ok().map(Bytes::from)
 }
 
 /// Build a header-only NoError response with TC=1. RFC 5966 §3 requires

--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -27,6 +27,7 @@ use super::proxies::udp::UdpProxy;
 use crate::config::DnsConfig;
 use crate::policy::NetworkPolicy;
 use crate::shared::SharedState;
+use crate::stack::GatewayIps;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -98,14 +99,10 @@ pub(crate) struct DnsResponse {
 impl DnsInterceptor {
     /// Create the DNS interceptor.
     ///
-    /// Binds a smoltcp UDP socket to port 53, creates the channel pair, and
-    /// spawns the background forwarder task. Returns the interceptor and
-    /// the shared [`DnsForwarderHandle`] used by the TCP/53 proxy.
-    ///
-    /// `gateway_ips` (the v4 + v6 addresses the gateway responds to) and
-    /// `network_policy` are forwarded to the per-query upstream selector:
-    /// queries to the gateway use the configured upstream; queries to
-    /// other IPs are routed directly subject to the policy.
+    /// Binds a smoltcp UDP socket to port 53, creates the channel pair, and spawns the
+    /// background forwarder task. Returns the interceptor and the shared [`DnsForwarderHandle`]
+    /// used by the TCP/53 proxy.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         sockets: &mut SocketSet<'_>,
         dns_config: DnsConfig,
@@ -113,6 +110,7 @@ impl DnsInterceptor {
         tokio_handle: &tokio::runtime::Handle,
         gateway_ips: Arc<HashSet<IpAddr>>,
         network_policy: Arc<NetworkPolicy>,
+        gateway: GatewayIps,
     ) -> (Self, DnsForwarderHandle) {
         // Create and bind the smoltcp UDP socket.
         let rx_meta = vec![PacketMetadata::EMPTY; DNS_SOCKET_PACKET_SLOTS];
@@ -152,6 +150,7 @@ impl DnsInterceptor {
             gateway_ips,
             network_policy,
             shared.clone(),
+            gateway,
         );
         UdpProxy::spawn(
             tokio_handle,

--- a/crates/network/lib/dns/proxies/tcp.rs
+++ b/crates/network/lib/dns/proxies/tcp.rs
@@ -46,7 +46,7 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// guest, extracts length-prefixed DNS messages, dispatches each
 /// through the shared [`DnsForwarder`] in its own sub-task, and writes
 /// length-prefixed responses back as they arrive.
-pub(crate) struct TcpProxy {
+pub(crate) struct DnsTcpProxy {
     /// The (resolver-IP, 53) the guest aimed at — passed to the
     /// forwarder for upstream selection.
     dst: SocketAddr,
@@ -66,7 +66,7 @@ pub(crate) struct TcpProxy {
 // Methods
 //--------------------------------------------------------------------------------------------------
 
-impl TcpProxy {
+impl DnsTcpProxy {
     /// Spawn a DNS-over-TCP proxy task for a newly established TCP/53
     /// connection. Waits for the forwarder, constructs a [`TcpProxy`],
     /// and drives it to completion.

--- a/crates/network/lib/icmp_relay.rs
+++ b/crates/network/lib/icmp_relay.rs
@@ -151,7 +151,7 @@ impl IcmpRelay {
 
         // Gateway echo is already handled upstream — skip.
         let dst_ip: Ipv4Addr = ipv4.dst_addr();
-        if dst_ip == config.gateway_ipv4 {
+        if dst_ip == config.gateway.ipv4 {
             return false;
         }
 
@@ -222,7 +222,7 @@ impl IcmpRelay {
 
         // Gateway echo is already handled upstream — skip.
         let dst_ip: Ipv6Addr = ipv6.dst_addr();
-        if dst_ip == config.gateway_ipv6 {
+        if dst_ip == config.gateway.ipv6 {
             return false;
         }
 

--- a/crates/network/lib/lib.rs
+++ b/crates/network/lib/lib.rs
@@ -17,3 +17,9 @@ pub mod shared;
 pub mod stack;
 pub mod tls;
 pub mod udp_relay;
+
+/// Static hostname the guest uses to reach the sandbox host.
+///
+/// The host-side DNS interceptor matches guest queries against this
+/// name, and agentd writes the same name into `/etc/hosts`.
+pub(crate) const HOST_ALIAS: &str = "host.microsandbox.internal";

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -9,12 +9,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
+use microsandbox_protocol::{ENV_HOST_ALIAS, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6};
 use msb_krun::backends::net::NetBackend;
 
 use crate::backend::SmoltcpBackend;
 use crate::config::NetworkConfig;
 use crate::shared::{DEFAULT_QUEUE_CAPACITY, SharedState};
-use crate::stack::{self, PollLoopConfig};
+use crate::stack::{self, GatewayIps, PollLoopConfig};
 use crate::tls::state::TlsState;
 
 //--------------------------------------------------------------------------------------------------
@@ -134,6 +135,14 @@ impl SmoltcpNetwork {
         }
     }
 
+    /// Get the gateway IPs for virtio-net configuration and domain-based policy rules.
+    fn gateway_ips(&self) -> GatewayIps {
+        GatewayIps {
+            ipv4: self.gateway_ipv4,
+            ipv6: self.gateway_ipv6,
+        }
+    }
+
     /// Start the smoltcp poll thread.
     ///
     /// Must be called before VM boot. Requires a tokio runtime handle for
@@ -143,9 +152,8 @@ impl SmoltcpNetwork {
         let poll_config = PollLoopConfig {
             gateway_mac: self.gateway_mac,
             guest_mac: self.guest_mac,
-            gateway_ipv4: self.gateway_ipv4,
+            gateway: self.gateway_ips(),
             guest_ipv4: self.guest_ipv4,
-            gateway_ipv6: self.gateway_ipv6,
             mtu: self.mtu as usize,
         };
         let network_policy = self.config.policy.clone();
@@ -190,7 +198,7 @@ impl SmoltcpNetwork {
     pub fn guest_env_vars(&self) -> Vec<(String, String)> {
         let mut vars = vec![
             (
-                "MSB_NET".into(),
+                ENV_NET.into(),
                 format!(
                     "iface=eth0,mac={},mtu={}",
                     format_mac(self.guest_mac),
@@ -198,19 +206,20 @@ impl SmoltcpNetwork {
                 ),
             ),
             (
-                "MSB_NET_IPV4".into(),
+                ENV_NET_IPV4.into(),
                 format!(
                     "addr={}/30,gw={},dns={}",
                     self.guest_ipv4, self.gateway_ipv4, self.gateway_ipv4,
                 ),
             ),
             (
-                "MSB_NET_IPV6".into(),
+                ENV_NET_IPV6.into(),
                 format!(
                     "addr={}/64,gw={},dns={}",
                     self.guest_ipv6, self.gateway_ipv6, self.gateway_ipv6,
                 ),
             ),
+            (ENV_HOST_ALIAS.into(), crate::HOST_ALIAS.into()),
         ];
 
         // Auto-expose secret placeholders as environment variables.
@@ -387,12 +396,14 @@ mod tests {
         let net = SmoltcpNetwork::new(config, 0);
         let vars = net.guest_env_vars();
 
-        assert_eq!(vars.len(), 3);
-        assert_eq!(vars[0].0, "MSB_NET");
+        assert_eq!(vars.len(), 4);
+        assert_eq!(vars[0].0, ENV_NET);
         assert!(vars[0].1.contains("iface=eth0"));
-        assert_eq!(vars[1].0, "MSB_NET_IPV4");
+        assert_eq!(vars[1].0, ENV_NET_IPV4);
         assert!(vars[1].1.contains("/30"));
-        assert_eq!(vars[2].0, "MSB_NET_IPV6");
+        assert_eq!(vars[2].0, ENV_NET_IPV6);
         assert!(vars[2].1.contains("/64"));
+        assert_eq!(vars[3].0, ENV_HOST_ALIAS);
+        assert_eq!(vars[3].1, crate::HOST_ALIAS);
     }
 }

--- a/crates/network/lib/policy/destination.rs
+++ b/crates/network/lib/policy/destination.rs
@@ -12,6 +12,9 @@ use super::DestinationGroup;
 //--------------------------------------------------------------------------------------------------
 
 /// Returns `true` if `addr` belongs to the given destination group.
+///
+/// `DestinationGroup::Host` is handled by the policy-level matcher
+/// because it needs per-sandbox gateway IPs; it returns `false` here.
 pub fn matches_group(group: DestinationGroup, addr: IpAddr) -> bool {
     match group {
         DestinationGroup::Loopback => is_loopback(addr),
@@ -19,6 +22,7 @@ pub fn matches_group(group: DestinationGroup, addr: IpAddr) -> bool {
         DestinationGroup::LinkLocal => is_link_local(addr),
         DestinationGroup::Metadata => is_metadata(addr),
         DestinationGroup::Multicast => is_multicast(addr),
+        DestinationGroup::Host => false,
     }
 }
 

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -116,6 +116,11 @@ pub enum DestinationGroup {
 
     /// Multicast addresses (`224.0.0.0/4`, `ff00::/8`).
     Multicast,
+
+    /// The sandbox host itself, reachable via the gateway IP and
+    /// `host.microsandbox.internal`. Matches against the per-sandbox
+    /// gateway IPs stored on [`SharedState`].
+    Host,
 }
 
 /// Protocol filter.
@@ -326,6 +331,7 @@ fn matches_destination(dest: &Destination, addr: IpAddr, shared: &SharedState) -
     match dest {
         Destination::Any => true,
         Destination::Cidr(network) => matches_cidr(network, addr),
+        Destination::Group(DestinationGroup::Host) => matches_host(addr, shared),
         Destination::Group(group) => matches_group(*group, addr),
         Destination::Domain(domain) => {
             shared.any_resolved_hostname(addr, |hostname| hostname == domain.as_str())
@@ -333,6 +339,16 @@ fn matches_destination(dest: &Destination, addr: IpAddr, shared: &SharedState) -
         Destination::DomainSuffix(suffix) => {
             shared.any_resolved_hostname(addr, |hostname| matches_suffix(hostname, suffix.as_str()))
         }
+    }
+}
+
+/// Matches the per-sandbox gateway IPs carried by [`SharedState`]. Returns
+/// `false` when gateway IPs haven't been set (e.g. isolated unit tests
+/// that don't exercise Host rules).
+fn matches_host(addr: IpAddr, shared: &SharedState) -> bool {
+    match addr {
+        IpAddr::V4(v4) => shared.gateway_ipv4().is_some_and(|gw| gw == v4),
+        IpAddr::V6(v6) => shared.gateway_ipv6().is_some_and(|gw| gw == v6),
     }
 }
 
@@ -357,6 +373,7 @@ fn matches_suffix(hostname: &str, suffix: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
     use std::time::Duration;
 
     use super::*;
@@ -384,6 +401,15 @@ mod tests {
         let shared = SharedState::new(4);
         cache(&shared, host, ResolvedHostnameFamily::Ipv4, ip_str);
         shared
+    }
+
+    /// Build a shared state with gateway IPs set, for `Group::Host` tests.
+    fn shared_with_gateway() -> (SharedState, Ipv4Addr, Ipv6Addr) {
+        let shared = SharedState::new(4);
+        let v4 = Ipv4Addr::new(100, 96, 0, 1);
+        let v6 = Ipv6Addr::new(0xfd42, 0x6d73, 0x62, 0, 0, 0, 0, 1);
+        shared.set_gateway_ips(v4, v6);
+        (shared, v4, v6)
     }
 
     fn egress_tcp(policy: &NetworkPolicy, ip_str: &str, shared: &SharedState) -> Action {
@@ -608,6 +634,110 @@ mod tests {
         assert!(
             egress_tcp(&policy, CLOUDFLARE_V6, &shared).is_deny(),
             "uncached IPv6 address must not match through an IPv4-only cache entry"
+        );
+    }
+
+    // -- Group::Host -------------------------------------------------------
+
+    #[test]
+    fn group_host_matches_gateway_v4() {
+        let (shared, gw4, _) = shared_with_gateway();
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![Rule::deny_outbound(Destination::Group(
+                DestinationGroup::Host,
+            ))],
+        };
+        let dst = SocketAddr::new(IpAddr::V4(gw4), 80);
+        assert_eq!(
+            policy.evaluate_egress(dst, Protocol::Tcp, &shared),
+            Action::Deny
+        );
+    }
+
+    #[test]
+    fn group_host_matches_gateway_v6() {
+        let (shared, _, gw6) = shared_with_gateway();
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![Rule::deny_outbound(Destination::Group(
+                DestinationGroup::Host,
+            ))],
+        };
+        let dst = SocketAddr::new(IpAddr::V6(gw6), 80);
+        assert_eq!(
+            policy.evaluate_egress(dst, Protocol::Tcp, &shared),
+            Action::Deny
+        );
+    }
+
+    #[test]
+    fn group_host_does_not_match_other_ips() {
+        let (shared, _, _) = shared_with_gateway();
+        let policy = NetworkPolicy {
+            default_action: Action::Allow,
+            rules: vec![Rule::deny_outbound(Destination::Group(
+                DestinationGroup::Host,
+            ))],
+        };
+        let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 80);
+        assert_eq!(
+            policy.evaluate_egress(dst, Protocol::Tcp, &shared),
+            Action::Allow
+        );
+    }
+
+    #[test]
+    fn public_only_preset_denies_host_gateway() {
+        let (shared, gw4, gw6) = shared_with_gateway();
+        let policy = NetworkPolicy::public_only();
+
+        let v4 = SocketAddr::new(IpAddr::V4(gw4), 80);
+        assert_eq!(
+            policy.evaluate_egress(v4, Protocol::Tcp, &shared),
+            Action::Deny,
+            "default policy should deny host via IPv4 gateway"
+        );
+
+        let v6 = SocketAddr::new(IpAddr::V6(gw6), 80);
+        assert_eq!(
+            policy.evaluate_egress(v6, Protocol::Tcp, &shared),
+            Action::Deny,
+            "default policy should deny host via IPv6 gateway (ULA fd42::/8)"
+        );
+    }
+
+    #[test]
+    fn allow_all_preset_permits_host_gateway() {
+        let (shared, gw4, _) = shared_with_gateway();
+        let policy = NetworkPolicy::allow_all();
+        let v4 = SocketAddr::new(IpAddr::V4(gw4), 80);
+        assert_eq!(
+            policy.evaluate_egress(v4, Protocol::Tcp, &shared),
+            Action::Allow
+        );
+    }
+
+    #[test]
+    fn group_host_allow_overrides_private_deny_when_ordered_first() {
+        let (shared, gw4, _) = shared_with_gateway();
+        let mut policy = NetworkPolicy::public_only();
+        policy.rules.insert(
+            0,
+            Rule::allow_outbound(Destination::Group(DestinationGroup::Host)),
+        );
+
+        let v4 = SocketAddr::new(IpAddr::V4(gw4), 80);
+        assert_eq!(
+            policy.evaluate_egress(v4, Protocol::Tcp, &shared),
+            Action::Allow
+        );
+
+        let other_private = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 80);
+        assert_eq!(
+            policy.evaluate_egress(other_private, Protocol::Tcp, &shared),
+            Action::Deny,
+            "non-host private destinations should still be blocked"
         );
     }
 }

--- a/crates/network/lib/shared.rs
+++ b/crates/network/lib/shared.rs
@@ -4,9 +4,9 @@
 //! All inter-thread communication flows through [`SharedState`], which holds
 //! lock-free frame queues and cross-platform [`WakePipe`] notifications.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{
-    Arc, Mutex,
+    Arc, Mutex, OnceLock,
     atomic::{AtomicU64, Ordering},
 };
 use std::time::{Duration, Instant};
@@ -67,6 +67,14 @@ pub struct SharedState {
     /// Resolved hostname index used to map destination IPs back to queried hostnames.
     resolved_hostnames: RwLock<TtlReverseIndex<ResolvedHostnameKey, IpAddr>>,
 
+    /// Per-sandbox gateway IPv4. Set once at boot; used by
+    /// `DestinationGroup::Host` rule matching and `host.microsandbox.internal`
+    /// DNS synthesis. `None` in isolated unit tests.
+    gateway_ipv4: OnceLock<Ipv4Addr>,
+
+    /// Per-sandbox gateway IPv6. Set once at boot. See `gateway_ipv4`.
+    gateway_ipv6: OnceLock<Ipv6Addr>,
+
     /// Aggregate network byte counters at the guest/runtime boundary.
     metrics: NetworkMetrics,
 }
@@ -109,8 +117,26 @@ impl SharedState {
             proxy_wake: WakePipe::new(),
             termination_hook: Mutex::new(None),
             resolved_hostnames: RwLock::new(TtlReverseIndex::default()),
+            gateway_ipv4: OnceLock::new(),
+            gateway_ipv6: OnceLock::new(),
             metrics: NetworkMetrics::default(),
         }
+    }
+
+    /// Set the per-sandbox gateway IPs. Called once at boot.
+    pub fn set_gateway_ips(&self, ipv4: Ipv4Addr, ipv6: Ipv6Addr) {
+        let _ = self.gateway_ipv4.set(ipv4);
+        let _ = self.gateway_ipv6.set(ipv6);
+    }
+
+    /// Gateway IPv4 address, if set.
+    pub fn gateway_ipv4(&self) -> Option<Ipv4Addr> {
+        self.gateway_ipv4.get().copied()
+    }
+
+    /// Gateway IPv6 address, if set.
+    pub fn gateway_ipv6(&self) -> Option<Ipv6Addr> {
+        self.gateway_ipv6.get().copied()
     }
 
     /// Install a host-side termination hook.

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -8,10 +8,10 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::time::Instant;
-use std::sync::atomic::Ordering;
 
 use smoltcp::wire::{
     EthernetAddress, EthernetFrame, EthernetProtocol, HardwareAddress, Icmpv4Packet, Icmpv4Repr,
@@ -25,7 +25,7 @@ use crate::device::SmoltcpDevice;
 use crate::dns::common::ports::DnsPortType;
 use crate::dns::{
     interceptor::DnsInterceptor,
-    proxies::{dot::DotProxy, tcp::TcpProxy},
+    proxies::{dot::DotProxy, tcp::DnsTcpProxy},
 };
 use crate::icmp_relay::IcmpRelay;
 use crate::policy::{NetworkPolicy, Protocol};
@@ -69,14 +69,24 @@ pub struct PollLoopConfig {
     pub gateway_mac: [u8; 6],
     /// Guest MAC address.
     pub guest_mac: [u8; 6],
-    /// Gateway IPv4 address.
-    pub gateway_ipv4: Ipv4Addr,
+    /// Gateway addresses (IPv4 + IPv6) owned by the smoltcp virtual
+    /// stack.
+    pub gateway: GatewayIps,
     /// Guest IPv4 address.
     pub guest_ipv4: Ipv4Addr,
-    /// Gateway IPv6 address.
-    pub gateway_ipv6: Ipv6Addr,
     /// IP-level MTU (e.g. 1500).
     pub mtu: usize,
+}
+
+/// Per-sandbox gateway addresses (v4 + v6) owned by the smoltcp virtual stack.
+/// Both families are always assigned. The proxy's `resolve_host_dst` helper uses
+/// these to rewrite gateway-bound connections to loopback at dial time.
+#[derive(Debug, Clone, Copy)]
+pub struct GatewayIps {
+    /// Gateway IPv4.
+    pub ipv4: Ipv4Addr,
+    /// Gateway IPv6.
+    pub ipv6: Ipv6Addr,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -115,24 +125,24 @@ pub fn create_interface(device: &mut SmoltcpDevice, config: &PollLoopConfig) -> 
     iface.update_ip_addrs(|addrs| {
         addrs
             .push(IpCidr::new(
-                IpAddress::Ipv4(config.gateway_ipv4),
+                IpAddress::Ipv4(config.gateway.ipv4),
                 // /30 subnet: gateway + guest.
                 30,
             ))
             .expect("failed to add gateway IPv4 address");
         addrs
-            .push(IpCidr::new(IpAddress::Ipv6(config.gateway_ipv6), 64))
+            .push(IpCidr::new(IpAddress::Ipv6(config.gateway.ipv6), 64))
             .expect("failed to add gateway IPv6 address");
     });
 
     // Default routes so smoltcp accepts traffic for all destinations.
     iface
         .routes_mut()
-        .add_default_ipv4_route(config.gateway_ipv4)
+        .add_default_ipv4_route(config.gateway.ipv4)
         .expect("failed to add default IPv4 route");
     iface
         .routes_mut()
-        .add_default_ipv6_route(config.gateway_ipv6)
+        .add_default_ipv6_route(config.gateway.ipv6)
         .expect("failed to add default IPv6 route");
 
     // Accept traffic destined for any IP, not just gateway addresses.
@@ -143,8 +153,8 @@ pub fn create_interface(device: &mut SmoltcpDevice, config: &PollLoopConfig) -> 
 
 /// Main smoltcp poll loop. Runs on a dedicated OS thread.
 ///
-/// Processes guest frames with pre-inspection, drives smoltcp's TCP/IP
-/// stack, and sleeps via `poll(2)` between events.
+/// Processes guest frames with pre-inspection, drives smoltcp's TCP/IP stack,
+/// and sleeps via `poll(2)` between events.
 ///
 /// # Phases per iteration
 ///
@@ -154,6 +164,23 @@ pub fn create_interface(device: &mut SmoltcpDevice, config: &PollLoopConfig) -> 
 ///    tasks (added by later tasks).
 /// 4. **Sleep** — `poll(2)` on `tx_wake` + `proxy_wake` pipes with smoltcp's
 ///    requested timeout.
+///
+/// # Arguments
+///
+/// * `shared` - Stack-wide shared state: `tx_ring` / `rx_ring` for the virtio-net boundary
+///   and the wake eventfds.
+/// * `config` - Resolved per-sandbox parameters (gateway / guest MAC + IPv4 + IPv6, MTU).
+/// * `network_policy` - User-provided egress policy. Evaluated against the sandbox's
+///   gateway IPs (stored on [`SharedState`]) so `DestinationGroup::Host` rules match.
+/// * `dns_config` - DNS interception settings (block lists, upstreams, timeout).
+/// * `tls_state` - Optional TLS MITM state; drives interception of intercepted ports and DoT
+///   when present.
+/// * `published_ports` - Host → guest port publishes; the publisher accepts inbound
+///   connections on the host-bind address and forwards into the guest.
+/// * `max_connections` - Optional cap on concurrent guest connections tracked by
+///   [`ConnectionTracker`]; `None` uses the default.
+/// * `tokio_handle` - Runtime handle used for proxy tasks, DNS forwarding, port publishing,
+///   and ICMP relays.
 #[allow(clippy::too_many_arguments)]
 pub fn smoltcp_poll_loop(
     shared: Arc<SharedState>,
@@ -172,13 +199,16 @@ pub fn smoltcp_poll_loop(
 
     // The DNS forwarder needs to know which IPs count as "the gateway"
     // (so it routes guest queries to those addresses through the
-    // configured upstream) and the network policy (so guest-chosen
+    // configured upstream) and a policy evaluator (so guest-chosen
     // `@target` resolvers are gated by egress rules just like any
     // other outbound).
     let gateway_ips: Arc<HashSet<IpAddr>> = Arc::new(HashSet::from([
-        IpAddr::V4(config.gateway_ipv4),
-        IpAddr::V6(config.gateway_ipv6),
+        IpAddr::V4(config.gateway.ipv4),
+        IpAddr::V6(config.gateway.ipv6),
     ]));
+    // Gateway IPs must be on SharedState before any egress evaluation runs,
+    // so `DestinationGroup::Host` rules can resolve to the right address.
+    shared.set_gateway_ips(config.gateway.ipv4, config.gateway.ipv6);
     let network_policy = Arc::new(network_policy);
 
     let (mut dns_interceptor, dns_forwarder_handle) = DnsInterceptor::new(
@@ -188,6 +218,7 @@ pub fn smoltcp_poll_loop(
         &tokio_handle,
         gateway_ips,
         network_policy.clone(),
+        config.gateway,
     );
     let mut port_publisher = PortPublisher::new(&published_ports, config.guest_ipv4, &tokio_handle);
     let mut udp_relay = UdpRelay::new(
@@ -326,7 +357,11 @@ pub fn smoltcp_poll_loop(
                         continue;
                     }
 
-                    udp_relay.relay_outbound(frame, src, dst);
+                    // Resolve the host-side destination for the dial.
+                    // `dst` stays unchanged so reply frames are stamped
+                    // with the IP the guest expects.
+                    let host_dst = resolve_host_dst(dst, config.gateway);
+                    udp_relay.relay_outbound(frame, src, dst, host_dst);
                     device.drop_staged_frame();
                 }
 
@@ -375,9 +410,10 @@ pub fn smoltcp_poll_loop(
                     .contains(&conn.dst.port())
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
+                let conn_dst = resolve_host_dst(conn.dst, config.gateway);
                 tls_proxy::spawn_tls_proxy(
                     &tokio_handle,
-                    conn.dst,
+                    conn_dst,
                     conn.from_smoltcp,
                     conn.to_smoltcp,
                     shared.clone(),
@@ -392,8 +428,10 @@ pub fn smoltcp_poll_loop(
                 // upstream based on `conn.dst.ip()` — the configured
                 // upstream for queries to the gateway, direct forward
                 // to the chosen `@target` (subject to egress policy)
-                // otherwise.
-                TcpProxy::spawn(
+                // otherwise. No gateway→loopback rewrite here: the
+                // forwarder dials the configured upstream, not the
+                // gateway.
+                DnsTcpProxy::spawn(
                     &tokio_handle,
                     conn.dst,
                     conn.from_smoltcp,
@@ -423,9 +461,10 @@ pub fn smoltcp_poll_loop(
                 continue;
             }
             // Plain TCP proxy.
+            let dst = resolve_host_dst(conn.dst, config.gateway);
             proxy::spawn_tcp_proxy(
                 &tokio_handle,
-                conn.dst,
+                dst,
                 conn.from_smoltcp,
                 conn.to_smoltcp,
                 shared.clone(),
@@ -484,6 +523,27 @@ pub fn smoltcp_poll_loop(
 // Functions: Helpers
 //--------------------------------------------------------------------------------------------------
 
+/// Map a guest-wire destination to its host-socket equivalent.
+///
+/// Gateway IPs rewrite to loopback (`127.0.0.1` / `::1`); everything else
+/// passes through. Shared by the TCP proxy dispatch and the UDP relay.
+///
+/// # Arguments
+///
+/// * `dst` - Destination from the guest's packet.
+/// * `gateway` - Per-sandbox gateway IPs that trigger the loopback rewrite.
+pub(crate) fn resolve_host_dst(dst: SocketAddr, gateway: GatewayIps) -> SocketAddr {
+    match dst.ip() {
+        IpAddr::V4(v4) if v4 == gateway.ipv4 => {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), dst.port())
+        }
+        IpAddr::V6(v6) if v6 == gateway.ipv6 => {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), dst.port())
+        }
+        _ => dst,
+    }
+}
+
 /// Get the current time as a smoltcp [`Instant`] using a monotonic clock.
 ///
 /// Uses `std::time::Instant` (monotonic) instead of `SystemTime` (wall
@@ -531,7 +591,7 @@ fn gateway_icmpv4_echo_reply(
     config: &PollLoopConfig,
 ) -> Option<Vec<u8>> {
     let ipv4 = Ipv4Packet::new_checked(eth.payload()).ok()?;
-    if ipv4.dst_addr() != config.gateway_ipv4 || ipv4.next_header() != IpProtocol::Icmp {
+    if ipv4.dst_addr() != config.gateway.ipv4 || ipv4.next_header() != IpProtocol::Icmp {
         return None;
     }
 
@@ -546,7 +606,7 @@ fn gateway_icmpv4_echo_reply(
     };
 
     let ipv4_repr = Ipv4Repr {
-        src_addr: config.gateway_ipv4,
+        src_addr: config.gateway.ipv4,
         dst_addr: ipv4.src_addr(),
         next_header: IpProtocol::Icmp,
         payload_len: 8 + data.len(),
@@ -582,7 +642,7 @@ fn gateway_icmpv6_echo_reply(
     config: &PollLoopConfig,
 ) -> Option<Vec<u8>> {
     let ipv6 = Ipv6Packet::new_checked(eth.payload()).ok()?;
-    if ipv6.dst_addr() != config.gateway_ipv6 || ipv6.next_header() != IpProtocol::Icmpv6 {
+    if ipv6.dst_addr() != config.gateway.ipv6 || ipv6.next_header() != IpProtocol::Icmpv6 {
         return None;
     }
 
@@ -603,7 +663,7 @@ fn gateway_icmpv6_echo_reply(
     };
 
     let ipv6_repr = Ipv6Repr {
-        src_addr: config.gateway_ipv6,
+        src_addr: config.gateway.ipv6,
         dst_addr: ipv6.src_addr(),
         next_header: IpProtocol::Icmpv6,
         payload_len: icmp_repr_buffer_len_v6(data),
@@ -624,7 +684,7 @@ fn gateway_icmpv6_echo_reply(
 
     ipv6_repr.emit(&mut Ipv6Packet::new_unchecked(&mut reply[14..54]));
     icmp_repr.emit(
-        &config.gateway_ipv6,
+        &config.gateway.ipv6,
         &ipv6.src_addr(),
         &mut Icmpv6Packet::new_unchecked(&mut reply[54..]),
         &smoltcp::phy::ChecksumCapabilities::default(),
@@ -938,9 +998,11 @@ mod tests {
         let poll_config = PollLoopConfig {
             gateway_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
             guest_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
-            gateway_ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            gateway: GatewayIps {
+                ipv4: Ipv4Addr::new(100, 96, 0, 1),
+                ipv6: Ipv6Addr::LOCALHOST,
+            },
             guest_ipv4: Ipv4Addr::new(100, 96, 0, 2),
-            gateway_ipv6: Ipv6Addr::LOCALHOST,
             mtu: 1500,
         };
         let mut device = SmoltcpDevice::new(shared.clone(), poll_config.mtu);
@@ -955,7 +1017,7 @@ mod tests {
             .push(build_arp_request_frame(
                 poll_config.guest_mac,
                 poll_config.guest_ipv4.octets(),
-                poll_config.gateway_ipv4.octets(),
+                poll_config.gateway.ipv4.octets(),
             ))
             .unwrap();
         shared
@@ -964,7 +1026,7 @@ mod tests {
                 poll_config.guest_mac,
                 poll_config.gateway_mac,
                 poll_config.guest_ipv4.octets(),
-                poll_config.gateway_ipv4.octets(),
+                poll_config.gateway.ipv4.octets(),
                 0x1234,
                 0xABCD,
                 b"ping",
@@ -997,7 +1059,7 @@ mod tests {
         assert_eq!(eth.ethertype(), EthernetProtocol::Ipv4);
 
         let ipv4 = Ipv4Packet::new_checked(eth.payload()).expect("valid IPv4 packet");
-        assert_eq!(Ipv4Addr::from(ipv4.src_addr()), poll_config.gateway_ipv4);
+        assert_eq!(Ipv4Addr::from(ipv4.src_addr()), poll_config.gateway.ipv4);
         assert_eq!(Ipv4Addr::from(ipv4.dst_addr()), poll_config.guest_ipv4);
         assert_eq!(ipv4.next_header(), IpProtocol::Icmp);
 
@@ -1012,6 +1074,40 @@ mod tests {
                 data: b"ping",
             }
         );
+    }
+
+    fn test_gateway() -> GatewayIps {
+        GatewayIps {
+            ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            ipv6: "fd42:6d73:62::1".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn resolve_host_dst_matches_ipv4() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V4(gw.ipv4), 8080);
+        assert_eq!(
+            resolve_host_dst(dst, gw),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+        );
+    }
+
+    #[test]
+    fn resolve_host_dst_matches_ipv6() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V6(gw.ipv6), 8080);
+        assert_eq!(
+            resolve_host_dst(dst, gw),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
+        );
+    }
+
+    #[test]
+    fn resolve_host_dst_passes_through_non_gateway() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 443);
+        assert_eq!(resolve_host_dst(dst, gw), dst);
     }
 
     #[test]
@@ -1037,9 +1133,11 @@ mod tests {
         let poll_config = PollLoopConfig {
             gateway_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
             guest_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
-            gateway_ipv4: Ipv4Addr::new(100, 96, 0, 1),
+            gateway: GatewayIps {
+                ipv4: Ipv4Addr::new(100, 96, 0, 1),
+                ipv6: Ipv6Addr::LOCALHOST,
+            },
             guest_ipv4: Ipv4Addr::new(100, 96, 0, 2),
-            gateway_ipv6: Ipv6Addr::LOCALHOST,
             mtu: 1500,
         };
         let mut device = SmoltcpDevice::new(shared.clone(), poll_config.mtu);
@@ -1052,7 +1150,7 @@ mod tests {
             .push(build_arp_request_frame(
                 poll_config.guest_mac,
                 poll_config.guest_ipv4.octets(),
-                poll_config.gateway_ipv4.octets(),
+                poll_config.gateway.ipv4.octets(),
             ))
             .unwrap();
         shared

--- a/crates/network/lib/udp_relay.rs
+++ b/crates/network/lib/udp_relay.rs
@@ -76,7 +76,15 @@ struct UdpSession {
 //--------------------------------------------------------------------------------------------------
 
 impl UdpRelay {
-    /// Create a new UDP relay.
+    /// Build a new UDP relay.
+    ///
+    /// # Arguments
+    ///
+    /// * `shared` - Stack-wide shared state used to inject response frames into `rx_ring`
+    ///   and wake the poll thread.
+    /// * `gateway_mac` - MAC address stamped as the source on synthesized response frames.
+    /// * `guest_mac` - MAC address stamped as the destination on synthesized response frames.
+    /// * `tokio_handle` - Runtime the per-session relay tasks are spawned on.
     pub fn new(
         shared: Arc<SharedState>,
         gateway_mac: [u8; 6],
@@ -94,15 +102,28 @@ impl UdpRelay {
 
     /// Relay an outbound UDP datagram from the guest.
     ///
-    /// Extracts the UDP payload from the raw ethernet frame, looks up or
-    /// creates a session, and sends the payload to the relay task.
-    pub fn relay_outbound(&mut self, frame: &[u8], src: SocketAddr, dst: SocketAddr) {
+    /// # Arguments
+    ///
+    /// * `frame` - Raw ethernet frame captured from the guest.
+    /// * `src` - Guest source address; keys the session and becomes the destination on
+    ///   response frames.
+    /// * `guest_dst` - Destination the guest wrote on the datagram. Retained as the session
+    ///   key and the source IP on replies.
+    /// * `host_dst` - Address the host socket actually connects to. Usually equal to
+    ///   `guest_dst`; the caller substitutes loopback when `guest_dst` matches the gateway IP.
+    pub fn relay_outbound(
+        &mut self,
+        frame: &[u8],
+        src: SocketAddr,
+        guest_dst: SocketAddr,
+        host_dst: SocketAddr,
+    ) {
         // Extract UDP payload from the ethernet frame.
         let Some(payload) = extract_udp_payload(frame) else {
             return;
         };
 
-        let key = (src, dst);
+        let key = (src, guest_dst);
 
         // Create session if it doesn't exist or has expired.
         if self
@@ -111,7 +132,7 @@ impl UdpRelay {
             .is_none_or(|s| s.last_active.elapsed() > SESSION_TIMEOUT)
         {
             self.sessions.remove(&key);
-            if let Some(session) = self.create_session(src, dst) {
+            if let Some(session) = self.create_session(src, guest_dst, host_dst) {
                 self.sessions.insert(key, session);
             } else {
                 return;
@@ -135,7 +156,12 @@ impl UdpRelay {
 
 impl UdpRelay {
     /// Create a new relay session: bind a host UDP socket and spawn a task.
-    fn create_session(&self, guest_src: SocketAddr, guest_dst: SocketAddr) -> Option<UdpSession> {
+    fn create_session(
+        &self,
+        guest_src: SocketAddr,
+        guest_dst: SocketAddr,
+        host_dst: SocketAddr,
+    ) -> Option<UdpSession> {
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
 
         let shared = self.shared.clone();
@@ -147,6 +173,7 @@ impl UdpRelay {
                 outbound_rx,
                 guest_src,
                 guest_dst,
+                host_dst,
                 shared,
                 gateway_mac,
                 guest_mac,
@@ -173,24 +200,53 @@ impl UdpRelay {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Async task that relays UDP between a host socket and the guest.
+/// Per-session UDP relay loop: forwards guest datagrams to a host socket, stamps the replies
+/// back into frames the guest accepts, and exits on idle timeout or channel close.
+///
+/// Binds an ephemeral host UDP socket in the address family of `host_dst` and `connect()`s it
+/// to that peer. The `connect` restricts the socket to that peer's datagrams, which both sets
+/// the default send target and filters spoofed inbound traffic. Responses are wrapped in a
+/// synthesised ethernet frame (src IP = `guest_dst`, dst = `guest_src`) and pushed into
+/// `rx_ring`.
+///
+/// # Arguments
+///
+/// * `outbound_rx` - Receives UDP payloads from the poll-loop side. Channel close signals
+///   session drop.
+/// * `guest_src` - Guest source address; stamped as the destination on reply frames.
+/// * `guest_dst` - Destination the guest wrote on the datagram. Stamped as the source IP on
+///   reply frames so the guest sees replies from the same address it dialed.
+/// * `host_dst` - Address the host socket connects to. Equal to `guest_dst` for external
+///   destinations; rewritten to loopback by [`crate::stack::resolve_host_dst`] when the guest
+///   addressed the gateway.
+/// * `shared` - Shared state; reply frames go into `rx_ring` and wake the poll thread.
+/// * `gateway_mac` - Source MAC on reply frames (guest sees replies from the gateway's MAC).
+/// * `guest_mac` - Destination MAC on reply frames.
+///
+/// # Errors
+///
+/// Returns [`std::io::Error`] when the initial `bind` or `connect` on
+/// the host UDP socket fails, or when the host-side `recv` fails after
+/// the socket was established.
+#[allow(clippy::too_many_arguments)]
 async fn udp_relay_task(
     mut outbound_rx: mpsc::Receiver<Bytes>,
     guest_src: SocketAddr,
     guest_dst: SocketAddr,
+    host_dst: SocketAddr,
     shared: Arc<SharedState>,
     gateway_mac: EthernetAddress,
     guest_mac: EthernetAddress,
 ) -> std::io::Result<()> {
-    // Bind a host UDP socket. Use the same address family as the destination.
-    let bind_addr: SocketAddr = match guest_dst {
+    // Bind a host UDP socket. Use the same address family as the host destination.
+    let bind_addr: SocketAddr = match host_dst {
         SocketAddr::V4(_) => (Ipv4Addr::UNSPECIFIED, 0u16).into(),
         SocketAddr::V6(_) => (std::net::Ipv6Addr::UNSPECIFIED, 0u16).into(),
     };
     let socket = UdpSocket::bind(bind_addr).await?;
     // Connect to the destination to restrict accepted source addresses,
     // preventing host-network entities from injecting spoofed datagrams.
-    socket.connect(guest_dst).await?;
+    socket.connect(host_dst).await?;
 
     let mut recv_buf = vec![0u8; RECV_BUF_SIZE];
     let timeout = SESSION_TIMEOUT;

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -161,6 +161,16 @@ pub const ENV_USER: &str = "MSB_USER";
 /// Defaults to the sandbox name when not explicitly set.
 pub const ENV_HOSTNAME: &str = "MSB_HOSTNAME";
 
+/// Environment variable carrying the DNS name the guest uses to reach
+/// the sandbox host (Docker's `host.docker.internal` equivalent).
+///
+/// The host-side network stack emits this value via its
+/// `guest_env_vars()` method; agentd reads it into
+/// [`crate::exec`]-adjacent boot params and writes the mapping into
+/// `/etc/hosts`. The value the network stack emits is a fixed
+/// protocol constant — today always `host.microsandbox.internal`.
+pub const ENV_HOST_ALIAS: &str = "MSB_HOST_ALIAS";
+
 /// Environment variable carrying sandbox-wide resource limits.
 ///
 /// Format: `resource=limit[:hard][;resource=limit[:hard];...]`

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -197,6 +197,49 @@ msb create python --name api -p 8080:80
 
 </CodeGroup>
 
+## Reaching the host
+
+From inside the sandbox, `host.microsandbox.internal` resolves to the host machine, same idea as Docker's `host.docker.internal`. Use it to call a dev server, database, or other process running on your machine without hard-coding an IP.
+
+```bash
+# Inside the sandbox:
+curl http://host.microsandbox.internal:8080
+```
+
+The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
+
+The default `public_only` preset denies host access — the sandbox gateway sits in a private range, same as any other local destination. Switch to `allow_all` (or a custom policy with `DestinationGroup::Host`) to open it:
+
+<CodeGroup>
+```rust Rust
+use microsandbox::NetworkPolicy;
+use microsandbox_network::policy::{Action, Destination, DestinationGroup, Rule};
+
+// Deny everything except the host.
+let policy = NetworkPolicy {
+    default_action: Action::Deny,
+    rules: vec![Rule::allow_outbound(Destination::Group(DestinationGroup::Host))],
+};
+```
+
+```typescript TypeScript
+const policy = {
+    defaultAction: "deny",
+    rules: [{ action: "allow", direction: "outbound", destination: "host" }],
+}
+```
+
+```python Python
+from microsandbox import Action, NetworkPolicy, Rule
+
+policy = NetworkPolicy(
+    default_action=Action.DENY,
+    rules=(Rule.allow(destination="host"),),
+)
+```
+
+</CodeGroup>
+
 ## Protocol support
 
 For most sandboxed workloads, networking behaves the way you'd expect:

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -298,3 +298,4 @@ String enum for well-known destination groups used in [`Rule.destination`](#rule
 | `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) |
 | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
 | `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
+| `"host"` | The host machine, reached via `host.microsandbox.internal` |

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -396,6 +396,7 @@ Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed
 
 | Value | Description |
 |-------|-------------|
+| `Host` | The host machine, reached via `host.microsandbox.internal` |
 | `LinkLocal` | `169.254.0.0/16`, `fe80::/10` |
 | `Loopback` | `127.0.0.0/8`, `::1` |
 | `Metadata` | Cloud metadata endpoints (`169.254.169.254`) |

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -118,7 +118,7 @@ A single network policy rule.
 | Field | Type | Description |
 |-------|------|-------------|
 | action | [`PolicyAction`](#policyaction) | What to do when this rule matches |
-| destination? | `string` | Target filter: `'any'`, `'private'`, `'loopback'`, `'metadata'`, `'multicast'`, `'link-local'`, a CIDR like `'10.0.0.0/8'`, an exact domain like `'example.com'`, or a suffix prefixed with `.` like `'.example.com'` (matches the apex and every subdomain). Domain and suffix strings are validated when the sandbox is created. |
+| destination? | `string` | Target filter: `'any'`, `'private'`, `'loopback'`, `'metadata'`, `'multicast'`, `'link-local'`, `'host'` (the host machine, reached via `host.microsandbox.internal`), a CIDR like `'10.0.0.0/8'`, an exact domain like `'example.com'`, or a suffix prefixed with `.` like `'.example.com'` (matches the apex and every subdomain). Domain and suffix strings are validated when the sandbox is created. |
 | direction? | [`PolicyDirection`](#policydirection) | Traffic direction |
 | port? | `string` | Single port (`"443"`) or range (`"8000-9000"`) |
 | protocol? | [`PolicyProtocol`](#policyprotocol) | Protocol filter |

--- a/sdk/node-ts/index.d.ts
+++ b/sdk/node-ts/index.d.ts
@@ -616,7 +616,7 @@ export interface PolicyRule {
    * - "1.2.3.4/24" — CIDR notation
    * - "example.com" — exact domain
    * - ".example.com" — domain suffix
-   * - "loopback", "private", "link-local", "metadata", "multicast" — destination group
+   * - "loopback", "private", "link-local", "metadata", "multicast", "host" — destination group
    */
   destination?: string
   /** Protocol filter: "tcp", "udp", "icmpv4", "icmpv6". */

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -818,6 +818,7 @@ fn convert_policy_rule(rule: &PolicyRule) -> Option<Rule> {
         Some("link-local") => Destination::Group(DestinationGroup::LinkLocal),
         Some("metadata") => Destination::Group(DestinationGroup::Metadata),
         Some("multicast") => Destination::Group(DestinationGroup::Multicast),
+        Some("host") => Destination::Group(DestinationGroup::Host),
         Some(s) if s.starts_with('.') => Destination::DomainSuffix(s.parse().ok()?),
         Some(s) if s.contains('/') => {
             // CIDR notation

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -60,6 +60,7 @@ class DestGroup(enum.StrEnum):
     LINK_LOCAL = "link-local"
     METADATA = "metadata"
     MULTICAST = "multicast"
+    HOST = "host"
 
 class ViolationAction(enum.StrEnum):
     BLOCK = "block"

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -420,6 +420,9 @@ fn apply_network(
                         "multicast" => microsandbox_network::policy::Destination::Group(
                             microsandbox_network::policy::DestinationGroup::Multicast,
                         ),
+                        "host" => microsandbox_network::policy::Destination::Group(
+                            microsandbox_network::policy::DestinationGroup::Host,
+                        ),
                         s if s.starts_with('.') => {
                             let name = s.parse().map_err(|e| {
                                 pyo3::exceptions::PyValueError::new_err(format!(


### PR DESCRIPTION
## problem

guests couldn't reach host-side services from inside the sandbox without hacky solutions.

## solution

added `host.microsandbox.internal` which automatically resolves to the per-sandbox gateway ip. agentd was modified to write the mapping to `/etc/hosts`. in addition, a `DestinationGroup::Host` was added, and devs can now explicitly allow traffic to the host machine.

closes https://github.com/superradcompany/microsandbox/pull/545
fixes https://github.com/superradcompany/microsandbox/issues/546