### PR TITLE
fix(ci): repair node sdk release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Release
 on:
   push:
     tags: ["v*"]
-    # TEMP: trigger on this fix branch to re-run npm publish for v0.4.0.
-    # Revert before merge.
-    branches: ["fix/release-node-sdk-artifact-paths"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -294,7 +291,6 @@ jobs:
   assemble:
     name: Assemble Release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -329,7 +325,6 @@ jobs:
   sync-mintlify:
     name: Sync mintlify branch
     needs: assemble
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -408,7 +403,6 @@ jobs:
   refresh-lockfile:
     name: Refresh npm lockfile
     needs: npm-publish
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -446,7 +440,6 @@ jobs:
   mcp-publish:
     name: Publish MCP server
     needs: npm-publish
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -474,7 +467,6 @@ jobs:
   crates-publish:
     name: Publish crates
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -509,7 +501,6 @@ jobs:
   pypi-publish:
     name: Publish Python SDK
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -542,7 +533,6 @@ jobs:
   docker-build:
     name: Docker (${{ matrix.arch }})
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -607,7 +597,6 @@ jobs:
   docker-manifest:
     name: Docker manifest
     needs: docker-build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Download digests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,9 +220,9 @@ jobs:
         with:
           name: node-sdk-${{ matrix.npm_dir }}
           path: |
-            sdk/node-ts/${{ matrix.node_file }}
-            sdk/node-ts/index.cjs
-            sdk/node-ts/index.d.cts
+            sdk/node-ts/native/${{ matrix.node_file }}
+            sdk/node-ts/native/index.cjs
+            sdk/node-ts/native/index.d.ts
 
       # -- Python SDK --
       - uses: astral-sh/setup-uv@v3
@@ -362,10 +362,18 @@ jobs:
           cp node-artifacts/node-sdk-linux-x64-gnu/microsandbox.linux-x64-gnu.node sdk/node-ts/npm/linux-x64-gnu/
           cp node-artifacts/node-sdk-linux-arm64-gnu/microsandbox.linux-arm64-gnu.node sdk/node-ts/npm/linux-arm64-gnu/
 
-          # Copy build-generated index.cjs and index.d.cts into root package
-          # (use darwin-arm64 — all platforms produce identical JS/types).
-          cp node-artifacts/node-sdk-darwin-arm64/index.cjs sdk/node-ts/index.cjs
-          cp node-artifacts/node-sdk-darwin-arm64/index.d.cts sdk/node-ts/index.d.cts
+          # Copy napi-generated bindings into the root package's native/ dir
+          # (use darwin-arm64; all platforms emit identical JS and types).
+          # napi build emits index.d.ts; rename to index.d.cts so nodenext
+          # resolution finds it next to the .cjs binding.
+          cp node-artifacts/node-sdk-darwin-arm64/index.cjs sdk/node-ts/native/index.cjs
+          cp node-artifacts/node-sdk-darwin-arm64/index.d.ts sdk/node-ts/native/index.d.cts
+
+      - name: Build TypeScript output (root package dist/)
+        working-directory: sdk/node-ts
+        run: |
+          npm ci
+          npm run build:ts
 
       - name: Publish platform packages
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     tags: ["v*"]
+    # TEMP: trigger on this fix branch to re-run npm publish for v0.4.0.
+    # Revert before merge.
+    branches: ["fix/release-node-sdk-artifact-paths"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -291,6 +294,7 @@ jobs:
   assemble:
     name: Assemble Release
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -325,6 +329,7 @@ jobs:
   sync-mintlify:
     name: Sync mintlify branch
     needs: assemble
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -403,6 +408,7 @@ jobs:
   refresh-lockfile:
     name: Refresh npm lockfile
     needs: npm-publish
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -440,6 +446,7 @@ jobs:
   mcp-publish:
     name: Publish MCP server
     needs: npm-publish
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -467,6 +474,7 @@ jobs:
   crates-publish:
     name: Publish crates
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -501,6 +509,7 @@ jobs:
   pypi-publish:
     name: Publish Python SDK
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -533,6 +542,7 @@ jobs:
   docker-build:
     name: Docker (${{ matrix.arch }})
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -597,6 +607,7 @@ jobs:
   docker-manifest:
     name: Docker manifest
     needs: docker-build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Download digests


### PR DESCRIPTION
## summary
- pointed `Upload Node SDK artifacts` at `sdk/node-ts/native/` (where `napi build --output-dir native` actually writes), so artifacts stop uploading empty.
- placed bindings at `sdk/node-ts/native/` and renamed `index.d.ts` to `index.d.cts` to match `package.json` `files` and nodenext resolution.
- ran `npm ci && npm run build:ts` in the publish job so `dist/` exists before `npm publish`.

## test plan
- [ ] re-run release; `Publish npm packages` succeeds and the published root tarball contains `dist/`, `native/index.cjs`, `native/index.d.cts`.