### PR TITLE
fix(ci): pass napi target only to build:native in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,8 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           npm ci
-          npm run build -- --target ${{ matrix.napi_target }}
+          npm run build:native -- --target ${{ matrix.napi_target }}
+          npm run build:ts
 
       - name: Upload Node SDK artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- the v0.4.0 release failed in the `Build Node SDK` step on every matrix target with `error TS5042: Option 'project' cannot be mixed with source files on a command line.`
- root cause: the workflow ran `npm run build -- --target <triple>` against the node sdk's `build` script, which is `npm run build:native && npm run build:ts`. npm appended the extra args to the chained command, so the target value leaked into `tsc -p tsconfig.json <triple>` and the typescript build failed.
- fix: invoke `build:native` and `build:ts` separately so `--target` only reaches the napi step.

## Test plan
- [ ] re-run the release workflow (or trigger a tag build) and confirm the `Build Node SDK` step succeeds on all three matrix targets (`linux-x86_64`, `linux-aarch64`, `darwin-aarch64`)
- [ ] confirm the uploaded `node-sdk-*` artifacts contain `dist/` output and the `*.node`, `index.cjs`, `index.d.cts` files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->