### PR TITLE
fix(cli): correct dns_block_domain help text (REFUSED, not NXDOMAIN)

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -101,7 +101,7 @@ pub struct SandboxOpts {
     #[arg(long = "no-net")]
     pub no_net: bool,
 
-    /// Block DNS lookups for a domain (returns NXDOMAIN).
+    /// Block DNS lookups for a domain (returns REFUSED).
     #[cfg(feature = "net")]
     #[arg(long)]
     pub dns_block_domain: Vec<String>,


### PR DESCRIPTION
### Summary

The CLI help string for `--dns-block-domain` says blocked domains return **NXDOMAIN**, but the implementation in `crates/network/lib/dns/forwarder.rs` actually returns **REFUSED**:

```rust
// crates/network/lib/dns/forwarder.rs:164-167
if is_domain_blocked(&domain, &self.config) {
    tracing::debug!(domain = %domain, "DNS query blocked by domain policy");
    return build_status_response(&query_msg, ResponseCode::Refused);
}
```

### Why it matters

- **NXDOMAIN** = "this name does not exist" (authoritative absence; downstream tooling may cache, retry alternative resolvers, or escalate)
- **REFUSED** = "this resolver chose not to answer" (policy / will not serve; debuggers immediately understand they hit a filter)

These are distinct DNS response codes per RFC 1035 §4.1.1 / RFC 8499. An operator setting `--dns-block-domain ads.example.com` and running `dig` will see `status: REFUSED` in the response — the CLI help should match.

### Change

One-line comment fix in `crates/cli/lib/commands/common.rs:104`. No behavior change. The implementation in `forwarder.rs` was already correct; only the user-visible documentation drifted.

### Context

Originally this was bundled into #625 alongside doc-comment fixes for the old `sdk/node-ts/{index.d.ts,index.d.cts,lib/types.rs}`. The SDK rewrite landed in #623 (`feat(sdk-node)!: redesign TypeScript SDK with builder API and bundled binaries`) made those three files vanish, so #625 is now CONFLICTING and being closed. This CLI fix was independent of the SDK and is the salvage piece.

### Verification

```sh
# Confirms current help text mismatch
$ rg "NXDOMAIN" crates/cli/
crates/cli/lib/commands/common.rs:104:    /// Block DNS lookups for a domain (returns NXDOMAIN).

# Confirms the actual return code
$ rg "is_domain_blocked|ResponseCode::Refused" crates/network/lib/dns/forwarder.rs
118:    Refused,
135:    Refused,
164:        if is_domain_blocked(&domain, &self.config) {
166:            return build_status_response(&query_msg, ResponseCode::Refused);
```

🤖 Authored by an AI agent (voidborne-d) with human review of the diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->