### PR TITLE
feat(network): redesign policy schema with per-rule direction (1/4)

### DIFF
--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -718,7 +718,10 @@ mod tests {
             .unwrap();
 
         assert!(!config.network.enabled);
-        assert_eq!(config.network.policy.default_action, Action::Deny);
+        // `disable_network()` uses `NetworkPolicy::none()` which is deny-all
+        // in both directions with no rules.
+        assert_eq!(config.network.policy.default_egress, Action::Deny);
+        assert_eq!(config.network.policy.default_ingress, Action::Deny);
         assert!(config.network.policy.rules.is_empty());
     }
 

--- a/crates/microsandbox/tests/dns_matrix/sandbox.rs
+++ b/crates/microsandbox/tests/dns_matrix/sandbox.rs
@@ -42,8 +42,9 @@ pub(crate) async fn setup_sandbox(
 pub(crate) fn deny_resolver(resolver: &str) -> Result<NetworkPolicy, Box<dyn std::error::Error>> {
     let ip: Ipv4Addr = resolver.parse()?;
     Ok(NetworkPolicy {
-        default_action: Action::Allow,
-        rules: vec![Rule::deny_outbound(Destination::Cidr(IpNetwork::V4(
+        default_egress: Action::Allow,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::deny_egress(Destination::Cidr(IpNetwork::V4(
             Ipv4Network::new(ip, 32)?,
         )))],
     })

--- a/crates/microsandbox/tests/dns_matrix/sandbox.rs
+++ b/crates/microsandbox/tests/dns_matrix/sandbox.rs
@@ -24,7 +24,7 @@ pub(crate) async fn setup_sandbox(
     configure_network: impl FnOnce(NetworkBuilder) -> NetworkBuilder,
 ) -> Result<(Sandbox, String), Box<dyn std::error::Error>> {
     let sb = Sandbox::builder(name)
-        .image("alpine")
+        .image("mirror.gcr.io/library/alpine")
         .cpus(1)
         .memory(512)
         .network(configure_network)

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -63,7 +63,7 @@ async fn setup_alpine(name: &str, policy: NetworkPolicy) -> Sandbox {
         .rules
         .insert(0, allow_domain_suffix_https(".alpinelinux.org"));
     let sb = Sandbox::builder(name)
-        .image("alpine")
+        .image("mirror.gcr.io/library/alpine")
         .cpus(1)
         .memory(512)
         .network(|n| n.policy(policy))

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -27,10 +27,10 @@ const CURL_FAIL: &str = "FAIL";
 /// Outbound HTTPS (TCP/443) allow rule for a specific hostname.
 fn allow_domain_https(domain: &str) -> Rule {
     Rule {
-        direction: Direction::Outbound,
+        direction: Direction::Egress,
         destination: Destination::Domain(domain.parse().expect("valid domain")),
-        protocol: Some(Protocol::Tcp),
-        ports: Some(PortRange::single(443)),
+        protocols: vec![Protocol::Tcp],
+        ports: vec![PortRange::single(443)],
         action: Action::Allow,
     }
 }
@@ -38,10 +38,10 @@ fn allow_domain_https(domain: &str) -> Rule {
 /// Outbound HTTPS (TCP/443) allow rule for a DNS suffix.
 fn allow_domain_suffix_https(suffix: &str) -> Rule {
     Rule {
-        direction: Direction::Outbound,
+        direction: Direction::Egress,
         destination: Destination::DomainSuffix(suffix.parse().expect("valid domain suffix")),
-        protocol: Some(Protocol::Tcp),
-        ports: Some(PortRange::single(443)),
+        protocols: vec![Protocol::Tcp],
+        ports: vec![PortRange::single(443)],
         action: Action::Allow,
     }
 }
@@ -126,7 +126,8 @@ fn reached_server(probe_output: &str) -> bool {
 async fn domain_policy_allows_whitelisted_https() {
     let name = "net-domain-policy-allow";
     let policy = NetworkPolicy {
-        default_action: Action::Deny,
+        default_egress: Action::Deny,
+        default_ingress: Action::Allow,
         rules: vec![
             allow_domain_https("pypi.org"),
             allow_domain_https("files.pythonhosted.org"),
@@ -185,7 +186,8 @@ async fn domain_policy_allows_whitelisted_https() {
 async fn domain_policy_suffix_allows_subdomain_https() {
     let name = "net-domain-policy-suffix";
     let policy = NetworkPolicy {
-        default_action: Action::Deny,
+        default_egress: Action::Deny,
+        default_ingress: Action::Allow,
         rules: vec![allow_domain_suffix_https(".pythonhosted.org")],
     };
     let sb = setup_alpine(name, policy).await;

--- a/crates/microsandbox/tests/host_access.rs
+++ b/crates/microsandbox/tests/host_access.rs
@@ -89,7 +89,7 @@ impl Drop for HostHttp {
 /// Boot an alpine sandbox with the given policy (or the default when `None`).
 async fn spawn_sandbox(name: &str, policy: Option<NetworkPolicy>) -> Sandbox {
     let builder = Sandbox::builder(name)
-        .image("alpine")
+        .image("mirror.gcr.io/library/alpine")
         .cpus(1)
         .memory(256)
         .replace();

--- a/crates/microsandbox/tests/host_access.rs
+++ b/crates/microsandbox/tests/host_access.rs
@@ -119,8 +119,9 @@ async fn read_gateway_ip(sb: &Sandbox) -> String {
 /// Allow host only; deny everything else.
 fn allow_host_only_policy() -> NetworkPolicy {
     NetworkPolicy {
-        default_action: Action::Deny,
-        rules: vec![Rule::allow_outbound(Destination::Group(
+        default_egress: Action::Deny,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::allow_egress(Destination::Group(
             DestinationGroup::Host,
         ))],
     }
@@ -129,8 +130,9 @@ fn allow_host_only_policy() -> NetworkPolicy {
 /// Deny host only; allow everything else.
 fn deny_host_group_policy() -> NetworkPolicy {
     NetworkPolicy {
-        default_action: Action::Allow,
-        rules: vec![Rule::deny_outbound(Destination::Group(
+        default_egress: Action::Allow,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::deny_egress(Destination::Group(
             DestinationGroup::Host,
         ))],
     }
@@ -140,8 +142,9 @@ fn deny_host_group_policy() -> NetworkPolicy {
 fn deny_gateway_cidr_policy(gateway_ip: &str) -> NetworkPolicy {
     let addr: Ipv4Addr = gateway_ip.parse().expect("valid gateway ipv4");
     NetworkPolicy {
-        default_action: Action::Allow,
-        rules: vec![Rule::deny_outbound(Destination::Cidr(IpNetwork::V4(
+        default_egress: Action::Allow,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::deny_egress(Destination::Cidr(IpNetwork::V4(
             Ipv4Network::new(addr, 32).expect("valid /32"),
         )))],
     }

--- a/crates/microsandbox/tests/tls.rs
+++ b/crates/microsandbox/tests/tls.rs
@@ -25,7 +25,7 @@ use test_utils::msb_test;
 async fn tls_intercept_handshake() {
     let name = "tls-test-intercept";
     let sandbox = Sandbox::builder(name)
-        .image("node:alpine")
+        .image("mirror.gcr.io/library/node:alpine")
         .cpus(1)
         .memory(512)
         .network(|n| n.tls(|t| t))
@@ -74,7 +74,7 @@ async fn tls_intercept_handshake() {
 async fn tls_bypass_domain_connects() {
     let name = "tls-test-bypass";
     let sandbox = Sandbox::builder(name)
-        .image("node:alpine")
+        .image("mirror.gcr.io/library/node:alpine")
         .cpus(1)
         .memory(512)
         .network(|n| n.tls(|t| t.bypass("example.com")))

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use crate::config::{DnsConfig, InterfaceOverrides, NetworkConfig, PortProtocol, PublishedPort};
 use crate::dns::Nameserver;
-use crate::policy::NetworkPolicy;
+use crate::policy::{DomainName, NetworkPolicy};
 use crate::secrets::config::{HostPattern, SecretEntry, SecretInjection, ViolationAction};
 use crate::tls::TlsConfig;
 
@@ -196,14 +196,43 @@ impl DnsBuilder {
     }
 
     /// Block a specific domain via DNS interception (returns REFUSED).
+    ///
+    /// Accepts any string-like input. The string is parsed and
+    /// canonicalized via [`DomainName`] internally before storage —
+    /// invalid names (failing the DNS label grammar) are silently
+    /// skipped with a `tracing::warn!`, since this is a configuration
+    /// path that should not block startup on a single malformed entry.
+    /// Valid entries are stored in canonical lowercase form, ready for
+    /// byte-equality match against the DNS interceptor's resolved-name
+    /// cache.
+    ///
+    /// TODO: retrofit to lazy-parse + accumulate-at-`.build()`,
+    /// matching the model the new `NetworkPolicy::builder()` uses.
     pub fn block_domain(mut self, domain: impl Into<String>) -> Self {
-        self.config.blocked_domains.push(domain.into());
+        let raw: String = domain.into();
+        match raw.parse::<DomainName>() {
+            Ok(name) => self.config.blocked_domains.push(name.into()),
+            Err(e) => {
+                tracing::warn!(domain = %raw, error = %e, "skipping invalid block_domain entry")
+            }
+        }
         self
     }
 
     /// Block a domain suffix via DNS interception (returns REFUSED).
+    ///
+    /// Same string-input + internal-parse + skip-on-invalid behavior as
+    /// [`Self::block_domain`]. Reuses [`DomainName`] for validation —
+    /// the suffix-vs-exact distinction lives in interpretation, not in
+    /// the validated value.
     pub fn block_domain_suffix(mut self, suffix: impl Into<String>) -> Self {
-        self.config.blocked_suffixes.push(suffix.into());
+        let raw: String = suffix.into();
+        match raw.parse::<DomainName>() {
+            Ok(name) => self.config.blocked_suffixes.push(name.into()),
+            Err(e) => {
+                tracing::warn!(suffix = %raw, error = %e, "skipping invalid block_domain_suffix entry")
+            }
+        }
         self
     }
 

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -763,12 +763,13 @@ mod tests {
         let shared = SharedState::new(4);
         let dst_ip = std::net::Ipv4Addr::new(8, 8, 8, 8);
         let policy = NetworkPolicy {
-            default_action: Action::Allow,
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
             rules: vec![Rule {
-                direction: Direction::Outbound,
+                direction: Direction::Egress,
                 destination: Destination::Cidr("8.8.8.8/32".parse().unwrap()),
-                protocol: Some(Protocol::Tcp),
-                ports: None,
+                protocols: vec![Protocol::Tcp],
+                ports: vec![],
                 action: Action::Deny,
             }],
         };
@@ -815,12 +816,13 @@ mod tests {
         let gw = gateway_set();
         let shared = SharedState::new(4);
         let policy = NetworkPolicy {
-            default_action: Action::Allow,
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
             rules: vec![Rule {
-                direction: Direction::Outbound,
+                direction: Direction::Egress,
                 destination: Destination::Cidr("1.1.1.1/32".parse().unwrap()),
-                protocol: Some(Protocol::Tcp),
-                ports: None,
+                protocols: vec![Protocol::Tcp],
+                ports: vec![],
                 action: Action::Deny,
             }],
         };

--- a/crates/network/lib/policy/destination.rs
+++ b/crates/network/lib/policy/destination.rs
@@ -1,11 +1,12 @@
-//! Destination group matching: maps `DestinationGroup` variants to concrete
-//! IP ranges for loopback, private, link-local, metadata, and multicast.
+//! Destination group matching: maps IP addresses to the
+//! [`DestinationGroup`] they belong to.
 
 use std::net::IpAddr;
 
 use ipnetwork::IpNetwork;
 
 use super::DestinationGroup;
+use crate::shared::SharedState;
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -13,16 +14,52 @@ use super::DestinationGroup;
 
 /// Returns `true` if `addr` belongs to the given destination group.
 ///
-/// `DestinationGroup::Host` is handled by the policy-level matcher
-/// because it needs per-sandbox gateway IPs; it returns `false` here.
-pub fn matches_group(group: DestinationGroup, addr: IpAddr) -> bool {
-    match group {
-        DestinationGroup::Loopback => is_loopback(addr),
-        DestinationGroup::Private => is_private(addr),
-        DestinationGroup::LinkLocal => is_link_local(addr),
-        DestinationGroup::Metadata => is_metadata(addr),
-        DestinationGroup::Multicast => is_multicast(addr),
-        DestinationGroup::Host => false,
+/// Built on a single private classifier (`addr_classify`) so adding a
+/// new `DestinationGroup` variant forces an exhaustive-match update
+/// in the classifier and a corresponding witness in the test suite.
+/// `Public` is the fallback when no other classification matches —
+/// there's no list of excluded groups to keep in sync.
+///
+/// Groups are disjoint: each IP belongs to exactly one. `Metadata`
+/// takes precedence over `LinkLocal` for `169.254.169.254`, and `Host`
+/// takes precedence over `Private` when the gateway IPs sit inside
+/// CGNAT or ULA ranges (which they currently do).
+pub fn matches_group(group: DestinationGroup, addr: IpAddr, shared: &SharedState) -> bool {
+    addr_classify(addr, shared) == group
+}
+
+/// Classify an IP into exactly one destination group.
+///
+/// Order matters: more specific tests first. `Host` first because
+/// today's gateway IPs land in CGNAT (`100.64.0.0/10`) and ULA
+/// (`fc00::/7`) ranges that `is_private` would otherwise claim.
+/// `Metadata` before `LinkLocal` because `169.254.169.254` is in the
+/// link-local CIDR.
+fn addr_classify(addr: IpAddr, shared: &SharedState) -> DestinationGroup {
+    if matches_host(addr, shared) {
+        DestinationGroup::Host
+    } else if is_metadata(addr) {
+        DestinationGroup::Metadata
+    } else if is_loopback(addr) {
+        DestinationGroup::Loopback
+    } else if is_private(addr) {
+        DestinationGroup::Private
+    } else if is_link_local(addr) {
+        DestinationGroup::LinkLocal
+    } else if is_multicast(addr) {
+        DestinationGroup::Multicast
+    } else {
+        DestinationGroup::Public
+    }
+}
+
+/// Matches the per-sandbox gateway IPs carried by [`SharedState`].
+/// Returns `false` when gateway IPs haven't been set (e.g. isolated
+/// unit tests that don't exercise Host rules).
+fn matches_host(addr: IpAddr, shared: &SharedState) -> bool {
+    match addr {
+        IpAddr::V4(v4) => shared.gateway_ipv4().is_some_and(|gw| gw == v4),
+        IpAddr::V6(v6) => shared.gateway_ipv6().is_some_and(|gw| gw == v6),
     }
 }
 
@@ -101,118 +138,285 @@ mod tests {
 
     use super::*;
 
+    /// SharedState with no gateway IPs — `Host` matching never fires.
+    fn no_host() -> SharedState {
+        SharedState::new(4)
+    }
+
+    /// SharedState wired with the canonical sandbox gateway IPs.
+    fn with_gateway() -> SharedState {
+        let s = SharedState::new(4);
+        s.set_gateway_ips(
+            Ipv4Addr::new(100, 96, 0, 1),
+            "fd42:6d73:62::1".parse().unwrap(),
+        );
+        s
+    }
+
     #[test]
-    fn test_loopback_v4() {
+    fn loopback_v4() {
+        let s = no_host();
         assert!(matches_group(
             DestinationGroup::Loopback,
-            IpAddr::V4(Ipv4Addr::LOCALHOST)
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            &s,
         ));
         assert!(matches_group(
             DestinationGroup::Loopback,
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            &s,
         ));
         assert!(!matches_group(
             DestinationGroup::Loopback,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            &s,
         ));
     }
 
     #[test]
-    fn test_loopback_v6() {
+    fn loopback_v6() {
+        let s = no_host();
         assert!(matches_group(
             DestinationGroup::Loopback,
-            IpAddr::V6(Ipv6Addr::LOCALHOST)
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            &s,
         ));
         assert!(!matches_group(
             DestinationGroup::Loopback,
-            IpAddr::V6("fe80::1".parse().unwrap())
+            IpAddr::V6("fe80::1".parse().unwrap()),
+            &s,
         ));
     }
 
     #[test]
-    fn test_private_v4() {
-        assert!(matches_group(
+    fn private_v4() {
+        let s = no_host();
+        for ip in [
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(172, 16, 0, 1),
+            Ipv4Addr::new(192, 168, 1, 1),
+            Ipv4Addr::new(100, 64, 0, 1),
+        ] {
+            assert!(matches_group(DestinationGroup::Private, IpAddr::V4(ip), &s));
+        }
+        assert!(!matches_group(
             DestinationGroup::Private,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            &s,
         ));
+    }
+
+    #[test]
+    fn private_v6_ula() {
+        let s = no_host();
         assert!(matches_group(
             DestinationGroup::Private,
-            IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))
-        ));
-        assert!(matches_group(
-            DestinationGroup::Private,
-            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))
-        ));
-        assert!(matches_group(
-            DestinationGroup::Private,
-            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))
+            IpAddr::V6("fd42:6d73:62:2a::1".parse().unwrap()),
+            &s,
         ));
         assert!(!matches_group(
             DestinationGroup::Private,
-            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))
+            IpAddr::V6("2001:db8::1".parse().unwrap()),
+            &s,
         ));
     }
 
     #[test]
-    fn test_private_v6_ula() {
-        assert!(matches_group(
-            DestinationGroup::Private,
-            IpAddr::V6("fd42:6d73:62:2a::1".parse().unwrap())
-        ));
-        assert!(!matches_group(
-            DestinationGroup::Private,
-            IpAddr::V6("2001:db8::1".parse().unwrap())
-        ));
-    }
-
-    #[test]
-    fn test_link_local() {
+    fn link_local() {
+        let s = no_host();
         assert!(matches_group(
             DestinationGroup::LinkLocal,
-            IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))
+            IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
+            &s,
         ));
         assert!(matches_group(
             DestinationGroup::LinkLocal,
-            IpAddr::V6("fe80::1".parse().unwrap())
+            IpAddr::V6("fe80::1".parse().unwrap()),
+            &s,
         ));
         assert!(!matches_group(
             DestinationGroup::LinkLocal,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            &s,
         ));
     }
 
     #[test]
-    fn test_metadata() {
+    fn metadata() {
+        let s = no_host();
         assert!(matches_group(
             DestinationGroup::Metadata,
-            IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))
+            IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
+            &s,
         ));
         assert!(!matches_group(
             DestinationGroup::Metadata,
-            IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))
+            IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
+            &s,
         ));
     }
 
+    /// `169.254.169.254` is in the link-local CIDR but classified as
+    /// `Metadata`. Groups are disjoint, so `LinkLocal` doesn't match
+    /// the metadata IP.
     #[test]
-    fn test_multicast() {
+    fn metadata_takes_precedence_over_link_local() {
+        let s = no_host();
+        let metadata_ip = IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254));
+        assert!(matches_group(DestinationGroup::Metadata, metadata_ip, &s));
+        assert!(!matches_group(DestinationGroup::LinkLocal, metadata_ip, &s));
+    }
+
+    #[test]
+    fn multicast() {
+        let s = no_host();
         assert!(matches_group(
             DestinationGroup::Multicast,
-            IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1))
+            IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+            &s,
         ));
         assert!(matches_group(
             DestinationGroup::Multicast,
-            IpAddr::V6("ff02::1".parse().unwrap())
+            IpAddr::V6("ff02::1".parse().unwrap()),
+            &s,
         ));
         assert!(!matches_group(
             DestinationGroup::Multicast,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            &s,
         ));
     }
 
     #[test]
-    fn test_cidr_match() {
+    fn cidr_match() {
         let net: IpNetwork = "10.0.0.0/8".parse().unwrap();
         assert!(matches_cidr(&net, IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))));
         assert!(!matches_cidr(&net, IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1))));
+    }
+
+    #[test]
+    fn public_v4_routable() {
+        let s = no_host();
+        for ip in [
+            Ipv4Addr::new(8, 8, 8, 8),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(151, 101, 0, 223),
+        ] {
+            assert!(matches_group(DestinationGroup::Public, IpAddr::V4(ip), &s));
+        }
+    }
+
+    #[test]
+    fn public_v6_routable() {
+        let s = no_host();
+        for ip in [
+            "2606:4700:4700::1111".parse().unwrap(),
+            "2001:db8::1".parse().unwrap(),
+        ] {
+            assert!(matches_group(DestinationGroup::Public, IpAddr::V6(ip), &s));
+        }
+    }
+
+    #[test]
+    fn public_excludes_other_categories() {
+        let s = no_host();
+        let not_public = [
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
+            IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V6("fd42:6d73:62:2a::1".parse().unwrap()),
+            IpAddr::V6("fe80::1".parse().unwrap()),
+            IpAddr::V6("ff02::1".parse().unwrap()),
+        ];
+        for ip in not_public {
+            assert!(
+                !matches_group(DestinationGroup::Public, ip, &s),
+                "expected {ip} to not be Public"
+            );
+        }
+    }
+
+    /// `Host` takes precedence over the static categories that would
+    /// otherwise claim the gateway IPs (CGNAT for IPv4, ULA for IPv6).
+    /// This means an `allow Public` rule won't accidentally allow host
+    /// traffic, and a `deny Private` rule won't accidentally cover the
+    /// host gateway either.
+    #[test]
+    fn host_takes_precedence_over_private() {
+        let s = with_gateway();
+        let v4 = IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1));
+        let v6 = IpAddr::V6("fd42:6d73:62::1".parse().unwrap());
+
+        assert!(matches_group(DestinationGroup::Host, v4, &s));
+        assert!(matches_group(DestinationGroup::Host, v6, &s));
+        assert!(!matches_group(DestinationGroup::Private, v4, &s));
+        assert!(!matches_group(DestinationGroup::Private, v6, &s));
+        assert!(!matches_group(DestinationGroup::Public, v4, &s));
+        assert!(!matches_group(DestinationGroup::Public, v6, &s));
+    }
+
+    /// Witness test: every `DestinationGroup` variant is producible by
+    /// the classifier given the right input. Adding a new variant
+    /// without wiring it into `addr_classify` makes this test fail
+    /// (the new variant has no witness IP).
+    #[test]
+    fn classifier_covers_every_destination_group() {
+        let s = with_gateway();
+        let cases: &[(IpAddr, DestinationGroup)] = &[
+            (
+                IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+                DestinationGroup::Public,
+            ),
+            (IpAddr::V4(Ipv4Addr::LOCALHOST), DestinationGroup::Loopback),
+            (
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                DestinationGroup::Private,
+            ),
+            (
+                IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
+                DestinationGroup::LinkLocal,
+            ),
+            (
+                IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
+                DestinationGroup::Metadata,
+            ),
+            (
+                IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+                DestinationGroup::Multicast,
+            ),
+            (
+                IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1)),
+                DestinationGroup::Host,
+            ),
+        ];
+
+        // Compile-time exhaustiveness check on the witness table:
+        // adding a new variant to `DestinationGroup` makes this match
+        // non-exhaustive, forcing the test author to add a witness row
+        // above. The runtime assertion below then verifies the witness
+        // actually maps to the new variant.
+        fn _exhaustive_witness_check(g: DestinationGroup) {
+            match g {
+                DestinationGroup::Public
+                | DestinationGroup::Loopback
+                | DestinationGroup::Private
+                | DestinationGroup::LinkLocal
+                | DestinationGroup::Metadata
+                | DestinationGroup::Multicast
+                | DestinationGroup::Host => (),
+            }
+        }
+
+        for (ip, expected) in cases {
+            assert_eq!(
+                addr_classify(*ip, &s),
+                *expected,
+                "expected {ip:?} to classify as {expected:?}"
+            );
+        }
     }
 }

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -1,4 +1,23 @@
 //! Policy types: rules, actions, destinations, and protocol matching.
+//!
+//! A [`NetworkPolicy`] is a single ordered rule list plus two direction-
+//! specific default actions. Each rule carries its direction
+//! ([`Direction`]) — `Egress`, `Ingress`, or `Both` — which determines
+//! which evaluator considers it. Rule lookup is first-match-wins per
+//! direction; if no rule of the right direction matches, the direction-
+//! specific default applies.
+//!
+//! The `Rule::destination` field is direction-dependent in interpretation.
+//! In an egress rule it matches the destination the guest is reaching;
+//! in an ingress rule it matches the source (peer) of the incoming
+//! connection. `Rule::ports` always refers to the guest-side port
+//! (destination for egress, listening port for ingress) — ingress does
+//! not filter by peer source port.
+//!
+//! [`Rule::protocols`] and [`Rule::ports`] are sets (Vecs); a rule
+//! matches if the packet's protocol is in `protocols` or `protocols` is
+//! empty (any-protocol), and likewise for ports. This compresses common
+//! cases like "TCP-or-UDP on 80-or-443 to Public" into a single rule.
 
 use std::net::{IpAddr, SocketAddr};
 
@@ -14,26 +33,36 @@ use super::name::DomainName;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Network policy with ordered rules.
+/// Network policy: single ordered rule list plus per-direction default actions.
 ///
-/// Rules are evaluated in first-match-wins order. If no rule matches,
-/// the default action is applied.
+/// Rules carry a [`Direction`] field that determines which evaluator
+/// considers them. Egress evaluation iterates rules where
+/// `direction ∈ {Egress, Both}`; ingress evaluation iterates rules where
+/// `direction ∈ {Ingress, Both}`. First-match-wins within a direction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkPolicy {
-    /// Default action for traffic not matching any rule.
-    #[serde(default)]
-    pub default_action: Action,
+    /// Default action for egress traffic not matching any rule.
+    /// `Deny` paired with an implicit allow-`Public` rule reproduces
+    /// today's "public internet only" reachability.
+    #[serde(default = "Action::deny")]
+    pub default_egress: Action,
 
-    /// Ordered list of rules (first match wins).
+    /// Default action for ingress traffic not matching any rule.
+    /// `Allow` so a sandbox publishing a port without an explicit
+    /// ingress rule still accepts traffic.
+    #[serde(default = "Action::allow")]
+    pub default_ingress: Action,
+
+    /// Ordered list of rules, evaluated first-match-wins per direction.
     #[serde(default)]
     pub rules: Vec<Rule>,
 }
 
 /// Action to take on matched traffic.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Action {
     /// Allow the traffic.
-    #[default]
     Allow,
 
     /// Silently drop.
@@ -41,34 +70,47 @@ pub enum Action {
 }
 
 /// A single network rule.
+///
+/// The `destination` field is direction-dependent: in an egress-direction
+/// rule, `destination` is what the guest is reaching; in an ingress-
+/// direction rule, `destination` is the source (peer) of the incoming
+/// connection. `Both`-direction rules apply in either path with the
+/// destination interpreted appropriately for each.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rule {
-    /// Traffic direction.
+    /// Direction this rule applies to: outbound, inbound, or either.
     pub direction: Direction,
 
-    /// Destination filter.
+    /// Destination filter. Direction-dependent interpretation.
     pub destination: Destination,
 
-    /// Protocol filter (None = any protocol).
+    /// Protocol set (empty = any protocol). The rule matches if the
+    /// packet's protocol is in this set.
     #[serde(default)]
-    pub protocol: Option<Protocol>,
+    pub protocols: Vec<Protocol>,
 
-    /// Port filter (None = any port).
+    /// Port-range set (empty = any port). Always the guest-side port:
+    /// destination port for egress, listening port for ingress.
     #[serde(default)]
-    pub ports: Option<PortRange>,
+    pub ports: Vec<PortRange>,
 
     /// Action to take.
     pub action: Action,
 }
 
-/// Traffic direction.
+/// Direction a rule applies to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Direction {
-    /// Outbound (guest → internet).
-    Outbound,
+    /// Outbound: guest → destination. Evaluated by `evaluate_egress`.
+    Egress,
 
-    /// Inbound (internet → guest).
-    Inbound,
+    /// Inbound: peer → guest. Evaluated by `evaluate_ingress`.
+    Ingress,
+
+    /// Either direction. The rule is matched by both evaluators
+    /// (egress and ingress).
+    Any,
 }
 
 /// Traffic destination specification.
@@ -79,6 +121,7 @@ pub enum Direction {
 /// can then rely on byte equality against the DNS cache's own
 /// canonical entries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Destination {
     /// Match any destination.
     Any,
@@ -100,15 +143,27 @@ pub enum Destination {
 }
 
 /// Pre-defined destination groups.
+///
+/// Categories are disjoint with one exception: `Metadata` is a single IP
+/// (`169.254.169.254`) that also falls inside the `LinkLocal` range.
+/// Membership order in [`matches_group`](super::destination::matches_group)
+/// gives `Metadata` precedence over `LinkLocal` for that IP. All other
+/// categories are disjoint; [`Public`](Self::Public) is defined as the
+/// complement of the other five.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DestinationGroup {
+    /// Public internet — any address not in one of the other categories.
+    Public,
+
     /// Loopback addresses (`127.0.0.0/8`, `::1`).
     Loopback,
 
-    /// Private IP ranges (RFC 1918 + RFC 4193 ULA).
+    /// Private IP ranges (RFC 1918 + RFC 4193 ULA + CGN).
     Private,
 
-    /// Link-local addresses (`169.254.0.0/16`, `fe80::/10`).
+    /// Link-local addresses (`169.254.0.0/16`, `fe80::/10`), excluding
+    /// the metadata IP which is categorized as [`Metadata`](Self::Metadata).
     LinkLocal,
 
     /// Cloud metadata endpoints (`169.254.169.254`).
@@ -125,6 +180,7 @@ pub enum DestinationGroup {
 
 /// Protocol filter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Protocol {
     /// TCP.
     Tcp,
@@ -154,53 +210,56 @@ pub struct PortRange {
 //--------------------------------------------------------------------------------------------------
 
 impl NetworkPolicy {
-    /// No network access — deny everything.
+    /// No network access — deny everything in both directions.
     pub fn none() -> Self {
         Self {
-            default_action: Action::Deny,
+            default_egress: Action::Deny,
+            default_ingress: Action::Deny,
             rules: vec![],
         }
     }
 
-    /// Unrestricted network access — allow everything.
+    /// Unrestricted network access — allow everything in both directions.
     pub fn allow_all() -> Self {
         Self {
-            default_action: Action::Allow,
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
             rules: vec![],
         }
     }
 
-    /// Public internet only — deny loopback, private, link-local, and
-    /// cloud metadata addresses.
+    /// Public internet only — allow egress to public IPs, deny private,
+    /// loopback, link-local, and metadata. Ingress defaults to allow
+    /// (preserves today's unfiltered published-port behavior).
     pub fn public_only() -> Self {
         Self {
-            default_action: Action::Allow,
-            rules: vec![
-                Rule::deny_outbound(Destination::Group(DestinationGroup::Loopback)),
-                Rule::deny_outbound(Destination::Group(DestinationGroup::Private)),
-                Rule::deny_outbound(Destination::Group(DestinationGroup::LinkLocal)),
-                Rule::deny_outbound(Destination::Group(DestinationGroup::Metadata)),
-            ],
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress(Destination::Group(
+                DestinationGroup::Public,
+            ))],
         }
     }
 
-    /// Non-local network access — allow public internet and private/LAN addresses,
-    /// but deny loopback, link-local, and cloud metadata addresses.
+    /// Non-local network access — allow public internet and private/LAN
+    /// egress; deny loopback, link-local, and metadata. Ingress defaults
+    /// to allow.
     pub fn non_local() -> Self {
         Self {
-            default_action: Action::Allow,
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
             rules: vec![
-                Rule::deny_outbound(Destination::Group(DestinationGroup::Loopback)),
-                Rule::deny_outbound(Destination::Group(DestinationGroup::LinkLocal)),
-                Rule::deny_outbound(Destination::Group(DestinationGroup::Metadata)),
+                Rule::allow_egress(Destination::Group(DestinationGroup::Public)),
+                Rule::allow_egress(Destination::Group(DestinationGroup::Private)),
             ],
         }
     }
 
-    /// Evaluate an outbound connection against the policy.
+    /// Evaluate an outbound connection against the rule list.
     ///
-    /// Returns the action from the first matching rule, or the default
-    /// action if no rule matches.
+    /// Iterates rules in order, considering only rules where
+    /// `direction ∈ {Egress, Any}`. Returns the action from the first
+    /// matching rule, or `default_egress` if no rule matches.
     pub fn evaluate_egress(
         &self,
         dst: SocketAddr,
@@ -208,31 +267,21 @@ impl NetworkPolicy {
         shared: &SharedState,
     ) -> Action {
         for rule in &self.rules {
-            if rule.direction != Direction::Outbound {
+            if !matches!(rule.direction, Direction::Egress | Direction::Any) {
                 continue;
             }
-            if let Some(ref rule_proto) = rule.protocol
-                && *rule_proto != protocol
-            {
-                continue;
-            }
-            if let Some(ref ports) = rule.ports
-                && !ports.contains(dst.port())
-            {
-                continue;
-            }
-            if !matches_destination(&rule.destination, dst.ip(), shared) {
+            if !rule_matches(rule, dst.ip(), Some(dst.port()), protocol, shared) {
                 continue;
             }
             return rule.action;
         }
-        self.default_action
+        self.default_egress
     }
 
-    /// Evaluate an outbound ICMP packet against the policy.
+    /// Evaluate an outbound ICMP packet against the rule list.
     ///
-    /// Same first-match-wins logic as [`Self::evaluate_egress`] but without port
-    /// matching — ICMP has no ports. Rules with a `ports` filter are
+    /// Same as [`Self::evaluate_egress`] but without port matching —
+    /// ICMP has no ports. Rules with a non-empty `ports` filter are
     /// skipped since applying a port range to a portless protocol would
     /// be semantically incorrect.
     pub fn evaluate_egress_ip(
@@ -242,23 +291,45 @@ impl NetworkPolicy {
         shared: &SharedState,
     ) -> Action {
         for rule in &self.rules {
-            if rule.direction != Direction::Outbound {
+            if !matches!(rule.direction, Direction::Egress | Direction::Any) {
                 continue;
             }
-            if let Some(ref rule_proto) = rule.protocol
-                && *rule_proto != protocol
-            {
+            if !rule.ports.is_empty() {
                 continue;
             }
-            if rule.ports.is_some() {
-                continue;
-            }
-            if !matches_destination(&rule.destination, dst, shared) {
+            if !rule_matches(rule, dst, None, protocol, shared) {
                 continue;
             }
             return rule.action;
         }
-        self.default_action
+        self.default_egress
+    }
+
+    /// Evaluate an inbound connection against the rule list.
+    ///
+    /// Iterates rules in order, considering only rules where
+    /// `direction ∈ {Ingress, Any}`. `peer` is the source of the
+    /// incoming connection (peer IP and source port — only the IP is
+    /// matched). `guest_port` is the guest-side listening port; rules'
+    /// `ports` filter is matched against `guest_port`, not the peer's
+    /// port.
+    pub fn evaluate_ingress(
+        &self,
+        peer: SocketAddr,
+        guest_port: u16,
+        protocol: Protocol,
+        shared: &SharedState,
+    ) -> Action {
+        for rule in &self.rules {
+            if !matches!(rule.direction, Direction::Ingress | Direction::Any) {
+                continue;
+            }
+            if !rule_matches(rule, peer.ip(), Some(guest_port), protocol, shared) {
+                continue;
+            }
+            return rule.action;
+        }
+        self.default_ingress
     }
 }
 
@@ -272,6 +343,16 @@ impl Action {
     pub fn is_deny(self) -> bool {
         matches!(self, Action::Deny)
     }
+
+    /// Helper for `#[serde(default)]` — returns [`Action::Allow`].
+    pub fn allow() -> Self {
+        Action::Allow
+    }
+
+    /// Helper for `#[serde(default)]` — returns [`Action::Deny`].
+    pub fn deny() -> Self {
+        Action::Deny
+    }
 }
 
 impl Default for NetworkPolicy {
@@ -281,22 +362,42 @@ impl Default for NetworkPolicy {
 }
 
 impl Rule {
-    /// Convenience: allow outbound to a destination.
-    pub fn allow_outbound(destination: Destination) -> Self {
-        Self::outbound(destination, Action::Allow)
+    /// Convenience: allow rule for egress, any protocol, any port.
+    pub fn allow_egress(destination: Destination) -> Self {
+        Self::new(Direction::Egress, destination, Action::Allow)
     }
 
-    /// Convenience: deny outbound to a destination.
-    pub fn deny_outbound(destination: Destination) -> Self {
-        Self::outbound(destination, Action::Deny)
+    /// Convenience: deny rule for egress, any protocol, any port.
+    pub fn deny_egress(destination: Destination) -> Self {
+        Self::new(Direction::Egress, destination, Action::Deny)
     }
 
-    fn outbound(destination: Destination, action: Action) -> Self {
+    /// Convenience: allow rule for ingress, any protocol, any port.
+    pub fn allow_ingress(destination: Destination) -> Self {
+        Self::new(Direction::Ingress, destination, Action::Allow)
+    }
+
+    /// Convenience: deny rule for ingress, any protocol, any port.
+    pub fn deny_ingress(destination: Destination) -> Self {
+        Self::new(Direction::Ingress, destination, Action::Deny)
+    }
+
+    /// Convenience: allow rule for either direction, any protocol, any port.
+    pub fn allow_any(destination: Destination) -> Self {
+        Self::new(Direction::Any, destination, Action::Allow)
+    }
+
+    /// Convenience: deny rule for either direction, any protocol, any port.
+    pub fn deny_any(destination: Destination) -> Self {
+        Self::new(Direction::Any, destination, Action::Deny)
+    }
+
+    fn new(direction: Direction, destination: Destination, action: Action) -> Self {
         Self {
-            direction: Direction::Outbound,
+            direction,
             destination,
-            protocol: None,
-            ports: None,
+            protocols: Vec::new(),
+            ports: Vec::new(),
             action,
         }
     }
@@ -326,29 +427,46 @@ impl PortRange {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
+/// Internal helper: does this rule match a flow's address/port/protocol?
+///
+/// The direction filter is applied by the caller (`evaluate_egress` /
+/// `evaluate_ingress`). This function checks only protocol set, port
+/// set, and destination match.
+fn rule_matches(
+    rule: &Rule,
+    addr: IpAddr,
+    port: Option<u16>,
+    protocol: Protocol,
+    shared: &SharedState,
+) -> bool {
+    if !rule.protocols.is_empty() && !rule.protocols.contains(&protocol) {
+        return false;
+    }
+    if !rule.ports.is_empty() {
+        let Some(p) = port else {
+            // Caller doesn't have a port (ICMP path). Skip rules that
+            // require a port match.
+            return false;
+        };
+        if !rule.ports.iter().any(|range| range.contains(p)) {
+            return false;
+        }
+    }
+    matches_destination(&rule.destination, addr, shared)
+}
+
 /// Check if an IP address matches a destination specification.
 fn matches_destination(dest: &Destination, addr: IpAddr, shared: &SharedState) -> bool {
     match dest {
         Destination::Any => true,
         Destination::Cidr(network) => matches_cidr(network, addr),
-        Destination::Group(DestinationGroup::Host) => matches_host(addr, shared),
-        Destination::Group(group) => matches_group(*group, addr),
+        Destination::Group(group) => matches_group(*group, addr, shared),
         Destination::Domain(domain) => {
             shared.any_resolved_hostname(addr, |hostname| hostname == domain.as_str())
         }
         Destination::DomainSuffix(suffix) => {
             shared.any_resolved_hostname(addr, |hostname| matches_suffix(hostname, suffix.as_str()))
         }
-    }
-}
-
-/// Matches the per-sandbox gateway IPs carried by [`SharedState`]. Returns
-/// `false` when gateway IPs haven't been set (e.g. isolated unit tests
-/// that don't exercise Host rules).
-fn matches_host(addr: IpAddr, shared: &SharedState) -> bool {
-    match addr {
-        IpAddr::V4(v4) => shared.gateway_ipv4().is_some_and(|gw| gw == v4),
-        IpAddr::V6(v6) => shared.gateway_ipv6().is_some_and(|gw| gw == v6),
     }
 }
 
@@ -418,8 +536,9 @@ mod tests {
 
     fn allow_rule(dest: Destination) -> NetworkPolicy {
         NetworkPolicy {
-            default_action: Action::Deny,
-            rules: vec![Rule::allow_outbound(dest)],
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress(dest)],
         }
     }
 
@@ -427,10 +546,10 @@ mod tests {
     /// used by the multi-rule default-deny scenarios below.
     fn allow_domain_tcp_443(domain: &str) -> Rule {
         Rule {
-            direction: Direction::Outbound,
+            direction: Direction::Egress,
             destination: Destination::Domain(domain.parse().unwrap()),
-            protocol: Some(Protocol::Tcp),
-            ports: Some(PortRange::single(443)),
+            protocols: vec![Protocol::Tcp],
+            ports: vec![PortRange::single(443)],
             action: Action::Allow,
         }
     }
@@ -490,12 +609,13 @@ mod tests {
         let shared = shared_with_host("pypi.org", PYPI_V4);
         let policy: NetworkPolicy = serde_json::from_str(
             r#"{
-                "default_action": "Deny",
+                "default_egress": "deny",
+                "default_ingress": "allow",
                 "rules": [
                     {
-                        "direction": "Outbound",
-                        "destination": { "Domain": "PyPI.Org." },
-                        "action": "Allow"
+                        "direction": "egress",
+                        "destination": { "domain": "PyPI.Org." },
+                        "action": "allow"
                     }
                 ]
             }"#,
@@ -520,7 +640,8 @@ mod tests {
         );
 
         let policy = NetworkPolicy {
-            default_action: Action::Deny,
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
             rules: vec![
                 allow_domain_tcp_443("pypi.org"),
                 allow_domain_tcp_443("files.pythonhosted.org"),
@@ -583,14 +704,15 @@ mod tests {
     fn allow_rule_before_deny_wins_on_shared_ip() {
         let shared = shared_with_host("pypi.org", PYPI_V4);
         let policy = NetworkPolicy {
-            default_action: Action::Deny,
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
             rules: vec![
-                Rule::allow_outbound(Destination::Domain("pypi.org".parse().unwrap())),
+                Rule::allow_egress(Destination::Domain("pypi.org".parse().unwrap())),
                 Rule {
-                    direction: Direction::Outbound,
+                    direction: Direction::Egress,
                     destination: Destination::Cidr("151.101.0.0/16".parse().unwrap()),
-                    protocol: None,
-                    ports: None,
+                    protocols: Vec::new(),
+                    ports: Vec::new(),
                     action: Action::Deny,
                 },
             ],
@@ -604,12 +726,13 @@ mod tests {
     fn udp_egress_consults_domain_cache() {
         let shared = shared_with_host("pypi.org", PYPI_V4);
         let policy = NetworkPolicy {
-            default_action: Action::Deny,
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
             rules: vec![Rule {
-                direction: Direction::Outbound,
+                direction: Direction::Egress,
                 destination: Destination::Domain("pypi.org".parse().unwrap()),
-                protocol: Some(Protocol::Udp),
-                ports: Some(PortRange::single(443)),
+                protocols: vec![Protocol::Udp],
+                ports: vec![PortRange::single(443)],
                 action: Action::Allow,
             }],
         };
@@ -643,8 +766,9 @@ mod tests {
     fn group_host_matches_gateway_v4() {
         let (shared, gw4, _) = shared_with_gateway();
         let policy = NetworkPolicy {
-            default_action: Action::Allow,
-            rules: vec![Rule::deny_outbound(Destination::Group(
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_egress(Destination::Group(
                 DestinationGroup::Host,
             ))],
         };
@@ -659,8 +783,9 @@ mod tests {
     fn group_host_matches_gateway_v6() {
         let (shared, _, gw6) = shared_with_gateway();
         let policy = NetworkPolicy {
-            default_action: Action::Allow,
-            rules: vec![Rule::deny_outbound(Destination::Group(
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_egress(Destination::Group(
                 DestinationGroup::Host,
             ))],
         };
@@ -675,8 +800,9 @@ mod tests {
     fn group_host_does_not_match_other_ips() {
         let (shared, _, _) = shared_with_gateway();
         let policy = NetworkPolicy {
-            default_action: Action::Allow,
-            rules: vec![Rule::deny_outbound(Destination::Group(
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_egress(Destination::Group(
                 DestinationGroup::Host,
             ))],
         };
@@ -724,7 +850,7 @@ mod tests {
         let mut policy = NetworkPolicy::public_only();
         policy.rules.insert(
             0,
-            Rule::allow_outbound(Destination::Group(DestinationGroup::Host)),
+            Rule::allow_egress(Destination::Group(DestinationGroup::Host)),
         );
 
         let v4 = SocketAddr::new(IpAddr::V4(gw4), 80);
@@ -739,5 +865,218 @@ mod tests {
             Action::Deny,
             "non-host private destinations should still be blocked"
         );
+    }
+
+    /// Ingress default is Allow; empty ingress-applicable rules means
+    /// all inbound traffic is permitted (today's unfiltered published-
+    /// port behavior).
+    #[test]
+    fn default_ingress_allows_unfiltered_with_no_rules() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy::default();
+        let peer = sock("198.51.100.10", 54321);
+        assert!(
+            policy
+                .evaluate_ingress(peer, 8080, Protocol::Tcp, &shared)
+                .is_allow()
+        );
+    }
+
+    /// Single rule with `direction: Ingress` only fires for ingress
+    /// evaluation, never for egress.
+    #[test]
+    fn ingress_rule_does_not_fire_on_egress() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Deny,
+            rules: vec![Rule::allow_ingress(Destination::Group(
+                DestinationGroup::Private,
+            ))],
+        };
+        // Egress to a private IP: ingress rule doesn't apply, falls to default_egress = Deny.
+        assert!(
+            policy
+                .evaluate_egress(sock("10.0.0.5", 443), Protocol::Tcp, &shared)
+                .is_deny()
+        );
+        // Ingress from a private peer: rule fires, allowed.
+        assert!(
+            policy
+                .evaluate_ingress(sock("10.0.0.5", 54321), 8080, Protocol::Tcp, &shared)
+                .is_allow()
+        );
+    }
+
+    /// `Direction::Any` rule fires for evaluation in either direction.
+    #[test]
+    fn any_direction_rule_matches_egress_and_ingress() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_any(Destination::Cidr(
+                "1.2.3.4/32".parse().unwrap(),
+            ))],
+        };
+        // Egress to 1.2.3.4: Any rule fires.
+        assert!(
+            policy
+                .evaluate_egress(sock("1.2.3.4", 443), Protocol::Tcp, &shared)
+                .is_deny()
+        );
+        // Ingress from 1.2.3.4: Any rule fires.
+        assert!(
+            policy
+                .evaluate_ingress(sock("1.2.3.4", 54321), 8080, Protocol::Tcp, &shared)
+                .is_deny()
+        );
+        // Egress to a different IP: rule doesn't match, falls to default_egress = Allow.
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 443), Protocol::Tcp, &shared)
+                .is_allow()
+        );
+    }
+
+    /// Wire-format casing: every field name and enum tag must serialize
+    /// in snake_case, and the serializer's output must round-trip back to
+    /// an equivalent value.
+    #[test]
+    fn serde_round_trip_uses_snake_case() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![
+                Rule {
+                    direction: Direction::Egress,
+                    destination: Destination::Group(DestinationGroup::LinkLocal),
+                    protocols: vec![Protocol::Tcp, Protocol::Icmpv4],
+                    ports: vec![],
+                    action: Action::Allow,
+                },
+                Rule {
+                    direction: Direction::Any,
+                    destination: Destination::DomainSuffix(".example.com".parse().unwrap()),
+                    protocols: vec![],
+                    ports: vec![],
+                    action: Action::Deny,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&policy).unwrap();
+
+        // Field names: snake_case directly from Rust source (no rename needed).
+        assert!(json.contains("\"default_egress\""), "JSON: {json}");
+        assert!(json.contains("\"default_ingress\""), "JSON: {json}");
+        // Enum tags: snake_case via rename_all on each enum.
+        assert!(json.contains("\"egress\""), "JSON: {json}");
+        assert!(json.contains("\"any\""), "JSON: {json}");
+        assert!(json.contains("\"allow\""), "JSON: {json}");
+        assert!(json.contains("\"deny\""), "JSON: {json}");
+        assert!(json.contains("\"link_local\""), "JSON: {json}");
+        assert!(json.contains("\"domain_suffix\""), "JSON: {json}");
+        assert!(json.contains("\"icmpv4\""), "JSON: {json}");
+        assert!(json.contains("\"tcp\""), "JSON: {json}");
+        // No PascalCase residue.
+        assert!(!json.contains("\"Egress\""), "JSON: {json}");
+        assert!(!json.contains("\"Allow\""), "JSON: {json}");
+        assert!(!json.contains("\"LinkLocal\""), "JSON: {json}");
+        assert!(!json.contains("\"DomainSuffix\""), "JSON: {json}");
+        // No camelCase residue.
+        assert!(!json.contains("\"linkLocal\""), "JSON: {json}");
+        assert!(!json.contains("\"domainSuffix\""), "JSON: {json}");
+        assert!(!json.contains("\"defaultEgress\""), "JSON: {json}");
+
+        // Round-trip back: must parse and produce a structurally equivalent value.
+        let back: NetworkPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.rules.len(), policy.rules.len());
+        assert!(matches!(back.default_egress, Action::Deny));
+        assert!(matches!(back.default_ingress, Action::Allow));
+        assert!(matches!(back.rules[0].direction, Direction::Egress));
+        assert!(matches!(back.rules[1].direction, Direction::Any));
+    }
+
+    /// Multi-protocol rule: TCP-or-UDP both match.
+    #[test]
+    fn multi_protocol_rule_matches_any_listed() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule {
+                direction: Direction::Egress,
+                destination: Destination::Group(DestinationGroup::Public),
+                protocols: vec![Protocol::Tcp, Protocol::Udp],
+                ports: vec![PortRange::single(443)],
+                action: Action::Allow,
+            }],
+        };
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 443), Protocol::Tcp, &shared)
+                .is_allow()
+        );
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 443), Protocol::Udp, &shared)
+                .is_allow()
+        );
+        // Different protocol — doesn't match, falls to default_egress.
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 443), Protocol::Icmpv4, &shared)
+                .is_deny()
+        );
+    }
+
+    /// Multi-port rule: 80 OR 443 both match.
+    #[test]
+    fn multi_port_rule_matches_any_listed() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule {
+                direction: Direction::Egress,
+                destination: Destination::Group(DestinationGroup::Public),
+                protocols: vec![Protocol::Tcp],
+                ports: vec![PortRange::single(80), PortRange::single(443)],
+                action: Action::Allow,
+            }],
+        };
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 80), Protocol::Tcp, &shared)
+                .is_allow()
+        );
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 443), Protocol::Tcp, &shared)
+                .is_allow()
+        );
+        // Different port — doesn't match, falls to default_egress.
+        assert!(
+            policy
+                .evaluate_egress(sock("8.8.8.8", 8080), Protocol::Tcp, &shared)
+                .is_deny()
+        );
+    }
+
+    /// The `Public` group matches IPs that are not in any of the other
+    /// categories.
+    #[test]
+    fn public_group_matches_complement_of_other_categories() {
+        let shared = SharedState::new(4);
+        let policy = allow_rule(Destination::Group(DestinationGroup::Public));
+
+        // Public IPs (8.8.8.8, an arbitrary non-private routable) are allowed.
+        assert!(egress_tcp(&policy, "8.8.8.8", &shared).is_allow());
+        // Private IPs are not in Public.
+        assert!(egress_tcp(&policy, "10.0.0.5", &shared).is_deny());
+        // Loopback is not in Public.
+        assert!(egress_tcp(&policy, "127.0.0.1", &shared).is_deny());
+        // Metadata is not in Public.
+        assert!(egress_tcp(&policy, "169.254.169.254", &shared).is_deny());
     }
 }

--- a/sdk/node-ts/lib/sandbox.rs
+++ b/sdk/node-ts/lib/sandbox.rs
@@ -569,10 +569,12 @@ async fn convert_config(config: SandboxConfig) -> Result<RustSandboxConfig> {
                     Some("deny") => Action::Deny,
                     _ => Action::Allow,
                 };
-                let rust_rules: Vec<_> = rules.iter().filter_map(convert_policy_rule).collect();
+                // TODO: replace this shim with a per-direction TS API.
+                let parsed_rules: Vec<_> = rules.iter().filter_map(convert_policy_rule).collect();
                 n = n.policy(NetworkPolicy {
-                    default_action,
-                    rules: rust_rules,
+                    default_egress: default_action,
+                    default_ingress: default_action,
+                    rules: parsed_rules,
                 });
             } else if let Some(ref policy) = network.policy {
                 n = n.policy(match policy.as_str() {
@@ -870,14 +872,19 @@ fn sandbox_handle_to_info(handle: &microsandbox::sandbox::SandboxHandle) -> Sand
     }
 }
 
+/// Convert a TS-side rule into the new single-list `Rule` shape with
+/// per-rule direction. The TS-side `direction` field accepts `"egress"`,
+/// `"ingress"`, `"any"`, or the legacy `"outbound"` / `"inbound"` aliases.
 fn convert_policy_rule(rule: &PolicyRule) -> Option<Rule> {
     let action = match rule.action.as_str() {
         "deny" => Action::Deny,
         _ => Action::Allow,
     };
     let direction = match rule.direction.as_deref() {
-        Some("inbound") => Direction::Inbound,
-        _ => Direction::Outbound,
+        Some("ingress") | Some("inbound") => Direction::Ingress,
+        Some("any") => Direction::Any,
+        // Default and "egress" / "outbound" map to Egress.
+        _ => Direction::Egress,
     };
     let destination = match rule.destination.as_deref() {
         Some("*") | None => Destination::Any,
@@ -887,6 +894,7 @@ fn convert_policy_rule(rule: &PolicyRule) -> Option<Rule> {
         Some("metadata") => Destination::Group(DestinationGroup::Metadata),
         Some("multicast") => Destination::Group(DestinationGroup::Multicast),
         Some("host") => Destination::Group(DestinationGroup::Host),
+        Some("public") => Destination::Group(DestinationGroup::Public),
         Some(s) if s.starts_with('.') => Destination::DomainSuffix(s.parse().ok()?),
         Some(s) if s.contains('/') => {
             // CIDR notation
@@ -897,24 +905,30 @@ fn convert_policy_rule(rule: &PolicyRule) -> Option<Rule> {
         }
         Some(s) => Destination::Domain(s.parse().ok()?),
     };
-    let protocol = rule.protocol.as_deref().map(|p| match p {
-        "udp" => Protocol::Udp,
-        "icmpv4" => Protocol::Icmpv4,
-        "icmpv6" => Protocol::Icmpv6,
-        _ => Protocol::Tcp,
-    });
-    let ports = rule.port.as_deref().and_then(|p| {
-        if let Some((start, end)) = p.split_once('-') {
-            Some(PortRange::range(start.parse().ok()?, end.parse().ok()?))
-        } else {
-            Some(PortRange::single(p.parse().ok()?))
+    let protocols = match rule.protocol.as_deref() {
+        Some(p) => vec![match p {
+            "udp" => Protocol::Udp,
+            "icmpv4" => Protocol::Icmpv4,
+            "icmpv6" => Protocol::Icmpv6,
+            _ => Protocol::Tcp,
+        }],
+        None => Vec::new(),
+    };
+    let ports = match rule.port.as_deref() {
+        Some(p) => {
+            if let Some((start, end)) = p.split_once('-') {
+                vec![PortRange::range(start.parse().ok()?, end.parse().ok()?)]
+            } else {
+                vec![PortRange::single(p.parse().ok()?)]
+            }
         }
-    });
+        None => Vec::new(),
+    };
 
     Some(Rule {
         direction,
         destination,
-        protocol,
+        protocols,
         ports,
         action,
     })

--- a/sdk/node-ts/tests/smoke.test.ts
+++ b/sdk/node-ts/tests/smoke.test.ts
@@ -10,7 +10,7 @@ describe("Node.js SDK Smoke Tests", () => {
 	beforeAll(async () => {
 		sandbox = await Sandbox.create({
 			name: SANDBOX_NAME,
-			image: "alpine",
+			image: "mirror.gcr.io/library/alpine",
 			cpus: 1,
 			memoryMib: 512,
 			replace: true,

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -396,7 +396,8 @@ fn apply_network(
             }
         };
 
-        let mut rules = Vec::new();
+        // TODO: replace this shim with a per-direction Python API.
+        let mut rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
         if let Some(rules_obj) = cp_dict.get_item("rules")?
             && !rules_obj.is_none()
         {
@@ -416,8 +417,9 @@ fn apply_network(
                 let direction_str: String =
                     extract_opt(&rd, "direction")?.unwrap_or_else(|| "egress".to_string());
                 let direction = match direction_str.as_str() {
-                    "egress" => microsandbox_network::policy::Direction::Outbound,
-                    "ingress" => microsandbox_network::policy::Direction::Inbound,
+                    "egress" => microsandbox_network::policy::Direction::Egress,
+                    "ingress" => microsandbox_network::policy::Direction::Ingress,
+                    "any" => microsandbox_network::policy::Direction::Any,
                     _ => {
                         return Err(pyo3::exceptions::PyValueError::new_err(format!(
                             "unknown direction: {direction_str}"
@@ -428,6 +430,9 @@ fn apply_network(
                 {
                     match dest_str.as_str() {
                         "*" => microsandbox_network::policy::Destination::Any,
+                        "public" => microsandbox_network::policy::Destination::Group(
+                            microsandbox_network::policy::DestinationGroup::Public,
+                        ),
                         "loopback" => microsandbox_network::policy::Destination::Group(
                             microsandbox_network::policy::DestinationGroup::Loopback,
                         ),
@@ -474,8 +479,8 @@ fn apply_network(
                 } else {
                     microsandbox_network::policy::Destination::Any
                 };
-                let protocol = if let Some(proto_str) = extract_opt::<String>(&rd, "protocol")? {
-                    Some(match proto_str.as_str() {
+                let protocols = if let Some(proto_str) = extract_opt::<String>(&rd, "protocol")? {
+                    let proto = match proto_str.as_str() {
                         "tcp" => microsandbox_network::policy::Protocol::Tcp,
                         "udp" => microsandbox_network::policy::Protocol::Udp,
                         "icmpv4" => microsandbox_network::policy::Protocol::Icmpv4,
@@ -485,23 +490,24 @@ fn apply_network(
                                 "unknown protocol: {proto_str}"
                             )));
                         }
-                    })
+                    };
+                    vec![proto]
                 } else {
-                    None
+                    Vec::new()
                 };
                 let ports = if let Some(port_val) = extract_opt::<String>(&rd, "port")? {
                     if let Ok(p) = port_val.parse::<u16>() {
-                        Some(microsandbox_network::policy::PortRange { start: p, end: p })
+                        vec![microsandbox_network::policy::PortRange { start: p, end: p }]
                     } else {
-                        None
+                        Vec::new()
                     }
                 } else {
-                    None
+                    Vec::new()
                 };
                 rules.push(microsandbox_network::policy::Rule {
                     direction,
                     destination,
-                    protocol,
+                    protocols,
                     ports,
                     action,
                 });
@@ -509,7 +515,8 @@ fn apply_network(
         }
 
         let policy = NetworkPolicy {
-            default_action,
+            default_egress: default_action,
+            default_ingress: default_action,
             rules,
         };
         builder = builder.network(|n| n.policy(policy));


### PR DESCRIPTION
first of four stacked PRs that together replace #615.

## what's in this pr

reworks the policy schema into a single ordered rules list with per-rule direction. legacy preset constructors stay as compat shims — cli surface and sdk presets still work after this lands.

- `NetworkPolicy { default_egress, default_ingress, rules: Vec<Rule> }` (was `default_action + rules`)
- each `Rule` carries its own `direction: Direction` (`Egress`, `Ingress`, or `Any`)
- `Rule.protocols: Vec<Protocol>` and `Rule.ports: Vec<PortRange>` are sets (empty = any)
- `DestinationGroup::Public` (complement of named categories)
- snake_case serde across every enum (`"egress"`, `"link_local"`, `"domain_suffix"`, `"tcp"`, ...)

legacy presets (`NetworkPolicy::public_only()`, `non_local()`, `allow_all()`, `none()`) are kept as compat shims that produce the new shape. sdk conversion paths (`sdk/{node-ts,python}`) ported. existing test fixtures (`domain_policy.rs`, `dns_matrix/sandbox.rs`, `forwarder.rs`, `host_access.rs` helpers) ported.

## what's not in this pr

| pr | scope |
| --- | --- |
| 2/4 | `NetworkPolicy::builder()` rust fluent api + `DnsBuilder` lazy-accumulate retrofit |
| 3/4 | `--net-rule` cli grammar + parser + flag wiring |
| 4/4 | ingress enforcement gate at `publisher.rs` |

## breaking changes (0.4)

- on-disk `network.json` from older binaries not deserializable
- `Direction::Outbound`/`Inbound` renamed to `Egress`/`Ingress`
- `Rule.protocol: Option<_>` and `Rule.ports: Option<_>` became `Vec<_>`
- `default_action` split into `default_egress` + `default_ingress`

## test plan

- [ ] `cargo test --workspace --lib` (already green locally)
- [ ] verify legacy `--network-policy public-only` still works (preset shim path)
- [ ] verify the snake_case wire format via the round-trip test in `policy/types.rs`