### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Build Node SDK
         working-directory: sdk/node-ts
-        run: npm install && npm run build
+        run: npm ci && npm run build
 
       # -- Checks (Python SDK) --
       - uses: astral-sh/setup-uv@v3
@@ -425,7 +425,7 @@ jobs:
       # -- Install deps & run tests --
       - name: Install Node.js dependencies
         working-directory: sdk/node-ts
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Run SDK smoke tests
         working-directory: sdk/node-ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Build Node SDK
         working-directory: sdk/node-ts
         run: |
-          npm install
+          npm ci
           npm run build -- --target ${{ matrix.napi_target }}
 
       - name: Upload Node SDK artifacts
@@ -385,6 +385,45 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: sdk/node-ts
         run: npm publish --access public
+
+  # ---------------------------------------------------------------------------
+  # Refresh sdk/node-ts/package-lock.json against the just-published platform
+  # packages, so main always has lockfile integrity hashes that satisfy
+  # `npm ci`. Opens a PR that the maintainer merges manually.
+  # ---------------------------------------------------------------------------
+  refresh-lockfile:
+    name: Refresh npm lockfile
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Wait for npm to index platform packages
+        run: sleep 60
+
+      - name: Regenerate lockfile
+        working-directory: sdk/node-ts
+        run: npm install --package-lock-only --ignore-scripts
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          title: "chore: refresh npm lockfile after ${{ github.ref_name }}"
+          body: |
+            Regenerates `sdk/node-ts/package-lock.json` against the platform packages published for ${{ github.ref_name }}, so `npm ci` keeps working on main.
+          branch: refresh-lockfile-${{ github.ref_name }}
+          commit-message: "chore: refresh npm lockfile after ${{ github.ref_name }}"
+          base: main
+          add-paths: sdk/node-ts/package-lock.json
+          delete-branch: true
 
   # ---------------------------------------------------------------------------
   # Publish MCP server to npm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2615,14 +2615,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2662,14 +2662,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "core-foundation 0.9.4",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "futures",
  "ipnetwork",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "libc",
  "scopeguard",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "test-macros"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.3.14"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.3.14"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
+microsandbox-protocol = { version = "0.4.0", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,12 +36,12 @@ dirs.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.3.14", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.3.14", path = "../image" }
-microsandbox-network = { version = "0.3.14", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
-microsandbox-runtime = { version = "0.3.14", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox = { version = "0.4.0", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.4.0", path = "../image" }
+microsandbox-network = { version = "0.4.0", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.0", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.0", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 rand.workspace = true
 reqwest.workspace = true
 rpassword.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 msb_krun = "0.1.11"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -30,14 +30,14 @@ dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.3.14", path = "../db" }
-microsandbox-filesystem = { version = "0.3.14", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.3.14", path = "../image" }
-microsandbox-migration = { version = "0.3.14", path = "../migration" }
-microsandbox-network = { version = "0.3.14", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
-microsandbox-runtime = { version = "0.3.14", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox-db = { version = "0.4.0", path = "../db" }
+microsandbox-filesystem = { version = "0.4.0", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.4.0", path = "../image" }
+microsandbox-migration = { version = "0.4.0", path = "../migration" }
+microsandbox-network = { version = "0.4.0", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.0", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.0", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true

--- a/crates/microsandbox/README.md
+++ b/crates/microsandbox/README.md
@@ -30,7 +30,7 @@ Lightweight VM sandboxes for running AI agents and untrusted code with hardware-
 
 ```toml
 [dependencies]
-microsandbox = "0.3"
+microsandbox = "0.4"
 ```
 
 ### Cargo Features
@@ -44,7 +44,7 @@ To disable networking:
 
 ```toml
 [dependencies]
-microsandbox = { version = "0.3", default-features = false, features = ["prebuilt"] }
+microsandbox = { version = "0.4", default-features = false, features = ["prebuilt"] }
 ```
 
 ## Quick Start

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,8 +23,8 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox-protocol = { version = "0.4.0", path = "../protocol" }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 msb_krun = { version = "0.1.11", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.3.14", path = "../db" }
-microsandbox-filesystem = { version = "0.3.14", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.3.14", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.3.14", path = "../protocol" }
-microsandbox-utils = { version = "0.3.14", path = "../utils" }
+microsandbox-db = { version = "0.4.0", path = "../db" }
+microsandbox-filesystem = { version = "0.4.0", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.4.0", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.0", path = "../protocol" }
+microsandbox-utils = { version = "0.4.0", path = "../utils" }
 msb_krun = { version = "0.1.11", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/docs/recipes/docker.mdx
+++ b/docs/recipes/docker.mdx
@@ -24,7 +24,7 @@ docker pull ghcr.io/superradcompany/microsandbox:latest
 Or pin to a specific version:
 
 ```bash
-docker pull ghcr.io/superradcompany/microsandbox:0.3.14
+docker pull ghcr.io/superradcompany/microsandbox:0.4.0
 ```
 
 ## Run a sandbox
@@ -53,5 +53,5 @@ docker run --privileged --device /dev/kvm \
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest release |
-| `x.y.z` (e.g. `0.3.14`) | Specific version |
-| `x.y` (e.g. `0.3`) | Latest patch of a minor version |
+| `x.y.z` (e.g. `0.4.0`) | Specific version |
+| `x.y` (e.g. `0.4`) | Latest patch of a minor version |

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.3.14",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -26,9 +26,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.0",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.0",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.3.14"
+    "microsandbox": "0.4.0"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.3.14", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.3.14", path = "../../crates/network" }
+microsandbox = { version = "0.4.0", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.0", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.3.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.3.14",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.js"
@@ -21,9 +21,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.0",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.0",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1848,8 +1848,8 @@
       "license": "MIT"
     },
     "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.3.14.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.4.0.tgz",
       "integrity": "sha512-RSOhkzmfXHTvm8+R2qcRihTGv5kRSL164rfs4q3gAigHFtTfYAUI2c+R6oX01b0V6/HBfvdrJKzihRpkrxQIWA==",
       "cpu": [
         "arm64"
@@ -1864,8 +1864,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.3.14.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.4.0.tgz",
       "integrity": "sha512-i5EiP8ZrNgOjNghBsvRqk5bZNKyaMFIGd/AvN/7tDKDYcffMdj/lAtQlwjIxHojlyeBzK3qor4idUG+GCVqyHA==",
       "cpu": [
         "arm64"
@@ -1880,8 +1880,8 @@
       }
     },
     "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.3.14.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.4.0.tgz",
       "integrity": "sha512-v34c42HhltWI/jNp9ciDO3y+fqIh7KLg4XZ4o+X/h2aL+1n7dEHwx/LGBDuLsRxq6pt78pdZrMT54AdazK6A0g==",
       "cpu": [
         "x64"

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,9 +43,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.3.14",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.3.14",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.3.14"
+    "@superradcompany/microsandbox-darwin-arm64": "0.4.0",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.0",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.0"
   },
   "files": [
     "dist",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.3.14", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.3.14", path = "../../crates/network" }
+microsandbox = { version = "0.4.0", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.0", path = "../../crates/network" }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }


### PR DESCRIPTION
bumps every 0.3.14 reference to 0.4.0 across the workspace, sdks, examples, and docs, and folds in #628's `npm ci` switch and post-publish lockfile refresh job. before cutting v0.4.0, enable "allow github actions to create and approve pull requests" so the refresh job can open its pr.