### PR TITLE
docs(networking): align with new policy, add ts builder

### DIFF
--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -22,7 +22,6 @@ Block lookups by exact match or suffix (e.g. `*.tracking.com`). Blocked queries 
 let sb = Sandbox::builder("safe-agent")
     .image("python")
     .network(|n| n
-        .policy(NetworkPolicy::public_only())
         .dns(|d| d
             .block_domain("malware.example.com")
             .block_domain_suffix(".tracking.com")
@@ -151,7 +150,7 @@ The block list and rebind protection only apply to queries the gateway can see. 
 **Not distinguishable from regular traffic** (operator must filter via network policy):
 - DNS over HTTPS (DoH, TCP/443)
 
-For strict DNS integrity, combine DoT interception with a network policy denying outbound `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
+For strict DNS integrity, combine DoT interception with a network policy denying egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway.
 
 ## Domain-based policy rules
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -6,107 +6,75 @@ icon: "network-wired"
 
 All network traffic from a sandbox flows through a host-controlled networking stack. From inside, the sandbox sees a normal network interface, but on the host side every packet is subject to policy before it goes anywhere. The sandbox's only path to the outside world is through this stack, so blocked traffic never leaves the VM.
 
-## Network presets
+## Defaults
 
-Three presets cover most cases. `public_only` is the default.
+Without any policy flags, sandboxes get **public-internet egress only**: routable destinations work, but private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), and the cloud metadata endpoint (`169.254.169.254`) are denied. Inbound traffic on published ports is unfiltered until you add an explicit ingress rule.
 
-- **`none`**: no network interface at all. The guest is fully offline.
-- **`public_only`**: blocks private, loopback, and link-local addresses so only routable public destinations are reachable. The blocked ranges are `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918 private), `127.0.0.0/8` (loopback), and `169.254.0.0/16` (link-local).
-- **`allow_all`**: no filtering, including access to the host machine and local network.
+To turn off networking entirely:
 
-<CodeGroup>
-```rust Rust
-use microsandbox::NetworkPolicy;
+```bash
+msb create python --name isolated --no-net
+```
 
-// Public internet only
-let sb = Sandbox::builder("web-agent")
+```rust
+let sb = Sandbox::builder("isolated")
     .image("python")
-    .network(|n| n.policy(NetworkPolicy::public_only()))
+    .network(|n| n.enabled(false))
     .create()
     .await?;
 ```
 
-```typescript TypeScript
-import { NetworkPolicy, Sandbox } from 'microsandbox'
-
-// No network access
-const sb1 = await Sandbox.create({
-    name: "isolated",
-    image: "python",
-    network: NetworkPolicy.none(),
-})
-
-// Public internet only (default, blocks private ranges)
-const sb2 = await Sandbox.create({
-    name: "web-agent",
-    image: "python",
-    network: NetworkPolicy.publicOnly(),
-})
-
-// Unrestricted access
-const sb3 = await Sandbox.create({
-    name: "dev",
-    image: "python",
-    network: NetworkPolicy.allowAll(),
-})
-```
-
-```python Python
-from microsandbox import Network, Sandbox
-
-# No network access
-sb1 = await Sandbox.create("isolated", image="python", network=Network.none())
-
-# Public internet only (default, blocks private ranges)
-sb2 = await Sandbox.create("web-agent", image="python", network=Network.public_only())
-
-# Unrestricted access
-sb3 = await Sandbox.create("dev", image="python", network=Network.allow_all())
-```
-
-```bash CLI
-# No network access
-msb create python --name isolated --no-network
-
-# Public internet only (default)
-msb create python --name web-agent
-```
-
-</CodeGroup>
-
 ## Custom policies
 
-When a preset isn't the right shape, build a policy with explicit egress and ingress rules. Rules are evaluated first-match-wins and anything that doesn't match falls through to `default_action`.
+A policy is a list of rules plus two direction-specific defaults:
 
-<CodeGroup>
-```rust Rust
-use microsandbox::Sandbox;
-use microsandbox::NetworkPolicy;
-use microsandbox_network::policy::{
-    Action, Destination, DestinationGroup, Direction, PortRange, Protocol, Rule,
-};
+```text
+default_egress  : Allow | Deny     (action when no egress rule matches)
+default_ingress : Allow | Deny     (action when no ingress rule matches)
+rules           : [Rule, ...]      (first match wins)
+```
 
-let policy = NetworkPolicy {
-    default_action: Action::Deny,
-    rules: vec![
-        Rule {
-            direction: Direction::Outbound,
-            destination: Destination::Any,
-            protocol: Some(Protocol::Tcp),
-            ports: Some(PortRange::single(443)),
-            action: Action::Allow,
-        },
-        Rule {
-            direction: Direction::Outbound,
-            destination: Destination::Any,
-            protocol: Some(Protocol::Udp),
-            ports: Some(PortRange::single(53)),
-            action: Action::Allow,
-        },
-        Rule::deny_outbound(Destination::Group(DestinationGroup::Metadata)),
-        Rule::deny_outbound(Destination::Group(DestinationGroup::Private)),
-    ],
-};
+Each rule carries its own direction (`Egress`, `Ingress`, or `Any`), a destination, an optional protocol set, an optional port set, and an action.
+
+### CLI
+
+`--net-rule` takes a comma-separated list of tokens shaped as
+`<action>[:<direction>]@<target>[:<proto>[:<ports>]]`. Direction defaults to `egress` when omitted. Repeating the flag concatenates tokens in argv order; first match wins.
+
+```bash
+# Public internet plus the host machine, deny everything else by default
+msb create python --name agent \
+    --net-rule "allow@public,allow@host"
+
+# Allow public internet plus a specific private host on tcp/443
+msb create alpine --name secure-agent \
+    --net-rule "allow@10.0.5.10:tcp:443,allow@public" \
+    --net-default-egress deny
+
+# Block tcp/445 to private IPs while keeping everything else open
+msb create alpine --name smb-blocked \
+    --net-default-egress allow \
+    --net-rule "deny@private:tcp:445"
+
+# Publish a port and only accept ingress from RFC1918 sources
+msb create python --name api \
+    --port 8080:8080 \
+    --net-rule "allow:ingress@private"
+```
+
+`<target>` accepts `any`, a group keyword (`public`, `private`, `loopback`, `link-local`, `meta`, `multicast`, `host`), an IP, a CIDR, a domain (with at least one dot), `domain=<name>` for single-label hostnames, or `suffix=<domain>` for subdomain matches.
+
+### Rust
+
+```rust
+use microsandbox::{NetworkPolicy, Sandbox};
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e
+        .tcp().port(443).allow_public()
+        .udp().port(53).allow_public())
+    .build()?;
 
 let sb = Sandbox::builder("secure-agent")
     .image("alpine")
@@ -115,53 +83,53 @@ let sb = Sandbox::builder("secure-agent")
     .await?;
 ```
 
-```typescript TypeScript
-import { Sandbox } from 'microsandbox'
+The builder accepts string inputs (`.ip("10.0.0.5")`, `.cidr("10.0.0.0/24")`, `.domain("api.example.com")`, etc.) and parses them at `.build()` time, so the chain stays clean. See the [Rust reference](/sdk/rust/networking) for the full surface (per-category shortcuts, the explicit-rule sub-builder, shadow-rule warnings).
 
+### TypeScript / Python
+
+Both SDKs accept policies as plain config objects matching the wire format. Direction strings are `"egress"`, `"ingress"`, or `"any"`. Group keywords match the CLI grammar.
+
+```typescript
 const sb = await Sandbox.create({
     name: "secure-agent",
     image: "alpine",
     network: {
-        rules: [
-            { action: "allow", direction: "outbound", protocol: "tcp", port: "443" },
-            { action: "allow", direction: "outbound", protocol: "udp", port: "53" },
-            { action: "deny", direction: "outbound", destination: "metadata" },
-            { action: "deny", direction: "outbound", destination: "private" },
-        ],
-        defaultAction: "deny",
+        policy: {
+            default_egress: "deny",
+            default_ingress: "allow",
+            rules: [
+                { action: "allow", direction: "egress", protocol: "tcp", port: "443" },
+                { action: "allow", direction: "egress", protocol: "udp", port: "53" },
+            ],
+        },
     },
 })
 ```
 
-```python Python
-from microsandbox import Action, Network, NetworkPolicy, Protocol, Rule, Sandbox
+```python
+from microsandbox import Sandbox
 
 sb = await Sandbox.create(
     "secure-agent",
     image="alpine",
-    network=Network(
-        policy=NetworkPolicy(
-            default_action=Action.DENY,
-            rules=(
-                Rule.allow(protocol=Protocol.TCP, port=443),
-                Rule.allow(protocol=Protocol.UDP, port=53),
-                Rule.deny(destination="metadata"),
-                Rule.deny(destination="private"),
-            ),
-        ),
-    ),
+    network={
+        "policy": {
+            "default_egress": "deny",
+            "default_ingress": "allow",
+            "rules": [
+                {"action": "allow", "direction": "egress", "protocol": "tcp", "port": "443"},
+                {"action": "allow", "direction": "egress", "protocol": "udp", "port": "53"},
+            ],
+        },
+    },
 )
 ```
 
-</CodeGroup>
-
-Rules can also target domains directly, either as an exact name (e.g. `example.com`) or as a suffix that covers every subdomain (e.g. `.example.com`, matching `api.example.com`, `foo.bar.example.com`, and the apex `example.com` itself). Domain rules rely on DNS pinning so the sandbox can map a connection's destination IP back to the domain that resolved to it. See [DNS](/networking/dns) and the [security model](/networking/security-model) for how that works.
+Domain rules match flows where the guest resolved the name through the sandbox's DNS interceptor. See [DNS](/networking/dns) for how the resolved-hostname cache works.
 
 ## Port mapping
 
 Expose ports from the sandbox to the host so services running inside the VM are reachable from your machine.
-
-In Rust, `SandboxBuilder::port()` and `port_udp()` are top-level shorthands, so you can publish ports without nesting everything inside `.network(...)`.
 
 <CodeGroup>
 ```rust Rust
@@ -169,7 +137,6 @@ let sb = Sandbox::builder("api")
     .image("python")
     .port(8080, 80)
     .port_udp(5353, 5353)
-    .network(|n| n.policy(NetworkPolicy::public_only()))
     .create()
     .await?;
 ```
@@ -179,7 +146,6 @@ const sb = await Sandbox.create({
     name: "api",
     image: "python",
     ports: { "8080": 80 },
-    network: NetworkPolicy.publicOnly(),
 })
 ```
 
@@ -208,45 +174,41 @@ curl http://host.microsandbox.internal:8080
 
 The name is wired through `/etc/hosts` and the DNS interceptor, so both standard resolvers and tools that bypass `/etc/hosts` (like `dig`) find it.
 
-The default `public_only` preset denies host access — the sandbox gateway sits in a private range, same as any other local destination. Switch to `allow_all` (or a custom policy with `DestinationGroup::Host`) to open it:
+The default policy denies host access — the sandbox gateway sits in a private range, same as any other local destination. Add the `host` group to open it:
 
-<CodeGroup>
-```rust Rust
-use microsandbox::NetworkPolicy;
-use microsandbox_network::policy::{Action, Destination, DestinationGroup, Rule};
-
-// Deny everything except the host.
-let policy = NetworkPolicy {
-    default_action: Action::Deny,
-    rules: vec![Rule::allow_outbound(Destination::Group(DestinationGroup::Host))],
-};
+```bash
+msb create python --name dev-agent \
+    --net-rule "allow@public,allow@host"
 ```
 
-```typescript TypeScript
-const policy = {
-    defaultAction: "deny",
-    rules: [{ action: "allow", direction: "outbound", destination: "host" }],
-}
+```rust
+NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.allow_public().allow_host())
+    .build()?
 ```
 
-```python Python
-from microsandbox import Action, NetworkPolicy, Rule
+### Loopback vs host: a common trap
 
-policy = NetworkPolicy(
-    default_action=Action.DENY,
-    rules=(Rule.allow(destination="host"),),
-)
-```
+`Group::Loopback` (`127.0.0.0/8`, `::1`) and `Group::Host` (the per-sandbox gateway IPs) are different things. The two-word summary:
 
-</CodeGroup>
+- **`loopback`** = the guest's own loopback interface. Services running inside the same VM.
+- **`host`** = the host machine, reached through `host.microsandbox.internal`.
+
+If you're coming from Docker and reach for `.allow_loopback()` to "let the sandbox talk to my host's localhost," that's the trap — you want `.allow_host()` instead. `.allow_loopback()` only fires for traffic *inside* the guest, which doesn't reach the policy gate under normal kernel routing anyway.
+
+`.deny_loopback()` does have a real use case: in `--net-default-egress allow` configurations, a process inside the guest could craft a packet bound to `eth0` with `dst=127.0.0.1`, route it past the guest kernel, and have smoltcp on the host land it on the host's loopback. `.deny_loopback()` blocks that vector. Default policies (with the implicit deny on egress) already cover this.
+
+If you want "everything near the sandbox" — guest loopback, link-local, and the host machine — `.allow_local()` is sugar for that triple. `Metadata` is deliberately excluded so cloud-IMDS isn't quietly exposed; opt in via `.allow_meta()` if you need it.
 
 ## Protocol support
 
 For most sandboxed workloads, networking behaves the way you'd expect:
 
-- Normal outbound **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
+- Normal egress **TCP** and **UDP** traffic works, including common tools and libraries like `curl`, `wget`, package managers, HTTP clients, database drivers, and DNS lookups.
 - **DNS** queries are intercepted on the host side. See [DNS](/networking/dns) for blocking, pinned resolvers, and query timeouts.
 - **ICMP echo** is supported: pinging external hosts works on systems that support unprivileged ICMP echo sockets.
+- **Ingress** on published ports is gated by the same policy. Denied connections drop with TCP RST so the peer sees `ECONNRESET`.
 
 <Note>
 **Raw sockets** and **full ICMP forwarding** are not supported because they require elevated privileges on the host. Tools that depend on richer ICMP behavior, such as `traceroute`, are outside the current scope.

--- a/docs/networking/security-model.mdx
+++ b/docs/networking/security-model.mdx
@@ -8,20 +8,31 @@ microsandbox's networking defaults are shaped around giving an AI agent, a scrap
 
 ## Private IPs and the host's local network
 
-The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The `public_only` preset (the default) addresses this by dropping any packet whose destination falls in:
+The largest class of real damage comes from workloads reaching things that live *inside* your network: the host machine itself, a local database, another VM on the same subnet. The default policy addresses this by denying egress to anything outside `Group::Public` (the complement of the named local categories), which covers:
 
-- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC1918 private ranges)
-- `127.0.0.0/8` (loopback)
-- `169.254.0.0/16` (link-local)
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` (RFC1918 + CGN private ranges)
+- `127.0.0.0/8`, `::1` (loopback)
+- `169.254.0.0/16`, `fe80::/10` (link-local)
+- `169.254.169.254` (cloud metadata, takes precedence over link-local)
+- the per-sandbox gateway IPs (`Group::Host`)
 
-If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Use `allow_all` only when the workload genuinely needs to reach local services, and `none` when it doesn't need network at all.
+If an agent runs `curl http://192.168.1.10` or `curl http://localhost:5432`, the packet is dropped before it leaves the host stack. Override the default with `--net-default-egress allow` only when the workload genuinely needs broad reach, or use `--no-net` when it doesn't need network at all.
 
 ## Cloud metadata endpoints
 
-On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. Because it sits in link-local space, the `public_only` preset already blocks it. For custom policies that start from `allow_all`, `DestinationGroup::Metadata` lets you deny it explicitly:
+On AWS, GCP, Azure, and similar platforms, `169.254.169.254` is the instance metadata service, a well-known SSRF target because it hands out temporary credentials to anything that can connect. The default policy blocks it via the `Group::Public` complement. For custom policies that flip `default_egress` to `Allow`, `Group::Metadata` lets you deny it explicitly:
+
+```bash
+msb create python --name agent \
+    --net-default-egress allow \
+    --net-rule "deny@meta"
+```
 
 ```rust
-Rule::deny_outbound(Destination::Group(DestinationGroup::Metadata)),
+NetworkPolicy::builder()
+    .default_allow()
+    .rule(|r| r.egress().deny_meta())
+    .build()?
 ```
 
 ## DNS rebinding
@@ -61,7 +72,7 @@ The same mechanism gates host-scoped secret injection. When a `SecretEntry` is r
 
 DNS-based defenses (block list, rebind protection, domain pinning) only work on queries the interceptor sees. The gateway intercepts UDP/53 and TCP/53 directly, and DoT (TCP/853) when TLS interception is enabled. Alternative transports are either refused at the port layer (DoQ, mDNS, LLMNR, NetBIOS-NS) or indistinguishable from regular traffic (DoH on TCP/443), and tunneled DNS (VPN, SOCKS5 hostname mode, HTTP `CONNECT`) is carried inside the outer encrypted flow and never reaches the forwarder.
 
-For workloads where DNS integrity matters, pair DoT interception with a network policy that denies outbound `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
+For workloads where DNS integrity matters, pair DoT interception with a network policy that denies egress `UDP/53`, `TCP/53`, and `TCP/853` to anything except the gateway. Tunneled DNS is a network-layer concern: close it by restricting egress to an allowlist that excludes tunnel destinations. See [DNS](/networking/dns) for the transport-by-transport breakdown.
 
 ## Out of scope
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -109,19 +109,23 @@ Unrestricted network access, including to private addresses and the host machine
 
 ### NetworkPolicy
 
-Frozen dataclass for a custom network policy with rules.
+Frozen dataclass for a custom network policy. Two per-direction defaults plus an ordered list of rules evaluated first-match-wins per direction.
 
 ```python
 NetworkPolicy(
-    default_action: Action = Action.ALLOW,
+    default_egress: Action = Action.DENY,
+    default_ingress: Action = Action.ALLOW,
     rules: tuple[Rule, ...] = (),
 )
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| default_action | [`Action`](#action) | `Action.ALLOW` | Action when no rule matches |
-| rules | `tuple[`[`Rule`](#rule)`, ...]` | `()` | Custom rules evaluated first-match-wins |
+| default_egress | [`Action`](#action) | `Action.DENY` | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | `Action.ALLOW` | Action when no ingress-applicable rule matches |
+| rules | `tuple[`[`Rule`](#rule)`, ...]` | `()` | Rules evaluated first-match-wins per direction |
+
+The defaults are asymmetric to preserve today's behavior: egress falls through to deny (today's `public_only` reachability when paired with the implicit `allow public` rule), ingress falls through to allow (today's unfiltered published-port behavior). See the [defaults rationale](/networking/overview#defaults).
 
 ---
 
@@ -142,10 +146,12 @@ Rule(
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | action | [`Action`](#action) | - | What to do when this rule matches |
-| direction | [`Direction`](#direction) | `Direction.EGRESS` | Traffic direction |
+| direction | [`Direction`](#direction) | `Direction.EGRESS` | Which evaluator considers this rule. `Direction.ANY` matches in either direction |
 | destination | `str \| None` | `None` | Target filter: a [`DestGroup`](#destgroup) value, domain, CIDR range, domain suffix (prefixed with `"."`), or `"*"` for any. Domain and suffix strings are validated at sandbox creation; invalid names raise `ValueError`. |
 | protocol | [`Protocol`](#protocol) ` \| None` | `None` | Protocol filter |
 | port | `int \| str \| None` | `None` | Single port (`443`) or range (`"8000-9000"`) |
+
+Ingress rules carrying ICMP protocols are rejected at sandbox creation: `publisher.rs` has no inbound ICMP path, so the rule would be dead code. Use `Direction.EGRESS` for ICMP allow/deny.
 
 ---
 
@@ -260,6 +266,7 @@ String enum for traffic direction.
 |-------|-------------|
 | `"egress"` | Traffic leaving the sandbox |
 | `"ingress"` | Traffic entering the sandbox (via published ports) |
+| `"any"` | Rule applies in either direction |
 
 ---
 
@@ -293,9 +300,10 @@ String enum for well-known destination groups used in [`Rule.destination`](#rule
 
 | Value | Description |
 |-------|-------------|
-| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`) |
-| `"private"` | Private/RFC 1918 addresses (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) |
-| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) |
+| `"public"` | Complement of the named categories — every address not in any other group |
+| `"private"` | Private/RFC 1918 addresses + ULA + CGN (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7`) |
+| `"loopback"` | Loopback addresses (`127.0.0.0/8`, `::1`) — the **guest's own** loopback, not the host. See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `"link-local"` | Link-local addresses (`169.254.0.0/16`, `fe80::/10`) excluding metadata |
 | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
 | `"multicast"` | Multicast addresses (`224.0.0.0/4`, `ff00::/8`) |
-| `"host"` | The host machine, reached via `host.microsandbox.internal` |
+| `"host"` | The host machine, reached via `host.microsandbox.internal`. This is the right group for "let the sandbox reach my host's localhost" — not `"loopback"` |

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -6,39 +6,113 @@ icon: "network-wired"
 
 See [Networking](/networking/overview) for conceptual overview and [TLS Interception](/networking/tls) for TLS proxy details.
 
-## NetworkPolicy presets
+## NetworkPolicy
 
-Static methods that return pre-configured policies.
+A network access policy consisting of two per-direction defaults and an ordered list of rules evaluated first-match-wins per direction.
 
----
+| Field | Type | Description |
+|-------|------|-------------|
+| default_egress | [`Action`](#action) | Action when no egress-applicable rule matches |
+| default_ingress | [`Action`](#action) | Action when no ingress-applicable rule matches |
+| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules; first match wins |
 
-#### NetworkPolicy::allow_all()
+The default `NetworkPolicy::default()` is `default_egress = Deny + implicit allow@public`, `default_ingress = Allow + no rules`. This preserves today's `public_only` egress behavior plus today's unfiltered published-port behavior. See the [defaults rationale](/networking/overview#defaults) for why the defaults are asymmetric.
 
-```rust
-fn allow_all() -> NetworkPolicy
-```
+### Presets
 
-Unrestricted network access, including to private addresses and the host machine.
-
----
-
-#### NetworkPolicy::none()
+Static methods that return pre-configured policies. Most callers should use the builder; presets exist as compat shims for the legacy API.
 
 ```rust
-fn none() -> NetworkPolicy
+NetworkPolicy::allow_all()    // unrestricted
+NetworkPolicy::none()         // deny both directions
+NetworkPolicy::public_only()  // egress=Deny + allow Public; ingress=Allow (today's default)
+NetworkPolicy::non_local()    // egress=Deny + allow Public+Private; ingress=Allow
 ```
 
-Deny all traffic. No network interface is created - the guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
+### NetworkPolicy::builder()
 
----
-
-#### NetworkPolicy::public_only()
+The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time; the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
 
 ```rust
-fn public_only() -> NetworkPolicy
+use microsandbox::NetworkPolicy;
+
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public().allow_private())
+    .rule(|r| r.any().deny().ip("198.51.100.5"))
+    .build()?;
 ```
 
-Block private address ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+#### Top-level methods
+
+| Method | Effect |
+|--------|--------|
+| `.default_allow()` | Set both `default_egress` and `default_ingress` to `Allow` |
+| `.default_deny()` | Set both to `Deny` |
+| `.default_egress(Action)` | Per-direction override |
+| `.default_ingress(Action)` | Per-direction override |
+| `.rule(\|r\| ...)` | Multi-rule batch; direction set inside via `.egress() / .ingress() / .any()` |
+| `.egress(\|e\| ...)` | Sugar for `.rule(\|r\| { r.egress(); ... })` |
+| `.ingress(\|i\| ...)` | Sugar with direction pre-set to `Ingress` |
+| `.any(\|a\| ...)` | Sugar with direction pre-set to `Any` (rule applies in either direction) |
+| `.build()` | `Result<NetworkPolicy, BuildError>` |
+
+The closure signature is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+
+#### Inside the closure: `RuleBuilder`
+
+Inside `.rule(|r| ...)` (or any of the direction sub-builders), state setters and rule-adders interleave freely. State accumulates eagerly across the closure; each rule-adder commits a rule using the state at that point.
+
+**State setters:**
+
+| Method | Effect |
+|--------|--------|
+| `.egress() / .ingress() / .any()` | Set direction. Last-write-wins. `.any()` makes rules apply in both directions |
+| `.tcp() / .udp() / .icmpv4() / .icmpv6()` | Add to the protocols set (set semantics; duplicates dedupe). ICMP is egress-only |
+| `.port(u16)` | Add a single port to the ports set |
+| `.port_range(u16, u16)` | Add an inclusive range. `lo > hi` records `BuildError::InvalidPortRange` |
+
+**Per-category rule-adders** (each commits one rule using the current state):
+
+| Method | Group |
+|--------|-------|
+| `.allow_public() / .deny_public()` | `Group::Public` (complement of named categories) |
+| `.allow_private() / .deny_private()` | `Group::Private` (RFC1918 + ULA + CGN) |
+| `.allow_loopback() / .deny_loopback()` | `Group::Loopback` (`127.0.0.0/8`, `::1`) — see the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
+| `.allow_link_local() / .deny_link_local()` | `Group::LinkLocal` (`169.254.0.0/16`, `fe80::/10`, excluding metadata) |
+| `.allow_meta() / .deny_meta()` | `Group::Metadata` (`169.254.169.254`). Dangerous on cloud hosts |
+| `.allow_multicast() / .deny_multicast()` | `Group::Multicast` |
+| `.allow_host() / .deny_host()` | `Group::Host` (per-sandbox gateway IPs that back `host.microsandbox.internal`) |
+
+**Composite sugar:**
+
+| Method | Effect |
+|--------|--------|
+| `.allow_local() / .deny_local()` | Adds **three** rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is explicitly **not** included (cloud-IMDS opt-in only via `.allow_meta()`) |
+
+**Explicit-rule sub-builder** (`.allow()` / `.deny()` open it):
+
+```rust
+.rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+.rule(|r| r.any().deny().cidr("198.51.100.0/24"))
+```
+
+Returns an [`ExplicitRuleBuilder`](#explicitrulebuilder) requiring a destination call (`.ip / .cidr / .domain / .domain_suffix / .group / .any`) to commit. Dropping without a destination call adds no rule (the type is `#[must_use]`).
+
+#### State accumulation
+
+State is **not reset** between rule-adders within a closure. Callers wanting different state per rule use separate `.rule()` calls or interleave state setters between adders:
+
+```rust
+.rule(|r| r.egress()
+    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
+    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
+                                       //   (UDP added; TCP and 443 still in state)
+```
+
+#### Shadow detection
+
+At `.build()` time, the builder walks the rules list and emits a `tracing::warn!` for any rule whose match set is fully contained in an earlier rule's match set in a compatible direction. Coverage is `Ip` / `Cidr` / `Group` destinations; domain shadowing is intentionally out of scope (depends on runtime DNS state).
 
 ---
 
@@ -46,7 +120,17 @@ Block private address ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `
 
 Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`.
 
----
+#### policy()
+
+```rust
+fn policy(self, policy: NetworkPolicy) -> Self
+```
+
+Set the network access policy. Override the default with a builder-constructed value:
+
+```rust
+.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
+```
 
 #### dns()
 
@@ -54,7 +138,7 @@ Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::ne
 fn dns(self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self
 ```
 
-Configure DNS interception via a closure. See [`DnsBuilder`](#dnsbuilder) for the methods available on `d`.
+Configure DNS interception. Errors accumulated by [`DnsBuilder`](#dnsbuilder) cascade up; the outermost `SandboxBuilder::build()` surfaces them as `MicrosandboxError::NetworkBuilder(BuildError)`.
 
 ```rust
 .network(|n| n
@@ -67,8 +151,6 @@ Configure DNS interception via a closure. See [`DnsBuilder`](#dnsbuilder) for th
 )
 ```
 
----
-
 #### max_connections()
 
 ```rust
@@ -77,29 +159,21 @@ fn max_connections(self, max: usize) -> Self
 
 Limit the maximum number of concurrent network connections from the sandbox.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| max | `usize` | Maximum concurrent connections |
-
----
-
 #### trust_host_cas()
 
 ```rust
 fn trust_host_cas(self, enabled: bool) -> Self
 ```
 
-Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when outbound HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle. Leave off to keep the guest validating strictly against its native trust store.
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
 
-**Parameters**
+#### tls()
 
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | `true` to copy the host trust store into the guest, `false` to disable |
+```rust
+fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
+```
 
----
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
 
 #### on_secret_violation()
 
@@ -109,51 +183,13 @@ fn on_secret_violation(self, action: ViolationAction) -> Self
 
 Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| action | [`ViolationAction`](#violationaction) | Response to a violation |
-
----
-
-#### policy()
-
-```rust
-fn policy(self, policy: NetworkPolicy) -> Self
-```
-
-Set the network access policy. Overrides the default `public_only` policy.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| policy | [`NetworkPolicy`](#networkpolicy-1) | Network access policy |
-
----
-
-#### tls()
-
-```rust
-fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
-```
-
-Configure TLS interception. The closure receives a [`TlsBuilder`](#tlsbuilder) for setting bypass domains, intercepted ports, CA certificates, and upstream verification.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| f | [`TlsBuilder`](#tlsbuilder) | Configure TLS interception. |
-
 ---
 
 ## DnsBuilder
 
 Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`.
 
----
+`block_domain` and `block_domain_suffix` use the same lazy-parse + accumulate-at-`.build()` model as `NetworkPolicy::builder()` — string inputs are stored raw, errors surface as `BuildError::InvalidBlockedDomain` / `InvalidBlockedDomainSuffix` from the outermost `.build()` in the chain.
 
 #### block_domain()
 
@@ -161,15 +197,7 @@ Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`.
 fn block_domain(self, domain: impl Into<String>) -> Self
 ```
 
-Block DNS lookups for an exact domain. The guest receives REFUSED for this domain. Can be called multiple times.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| domain | `impl Into<String>` | Domain to block (e.g. `"malware.example.com"`) |
-
----
+Block DNS lookups for an exact domain. The guest receives REFUSED for this domain.
 
 #### block_domain_suffix()
 
@@ -179,29 +207,13 @@ fn block_domain_suffix(self, suffix: impl Into<String>) -> Self
 
 Block DNS lookups for all subdomains matching a suffix. For example, `.tracking.com` blocks `a.tracking.com`, `b.c.tracking.com`, etc.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| suffix | `impl Into<String>` | Domain suffix (e.g. `".tracking.com"`) |
-
----
-
 #### rebind_protection()
 
 ```rust
 fn rebind_protection(self, enabled: bool) -> Self
 ```
 
-When enabled, DNS responses that resolve to private IP addresses are blocked. This prevents DNS rebinding attacks where an attacker-controlled domain resolves to an internal service. Default: `true`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| enabled | `bool` | Enable or disable |
-
----
+When enabled, DNS responses that resolve to private IP addresses are blocked. This prevents DNS rebinding attacks. Default: `true`.
 
 #### nameservers()
 
@@ -212,17 +224,7 @@ where
     I::Item: Into<Nameserver>,
 ```
 
-Set the upstream nameservers to forward DNS queries to. When one or more are set, the interceptor uses these instead of the nameservers in the host's `/etc/resolv.conf`. Replaces any previously-set nameservers. Useful for pinning specific resolvers (e.g. `1.1.1.1:53`) or working around split-DNS / VPN setups.
-
-Each element is any type convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`). Hostnames are resolved once at startup via the host's OS resolver.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| nameservers | `IntoIterator<Item: Into<Nameserver>>` | Iterable of nameservers |
-
----
+Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
 
 #### query_timeout_ms()
 
@@ -232,129 +234,20 @@ fn query_timeout_ms(self, ms: u64) -> Self
 
 Set the per-DNS-query timeout in milliseconds. Default: `5000`.
 
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| ms | `u64` | Timeout in milliseconds |
-
 ---
 
 ## TlsBuilder
 
 Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
 
----
-
-#### block_quic()
-
-```rust
-fn block_quic(self, block: bool) -> Self
-```
-
-Block QUIC/HTTP3 (UDP) traffic on intercepted ports, forcing clients to fall back to TCP/TLS where interception is possible. Default: `true`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| block | `bool` | Enable or disable |
-
----
-
-#### bypass()
-
-```rust
-fn bypass(self, pattern: impl Into<String>) -> Self
-```
-
-Skip TLS interception for connections to this domain. Traffic passes through as an opaque TCP stream. Supports `*.suffix` wildcards. Use for domains that use certificate pinning.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| pattern | `impl Into<String>` | Domain or wildcard (e.g. `"*.pinned-api.com"`) |
-
----
-
-#### intercept_ca_cert()
-
-```rust
-fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
-```
-
-Provide a custom CA certificate for TLS interception. By default, microsandbox generates an ephemeral CA and installs it in the guest's trust store. Use this to provide a stable CA across sandbox restarts.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<PathBuf>` | Path to PEM-encoded CA certificate |
-
----
-
-#### intercept_ca_key()
-
-```rust
-fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
-```
-
-Provide the private key for the custom interception CA certificate.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<PathBuf>` | Path to PEM-encoded CA private key |
-
----
-
-#### intercepted_ports()
-
-```rust
-fn intercepted_ports(self, ports: Vec<u16>) -> Self
-```
-
-Set the TCP ports where TLS interception is active. Default: `[443]`. Add additional ports if services use non-standard HTTPS ports.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| ports | `Vec<u16>` | List of TCP ports |
-
----
-
-#### upstream_ca_cert()
-
-```rust
-fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
-```
-
-Trust an additional CA certificate when verifying upstream servers. Use this when connecting to servers with self-signed or private PKI certificates. Can be called multiple times to add several CAs.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| path | `impl Into<PathBuf>` | Path to PEM-encoded CA certificate |
-
----
-
-#### verify_upstream()
-
-```rust
-fn verify_upstream(self, verify: bool) -> Self
-```
-
-Control whether the TLS proxy verifies the upstream server's certificate. When `true`, connections to servers with invalid or self-signed certificates are rejected. When `false`, all server certificates are accepted. Default: `true`.
-
-**Parameters**
-
-| Name | Type | Description |
-|------|------|-------------|
-| verify | `bool` | Enable or disable |
+| Method | Effect |
+|--------|--------|
+| `.bypass(pattern)` | Skip TLS interception for this domain. Supports `*.suffix` wildcards |
+| `.intercepted_ports(ports)` | TCP ports where interception is active. Default: `[443]` |
+| `.intercept_ca_cert(path)` / `.intercept_ca_key(path)` | Provide a stable CA across sandbox restarts |
+| `.upstream_ca_cert(path)` | Trust an additional CA when verifying upstream servers |
+| `.verify_upstream(bool)` | Whether the proxy verifies upstream server certs. Default: `true` |
+| `.block_quic(bool)` | Block QUIC/HTTP3 on intercepted ports. Default: `true` |
 
 ---
 
@@ -367,73 +260,72 @@ Control whether the TLS proxy verifies the upstream server's certificate. When `
 | `Allow` | Permit the traffic |
 | `Deny` | Drop the traffic silently |
 
-### Destination
-
-| Variant | Description |
-|---------|-------------|
-| `Any` | Match any address |
-| `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`) |
-| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
-| `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
-| `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
-
-### DomainName
-
-A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching can be a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
-
-```rust
-use microsandbox_network::policy::{Destination, DomainName};
-
-let exact: DomainName = "PyPI.Org.".parse()?;        // -> "pypi.org"
-let suffix: DomainName = ".example.com".parse()?;    // -> "example.com"
-
-let rule = Rule::allow_outbound(Destination::Domain(exact));
-```
-
-Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
-
-### DestinationGroup
-
-| Value | Description |
-|-------|-------------|
-| `Host` | The host machine, reached via `host.microsandbox.internal` |
-| `LinkLocal` | `169.254.0.0/16`, `fe80::/10` |
-| `Loopback` | `127.0.0.0/8`, `::1` |
-| `Metadata` | Cloud metadata endpoints (`169.254.169.254`) |
-| `Multicast` | `224.0.0.0/4`, `ff00::/8` |
-| `Private` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` |
+Wire format: `"allow"` / `"deny"`.
 
 ### Direction
 
 | Value | Description |
 |-------|-------------|
-| `Inbound` | Traffic entering the sandbox (via published ports) |
-| `Outbound` | Traffic leaving the sandbox |
+| `Egress` | Traffic leaving the sandbox |
+| `Ingress` | Traffic entering the sandbox (via published ports) |
+| `Any` | Rule applies in either direction |
 
-### NetworkPolicy
+Wire format: `"egress"` / `"ingress"` / `"any"`.
 
-A network access policy consisting of a default action and an ordered list of rules evaluated first-match-wins.
+### Destination
 
-| Field | Type | Description |
-|-------|------|-------------|
-| default_action | [`Action`](#action) | Action when no rule matches |
-| rules | `Vec<`[`Rule`](#rule)`>` | Ordered list of rules |
+| Variant | Description |
+|---------|-------------|
+| `Any` | Match any address |
+| `Cidr(IpNetwork)` | Match a CIDR range (e.g. `10.0.0.0/8`); single IPs are stored as `/32` or `/128` |
+| `Domain(`[`DomainName`](#domainname)`)` | Match an exact domain (e.g. `example.com`) |
+| `DomainSuffix(`[`DomainName`](#domainname)`)` | Match the apex domain and every subdomain (e.g. `example.com` and `api.example.com`) |
+| `Group(`[`DestinationGroup`](#destinationgroup)`)` | Match a predefined address group |
+
+### DestinationGroup
+
+| Value | Wire format | Matches |
+|-------|-------------|---------|
+| `Public` | `"public"` | Complement of the other categories — every address not in any other group |
+| `Private` | `"private"` | `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, `fc00::/7` |
+| `Loopback` | `"loopback"` | `127.0.0.0/8`, `::1` (the **guest's own** loopback, not the host) |
+| `LinkLocal` | `"link_local"` | `169.254.0.0/16`, `fe80::/10` (excludes metadata) |
+| `Metadata` | `"metadata"` | Cloud metadata endpoints (`169.254.169.254`) |
+| `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
+| `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
+
+### DomainName
+
+A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
+
+```rust
+use microsandbox_network::policy::{Destination, DomainName};
+
+let exact: DomainName = "PyPI.Org.".parse()?;     // -> "pypi.org"
+let suffix: DomainName = ".example.com".parse()?;  // -> "example.com"
+```
+
+Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed names like `_service._tcp.example.com` are accepted.
+
+The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()` — callers don't need to construct `DomainName` directly.
+
+### Protocol
+
+| Value | Wire format |
+|-------|-------------|
+| `Tcp` | `"tcp"` |
+| `Udp` | `"udp"` |
+| `Icmpv4` | `"icmpv4"` |
+| `Icmpv6` | `"icmpv6"` |
+
+ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carrying an ICMP protocol fails build with `BuildError::IngressDoesNotSupportIcmp`.
 
 ### PortRange
 
 | Method | Description |
 |--------|-------------|
-| `PortRange::range(start, end)` | Match a range of ports (inclusive) |
 | `PortRange::single(port)` | Match a single port |
-
-### Protocol
-
-| Value | Description |
-|-------|-------------|
-| `Icmpv4` | ICMPv4 traffic |
-| `Icmpv6` | ICMPv6 traffic |
-| `Tcp` | TCP traffic |
-| `Udp` | UDP traffic |
+| `PortRange::range(start, end)` | Match an inclusive range |
 
 ### Rule
 
@@ -441,18 +333,53 @@ A single network policy rule.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| action | [`Action`](#action) | What to do when this rule matches |
-| destination | [`Destination`](#destination) | Target address filter |
-| direction | [`Direction`](#direction) | Traffic direction |
-| ports | `Option<`[`PortRange`](#portrange)`>` | Port filter (`None` matches all) |
-| protocol | `Option<`[`Protocol`](#protocol)`>` | Protocol filter (`None` matches all) |
+| direction | [`Direction`](#direction) | Which evaluator considers this rule |
+| destination | [`Destination`](#destination) | Target filter (egress destination / ingress source) |
+| protocols | `Vec<`[`Protocol`](#protocol)`>` | Set semantics; empty = any protocol |
+| ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
+| action | [`Action`](#action) | What to do on match |
 
 **Convenience constructors:**
 
 | Method | Description |
 |--------|-------------|
-| `Rule::allow_outbound(destination)` | Create an outbound allow rule |
-| `Rule::deny_outbound(destination)` | Create an outbound deny rule |
+| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
+| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
+| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
+| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
+| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
+| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
+
+### ExplicitRuleBuilder
+
+Returned by [`RuleBuilder`](#networkpolicybuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]` — dropping without a call adds no rule.
+
+| Method | Effect |
+|--------|--------|
+| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
+| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
+| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
+| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
+| `.group(DestinationGroup)` | Commit with `Destination::Group` |
+| `.any()` | Commit with `Destination::Any` |
+
+### BuildError
+
+Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
+
+| Variant | Cause |
+|---------|-------|
+| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
+| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
+| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
+| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
+| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+| `InvalidBlockedDomain { raw, source }` | `DnsBuilder::block_domain` got an unparseable value |
+| `InvalidBlockedDomainSuffix { raw, source }` | `DnsBuilder::block_domain_suffix` got an unparseable value |
+
+Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
 
 ### ViolationAction
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -99,8 +99,9 @@ DNS interception settings.
 
 | Value | Description |
 |-------|-------------|
-| `'inbound'` | Traffic entering the sandbox (via published ports) |
-| `'outbound'` | Traffic leaving the sandbox |
+| `'egress'` | Traffic leaving the sandbox |
+| `'ingress'` | Traffic entering the sandbox (via published ports) |
+| `'any'` | Rule applies in either direction |
 
 ### PolicyProtocol
 

--- a/examples/rust/net-policy/bin/main.rs
+++ b/examples/rust/net-policy/bin/main.rs
@@ -1,13 +1,14 @@
-//! Network policy — public-only (default), allow-all, and no-network modes.
+//! Network policy — three modes built with the fluent `NetworkPolicy::builder()`.
 //!
-//! Demonstrates how `NetworkPolicy` controls what the sandbox can reach.
-//! The default `public_only()` blocks private/loopback addresses.
+//! Demonstrates the default policy (public internet only), an
+//! allow-all override, and a custom policy that allows public egress
+//! plus a specific private host on tcp/443.
 
 use microsandbox::{NetworkPolicy, Sandbox};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Default (public-only) — public internet works.
+    // 1. Default policy — public internet works, private/loopback denied.
     let sandbox = Sandbox::builder("net-policy-public")
         .image("alpine")
         .cpus(1)
@@ -24,11 +25,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sandbox.stop_and_wait().await?;
 
     // 2. Allow-all — everything reachable, including private networks.
+    let allow_all = NetworkPolicy::builder().default_allow().build()?;
     let sandbox = Sandbox::builder("net-policy-all")
         .image("alpine")
         .cpus(1)
         .memory(512)
-        .network(|n| n.policy(NetworkPolicy::allow_all()))
+        .network(|n| n.policy(allow_all))
         .replace()
         .create()
         .await?;
@@ -36,30 +38,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output = sandbox
         .shell("wget -q -O /dev/null --timeout=5 http://example.com && echo OK || echo FAIL")
         .await?;
-    println!("Public HTTP: {}", output.stdout()?.trim());
+    println!("Allow-all HTTP: {}", output.stdout()?.trim());
 
     sandbox.stop_and_wait().await?;
 
-    // 3. No network — all connections denied.
-    let sandbox = Sandbox::builder("net-policy-none")
+    // 3. Custom policy — public egress plus a specific private host on tcp/443.
+    let custom = NetworkPolicy::builder()
+        .default_deny()
+        .egress(|e| e.allow_public())
+        .rule(|r| r.egress().tcp().port(443).allow().ip("10.0.5.10"))
+        .build()?;
+    let sandbox = Sandbox::builder("net-policy-custom")
         .image("alpine")
         .cpus(1)
         .memory(512)
+        .network(|n| n.policy(custom))
         .replace()
         .create()
         .await?;
 
     let output = sandbox
-        .shell("wget -q -O /dev/null --timeout=3 http://example.com && echo OK || echo BLOCKED")
+        .shell("wget -q -O /dev/null --timeout=5 http://example.com && echo OK || echo FAIL")
         .await?;
-    println!("Public HTTP: {}", output.stdout()?.trim());
+    println!("Custom-policy HTTP: {}", output.stdout()?.trim());
 
     sandbox.stop_and_wait().await?;
 
     // Cleanup.
     Sandbox::remove("net-policy-public").await?;
     Sandbox::remove("net-policy-all").await?;
-    Sandbox::remove("net-policy-none").await?;
+    Sandbox::remove("net-policy-custom").await?;
 
     Ok(())
 }

--- a/sdk/node-ts/index.cjs
+++ b/sdk/node-ts/index.cjs
@@ -588,6 +588,7 @@ module.exports.JsMetricsStream = nativeBinding.JsMetricsStream
 module.exports.Mount = nativeBinding.Mount
 module.exports.NetworkPolicy = nativeBinding.NetworkPolicy
 module.exports.JsNetworkPolicy = nativeBinding.JsNetworkPolicy
+module.exports.NetworkPolicyBuilder = nativeBinding.NetworkPolicyBuilder
 module.exports.Patch = nativeBinding.Patch
 module.exports.Sandbox = nativeBinding.Sandbox
 module.exports.SandboxFs = nativeBinding.SandboxFs

--- a/sdk/node-ts/index.d.cts
+++ b/sdk/node-ts/index.d.cts
@@ -156,11 +156,19 @@ export declare class Mount {
  * ```js
  * import { NetworkPolicy, Sandbox } from 'microsandbox'
  *
- * const sb = await Sandbox.create({
+ * // legacy preset
+ * const sb1 = await Sandbox.create({
  *     name: "worker",
  *     image: "python",
  *     network: NetworkPolicy.publicOnly(),
  * })
+ *
+ * // fluent builder
+ * const policy = NetworkPolicy.builder()
+ *     .defaultDeny()
+ *     .egress().tcp().port(443).allowPublic().allowPrivate()
+ *     .any().denyIp("198.51.100.5")
+ *     .build()
  * ```
  */
 export declare class NetworkPolicy {
@@ -170,8 +178,169 @@ export declare class NetworkPolicy {
   static publicOnly(): NetworkConfig
   /** Unrestricted network access. */
   static allowAll(): NetworkConfig
+  /**
+   * Open a fluent [`NetworkPolicyBuilder`] for composing a custom
+   * policy. See the `NetworkPolicyBuilder` class for the full
+   * chainable surface.
+   */
+  static builder(): NetworkPolicyBuilder
 }
 export type JsNetworkPolicy = NetworkPolicy
+
+/**
+ * Fluent builder for [`NetworkConfig`]-shaped policies. Mirrors the
+ * rust `NetworkPolicy::builder()` surface, flattened so the chain
+ * stays readable in javascript without nested closures.
+ *
+ * State setters (`.egress() / .ingress() / .any()` for direction,
+ * `.tcp() / .udp() / .icmpv4() / .icmpv6()` for the protocols set,
+ * `.port(n) / .portRange(lo, hi)` for the ports set) accumulate
+ * eagerly. Each rule-adder commits one rule using the closure's
+ * current state. State is **not reset** between rule-adders.
+ *
+ * `.build()` returns a [`NetworkConfig`] with `defaultEgress`,
+ * `defaultIngress`, and `rules` populated. Pass it through
+ * `Sandbox.create({ network: ... })` like any other network config.
+ */
+export declare class NetworkPolicyBuilder {
+  /**
+   * Construct an empty builder. Prefer [`JsNetworkPolicy::builder`]
+   * (`NetworkPolicy.builder()` in JS) over calling this directly.
+   */
+  constructor()
+  /** Set both `defaultEgress` and `defaultIngress` to `"allow"`. */
+  defaultAllow(): this
+  /** Set both `defaultEgress` and `defaultIngress` to `"deny"`. */
+  defaultDeny(): this
+  /** Per-direction override for the egress default action. */
+  defaultEgress(action: PolicyAction): this
+  /** Per-direction override for the ingress default action. */
+  defaultIngress(action: PolicyAction): this
+  /** Set the direction for subsequent rule-adders to `"egress"`. */
+  egress(): this
+  /** Set the direction for subsequent rule-adders to `"ingress"`. */
+  ingress(): this
+  /**
+   * Set the direction for subsequent rule-adders to `"any"`. Rules
+   * committed with this direction match in either direction.
+   */
+  any(): this
+  /** Add `"tcp"` to the protocols set (set semantics; duplicates dedupe). */
+  tcp(): this
+  /** Add `"udp"` to the protocols set. */
+  udp(): this
+  /**
+   * Add `"icmpv4"` to the protocols set. Egress-only — committing a
+   * rule with `"icmpv4"` and direction `"ingress"` or `"any"` will
+   * be rejected at sandbox creation.
+   */
+  icmpv4(): this
+  /** Add `"icmpv6"` to the protocols set. Egress-only. */
+  icmpv6(): this
+  /** Add a single port to the ports set. */
+  port(port: number): this
+  /**
+   * Add an inclusive port range to the ports set, formatted as
+   * `"<lo>-<hi>"` on the wire. `lo > hi` is rejected at sandbox
+   * creation.
+   */
+  portRange(lo: number, hi: number): this
+  /** Allow the `"public"` group (complement of named categories). */
+  allowPublic(): this
+  /** Deny the `"public"` group. */
+  denyPublic(): this
+  /** Allow the `"private"` group (RFC1918 + ULA + CGN). */
+  allowPrivate(): this
+  /** Deny the `"private"` group. */
+  denyPrivate(): this
+  /**
+   * Allow the `"loopback"` group (`127.0.0.0/8`, `::1`) — the
+   * **guest's own** loopback interface. Not the host machine. To
+   * reach a service on the host's localhost, use [`Self::allow_host`].
+   */
+  allowLoopback(): this
+  /**
+   * Deny the `"loopback"` group. Useful in `defaultEgress = "allow"`
+   * configurations to block crafted-packet leaks where a process
+   * inside the guest binds a raw socket to eth0 with `dst=127.0.0.1`.
+   */
+  denyLoopback(): this
+  /**
+   * Allow the `"link-local"` group (`169.254.0.0/16`, `fe80::/10`).
+   * Excludes the metadata IP (categorized as `"metadata"`).
+   */
+  allowLinkLocal(): this
+  /** Deny the `"link-local"` group. */
+  denyLinkLocal(): this
+  /**
+   * Allow the `"metadata"` group (`169.254.169.254`). **Dangerous on
+   * cloud hosts** — exposes IAM credentials.
+   */
+  allowMeta(): this
+  /** Deny the `"metadata"` group. */
+  denyMeta(): this
+  /** Allow the `"multicast"` group (`224.0.0.0/4`, `ff00::/8`). */
+  allowMulticast(): this
+  /** Deny the `"multicast"` group. */
+  denyMulticast(): this
+  /**
+   * Allow the `"host"` group — the per-sandbox gateway IPs that
+   * back `host.microsandbox.internal`. This is the right shortcut
+   * for "let the sandbox reach my host's localhost", not
+   * [`Self::allow_loopback`].
+   */
+  allowHost(): this
+  /** Deny the `"host"` group. */
+  denyHost(): this
+  /**
+   * Allow `"loopback"` + `"link-local"` + `"host"` — the three
+   * "near the sandbox" groups a developer typically wants together
+   * when running locally. Adds **three rules** atomically using
+   * the current state. `"metadata"` is explicitly **not** included.
+   */
+  allowLocal(): this
+  /** Deny `"loopback"` + `"link-local"` + `"host"` (no metadata). */
+  denyLocal(): this
+  /**
+   * Allow traffic to a specific IP address (stored as `/32` or
+   * `/128` CIDR on the wire).
+   */
+  allowIp(ip: string): this
+  /** Deny traffic to a specific IP address. */
+  denyIp(ip: string): this
+  /** Allow traffic to a CIDR range (e.g. `"10.0.0.0/8"`). */
+  allowCidr(cidr: string): this
+  /** Deny traffic to a CIDR range. */
+  denyCidr(cidr: string): this
+  /**
+   * Allow traffic to an exact domain (e.g. `"api.example.com"`).
+   * Domain rules require the guest to resolve through the
+   * sandbox's DNS interceptor.
+   */
+  allowDomain(domain: string): this
+  /** Deny traffic to an exact domain. */
+  denyDomain(domain: string): this
+  /**
+   * Allow traffic to any subdomain matching this suffix. The
+   * suffix should be prefixed with `"."` (e.g.
+   * `".pythonhosted.org"` matches `files.pythonhosted.org`).
+   */
+  allowDomainSuffix(suffix: string): this
+  /** Deny traffic to any subdomain matching this suffix. */
+  denyDomainSuffix(suffix: string): this
+  /** Allow traffic to any destination (`"*"`). */
+  allowAny(): this
+  /** Deny traffic to any destination. */
+  denyAny(): this
+  /**
+   * Materialize the accumulated state into a [`NetworkConfig`]
+   * suitable for `Sandbox.create({ network: ... })`. Errors in the
+   * rule contents (invalid ip / cidr / domain strings, lo > hi
+   * port range, icmp on a non-egress rule) surface at sandbox
+   * creation, not here.
+   */
+  build(): NetworkConfig
+}
 
 /**
  * Factory for creating rootfs patch configurations.
@@ -591,14 +760,30 @@ export interface NetworkConfig {
   policy?: string
   /** Custom policy rules (first match wins). Overrides `policy` preset. */
   rules?: Array<PolicyRule>
-  /** Default action when no rule matches: "allow" or "deny". */
-  defaultAction?: string
+  /**
+   * Default action for egress traffic when no rule matches: "allow" or
+   * "deny". When omitted, falls through to today's `public_only`
+   * behavior (deny + implicit allow public).
+   */
+  defaultEgress?: string
+  /**
+   * Default action for ingress traffic when no rule matches: "allow" or
+   * "deny". When omitted, defaults to "allow" (today's unfiltered
+   * published-port behavior).
+   */
+  defaultIngress?: string
   /** DNS interception configuration. */
   dns?: DnsConfig
   /** TLS interception configuration. */
   tls?: TlsConfig
   /** Max concurrent connections (default: 256). */
   maxConnections?: number
+  /**
+   * Ship the host's trusted CAs into the guest at boot so outbound TLS
+   * works behind corporate MITM proxies (Warp Zero Trust, Zscaler,
+   * etc.). Opt-in. Default: false.
+   */
+  trustHostCas?: boolean
 }
 
 /** Rootfs patch applied before VM startup. */
@@ -645,8 +830,9 @@ export declare const enum PolicyAction {
 
 /** Network policy rule direction. */
 export declare const enum PolicyDirection {
-  Outbound = 'outbound',
-  Inbound = 'inbound'
+  Egress = 'egress',
+  Ingress = 'ingress',
+  Any = 'any'
 }
 
 /** Network policy rule protocol. */

--- a/sdk/node-ts/lib/helpers.rs
+++ b/sdk/node-ts/lib/helpers.rs
@@ -80,10 +80,12 @@ pub enum PolicyAction {
 /// Network policy rule direction.
 #[napi(string_enum)]
 pub enum PolicyDirection {
-    #[napi(value = "outbound")]
-    Outbound,
-    #[napi(value = "inbound")]
-    Inbound,
+    #[napi(value = "egress")]
+    Egress,
+    #[napi(value = "ingress")]
+    Ingress,
+    #[napi(value = "any")]
+    Any,
 }
 
 /// Network policy rule protocol.
@@ -371,7 +373,8 @@ impl JsNetworkPolicy {
         NetworkConfig {
             policy: Some("none".to_string()),
             rules: None,
-            default_action: None,
+            default_egress: None,
+            default_ingress: None,
             dns: None,
             tls: None,
             max_connections: None,
@@ -385,7 +388,8 @@ impl JsNetworkPolicy {
         NetworkConfig {
             policy: Some("public-only".to_string()),
             rules: None,
-            default_action: None,
+            default_egress: None,
+            default_ingress: None,
             dns: None,
             tls: None,
             max_connections: None,
@@ -399,7 +403,8 @@ impl JsNetworkPolicy {
         NetworkConfig {
             policy: Some("allow-all".to_string()),
             rules: None,
-            default_action: None,
+            default_egress: None,
+            default_ingress: None,
             dns: None,
             tls: None,
             max_connections: None,

--- a/sdk/node-ts/lib/helpers.rs
+++ b/sdk/node-ts/lib/helpers.rs
@@ -235,14 +235,45 @@ pub struct Mount;
 /// ```js
 /// import { NetworkPolicy, Sandbox } from 'microsandbox'
 ///
-/// const sb = await Sandbox.create({
+/// // legacy preset
+/// const sb1 = await Sandbox.create({
 ///     name: "worker",
 ///     image: "python",
 ///     network: NetworkPolicy.publicOnly(),
 /// })
+///
+/// // fluent builder
+/// const policy = NetworkPolicy.builder()
+///     .defaultDeny()
+///     .egress().tcp().port(443).allowPublic().allowPrivate()
+///     .any().denyIp("198.51.100.5")
+///     .build()
 /// ```
 #[napi(js_name = "NetworkPolicy")]
 pub struct JsNetworkPolicy;
+
+/// Fluent builder for [`NetworkConfig`]-shaped policies. Mirrors the
+/// rust `NetworkPolicy::builder()` surface, flattened so the chain
+/// stays readable in javascript without nested closures.
+///
+/// State setters (`.egress() / .ingress() / .any()` for direction,
+/// `.tcp() / .udp() / .icmpv4() / .icmpv6()` for the protocols set,
+/// `.port(n) / .portRange(lo, hi)` for the ports set) accumulate
+/// eagerly. Each rule-adder commits one rule using the closure's
+/// current state. State is **not reset** between rule-adders.
+///
+/// `.build()` returns a [`NetworkConfig`] with `defaultEgress`,
+/// `defaultIngress`, and `rules` populated. Pass it through
+/// `Sandbox.create({ network: ... })` like any other network config.
+#[napi(js_name = "NetworkPolicyBuilder")]
+pub struct NetworkPolicyBuilder {
+    direction: Option<PolicyDirection>,
+    protocols: Vec<PolicyProtocol>,
+    ports: Vec<String>,
+    rules: Vec<PolicyRule>,
+    default_egress: Option<PolicyAction>,
+    default_ingress: Option<PolicyAction>,
+}
 
 /// Factory for creating secret entries.
 ///
@@ -410,6 +441,468 @@ impl JsNetworkPolicy {
             max_connections: None,
             trust_host_cas: None,
         }
+    }
+
+    /// Open a fluent [`NetworkPolicyBuilder`] for composing a custom
+    /// policy. See the `NetworkPolicyBuilder` class for the full
+    /// chainable surface.
+    #[napi]
+    pub fn builder() -> NetworkPolicyBuilder {
+        NetworkPolicyBuilder::new()
+    }
+}
+
+#[napi]
+impl NetworkPolicyBuilder {
+    /// Construct an empty builder. Prefer [`JsNetworkPolicy::builder`]
+    /// (`NetworkPolicy.builder()` in JS) over calling this directly.
+    #[napi(constructor)]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            direction: None,
+            protocols: Vec::new(),
+            ports: Vec::new(),
+            rules: Vec::new(),
+            default_egress: None,
+            default_ingress: None,
+        }
+    }
+
+    // -- defaults ----------------------------------------------------
+
+    /// Set both `defaultEgress` and `defaultIngress` to `"allow"`.
+    #[napi]
+    pub fn default_allow(&mut self) -> &Self {
+        self.default_egress = Some(PolicyAction::Allow);
+        self.default_ingress = Some(PolicyAction::Allow);
+        self
+    }
+
+    /// Set both `defaultEgress` and `defaultIngress` to `"deny"`.
+    #[napi]
+    pub fn default_deny(&mut self) -> &Self {
+        self.default_egress = Some(PolicyAction::Deny);
+        self.default_ingress = Some(PolicyAction::Deny);
+        self
+    }
+
+    /// Per-direction override for the egress default action.
+    #[napi]
+    pub fn default_egress(&mut self, action: PolicyAction) -> &Self {
+        self.default_egress = Some(action);
+        self
+    }
+
+    /// Per-direction override for the ingress default action.
+    #[napi]
+    pub fn default_ingress(&mut self, action: PolicyAction) -> &Self {
+        self.default_ingress = Some(action);
+        self
+    }
+
+    // -- direction setters ------------------------------------------
+
+    /// Set the direction for subsequent rule-adders to `"egress"`.
+    #[napi]
+    pub fn egress(&mut self) -> &Self {
+        self.direction = Some(PolicyDirection::Egress);
+        self
+    }
+
+    /// Set the direction for subsequent rule-adders to `"ingress"`.
+    #[napi]
+    pub fn ingress(&mut self) -> &Self {
+        self.direction = Some(PolicyDirection::Ingress);
+        self
+    }
+
+    /// Set the direction for subsequent rule-adders to `"any"`. Rules
+    /// committed with this direction match in either direction.
+    #[napi]
+    pub fn any(&mut self) -> &Self {
+        self.direction = Some(PolicyDirection::Any);
+        self
+    }
+
+    // -- protocol setters --------------------------------------------
+
+    /// Add `"tcp"` to the protocols set (set semantics; duplicates dedupe).
+    #[napi]
+    pub fn tcp(&mut self) -> &Self {
+        self.add_protocol(PolicyProtocol::Tcp);
+        self
+    }
+
+    /// Add `"udp"` to the protocols set.
+    #[napi]
+    pub fn udp(&mut self) -> &Self {
+        self.add_protocol(PolicyProtocol::Udp);
+        self
+    }
+
+    /// Add `"icmpv4"` to the protocols set. Egress-only — committing a
+    /// rule with `"icmpv4"` and direction `"ingress"` or `"any"` will
+    /// be rejected at sandbox creation.
+    #[napi]
+    pub fn icmpv4(&mut self) -> &Self {
+        self.add_protocol(PolicyProtocol::Icmpv4);
+        self
+    }
+
+    /// Add `"icmpv6"` to the protocols set. Egress-only.
+    #[napi]
+    pub fn icmpv6(&mut self) -> &Self {
+        self.add_protocol(PolicyProtocol::Icmpv6);
+        self
+    }
+
+    fn add_protocol(&mut self, p: PolicyProtocol) {
+        let already_present = self.protocols.iter().any(|existing| {
+            matches!(
+                (existing, &p),
+                (PolicyProtocol::Tcp, PolicyProtocol::Tcp)
+                    | (PolicyProtocol::Udp, PolicyProtocol::Udp)
+                    | (PolicyProtocol::Icmpv4, PolicyProtocol::Icmpv4)
+                    | (PolicyProtocol::Icmpv6, PolicyProtocol::Icmpv6)
+            )
+        });
+        if !already_present {
+            self.protocols.push(p);
+        }
+    }
+
+    // -- port setters ------------------------------------------------
+
+    /// Add a single port to the ports set.
+    #[napi]
+    pub fn port(&mut self, port: u16) -> &Self {
+        let s = port.to_string();
+        if !self.ports.contains(&s) {
+            self.ports.push(s);
+        }
+        self
+    }
+
+    /// Add an inclusive port range to the ports set, formatted as
+    /// `"<lo>-<hi>"` on the wire. `lo > hi` is rejected at sandbox
+    /// creation.
+    #[napi]
+    pub fn port_range(&mut self, lo: u16, hi: u16) -> &Self {
+        let s = format!("{lo}-{hi}");
+        if !self.ports.contains(&s) {
+            self.ports.push(s);
+        }
+        self
+    }
+
+    // -- atomic group rule-adders ------------------------------------
+
+    /// Allow the `"public"` group (complement of named categories).
+    #[napi]
+    pub fn allow_public(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "public");
+        self
+    }
+
+    /// Deny the `"public"` group.
+    #[napi]
+    pub fn deny_public(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "public");
+        self
+    }
+
+    /// Allow the `"private"` group (RFC1918 + ULA + CGN).
+    #[napi]
+    pub fn allow_private(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "private");
+        self
+    }
+
+    /// Deny the `"private"` group.
+    #[napi]
+    pub fn deny_private(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "private");
+        self
+    }
+
+    /// Allow the `"loopback"` group (`127.0.0.0/8`, `::1`) — the
+    /// **guest's own** loopback interface. Not the host machine. To
+    /// reach a service on the host's localhost, use [`Self::allow_host`].
+    #[napi]
+    pub fn allow_loopback(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "loopback");
+        self
+    }
+
+    /// Deny the `"loopback"` group. Useful in `defaultEgress = "allow"`
+    /// configurations to block crafted-packet leaks where a process
+    /// inside the guest binds a raw socket to eth0 with `dst=127.0.0.1`.
+    #[napi]
+    pub fn deny_loopback(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "loopback");
+        self
+    }
+
+    /// Allow the `"link-local"` group (`169.254.0.0/16`, `fe80::/10`).
+    /// Excludes the metadata IP (categorized as `"metadata"`).
+    #[napi]
+    pub fn allow_link_local(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "link-local");
+        self
+    }
+
+    /// Deny the `"link-local"` group.
+    #[napi]
+    pub fn deny_link_local(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "link-local");
+        self
+    }
+
+    /// Allow the `"metadata"` group (`169.254.169.254`). **Dangerous on
+    /// cloud hosts** — exposes IAM credentials.
+    #[napi]
+    pub fn allow_meta(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "metadata");
+        self
+    }
+
+    /// Deny the `"metadata"` group.
+    #[napi]
+    pub fn deny_meta(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "metadata");
+        self
+    }
+
+    /// Allow the `"multicast"` group (`224.0.0.0/4`, `ff00::/8`).
+    #[napi]
+    pub fn allow_multicast(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "multicast");
+        self
+    }
+
+    /// Deny the `"multicast"` group.
+    #[napi]
+    pub fn deny_multicast(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "multicast");
+        self
+    }
+
+    /// Allow the `"host"` group — the per-sandbox gateway IPs that
+    /// back `host.microsandbox.internal`. This is the right shortcut
+    /// for "let the sandbox reach my host's localhost", not
+    /// [`Self::allow_loopback`].
+    #[napi]
+    pub fn allow_host(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "host");
+        self
+    }
+
+    /// Deny the `"host"` group.
+    #[napi]
+    pub fn deny_host(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "host");
+        self
+    }
+
+    // -- composite sugar ---------------------------------------------
+
+    /// Allow `"loopback"` + `"link-local"` + `"host"` — the three
+    /// "near the sandbox" groups a developer typically wants together
+    /// when running locally. Adds **three rules** atomically using
+    /// the current state. `"metadata"` is explicitly **not** included.
+    #[napi]
+    pub fn allow_local(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Allow, "loopback");
+        self.commit_group(PolicyAction::Allow, "link-local");
+        self.commit_group(PolicyAction::Allow, "host");
+        self
+    }
+
+    /// Deny `"loopback"` + `"link-local"` + `"host"` (no metadata).
+    #[napi]
+    pub fn deny_local(&mut self) -> &Self {
+        self.commit_group(PolicyAction::Deny, "loopback");
+        self.commit_group(PolicyAction::Deny, "link-local");
+        self.commit_group(PolicyAction::Deny, "host");
+        self
+    }
+
+    // -- atomic explicit rule-adders ---------------------------------
+
+    /// Allow traffic to a specific IP address (stored as `/32` or
+    /// `/128` CIDR on the wire).
+    #[napi]
+    pub fn allow_ip(&mut self, ip: String) -> &Self {
+        self.commit_destination(PolicyAction::Allow, ip);
+        self
+    }
+
+    /// Deny traffic to a specific IP address.
+    #[napi]
+    pub fn deny_ip(&mut self, ip: String) -> &Self {
+        self.commit_destination(PolicyAction::Deny, ip);
+        self
+    }
+
+    /// Allow traffic to a CIDR range (e.g. `"10.0.0.0/8"`).
+    #[napi]
+    pub fn allow_cidr(&mut self, cidr: String) -> &Self {
+        self.commit_destination(PolicyAction::Allow, cidr);
+        self
+    }
+
+    /// Deny traffic to a CIDR range.
+    #[napi]
+    pub fn deny_cidr(&mut self, cidr: String) -> &Self {
+        self.commit_destination(PolicyAction::Deny, cidr);
+        self
+    }
+
+    /// Allow traffic to an exact domain (e.g. `"api.example.com"`).
+    /// Domain rules require the guest to resolve through the
+    /// sandbox's DNS interceptor.
+    #[napi]
+    pub fn allow_domain(&mut self, domain: String) -> &Self {
+        self.commit_destination(PolicyAction::Allow, domain);
+        self
+    }
+
+    /// Deny traffic to an exact domain.
+    #[napi]
+    pub fn deny_domain(&mut self, domain: String) -> &Self {
+        self.commit_destination(PolicyAction::Deny, domain);
+        self
+    }
+
+    /// Allow traffic to any subdomain matching this suffix. The
+    /// suffix should be prefixed with `"."` (e.g.
+    /// `".pythonhosted.org"` matches `files.pythonhosted.org`).
+    #[napi]
+    pub fn allow_domain_suffix(&mut self, suffix: String) -> &Self {
+        let s = if suffix.starts_with('.') {
+            suffix
+        } else {
+            format!(".{suffix}")
+        };
+        self.commit_destination(PolicyAction::Allow, s);
+        self
+    }
+
+    /// Deny traffic to any subdomain matching this suffix.
+    #[napi]
+    pub fn deny_domain_suffix(&mut self, suffix: String) -> &Self {
+        let s = if suffix.starts_with('.') {
+            suffix
+        } else {
+            format!(".{suffix}")
+        };
+        self.commit_destination(PolicyAction::Deny, s);
+        self
+    }
+
+    /// Allow traffic to any destination (`"*"`).
+    #[napi]
+    pub fn allow_any(&mut self) -> &Self {
+        self.commit_destination(PolicyAction::Allow, "*".to_string());
+        self
+    }
+
+    /// Deny traffic to any destination.
+    #[napi]
+    pub fn deny_any(&mut self) -> &Self {
+        self.commit_destination(PolicyAction::Deny, "*".to_string());
+        self
+    }
+
+    // -- internal commit helpers ------------------------------------
+
+    fn commit_group(&mut self, action: PolicyAction, group: &str) {
+        self.commit_destination(action, group.to_string());
+    }
+
+    fn commit_destination(&mut self, action: PolicyAction, destination: String) {
+        let action_str = action_ref_to_str(&action).to_string();
+        let direction_str = self
+            .direction
+            .as_ref()
+            .map(direction_to_str)
+            .map(String::from);
+        let protocol_str = self
+            .protocols
+            .first()
+            .map(protocol_to_str)
+            .map(String::from);
+        let port_str = self.ports.first().cloned();
+        self.rules.push(PolicyRule {
+            action: action_str,
+            direction: direction_str,
+            destination: Some(destination),
+            protocol: protocol_str,
+            port: port_str,
+        });
+    }
+
+    // -- terminator --------------------------------------------------
+
+    /// Materialize the accumulated state into a [`NetworkConfig`]
+    /// suitable for `Sandbox.create({ network: ... })`. Errors in the
+    /// rule contents (invalid ip / cidr / domain strings, lo > hi
+    /// port range, icmp on a non-egress rule) surface at sandbox
+    /// creation, not here.
+    #[napi]
+    pub fn build(&self) -> NetworkConfig {
+        let cloned_rules: Vec<PolicyRule> = self
+            .rules
+            .iter()
+            .map(|r| PolicyRule {
+                action: r.action.clone(),
+                direction: r.direction.clone(),
+                destination: r.destination.clone(),
+                protocol: r.protocol.clone(),
+                port: r.port.clone(),
+            })
+            .collect();
+        NetworkConfig {
+            policy: None,
+            rules: Some(cloned_rules),
+            default_egress: self
+                .default_egress
+                .as_ref()
+                .map(|a| action_ref_to_str(a).to_string()),
+            default_ingress: self
+                .default_ingress
+                .as_ref()
+                .map(|a| action_ref_to_str(a).to_string()),
+            dns: None,
+            tls: None,
+            max_connections: None,
+            trust_host_cas: None,
+        }
+    }
+}
+
+fn action_ref_to_str(action: &PolicyAction) -> &'static str {
+    match action {
+        PolicyAction::Allow => "allow",
+        PolicyAction::Deny => "deny",
+    }
+}
+
+fn direction_to_str(direction: &PolicyDirection) -> &'static str {
+    match direction {
+        PolicyDirection::Egress => "egress",
+        PolicyDirection::Ingress => "ingress",
+        PolicyDirection::Any => "any",
+    }
+}
+
+fn protocol_to_str(protocol: &PolicyProtocol) -> &'static str {
+    match protocol {
+        PolicyProtocol::Tcp => "tcp",
+        PolicyProtocol::Udp => "udp",
+        PolicyProtocol::Icmpv4 => "icmpv4",
+        PolicyProtocol::Icmpv6 => "icmpv6",
     }
 }
 

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -565,15 +565,22 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
         builder = builder.network(|mut n| {
             // Policy: preset or custom rules
             if let Some(ref rules) = network.rules {
-                let default_action = match network.default_action.as_deref() {
+                let parse_action = |s: Option<&str>, default: Action| match s {
                     Some("deny") => Action::Deny,
-                    _ => Action::Allow,
+                    Some("allow") => Action::Allow,
+                    _ => default,
                 };
-                // TODO: replace this shim with a per-direction TS API.
+                // Asymmetric defaults match today's behavior: egress defaults
+                // to Deny (the implicit allow-public rule comes via the rules
+                // list when present), ingress defaults to Allow (today's
+                // unfiltered published-port behavior).
+                let default_egress = parse_action(network.default_egress.as_deref(), Action::Deny);
+                let default_ingress =
+                    parse_action(network.default_ingress.as_deref(), Action::Allow);
                 let parsed_rules: Vec<_> = rules.iter().filter_map(convert_policy_rule).collect();
                 n = n.policy(NetworkPolicy {
-                    default_egress: default_action,
-                    default_ingress: default_action,
+                    default_egress,
+                    default_ingress,
                     rules: parsed_rules,
                 });
             } else if let Some(ref policy) = network.policy {

--- a/sdk/node-ts/lib/types.rs
+++ b/sdk/node-ts/lib/types.rs
@@ -127,8 +127,14 @@ pub struct NetworkConfig {
     pub policy: Option<String>,
     /// Custom policy rules (first match wins). Overrides `policy` preset.
     pub rules: Option<Vec<PolicyRule>>,
-    /// Default action when no rule matches: "allow" or "deny".
-    pub default_action: Option<String>,
+    /// Default action for egress traffic when no rule matches: "allow" or
+    /// "deny". When omitted, falls through to today's `public_only`
+    /// behavior (deny + implicit allow public).
+    pub default_egress: Option<String>,
+    /// Default action for ingress traffic when no rule matches: "allow" or
+    /// "deny". When omitted, defaults to "allow" (today's unfiltered
+    /// published-port behavior).
+    pub default_ingress: Option<String>,
     /// DNS interception configuration.
     pub dns: Option<DnsConfig>,
     /// TLS interception configuration.

--- a/sdk/node-ts/tests/policy-builder.test.ts
+++ b/sdk/node-ts/tests/policy-builder.test.ts
@@ -1,129 +1,129 @@
 /// <reference types="node" />
 import { describe, it, expect } from "vitest";
-import { NetworkPolicy, PolicyAction } from "../index.mjs";
+import { NetworkPolicy } from "../index.mjs";
 
 // Pure-shape tests — no sandbox runtime required. Verifies that the
 // fluent NetworkPolicyBuilder produces the expected `NetworkConfig`
 // shape and that chaining works end-to-end.
 
 describe("NetworkPolicyBuilder", () => {
-	it("empty builder produces an empty rules array and unset defaults", () => {
-		const cfg = NetworkPolicy.builder().build();
-		expect(cfg.rules).toEqual([]);
-		expect(cfg.defaultEgress).toBeUndefined();
-		expect(cfg.defaultIngress).toBeUndefined();
-		expect(cfg.policy).toBeUndefined();
-	});
+  it("empty builder produces an empty rules array and unset defaults", () => {
+    const cfg = NetworkPolicy.builder().build();
+    expect(cfg.rules).toEqual([]);
+    expect(cfg.defaultEgress).toBeUndefined();
+    expect(cfg.defaultIngress).toBeUndefined();
+    expect(cfg.policy).toBeUndefined();
+  });
 
-	it("defaultDeny sets both directions to deny", () => {
-		const cfg = NetworkPolicy.builder().defaultDeny().build();
-		expect(cfg.defaultEgress).toBe("deny");
-		expect(cfg.defaultIngress).toBe("deny");
-	});
+  it("defaultDeny sets both directions to deny", () => {
+    const cfg = NetworkPolicy.builder().defaultDeny().build();
+    expect(cfg.defaultEgress).toBe("deny");
+    expect(cfg.defaultIngress).toBe("deny");
+  });
 
-	it("defaultEgress / defaultIngress override individually", () => {
-		const cfg = NetworkPolicy.builder()
-			.defaultDeny()
-			.defaultIngress(PolicyAction.Allow)
-			.build();
-		expect(cfg.defaultEgress).toBe("deny");
-		expect(cfg.defaultIngress).toBe("allow");
-	});
+  it("defaultEgress / defaultIngress override individually", () => {
+    const cfg = NetworkPolicy.builder()
+      .defaultDeny()
+      .defaultIngress("allow")
+      .build();
+    expect(cfg.defaultEgress).toBe("deny");
+    expect(cfg.defaultIngress).toBe("allow");
+  });
 
-	it("egress sub-builder commits one rule per shortcut", () => {
-		const cfg = NetworkPolicy.builder()
-			.defaultDeny()
-			.egress()
-			.tcp()
-			.port(443)
-			.allowPublic()
-			.allowPrivate()
-			.build();
-		expect(cfg.rules).toHaveLength(2);
-		expect(cfg.rules![0]).toMatchObject({
-			action: "allow",
-			direction: "egress",
-			destination: "public",
-			protocol: "tcp",
-			port: "443",
-		});
-		expect(cfg.rules![1]).toMatchObject({
-			action: "allow",
-			direction: "egress",
-			destination: "private",
-			protocol: "tcp",
-			port: "443",
-		});
-	});
+  it("egress sub-builder commits one rule per shortcut", () => {
+    const cfg = NetworkPolicy.builder()
+      .defaultDeny()
+      .egress()
+      .tcp()
+      .port(443)
+      .allowPublic()
+      .allowPrivate()
+      .build();
+    expect(cfg.rules).toHaveLength(2);
+    expect(cfg.rules![0]).toMatchObject({
+      action: "allow",
+      direction: "egress",
+      destination: "public",
+      protocol: "tcp",
+      port: "443",
+    });
+    expect(cfg.rules![1]).toMatchObject({
+      action: "allow",
+      direction: "egress",
+      destination: "private",
+      protocol: "tcp",
+      port: "443",
+    });
+  });
 
-	it("allowLocal expands to three rules (loopback + link-local + host)", () => {
-		const cfg = NetworkPolicy.builder().egress().allowLocal().build();
-		expect(cfg.rules).toHaveLength(3);
-		expect(cfg.rules!.map((r) => r.destination)).toEqual([
-			"loopback",
-			"link-local",
-			"host",
-		]);
-	});
+  it("allowLocal expands to three rules (loopback + link-local + host)", () => {
+    const cfg = NetworkPolicy.builder().egress().allowLocal().build();
+    expect(cfg.rules).toHaveLength(3);
+    expect(cfg.rules!.map((r) => r.destination)).toEqual([
+      "loopback",
+      "link-local",
+      "host",
+    ]);
+  });
 
-	it("allow_host vs allow_loopback target different groups", () => {
-		const cfg = NetworkPolicy.builder()
-			.egress()
-			.allowHost()
-			.allowLoopback()
-			.build();
-		expect(cfg.rules!.map((r) => r.destination)).toEqual(["host", "loopback"]);
-	});
+  it("allow_host vs allow_loopback target different groups", () => {
+    const cfg = NetworkPolicy.builder()
+      .egress()
+      .allowHost()
+      .allowLoopback()
+      .build();
+    expect(cfg.rules!.map((r) => r.destination)).toEqual(["host", "loopback"]);
+  });
 
-	it("explicit-destination shortcuts commit with the IP / CIDR / domain", () => {
-		const cfg = NetworkPolicy.builder()
-			.any()
-			.denyIp("198.51.100.5")
-			.egress()
-			.tcp()
-			.port(443)
-			.allowDomain("api.example.com")
-			.allowDomainSuffix(".pythonhosted.org")
-			.allowCidr("10.0.0.0/8")
-			.build();
-		expect(cfg.rules).toHaveLength(4);
-		expect(cfg.rules![0]).toMatchObject({
-			action: "deny",
-			direction: "any",
-			destination: "198.51.100.5",
-		});
-		expect(cfg.rules![1]).toMatchObject({
-			action: "allow",
-			direction: "egress",
-			destination: "api.example.com",
-			protocol: "tcp",
-			port: "443",
-		});
-		expect(cfg.rules![2].destination).toBe(".pythonhosted.org");
-		expect(cfg.rules![3].destination).toBe("10.0.0.0/8");
-	});
+  it("explicit-destination shortcuts commit with the IP / CIDR / domain", () => {
+    const cfg = NetworkPolicy.builder()
+      .any()
+      .denyIp("198.51.100.5")
+      .egress()
+      .tcp()
+      .port(443)
+      .allowDomain("api.example.com")
+      .allowDomainSuffix(".pythonhosted.org")
+      .allowCidr("10.0.0.0/8")
+      .build();
+    expect(cfg.rules).toHaveLength(4);
+    expect(cfg.rules![0]).toMatchObject({
+      action: "deny",
+      direction: "any",
+      destination: "198.51.100.5",
+    });
+    expect(cfg.rules![1]).toMatchObject({
+      action: "allow",
+      direction: "egress",
+      destination: "api.example.com",
+      protocol: "tcp",
+      port: "443",
+    });
+    expect(cfg.rules![2].destination).toBe(".pythonhosted.org");
+    expect(cfg.rules![3].destination).toBe("10.0.0.0/8");
+  });
 
-	it("portRange formats as <lo>-<hi> on the wire", () => {
-		const cfg = NetworkPolicy.builder()
-			.egress()
-			.tcp()
-			.portRange(80, 443)
-			.allowPublic()
-			.build();
-		expect(cfg.rules![0].port).toBe("80-443");
-	});
+  it("portRange formats as <lo>-<hi> on the wire", () => {
+    const cfg = NetworkPolicy.builder()
+      .egress()
+      .tcp()
+      .portRange(80, 443)
+      .allowPublic()
+      .build();
+    expect(cfg.rules![0].port).toBe("80-443");
+  });
 
-	it("protocol set dedupes on insert", () => {
-		const cfg = NetworkPolicy.builder()
-			.egress()
-			.tcp()
-			.tcp()
-			.udp()
-			.tcp()
-			.allowPublic()
-			.build();
-		// First protocol wins on the wire (rules carry one protocol per entry today);
-		// the dedup just prevents the set from growing past the unique values.
-		expect(cfg.rules![0].protocol).toBe("tcp");
-	});
+  it("protocol set dedupes on insert", () => {
+    const cfg = NetworkPolicy.builder()
+      .egress()
+      .tcp()
+      .tcp()
+      .udp()
+      .tcp()
+      .allowPublic()
+      .build();
+    // First protocol wins on the wire (rules carry one protocol per entry today);
+    // the dedup just prevents the set from growing past the unique values.
+    expect(cfg.rules![0].protocol).toBe("tcp");
+  });
 });

--- a/sdk/node-ts/tests/policy-builder.test.ts
+++ b/sdk/node-ts/tests/policy-builder.test.ts
@@ -1,0 +1,129 @@
+/// <reference types="node" />
+import { describe, it, expect } from "vitest";
+import { NetworkPolicy, PolicyAction } from "../index.mjs";
+
+// Pure-shape tests — no sandbox runtime required. Verifies that the
+// fluent NetworkPolicyBuilder produces the expected `NetworkConfig`
+// shape and that chaining works end-to-end.
+
+describe("NetworkPolicyBuilder", () => {
+	it("empty builder produces an empty rules array and unset defaults", () => {
+		const cfg = NetworkPolicy.builder().build();
+		expect(cfg.rules).toEqual([]);
+		expect(cfg.defaultEgress).toBeUndefined();
+		expect(cfg.defaultIngress).toBeUndefined();
+		expect(cfg.policy).toBeUndefined();
+	});
+
+	it("defaultDeny sets both directions to deny", () => {
+		const cfg = NetworkPolicy.builder().defaultDeny().build();
+		expect(cfg.defaultEgress).toBe("deny");
+		expect(cfg.defaultIngress).toBe("deny");
+	});
+
+	it("defaultEgress / defaultIngress override individually", () => {
+		const cfg = NetworkPolicy.builder()
+			.defaultDeny()
+			.defaultIngress(PolicyAction.Allow)
+			.build();
+		expect(cfg.defaultEgress).toBe("deny");
+		expect(cfg.defaultIngress).toBe("allow");
+	});
+
+	it("egress sub-builder commits one rule per shortcut", () => {
+		const cfg = NetworkPolicy.builder()
+			.defaultDeny()
+			.egress()
+			.tcp()
+			.port(443)
+			.allowPublic()
+			.allowPrivate()
+			.build();
+		expect(cfg.rules).toHaveLength(2);
+		expect(cfg.rules![0]).toMatchObject({
+			action: "allow",
+			direction: "egress",
+			destination: "public",
+			protocol: "tcp",
+			port: "443",
+		});
+		expect(cfg.rules![1]).toMatchObject({
+			action: "allow",
+			direction: "egress",
+			destination: "private",
+			protocol: "tcp",
+			port: "443",
+		});
+	});
+
+	it("allowLocal expands to three rules (loopback + link-local + host)", () => {
+		const cfg = NetworkPolicy.builder().egress().allowLocal().build();
+		expect(cfg.rules).toHaveLength(3);
+		expect(cfg.rules!.map((r) => r.destination)).toEqual([
+			"loopback",
+			"link-local",
+			"host",
+		]);
+	});
+
+	it("allow_host vs allow_loopback target different groups", () => {
+		const cfg = NetworkPolicy.builder()
+			.egress()
+			.allowHost()
+			.allowLoopback()
+			.build();
+		expect(cfg.rules!.map((r) => r.destination)).toEqual(["host", "loopback"]);
+	});
+
+	it("explicit-destination shortcuts commit with the IP / CIDR / domain", () => {
+		const cfg = NetworkPolicy.builder()
+			.any()
+			.denyIp("198.51.100.5")
+			.egress()
+			.tcp()
+			.port(443)
+			.allowDomain("api.example.com")
+			.allowDomainSuffix(".pythonhosted.org")
+			.allowCidr("10.0.0.0/8")
+			.build();
+		expect(cfg.rules).toHaveLength(4);
+		expect(cfg.rules![0]).toMatchObject({
+			action: "deny",
+			direction: "any",
+			destination: "198.51.100.5",
+		});
+		expect(cfg.rules![1]).toMatchObject({
+			action: "allow",
+			direction: "egress",
+			destination: "api.example.com",
+			protocol: "tcp",
+			port: "443",
+		});
+		expect(cfg.rules![2].destination).toBe(".pythonhosted.org");
+		expect(cfg.rules![3].destination).toBe("10.0.0.0/8");
+	});
+
+	it("portRange formats as <lo>-<hi> on the wire", () => {
+		const cfg = NetworkPolicy.builder()
+			.egress()
+			.tcp()
+			.portRange(80, 443)
+			.allowPublic()
+			.build();
+		expect(cfg.rules![0].port).toBe("80-443");
+	});
+
+	it("protocol set dedupes on insert", () => {
+		const cfg = NetworkPolicy.builder()
+			.egress()
+			.tcp()
+			.tcp()
+			.udp()
+			.tcp()
+			.allowPublic()
+			.build();
+		// First protocol wins on the wire (rules carry one protocol per entry today);
+		// the dedup just prevents the set from growing past the unique values.
+		expect(cfg.rules![0].protocol).toBe("tcp");
+	});
+});

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -43,6 +43,7 @@ class Action(enum.StrEnum):
 class Direction(enum.StrEnum):
     EGRESS = "egress"
     INGRESS = "ingress"
+    ANY = "any"
 
 class Protocol(enum.StrEnum):
     TCP = "tcp"
@@ -490,12 +491,23 @@ class Rule:
 
 @dataclass(frozen=True, slots=True)
 class NetworkPolicy:
-    """Custom network policy with rules. Mirrors Rust's NetworkPolicy { default_action, rules }."""
-    default_action: Action = Action.ALLOW
+    """Custom network policy with rules.
+
+    Mirrors Rust's `NetworkPolicy { default_egress, default_ingress, rules }`.
+    The defaults are asymmetric to preserve today's behavior:
+    egress falls through to deny (today's `public_only` reachability when
+    paired with the implicit allow-public rule); ingress falls through
+    to allow (today's unfiltered published-port behavior).
+    """
+    default_egress: Action = Action.DENY
+    default_ingress: Action = Action.ALLOW
     rules: tuple[Rule, ...] = ()
 
     def _to_dict(self) -> dict:
-        d: dict = {"default_action": str(self.default_action)}
+        d: dict = {
+            "default_egress": str(self.default_egress),
+            "default_ingress": str(self.default_ingress),
+        }
         if self.rules:
             d["rules"] = [
                 {

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -384,19 +384,31 @@ fn apply_network(
         && !custom.is_none()
     {
         let cp_dict = as_dict(&custom)?;
-        let default_action_str: String =
-            extract_opt(&cp_dict, "default_action")?.unwrap_or_else(|| "allow".to_string());
-        let default_action = match default_action_str.as_str() {
-            "allow" => microsandbox_network::policy::Action::Allow,
-            "deny" => microsandbox_network::policy::Action::Deny,
-            _ => {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "unknown default_action: {default_action_str}"
-                )));
+        let parse_action_field = |field: &str,
+                                  default: microsandbox_network::policy::Action|
+         -> PyResult<microsandbox_network::policy::Action> {
+            let s: Option<String> = extract_opt(&cp_dict, field)?;
+            match s.as_deref() {
+                None => Ok(default),
+                Some("allow") => Ok(microsandbox_network::policy::Action::Allow),
+                Some("deny") => Ok(microsandbox_network::policy::Action::Deny),
+                Some(other) => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "unknown {field}: {other}"
+                ))),
             }
         };
+        // Asymmetric defaults match the rest of the stack: egress falls
+        // through to Deny (preserves today's `public_only` reachability
+        // when paired with an implicit allow-public rule); ingress falls
+        // through to Allow (preserves today's unfiltered published-port
+        // behavior).
+        let default_egress =
+            parse_action_field("default_egress", microsandbox_network::policy::Action::Deny)?;
+        let default_ingress = parse_action_field(
+            "default_ingress",
+            microsandbox_network::policy::Action::Allow,
+        )?;
 
-        // TODO: replace this shim with a per-direction Python API.
         let mut rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
         if let Some(rules_obj) = cp_dict.get_item("rules")?
             && !rules_obj.is_none()
@@ -515,8 +527,8 @@ fn apply_network(
         }
 
         let policy = NetworkPolicy {
-            default_egress: default_action,
-            default_ingress: default_action,
+            default_egress,
+            default_ingress,
             rules,
         };
         builder = builder.network(|n| n.policy(policy));


### PR DESCRIPTION
follow-up to #615. brings the docs, rust example, and ts/python sdks in line with the new networking policy.

## what changed

- networking + sdk docs rewritten to use the new `--net-rule` flag and `NetworkPolicy::builder()` api. dropped references to the old presets.
- added a "loopback vs host" callout to flag a common mix-up: loopback rules don't gate guest-to-host traffic, host rules do.
- rust example switched from struct-literal policy to the builder.
- ts + python types now have separate `defaultEgress` and `defaultIngress` (so each direction can carry its own fallback action) plus a new `Direction.any`.
- added a chainable `NetworkPolicy.builder()` to the typescript sdk so its api matches the rust one.

## test plan

- [ ] read the rendered mdx pages
- [ ] grep changed files for leftover old terms: `outbound|inbound|public_only|--no-network|--network-policy|default_action`
- [ ] `cargo check --workspace --tests`
- [ ] `npm test sdk/node-ts/tests/policy-builder.test.ts`