### PR TITLE
docs(sdk): normalize builder, factory, and section structure across sdk references

### DIFF
--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -30,31 +30,26 @@ Network(
 | max_connections | `int \| None` | `None` | Maximum concurrent connections |
 | trust_host_cas | `bool \| None` | `False` | Ship the host's trusted root CAs into the guest at boot so outbound TLS works behind corporate MITM proxies (Warp Zero Trust, Zscaler, etc.). Opt-in |
 
-### DnsConfig
+---
 
-Frozen dataclass for DNS interception settings.
+#### allow_all()
 
 ```python
-DnsConfig(
-    block_domains: tuple[str, ...] = (),
-    block_domain_suffixes: tuple[str, ...] = (),
-    rebind_protection: bool = True,
-    nameservers: tuple[str, ...] = (),
-    query_timeout_ms: int | None = None,
-)
+@classmethod
+def allow_all() -> Network
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| block_domains | `tuple[str, ...]` | `()` | Block DNS for exact domains (returns REFUSED) |
-| block_domain_suffixes | `tuple[str, ...]` | `()` | Block DNS for all subdomains of a suffix |
-| rebind_protection | `bool` | `True` | Block DNS responses resolving to private IPs |
-| nameservers | `tuple[str, ...]` | `()` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
-| query_timeout_ms | `int \| None` | `None` | Per-DNS-query timeout in milliseconds (default: 5000) |
+Unrestricted network access, including to private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Network`](#network) | Unrestricted network configuration |
 
 ---
 
-#### Network.none()
+#### none()
 
 ```python
 @classmethod
@@ -71,7 +66,7 @@ Deny all traffic. No network interface is created -- the guest is fully offline.
 
 ---
 
-#### Network.public_only()
+#### public_only()
 
 ```python
 @classmethod
@@ -85,23 +80,6 @@ Block private address ranges and cloud metadata endpoints. Allow everything else
 | Type | Description |
 |------|-------------|
 | [`Network`](#network) | Public-only network configuration |
-
----
-
-#### Network.allow_all()
-
-```python
-@classmethod
-def allow_all() -> Network
-```
-
-Unrestricted network access, including to private addresses and the host machine.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| [`Network`](#network) | Unrestricted network configuration |
 
 ---
 
@@ -155,7 +133,7 @@ Ingress rules carrying ICMP protocols are rejected at sandbox creation: `publish
 
 ---
 
-#### Rule.allow()
+#### allow()
 
 ```python
 @classmethod
@@ -187,7 +165,7 @@ Create a rule that permits matching traffic.
 
 ---
 
-#### Rule.deny()
+#### deny()
 
 ```python
 @classmethod
@@ -216,6 +194,30 @@ Create a rule that blocks matching traffic.
 | Type | Description |
 |------|-------------|
 | [`Rule`](#rule) | A deny rule |
+
+---
+
+### DnsConfig
+
+Frozen dataclass for DNS interception settings within [`Network`](#network).
+
+```python
+DnsConfig(
+    block_domains: tuple[str, ...] = (),
+    block_domain_suffixes: tuple[str, ...] = (),
+    rebind_protection: bool = True,
+    nameservers: tuple[str, ...] = (),
+    query_timeout_ms: int | None = None,
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| block_domains | `tuple[str, ...]` | `()` | Block DNS for exact domains (returns REFUSED) |
+| block_domain_suffixes | `tuple[str, ...]` | `()` | Block DNS for all subdomains of a suffix |
+| rebind_protection | `bool` | `True` | Block DNS responses resolving to private IPs |
+| nameservers | `tuple[str, ...]` | `()` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
+| query_timeout_ms | `int \| None` | `None` | Per-DNS-query timeout in milliseconds (default: 5000) |
 
 ---
 

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -12,7 +12,7 @@ Static factory for creating secret entries used in `SandboxConfig.secrets`.
 
 ---
 
-#### Secret.env()
+#### env()
 
 ```python
 @staticmethod
@@ -54,7 +54,7 @@ Create a secret entry that maps an environment variable to a real value. The gue
 
 ### SecretEntry
 
-Frozen dataclass returned by [`Secret.env()`](#secretenv) and used in `SandboxConfig.secrets`.
+Frozen dataclass returned by [`Secret.env()`](#env) and used in `SandboxConfig.secrets`.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -97,12 +97,29 @@ Delete a named volume and its contents. Fails if the volume is currently mounted
 
 ---
 
-## Volume instance properties
+## Instance properties
 
-| Property | Type | Description |
-|----------|------|-------------|
-| name | `str` | Volume name |
-| path | `str` | Host path to the volume directory |
+---
+
+#### name
+
+```python
+@property
+def name(self) -> str
+```
+
+Volume name.
+
+---
+
+#### path
+
+```python
+@property
+def path(self) -> str
+```
+
+Host path to the volume's directory.
 
 ---
 
@@ -178,22 +195,6 @@ Use an in-memory filesystem. Contents are discarded when the sandbox stops.
 | Type | Description |
 |------|-------------|
 | `dict` | Mount configuration dictionary |
-
----
-
-## VolumeHandle
-
-Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| name | `str` | Volume name |
-| quota_mib | `int \| None` | Storage quota in MiB |
-| used_bytes | `int` | Current disk usage in bytes |
-| labels | `dict[str, str]` | Metadata labels |
-| created_at | `float \| None` | Creation timestamp (ms since epoch) |
-| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
-| remove() | *(async)* `None` | Delete this volume |
 
 ---
 
@@ -341,6 +342,20 @@ Check whether a path exists within the volume.
 ---
 
 ## Types
+
+### VolumeHandle
+
+Handle to an existing named volume, returned by [`Volume.get()`](#volumeget) and [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `str` | Volume name |
+| quota_mib | `int \| None` | Storage quota in MiB |
+| used_bytes | `int` | Current disk usage in bytes |
+| labels | `dict[str, str]` | Metadata labels |
+| created_at | `float \| None` | Creation timestamp (ms since epoch) |
+| fs | [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+| remove() | *(async)* `None` | Delete this volume |
 
 ### MountConfig
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -20,18 +20,77 @@ The default `NetworkPolicy::default()` is `default_egress = Deny + implicit allo
 
 ### Presets
 
-Static methods that return pre-configured policies. Most callers should use the builder; presets exist as compat shims for the legacy API.
+Static methods that return pre-configured policies. Most callers should use [`NetworkPolicyBuilder`](#networkpolicybuilder); presets exist as compat shims for the legacy API.
+
+---
+
+#### allow_all()
 
 ```rust
-NetworkPolicy::allow_all()    // unrestricted
-NetworkPolicy::none()         // deny both directions
-NetworkPolicy::public_only()  // egress=Deny + allow Public; ingress=Allow (today's default)
-NetworkPolicy::non_local()    // egress=Deny + allow Public+Private; ingress=Allow
+fn allow_all() -> Self
 ```
 
-### NetworkPolicy::builder()
+Unrestricted access — allow everything in both directions.
 
-The fluent builder is the primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time; the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Allow-all policy |
+
+---
+
+#### non_local()
+
+```rust
+fn non_local() -> Self
+```
+
+Egress to public and private (RFC1918) IPs; deny loopback, link-local, and metadata. Ingress unrestricted.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Non-local egress policy |
+
+---
+
+#### none()
+
+```rust
+fn none() -> Self
+```
+
+Deny everything in both directions.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Deny-all policy |
+
+---
+
+#### public_only()
+
+```rust
+fn public_only() -> Self
+```
+
+Egress to public IPs only; ingress unrestricted (preserves today's published-port behavior).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Public-only egress policy |
+
+---
+
+## NetworkPolicyBuilder
+
+Fluent builder for [`NetworkPolicy`](#networkpolicy). The primary construction path. String inputs (`.ip(&str)`, `.cidr(&str)`, `.domain(&str)`, `.domain_suffix(&str)`) are stored raw and parsed at `.build()` time; the chain stays clean. The first parse / validation failure surfaces as [`BuildError`](#builderror).
 
 ```rust
 use microsandbox::NetworkPolicy;
@@ -43,76 +102,558 @@ let policy = NetworkPolicy::builder()
     .build()?;
 ```
 
-#### Top-level methods
+State accumulates eagerly inside `.rule(|r| ...)` closures; each rule-adder commits a rule using the state at that point. State is **not reset** between rule-adders within the same closure — use separate `.rule()` calls for different state.
 
-| Method | Effect |
-|--------|--------|
-| `.default_allow()` | Set both `default_egress` and `default_ingress` to `Allow` |
-| `.default_deny()` | Set both to `Deny` |
-| `.default_egress(Action)` | Per-direction override |
-| `.default_ingress(Action)` | Per-direction override |
-| `.rule(\|r\| ...)` | Multi-rule batch; direction set inside via `.egress() / .ingress() / .any()` |
-| `.egress(\|e\| ...)` | Sugar for `.rule(\|r\| { r.egress(); ... })` |
-| `.ingress(\|i\| ...)` | Sugar with direction pre-set to `Ingress` |
-| `.any(\|a\| ...)` | Sugar with direction pre-set to `Any` (rule applies in either direction) |
-| `.build()` | `Result<NetworkPolicy, BuildError>` |
+At `.build()` time, the builder walks the rules list and emits a `tracing::warn!` for any rule whose match set is fully contained in an earlier rule's match set in a compatible direction. Coverage is `Ip` / `Cidr` / `Group` destinations; domain shadowing is out of scope (depends on runtime DNS state).
 
-The closure signature is `FnOnce(&mut RuleBuilder) -> &mut RuleBuilder`. A chain ending in any rule-adder (`.allow_public()`, `.deny().ip(...)`, etc.) returns the builder reference and satisfies the bound. Multi-statement bodies end with an explicit `r` return.
+---
 
-#### Inside the closure: `RuleBuilder`
+#### any()
 
-Inside `.rule(|r| ...)` (or any of the direction sub-builders), state setters and rule-adders interleave freely. State accumulates eagerly across the closure; each rule-adder commits a rule using the state at that point.
+```rust
+fn any<F>(self, f: F) -> Self
+where
+    F: FnOnce(&mut RuleBuilder) -> &mut RuleBuilder,
+```
 
-**State setters:**
+Sugar for `.rule(|r| ...)` with direction pre-set to `Any`. Rules apply in both directions.
 
-| Method | Effect |
-|--------|--------|
-| `.egress() / .ingress() / .any()` | Set direction. Last-write-wins. `.any()` makes rules apply in both directions |
-| `.tcp() / .udp() / .icmpv4() / .icmpv6()` | Add to the protocols set (set semantics; duplicates dedupe). ICMP is egress-only |
-| `.port(u16)` | Add a single port to the ports set |
-| `.port_range(u16, u16)` | Add an inclusive range. `lo > hi` records `BuildError::InvalidPortRange` |
+**Parameters**
 
-**Per-category rule-adders** (each commits one rule using the current state):
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`RuleBuilder`](#rulebuilder) closure | Configure direction-agnostic rules. |
 
-| Method | Group |
-|--------|-------|
-| `.allow_public() / .deny_public()` | `Group::Public` (complement of named categories) |
-| `.allow_private() / .deny_private()` | `Group::Private` (RFC1918 + ULA + CGN) |
-| `.allow_loopback() / .deny_loopback()` | `Group::Loopback` (`127.0.0.0/8`, `::1`) — see the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap) |
-| `.allow_link_local() / .deny_link_local()` | `Group::LinkLocal` (`169.254.0.0/16`, `fe80::/10`, excluding metadata) |
-| `.allow_meta() / .deny_meta()` | `Group::Metadata` (`169.254.169.254`). Dangerous on cloud hosts |
-| `.allow_multicast() / .deny_multicast()` | `Group::Multicast` |
-| `.allow_host() / .deny_host()` | `Group::Host` (per-sandbox gateway IPs that back `host.microsandbox.internal`) |
+---
 
-**Composite sugar:**
+#### build()
 
-| Method | Effect |
-|--------|--------|
-| `.allow_local() / .deny_local()` | Adds **three** rules atomically: `Loopback + LinkLocal + Host`. `Metadata` is explicitly **not** included (cloud-IMDS opt-in only via `.allow_meta()`) |
+```rust
+fn build(self) -> Result<NetworkPolicy, BuildError>
+```
 
-**Explicit-rule sub-builder** (`.allow()` / `.deny()` open it):
+Materialize the policy. Surfaces the first parse / validation failure as [`BuildError`](#builderror).
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Result<`[`NetworkPolicy`](#networkpolicy)`, `[`BuildError`](#builderror)`>` | Policy or first build error |
+
+---
+
+#### default_allow()
+
+```rust
+fn default_allow(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Allow`.
+
+---
+
+#### default_deny()
+
+```rust
+fn default_deny(self) -> Self
+```
+
+Set both `default_egress` and `default_ingress` to `Deny`.
+
+---
+
+#### default_egress()
+
+```rust
+fn default_egress(self, action: Action) -> Self
+```
+
+Override the default egress action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action when no egress rule matches |
+
+---
+
+#### default_ingress()
+
+```rust
+fn default_ingress(self, action: Action) -> Self
+```
+
+Override the default ingress action.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`Action`](#action) | Default action when no ingress rule matches |
+
+---
+
+#### egress()
+
+```rust
+fn egress<F>(self, f: F) -> Self
+where
+    F: FnOnce(&mut RuleBuilder) -> &mut RuleBuilder,
+```
+
+Sugar for `.rule(|r| { r.egress(); f(r) })`. Direction is pre-set to `Egress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`RuleBuilder`](#rulebuilder) closure | Configure egress rules. |
+
+---
+
+#### ingress()
+
+```rust
+fn ingress<F>(self, f: F) -> Self
+where
+    F: FnOnce(&mut RuleBuilder) -> &mut RuleBuilder,
+```
+
+Sugar for `.rule(|r| ...)` with direction pre-set to `Ingress`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`RuleBuilder`](#rulebuilder) closure | Configure ingress rules. |
+
+---
+
+#### rule()
+
+```rust
+fn rule<F>(self, f: F) -> Self
+where
+    F: FnOnce(&mut RuleBuilder) -> &mut RuleBuilder,
+```
+
+Open a [`RuleBuilder`](#rulebuilder) for one or more rules. Direction is set inside via `.egress()`, `.ingress()`, or `.any()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`RuleBuilder`](#rulebuilder) closure | Configure rules. |
+
+---
+
+## RuleBuilder
+
+Builder opened by [`NetworkPolicyBuilder::rule()`](#rule), `.egress()`, `.ingress()`, or `.any()`. State setters and rule-adders interleave freely; each rule-adder commits a rule using the current state.
+
+```rust
+.rule(|r| r.egress().tcp().port(443).allow_public().allow_private())
+```
+
+---
+
+#### allow()
+
+```rust
+fn allow(&mut self) -> RuleDestinationBuilder<'_>
+```
+
+Open a [`RuleDestinationBuilder`](#ruledestinationbuilder) for an explicit allow rule. Requires a destination call (`.ip`, `.cidr`, `.domain`, `.domain_suffix`, `.group`, `.any`) to commit. Dropping without a destination call adds no rule — the type is `#[must_use]`.
 
 ```rust
 .rule(|r| r.egress().tcp().port(443).allow().domain("api.example.com"))
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`RuleDestinationBuilder`](#ruledestinationbuilder) | Sub-builder requiring one destination call to commit |
+
+---
+
+#### allow_host()
+
+```rust
+fn allow_host(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::Host` (per-sandbox gateway IPs that back `host.microsandbox.internal`).
+
+---
+
+#### allow_link_local()
+
+```rust
+fn allow_link_local(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::LinkLocal` (`169.254.0.0/16`, `fe80::/10`, excluding metadata).
+
+---
+
+#### allow_local()
+
+```rust
+fn allow_local(&mut self) -> &mut Self
+```
+
+Composite shorthand: commits **three** allow rules atomically — `Loopback + LinkLocal + Host`. `Metadata` is intentionally excluded (opt in via [`allow_meta()`](#allow_meta) on cloud hosts).
+
+---
+
+#### allow_loopback()
+
+```rust
+fn allow_loopback(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::Loopback` (`127.0.0.0/8`, `::1`). See the [loopback-vs-host watch-out](/networking/overview#loopback-vs-host-a-common-trap).
+
+---
+
+#### allow_meta()
+
+```rust
+fn allow_meta(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::Metadata` (`169.254.169.254`). Dangerous on cloud hosts.
+
+---
+
+#### allow_multicast()
+
+```rust
+fn allow_multicast(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::Multicast`.
+
+---
+
+#### allow_private()
+
+```rust
+fn allow_private(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::Private` (RFC1918 + ULA + CGN).
+
+---
+
+#### allow_public()
+
+```rust
+fn allow_public(&mut self) -> &mut Self
+```
+
+Commit an allow rule for `Group::Public` — the complement of all other named groups.
+
+---
+
+#### any()
+
+```rust
+fn any(&mut self) -> &mut Self
+```
+
+Set direction to `Any` — rules apply in both directions. Last-write-wins.
+
+---
+
+#### deny()
+
+```rust
+fn deny(&mut self) -> RuleDestinationBuilder<'_>
+```
+
+Open a [`RuleDestinationBuilder`](#ruledestinationbuilder) for an explicit deny rule. See [`allow()`](#allow) for usage.
+
+```rust
 .rule(|r| r.any().deny().cidr("198.51.100.0/24"))
 ```
 
-Returns an [`ExplicitRuleBuilder`](#explicitrulebuilder) requiring a destination call (`.ip / .cidr / .domain / .domain_suffix / .group / .any`) to commit. Dropping without a destination call adds no rule (the type is `#[must_use]`).
+**Returns**
 
-#### State accumulation
+| Type | Description |
+|------|-------------|
+| [`RuleDestinationBuilder`](#ruledestinationbuilder) | Sub-builder requiring one destination call to commit |
 
-State is **not reset** between rule-adders within a closure. Callers wanting different state per rule use separate `.rule()` calls or interleave state setters between adders:
+---
+
+#### deny_host()
 
 ```rust
-.rule(|r| r.egress()
-    .tcp().port(443).allow_public()    // rule 1: egress, TCP, 443, allow Public
-    .udp().allow_private())            // rule 2: egress, [TCP, UDP], 443, allow Private
-                                       //   (UDP added; TCP and 443 still in state)
+fn deny_host(&mut self) -> &mut Self
 ```
 
-#### Shadow detection
+Commit a deny rule for `Group::Host`.
 
-At `.build()` time, the builder walks the rules list and emits a `tracing::warn!` for any rule whose match set is fully contained in an earlier rule's match set in a compatible direction. Coverage is `Ip` / `Cidr` / `Group` destinations; domain shadowing is intentionally out of scope (depends on runtime DNS state).
+---
+
+#### deny_link_local()
+
+```rust
+fn deny_link_local(&mut self) -> &mut Self
+```
+
+Commit a deny rule for `Group::LinkLocal`.
+
+---
+
+#### deny_local()
+
+```rust
+fn deny_local(&mut self) -> &mut Self
+```
+
+Composite shorthand: commits **three** deny rules atomically — `Loopback + LinkLocal + Host`. `Metadata` is intentionally excluded.
+
+---
+
+#### deny_loopback()
+
+```rust
+fn deny_loopback(&mut self) -> &mut Self
+```
+
+Commit a deny rule for `Group::Loopback`.
+
+---
+
+#### deny_meta()
+
+```rust
+fn deny_meta(&mut self) -> &mut Self
+```
+
+Commit a deny rule for `Group::Metadata`.
+
+---
+
+#### deny_multicast()
+
+```rust
+fn deny_multicast(&mut self) -> &mut Self
+```
+
+Commit a deny rule for `Group::Multicast`.
+
+---
+
+#### deny_private()
+
+```rust
+fn deny_private(&mut self) -> &mut Self
+```
+
+Commit a deny rule for `Group::Private`.
+
+---
+
+#### deny_public()
+
+```rust
+fn deny_public(&mut self) -> &mut Self
+```
+
+Commit a deny rule for `Group::Public`.
+
+---
+
+#### egress()
+
+```rust
+fn egress(&mut self) -> &mut Self
+```
+
+Set direction to `Egress`. Last-write-wins.
+
+---
+
+#### icmpv4()
+
+```rust
+fn icmpv4(&mut self) -> &mut Self
+```
+
+Add `Icmpv4` to the protocols set. ICMP is egress-only — ingress / any rules carrying ICMP fail build.
+
+---
+
+#### icmpv6()
+
+```rust
+fn icmpv6(&mut self) -> &mut Self
+```
+
+Add `Icmpv6` to the protocols set. ICMP is egress-only.
+
+---
+
+#### ingress()
+
+```rust
+fn ingress(&mut self) -> &mut Self
+```
+
+Set direction to `Ingress`. Last-write-wins.
+
+---
+
+#### port()
+
+```rust
+fn port(&mut self, port: u16) -> &mut Self
+```
+
+Add a single port to the ports set.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `u16` | Port number |
+
+---
+
+#### port_range()
+
+```rust
+fn port_range(&mut self, lo: u16, hi: u16) -> &mut Self
+```
+
+Add an inclusive port range. `lo > hi` records `BuildError::InvalidPortRange`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| lo | `u16` | Range start (inclusive) |
+| hi | `u16` | Range end (inclusive) |
+
+---
+
+#### tcp()
+
+```rust
+fn tcp(&mut self) -> &mut Self
+```
+
+Add `Tcp` to the protocols set. Set semantics; duplicates dedupe.
+
+---
+
+#### udp()
+
+```rust
+fn udp(&mut self) -> &mut Self
+```
+
+Add `Udp` to the protocols set.
+
+---
+
+## RuleDestinationBuilder
+
+Returned by [`RuleBuilder::allow()`](#allow) / [`RuleBuilder::deny()`](#deny). Requires exactly one destination method call to commit the rule. The type is `#[must_use]` — dropping without a call adds no rule.
+
+---
+
+#### any()
+
+```rust
+fn any(self) -> &mut RuleBuilder
+```
+
+Commit with `Destination::Any` — match any address.
+
+---
+
+#### cidr()
+
+```rust
+fn cidr(self, cidr: impl Into<String>) -> &mut RuleBuilder
+```
+
+Commit with `Destination::Cidr`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cidr | `impl Into<String>` | CIDR range (e.g. `"10.0.0.0/8"`) |
+
+---
+
+#### domain()
+
+```rust
+fn domain(self, domain: impl Into<String>) -> &mut RuleBuilder
+```
+
+Commit with `Destination::Domain`. Matches the exact domain only.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `impl Into<String>` | Domain name (e.g. `"api.example.com"`) |
+
+---
+
+#### domain_suffix()
+
+```rust
+fn domain_suffix(self, suffix: impl Into<String>) -> &mut RuleBuilder
+```
+
+Commit with `Destination::DomainSuffix`. Matches the apex domain and every subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `impl Into<String>` | Domain suffix (e.g. `"example.com"`) |
+
+---
+
+#### group()
+
+```rust
+fn group(self, group: DestinationGroup) -> &mut RuleBuilder
+```
+
+Commit with `Destination::Group`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| group | [`DestinationGroup`](#destinationgroup) | Predefined address group |
+
+---
+
+#### ip()
+
+```rust
+fn ip(self, ip: impl Into<String>) -> &mut RuleBuilder
+```
+
+Commit with `Destination::Cidr` of the IP as `/32` (IPv4) or `/128` (IPv6).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| ip | `impl Into<String>` | IPv4 or IPv6 address literal |
 
 ---
 
@@ -120,17 +661,7 @@ At `.build()` time, the builder walks the rules list and emits a `tracing::warn!
 
 Builder for configuring the sandbox's network stack. Used in `SandboxBuilder::network(|n| n...)`.
 
-#### policy()
-
-```rust
-fn policy(self, policy: NetworkPolicy) -> Self
-```
-
-Set the network access policy. Override the default with a builder-constructed value:
-
-```rust
-.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
-```
+---
 
 #### dns()
 
@@ -151,6 +682,14 @@ Configure DNS interception. Errors accumulated by [`DnsBuilder`](#dnsbuilder) ca
 )
 ```
 
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`DnsBuilder`](#dnsbuilder) closure | Configure DNS |
+
+---
+
 #### max_connections()
 
 ```rust
@@ -159,21 +698,13 @@ fn max_connections(self, max: usize) -> Self
 
 Limit the maximum number of concurrent network connections from the sandbox.
 
-#### trust_host_cas()
+**Parameters**
 
-```rust
-fn trust_host_cas(self, enabled: bool) -> Self
-```
+| Name | Type | Description |
+|------|------|-------------|
+| max | `usize` | Maximum concurrent connections |
 
-Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
-
-#### tls()
-
-```rust
-fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
-```
-
-Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+---
 
 #### on_secret_violation()
 
@@ -183,6 +714,64 @@ fn on_secret_violation(self, action: ViolationAction) -> Self
 
 Set the action taken when a secret placeholder is detected in traffic destined for a host not in the secret's allow list.
 
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`ViolationAction`](#violationaction) | Violation action |
+
+---
+
+#### policy()
+
+```rust
+fn policy(self, policy: NetworkPolicy) -> Self
+```
+
+Set the network access policy. Override the default with a builder-constructed value:
+
+```rust
+.network(|n| n.policy(NetworkPolicy::builder().default_deny().build()?))
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`NetworkPolicy`](#networkpolicy) | Active policy |
+
+---
+
+#### tls()
+
+```rust
+fn tls(self, f: impl FnOnce(TlsBuilder) -> TlsBuilder) -> Self
+```
+
+Configure TLS interception. See [`TlsBuilder`](#tlsbuilder).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| f | [`TlsBuilder`](#tlsbuilder) closure | Configure TLS |
+
+---
+
+#### trust_host_cas()
+
+```rust
+fn trust_host_cas(self, enabled: bool) -> Self
+```
+
+Whether to ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in when egress HTTPS inside the sandbox needs to work behind corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) whose gateway CA is installed on the host but unknown to the guest's stock Mozilla bundle.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | `true` to ship host CAs |
+
 ---
 
 ## DnsBuilder
@@ -190,6 +779,8 @@ Set the action taken when a secret placeholder is detected in traffic destined f
 Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`.
 
 `block_domain` and `block_domain_suffix` use the same lazy-parse + accumulate-at-`.build()` model as `NetworkPolicy::builder()` — string inputs are stored raw, errors surface as `BuildError::InvalidBlockedDomain` / `InvalidBlockedDomainSuffix` from the outermost `.build()` in the chain.
+
+---
 
 #### block_domain()
 
@@ -199,6 +790,14 @@ fn block_domain(self, domain: impl Into<String>) -> Self
 
 Block DNS lookups for an exact domain. The guest receives REFUSED for this domain.
 
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `impl Into<String>` | FQDN (e.g. `"malware.example.com"`) |
+
+---
+
 #### block_domain_suffix()
 
 ```rust
@@ -207,13 +806,13 @@ fn block_domain_suffix(self, suffix: impl Into<String>) -> Self
 
 Block DNS lookups for all subdomains matching a suffix. For example, `.tracking.com` blocks `a.tracking.com`, `b.c.tracking.com`, etc.
 
-#### rebind_protection()
+**Parameters**
 
-```rust
-fn rebind_protection(self, enabled: bool) -> Self
-```
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `impl Into<String>` | Domain suffix |
 
-When enabled, DNS responses that resolve to private IP addresses are blocked. This prevents DNS rebinding attacks. Default: `true`.
+---
 
 #### nameservers()
 
@@ -226,6 +825,14 @@ where
 
 Set the upstream nameservers to forward DNS queries to. Replaces any previously-set nameservers. Each element is convertible into `Nameserver` (`SocketAddr`, `IpAddr`, or a parsed string via `"dns.google:53".parse::<Nameserver>()?`).
 
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| nameservers | `IntoIterator<Item: Into<Nameserver>>` | Upstream resolvers |
+
+---
+
 #### query_timeout_ms()
 
 ```rust
@@ -234,20 +841,145 @@ fn query_timeout_ms(self, ms: u64) -> Self
 
 Set the per-DNS-query timeout in milliseconds. Default: `5000`.
 
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| ms | `u64` | Timeout in milliseconds |
+
+---
+
+#### rebind_protection()
+
+```rust
+fn rebind_protection(self, enabled: bool) -> Self
+```
+
+When enabled, DNS responses that resolve to private IP addresses are blocked. This prevents DNS rebinding attacks. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `bool` | `false` disables protection |
+
 ---
 
 ## TlsBuilder
 
 Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
 
-| Method | Effect |
-|--------|--------|
-| `.bypass(pattern)` | Skip TLS interception for this domain. Supports `*.suffix` wildcards |
-| `.intercepted_ports(ports)` | TCP ports where interception is active. Default: `[443]` |
-| `.intercept_ca_cert(path)` / `.intercept_ca_key(path)` | Provide a stable CA across sandbox restarts |
-| `.upstream_ca_cert(path)` | Trust an additional CA when verifying upstream servers |
-| `.verify_upstream(bool)` | Whether the proxy verifies upstream server certs. Default: `true` |
-| `.block_quic(bool)` | Block QUIC/HTTP3 on intercepted ports. Default: `true` |
+---
+
+#### block_quic()
+
+```rust
+fn block_quic(self, block: bool) -> Self
+```
+
+Block QUIC / HTTP3 on intercepted ports (forces clients to fall back to TCP, which the proxy can read). Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| block | `bool` | `true` to block QUIC |
+
+---
+
+#### bypass()
+
+```rust
+fn bypass(self, pattern: impl Into<String>) -> Self
+```
+
+Skip TLS interception for a domain. Supports `*.suffix` wildcards. Can be called multiple times.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `impl Into<String>` | Domain or `*.suffix` pattern |
+
+---
+
+#### intercept_ca_cert()
+
+```rust
+fn intercept_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+Path to a stable CA certificate used by the interception proxy. Pair with [`intercept_ca_key()`](#intercept_ca_key) to keep the same CA across sandbox restarts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<PathBuf>` | Path to PEM-encoded CA certificate |
+
+---
+
+#### intercept_ca_key()
+
+```rust
+fn intercept_ca_key(self, path: impl Into<PathBuf>) -> Self
+```
+
+Path to the private key for the interception CA.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<PathBuf>` | Path to PEM-encoded CA key |
+
+---
+
+#### intercepted_ports()
+
+```rust
+fn intercepted_ports(self, ports: Vec<u16>) -> Self
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| ports | `Vec<u16>` | TCP ports to intercept |
+
+---
+
+#### upstream_ca_cert()
+
+```rust
+fn upstream_ca_cert(self, path: impl Into<PathBuf>) -> Self
+```
+
+Trust an additional CA when the proxy verifies upstream server certificates.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `impl Into<PathBuf>` | Path to PEM-encoded CA certificate |
+
+---
+
+#### verify_upstream()
+
+```rust
+fn verify_upstream(self, verify: bool) -> Self
+```
+
+Whether the proxy verifies upstream server certificates. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| verify | `bool` | `true` to enforce upstream verification |
 
 ---
 
@@ -262,15 +994,23 @@ Builder for TLS interception settings. Used in `NetworkBuilder::tls(|t| t...)`.
 
 Wire format: `"allow"` / `"deny"`.
 
-### Direction
+### BuildError
 
-| Value | Description |
-|-------|-------------|
-| `Egress` | Traffic leaving the sandbox |
-| `Ingress` | Traffic entering the sandbox (via published ports) |
-| `Any` | Rule applies in either direction |
+Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
 
-Wire format: `"egress"` / `"ingress"` / `"any"`.
+| Variant | Cause |
+|---------|-------|
+| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
+| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
+| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
+| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
+| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
+| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
+| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
+| `InvalidBlockedDomain { raw, source }` | `DnsBuilder::block_domain` got an unparseable value |
+| `InvalidBlockedDomainSuffix { raw, source }` | `DnsBuilder::block_domain_suffix` got an unparseable value |
+
+Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
 
 ### Destination
 
@@ -294,6 +1034,16 @@ Wire format: `"egress"` / `"ingress"` / `"any"`.
 | `Multicast` | `"multicast"` | `224.0.0.0/4`, `ff00::/8` |
 | `Host` | `"host"` | Per-sandbox gateway IPs that back `host.microsandbox.internal` |
 
+### Direction
+
+| Value | Description |
+|-------|-------------|
+| `Egress` | Traffic leaving the sandbox |
+| `Ingress` | Traffic entering the sandbox (via published ports) |
+| `Any` | Rule applies in either direction |
+
+Wire format: `"egress"` / `"ingress"` / `"any"`.
+
 ### DomainName
 
 A validated DNS name. Construction goes through `str::parse` (or `TryFrom<String>`), which delegates to `hickory_proto::rr::Name` and canonicalizes the input (lowercased ASCII, leading and trailing dots stripped) so rule matching is a byte-wise compare against the DNS cache. Invalid inputs return a `DomainNameError`.
@@ -309,6 +1059,13 @@ Labels follow the permissive DNS grammar (RFC 2181 §11), so underscore-prefixed
 
 The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and parse them lazily at `.build()` — callers don't need to construct `DomainName` directly.
 
+### PortRange
+
+| Method | Description |
+|--------|-------------|
+| `PortRange::single(port)` | Match a single port |
+| `PortRange::range(start, end)` | Match an inclusive range |
+
 ### Protocol
 
 | Value | Wire format |
@@ -320,16 +1077,9 @@ The builder methods (`.domain(&str)`, `.domain_suffix(&str)`) take strings and p
 
 ICMP protocols are egress-only. A rule with direction `Ingress` or `Any` carrying an ICMP protocol fails build with `BuildError::IngressDoesNotSupportIcmp`.
 
-### PortRange
-
-| Method | Description |
-|--------|-------------|
-| `PortRange::single(port)` | Match a single port |
-| `PortRange::range(start, end)` | Match an inclusive range |
-
 ### Rule
 
-A single network policy rule.
+A single network policy rule. Use [`RuleBuilder`](#rulebuilder) via [`NetworkPolicyBuilder`](#networkpolicybuilder) to construct rules; the convenience constructors below are for cases where you build a `Rule` directly.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -339,47 +1089,7 @@ A single network policy rule.
 | ports | `Vec<`[`PortRange`](#portrange)`>` | Set semantics; empty = any port. Always guest-side (egress destination port / ingress listening port) |
 | action | [`Action`](#action) | What to do on match |
 
-**Convenience constructors:**
-
-| Method | Description |
-|--------|-------------|
-| `Rule::allow_egress(destination)` | Allow rule, direction `Egress` |
-| `Rule::deny_egress(destination)` | Deny rule, direction `Egress` |
-| `Rule::allow_ingress(destination)` | Allow rule, direction `Ingress` |
-| `Rule::deny_ingress(destination)` | Deny rule, direction `Ingress` |
-| `Rule::allow_any(destination)` | Allow rule, direction `Any` |
-| `Rule::deny_any(destination)` | Deny rule, direction `Any` |
-
-### ExplicitRuleBuilder
-
-Returned by [`RuleBuilder`](#networkpolicybuilder)`::allow()` / `::deny()`. Requires exactly one destination method call to commit the rule. The type is `#[must_use]` — dropping without a call adds no rule.
-
-| Method | Effect |
-|--------|--------|
-| `.ip(impl Into<String>)` | Commit with `Destination::Cidr` of the IP as `/32` or `/128` |
-| `.cidr(impl Into<String>)` | Commit with `Destination::Cidr` |
-| `.domain(impl Into<String>)` | Commit with `Destination::Domain` |
-| `.domain_suffix(impl Into<String>)` | Commit with `Destination::DomainSuffix` |
-| `.group(DestinationGroup)` | Commit with `Destination::Group` |
-| `.any()` | Commit with `Destination::Any` |
-
-### BuildError
-
-Errors surfaced by the builders' `.build()` methods. The same enum covers `NetworkPolicy::builder()`, `DnsBuilder`, and `NetworkBuilder` (the network and DNS builders accumulate errors lazily; the first failure surfaces from the outermost `.build()` in the chain).
-
-| Variant | Cause |
-|---------|-------|
-| `DirectionNotSet { rule_index }` | A rule was committed without `.egress() / .ingress() / .any()` |
-| `MissingDestination { rule_index }` | `.allow()` or `.deny()` was called but no destination method followed |
-| `InvalidIp { rule_index, raw }` | `.ip(&str)` got an unparseable value |
-| `InvalidCidr { rule_index, raw }` | `.cidr(&str)` got an unparseable value |
-| `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
-| `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
-| `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
-| `InvalidBlockedDomain { raw, source }` | `DnsBuilder::block_domain` got an unparseable value |
-| `InvalidBlockedDomainSuffix { raw, source }` | `DnsBuilder::block_domain_suffix` got an unparseable value |
-
-Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
+**Convenience constructors:** `Rule::allow_egress(dst)`, `Rule::deny_egress(dst)`, `Rule::allow_ingress(dst)`, `Rule::deny_ingress(dst)`, `Rule::allow_any(dst)`, `Rule::deny_any(dst)` — each returns a `Rule` with the matching `direction` and `action`, no protocol or port filters, and the supplied [`Destination`](#destination).
 
 ### ViolationAction
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -130,7 +130,7 @@ Restart a stopped sandbox in detached mode. The sandbox survives after your proc
 
 ---
 
-## Instance methods
+## Instance properties
 
 ---
 
@@ -147,6 +147,42 @@ Access the sandbox's full configuration.
 | Type | Description |
 |------|-------------|
 | [`&SandboxConfig`](#sandboxconfig) | Sandbox configuration |
+
+---
+
+#### name()
+
+```rust
+fn name(&self) -> &str
+```
+
+Get the sandbox name.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `&str` | Sandbox name |
+
+---
+
+#### owns_lifecycle()
+
+```rust
+fn owns_lifecycle(&self) -> bool
+```
+
+Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` if attached |
+
+---
+
+## Instance methods
 
 ---
 
@@ -231,38 +267,6 @@ Stream resource metrics at a regular interval. Returns an async stream that yiel
 | Type | Description |
 |------|-------------|
 | `impl Stream<Item = Result<`[`SandboxMetrics`](#sandboxmetrics)`>>` | Async stream of metrics |
-
----
-
-#### name()
-
-```rust
-fn name(&self) -> &str
-```
-
-Get the sandbox name.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `&str` | Sandbox name |
-
----
-
-#### owns_lifecycle()
-
-```rust
-fn owns_lifecycle(&self) -> bool
-```
-
-Whether this handle owns the sandbox lifecycle. `true` in attached mode (sandbox stops when your process exits), `false` in detached mode.
-
-**Returns**
-
-| Type | Description |
-|------|-------------|
-| `bool` | `true` if attached |
 
 ---
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -21,17 +21,24 @@ await using sb = await Sandbox.builder("filtered")
   .create();
 ```
 
-For port publishing, use `SandboxBuilder.port(host, guest)` / `portUdp(host, guest)` (or the equivalent methods on `NetworkBuilder`).
+For port publishing, use `SandboxBuilder.port(host, guest)` / `portUdp(host, guest)` (or the equivalent methods on [`NetworkBuilder`](#networkbuilder)).
 
 ## NetworkPolicy
 
-Static factory for creating preset policies. Each helper returns a plain `NetworkPolicy` value that can be passed to `NetworkBuilder.policy(...)`.
+```typescript
+interface NetworkPolicy {
+  readonly defaultEgress: Action;
+  readonly defaultIngress: Action;
+  readonly rules: readonly Rule[];
+}
+```
+
+A network access policy: per-direction defaults plus an ordered list of rules evaluated first-match-wins per direction. Use the preset factories below for common cases, or build a literal directly.
 
 ```typescript
 import { NetworkPolicy, Rule, Destination } from "microsandbox";
 
-// Custom policy
-const custom = {
+const custom: NetworkPolicy = {
   defaultEgress: "deny",
   defaultIngress: "allow",
   rules: [
@@ -43,17 +50,23 @@ const custom = {
 
 ---
 
-#### NetworkPolicy.allowAll()
+#### allowAll()
 
 ```typescript
 static allowAll(): NetworkPolicy
 ```
 
-Unrestricted network access, including to private addresses and the host machine.
+Unrestricted network access, including private addresses and the host machine.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Allow-all policy |
 
 ---
 
-#### NetworkPolicy.none()
+#### none()
 
 ```typescript
 static none(): NetworkPolicy
@@ -61,19 +74,15 @@ static none(): NetworkPolicy
 
 Deny all traffic. The guest is fully offline. `exec` and `fs` still work since they use the host-guest channel, not the network.
 
----
+**Returns**
 
-#### NetworkPolicy.publicOnly()
-
-```typescript
-static publicOnly(): NetworkPolicy
-```
-
-Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Deny-all policy |
 
 ---
 
-#### NetworkPolicy.nonLocal()
+#### nonLocal()
 
 ```typescript
 static nonLocal(): NetworkPolicy
@@ -81,122 +90,31 @@ static nonLocal(): NetworkPolicy
 
 Allow egress to public + private (LAN) destinations; ingress allowed by default.
 
----
+**Returns**
 
-## Rules and destinations
-
-### Rule
-
-Factory for individual policy rules. Each method returns a single [`Rule`](#rule-1) value.
-
-| Method | Direction | Action |
-|--------|-----------|--------|
-| `Rule.allowEgress(dest)` | egress | allow |
-| `Rule.denyEgress(dest)` | egress | deny |
-| `Rule.allowIngress(dest)` | ingress | allow |
-| `Rule.denyIngress(dest)` | ingress | deny |
-| `Rule.allowAny(dest)` | any | allow |
-| `Rule.denyAny(dest)` | any | deny |
-
-### Destination
-
-Factory for rule destinations.
-
-| Method | Description |
-|--------|-------------|
-| `Destination.any()` | Match any destination |
-| `Destination.cidr(cidr)` | Match an IP range, e.g. `"10.0.0.0/8"` |
-| `Destination.domain(domain)` | Exact domain match |
-| `Destination.domainSuffix(suffix)` | Match the apex and every subdomain |
-| `Destination.group(group)` | Match a [`DestinationGroup`](#destinationgroup) |
-
-### PortRange
-
-| Method | Description |
-|--------|-------------|
-| `PortRange.single(port)` | Single port (`{ start, end }` set to the same value) |
-| `PortRange.range(start, end)` | Inclusive port range |
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Non-local egress policy |
 
 ---
 
-## NetworkBuilder
-
-Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
-
-| Method | Description |
-|--------|-------------|
-| `enabled(b)` | Enable or disable networking. |
-| `port(host, guest)` | Publish a TCP port. |
-| `portUdp(host, guest)` | Publish a UDP port. |
-| `policy(NetworkPolicy)` | Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal. |
-| `dns(d => ...)` | Configure DNS — see [`DnsBuilder`](#dnsbuilder). |
-| `tls(t => ...)` | Configure TLS — see [`TlsBuilder`](#tlsbuilder). |
-| `secret(s => ...)` | Add a secret — see [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder). |
-| `secretEnv(envVar, value, placeholder, allowedHost)` | Four-arg explicit-placeholder shorthand. |
-| `onSecretViolation(action)` | Action on disallowed secret use — see [`ViolationAction`](/sdk/typescript/secrets#violationaction). |
-| `maxConnections(n)` | Maximum concurrent connections. |
-| `trustHostCAs(enabled)` | Ship the host's trusted root CAs into the guest at boot. Opt-in. |
-| `build()` | Internal — produce a [`NetworkConfig`](#networkconfig). |
-
----
-
-## DnsBuilder
-
-| Method | Description |
-|--------|-------------|
-| `blockDomain(domain)` | Block a specific FQDN (returns REFUSED). |
-| `blockDomainSuffix(suffix)` | Block any name ending in `suffix`. |
-| `nameservers(servers)` | Override upstream nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). |
-| `rebindProtection(enabled)` | Toggle DNS rebinding protection. |
-| `queryTimeoutMs(ms)` | Per-query timeout. |
-| `build()` | Internal — produce a [`DnsConfig`](#dnsconfig). |
-
----
-
-## TlsBuilder
-
-| Method | Description |
-|--------|-------------|
-| `bypass(pattern)` | Skip interception for hosts matching this glob (e.g. `"*.internal.corp"`). |
-| `verifyUpstream(verify)` | Verify upstream server certificates. Default `true`. |
-| `interceptedPorts(ports)` | TCP ports to intercept. Default `[443]`. |
-| `blockQuic(block)` | Block QUIC on intercepted ports, forcing TCP/TLS fallback. |
-| `upstreamCaCert(path)` | Add a PEM file with extra root CAs the proxy should trust. |
-| `interceptCaCert(path)` | PEM file used as the intercepting CA's certificate. |
-| `interceptCaKey(path)` | PEM file used as the intercepting CA's private key. |
-| `build()` | Internal — produce a [`TlsConfig`](#tlsconfig). |
-
----
-
-## Types
-
-### NetworkConfig
-
-Built network configuration produced by `NetworkBuilder.build()`.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| enabled | `boolean` | Master enable flag |
-| ports | `readonly PublishedPort[]` | Port publishings |
-| policy | [`NetworkPolicy`](#networkpolicy-1) ` \| null` | Active policy |
-| dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
-| tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
-| secrets | `readonly SecretEntry[]` | Secret entries |
-| secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
-| maxConnections | `number \| null` | Maximum concurrent connections |
-| trustHostCAs | `boolean` | Ship host CAs into the guest |
-
-### NetworkPolicy
+#### publicOnly()
 
 ```typescript
-interface NetworkPolicy {
-  readonly defaultEgress: Action;
-  readonly defaultIngress: Action;
-  readonly rules: readonly Rule[];
-}
+static publicOnly(): NetworkPolicy
 ```
 
-### Rule
+Block private address ranges and cloud metadata endpoints. Allow everything else. This is the **default** policy.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`NetworkPolicy`](#networkpolicy) | Public-only egress policy |
+
+---
+
+## Rule
 
 ```typescript
 interface Rule {
@@ -208,7 +126,143 @@ interface Rule {
 }
 ```
 
-### Destination
+A single network policy rule. Use the factories below to build rules without writing the literal shape.
+
+---
+
+#### allowAny()
+
+```typescript
+allowAny(destination: Destination): Rule
+```
+
+Allow `destination` in either direction.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination) | Match target |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | Direction-agnostic allow rule |
+
+---
+
+#### allowEgress()
+
+```typescript
+allowEgress(destination: Destination): Rule
+```
+
+Allow egress to `destination`. No protocol or port filter.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination) | Egress target |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | Allow-egress rule |
+
+---
+
+#### allowIngress()
+
+```typescript
+allowIngress(destination: Destination): Rule
+```
+
+Allow ingress from `destination`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination) | Ingress source |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | Allow-ingress rule |
+
+---
+
+#### denyAny()
+
+```typescript
+denyAny(destination: Destination): Rule
+```
+
+Deny `destination` in either direction.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination) | Match target |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | Direction-agnostic deny rule |
+
+---
+
+#### denyEgress()
+
+```typescript
+denyEgress(destination: Destination): Rule
+```
+
+Deny egress to `destination`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination) | Egress target |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | Deny-egress rule |
+
+---
+
+#### denyIngress()
+
+```typescript
+denyIngress(destination: Destination): Rule
+```
+
+Deny ingress from `destination`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| destination | [`Destination`](#destination) | Ingress source |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Rule`](#rule) | Deny-ingress rule |
+
+---
+
+## Destination
 
 ```typescript
 type Destination =
@@ -218,6 +272,581 @@ type Destination =
   | { kind: "domainSuffix"; suffix: string }
   | { kind: "group"; group: DestinationGroup };
 ```
+
+Discriminated union of rule destinations. Use the factories below to construct values without typing the literal shape.
+
+---
+
+#### any()
+
+```typescript
+any(): Destination
+```
+
+Match any destination.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Destination`](#destination) | `{ kind: "any" }` |
+
+---
+
+#### cidr()
+
+```typescript
+cidr(cidr: string): Destination
+```
+
+Match an IP range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cidr | `string` | CIDR (e.g. `"10.0.0.0/8"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Destination`](#destination) | CIDR destination |
+
+---
+
+#### domain()
+
+```typescript
+domain(domain: string): Destination
+```
+
+Match an exact domain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `string` | Domain name (e.g. `"api.openai.com"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Destination`](#destination) | Domain destination |
+
+---
+
+#### domainSuffix()
+
+```typescript
+domainSuffix(suffix: string): Destination
+```
+
+Match a domain suffix and every subdomain.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Suffix (e.g. `"example.com"`) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Destination`](#destination) | Domain-suffix destination |
+
+---
+
+#### group()
+
+```typescript
+group(group: DestinationGroup): Destination
+```
+
+Match a predefined address group.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| group | [`DestinationGroup`](#destinationgroup) | Group name |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`Destination`](#destination) | Group destination |
+
+---
+
+## PortRange
+
+```typescript
+interface PortRange {
+  readonly start: number;
+  readonly end: number;
+}
+```
+
+Inclusive port range used in rule port filters.
+
+---
+
+#### range()
+
+```typescript
+range(start: number, end: number): PortRange
+```
+
+An inclusive range.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| start | `number` | Range start (inclusive) |
+| end | `number` | Range end (inclusive) |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PortRange`](#portrange) | Inclusive range |
+
+---
+
+#### single()
+
+```typescript
+single(port: number): PortRange
+```
+
+A single-port range — `start` and `end` set to the same value.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| port | `number` | Port number |
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`PortRange`](#portrange) | Single-port range |
+
+---
+
+## NetworkBuilder
+
+Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter returns the same builder.
+
+---
+
+#### dns()
+
+```typescript
+dns(configure: (b: DnsBuilder) => DnsBuilder): this
+```
+
+Configure DNS interception via a [`DnsBuilder`](#dnsbuilder) callback.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | [`DnsBuilder`](#dnsbuilder) callback | Configure DNS |
+
+---
+
+#### enabled()
+
+```typescript
+enabled(enabled: boolean): this
+```
+
+Master enable flag. Off disables the network stack entirely.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `false` to disable networking |
+
+---
+
+#### maxConnections()
+
+```typescript
+maxConnections(max: number): this
+```
+
+Limit the maximum number of concurrent network connections from the sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| max | `number` | Maximum concurrent connections |
+
+---
+
+#### onSecretViolation()
+
+```typescript
+onSecretViolation(action: ViolationAction): this
+```
+
+Action taken when a secret placeholder reaches a host outside its allow list.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| action | [`ViolationAction`](/sdk/typescript/secrets#violationaction) | Violation action |
+
+---
+
+#### policy()
+
+```typescript
+policy(policy: NetworkPolicy): this
+```
+
+Set the network access policy. Use a [`NetworkPolicy`](#networkpolicy) preset factory or a literal.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`NetworkPolicy`](#networkpolicy) | Active policy |
+
+---
+
+#### port()
+
+```typescript
+port(hostPort: number, guestPort: number): this
+```
+
+Publish a TCP port from host to guest.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPort | `number` | Port on the host |
+| guestPort | `number` | Port inside the sandbox |
+
+---
+
+#### portUdp()
+
+```typescript
+portUdp(hostPort: number, guestPort: number): this
+```
+
+Publish a UDP port from host to guest.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPort | `number` | Port on the host |
+| guestPort | `number` | Port inside the sandbox |
+
+---
+
+#### secret()
+
+```typescript
+secret(configure: (b: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret with full configuration. See [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) callback | Configure the secret |
+
+---
+
+#### secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, placeholder: string, allowedHost: string): this
+```
+
+Four-argument explicit-placeholder shorthand. Sister to `SandboxBuilder.secretEnv()` (3-arg) which auto-generates the placeholder.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Secret value |
+| placeholder | `string` | Custom placeholder string |
+| allowedHost | `string` | Allowed destination host |
+
+---
+
+#### tls()
+
+```typescript
+tls(configure: (b: TlsBuilder) => TlsBuilder): this
+```
+
+Configure TLS interception via a [`TlsBuilder`](#tlsbuilder) callback.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | [`TlsBuilder`](#tlsbuilder) callback | Configure TLS |
+
+---
+
+#### trustHostCAs()
+
+```typescript
+trustHostCAs(enabled: boolean): this
+```
+
+Ship the host's trusted root CAs into the guest at boot. Default: `false`. Opt in for environments where corporate MITM proxies (Cloudflare Warp Zero Trust, Zscaler, Netskope, etc.) install a gateway CA on the host that the guest's stock bundle doesn't know about.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `true` to ship host CAs |
+
+---
+
+## DnsBuilder
+
+Builder for DNS interception settings. Used in `NetworkBuilder.dns(d => ...)`.
+
+---
+
+#### blockDomain()
+
+```typescript
+blockDomain(domain: string): this
+```
+
+Block DNS lookups for an exact domain. The guest receives REFUSED.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| domain | `string` | FQDN (e.g. `"malware.example.com"`) |
+
+---
+
+#### blockDomainSuffix()
+
+```typescript
+blockDomainSuffix(suffix: string): this
+```
+
+Block DNS lookups for any name ending in `suffix`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| suffix | `string` | Domain suffix (e.g. `".tracking.com"`) |
+
+---
+
+#### nameservers()
+
+```typescript
+nameservers(servers: Iterable<string>): this
+```
+
+Override the upstream nameservers. Each entry can be `IP`, `IP:PORT`, `HOST`, or `HOST:PORT`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| servers | `Iterable<string>` | Upstream resolver addresses |
+
+---
+
+#### queryTimeoutMs()
+
+```typescript
+queryTimeoutMs(ms: number): this
+```
+
+Per-DNS-query timeout in milliseconds. Default: `5000`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| ms | `number` | Timeout in milliseconds |
+
+---
+
+#### rebindProtection()
+
+```typescript
+rebindProtection(enabled: boolean): this
+```
+
+Toggle DNS rebinding protection. When enabled, responses resolving to private IPs are blocked. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `false` disables protection |
+
+---
+
+## TlsBuilder
+
+Builder for TLS interception settings. Used in `NetworkBuilder.tls(t => ...)`.
+
+---
+
+#### blockQuic()
+
+```typescript
+blockQuic(block: boolean): this
+```
+
+Block QUIC / HTTP3 on intercepted ports (forces clients to fall back to TCP, which the proxy can read). Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| block | `boolean` | `true` to block QUIC |
+
+---
+
+#### bypass()
+
+```typescript
+bypass(pattern: string): this
+```
+
+Skip interception for hosts matching a glob (e.g. `"*.internal.corp"`). Can be called multiple times.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `string` | Domain or `*.suffix` pattern |
+
+---
+
+#### interceptCaCert()
+
+```typescript
+interceptCaCert(path: string): this
+```
+
+Path to the PEM file used as the intercepting CA's certificate. Pair with [`interceptCaKey()`](#interceptcakey) to keep the same CA across sandbox restarts.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Path to PEM-encoded CA cert |
+
+---
+
+#### interceptCaKey()
+
+```typescript
+interceptCaKey(path: string): this
+```
+
+Path to the PEM file used as the intercepting CA's private key.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Path to PEM-encoded CA key |
+
+---
+
+#### interceptedPorts()
+
+```typescript
+interceptedPorts(ports: Iterable<number>): this
+```
+
+TCP ports where interception is active. Default: `[443]`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| ports | `Iterable<number>` | TCP ports to intercept |
+
+---
+
+#### upstreamCaCert()
+
+```typescript
+upstreamCaCert(path: string): this
+```
+
+Add a PEM file with extra root CAs the proxy should trust when verifying upstream servers. Can be called multiple times.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Path to PEM-encoded CA bundle |
+
+---
+
+#### verifyUpstream()
+
+```typescript
+verifyUpstream(verify: boolean): this
+```
+
+Whether the proxy verifies upstream server certificates. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| verify | `boolean` | `true` to enforce upstream verification |
+
+---
+
+## Types
+
+### NetworkConfig
+
+Built network configuration produced internally by `NetworkBuilder.build()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| enabled | `boolean` | Master enable flag |
+| ports | `readonly PublishedPort[]` | Port publishings |
+| policy | [`NetworkPolicy`](#networkpolicy) ` \| null` | Active policy |
+| dns | [`DnsConfig`](#dnsconfig) ` \| null` | DNS interception |
+| tls | [`TlsConfig`](#tlsconfig) ` \| null` | TLS interception |
+| secrets | `readonly SecretEntry[]` | Secret entries |
+| secretViolation | [`ViolationAction`](/sdk/typescript/secrets#violationaction) ` \| null` | Action on disallowed secret use |
+| maxConnections | `number \| null` | Maximum concurrent connections |
+| trustHostCAs | `boolean` | Ship host CAs into the guest |
 
 ### Action
 
@@ -259,15 +888,6 @@ type DestinationGroup =
 | `'metadata'` | Cloud metadata endpoints (`169.254.169.254`, `fd00:ec2::254`) |
 | `'multicast'` | Multicast addresses |
 | `'host'` | The host machine, reached via `host.microsandbox.internal` |
-
-### PortRange
-
-```typescript
-interface PortRange {
-  readonly start: number;
-  readonly end: number;
-}
-```
 
 ### DnsConfig
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -146,16 +146,6 @@ Restart a stopped sandbox in detached mode.
 
 ---
 
-#### name
-
-```typescript
-readonly name: string
-```
-
-Sandbox name.
-
----
-
 #### config
 
 ```typescript
@@ -163,6 +153,16 @@ readonly config: Readonly<SandboxConfig>
 ```
 
 The frozen configuration the sandbox was built with.
+
+---
+
+#### name
+
+```typescript
+readonly name: string
+```
+
+Sandbox name.
 
 ---
 
@@ -326,46 +326,514 @@ Implements `AsyncDisposable` so the sandbox can be used with `await using`. When
 
 ---
 
+## SandboxBuilder
+
+Fluent configuration builder returned by [`Sandbox.builder(name)`](#sandboxbuilder). Every setter returns the same builder so calls can be chained. Terminate with `.create()`, `.createDetached()`, or `.build()`.
+
+---
+
+#### addPatch()
+
+```typescript
+addPatch(patch: Patch): this
+```
+
+Append a pre-built `Patch` value.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| patch | `Patch` | A constructed patch |
+
+---
+
+#### build()
+
+```typescript
+build(): SandboxConfig
+```
+
+Materialize the accumulated state into a [`SandboxConfig`](#sandboxconfig) without booting. Throws `InvalidConfigError` if `.image(...)` was never called.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SandboxConfig`](#sandboxconfig) | Frozen configuration |
+
+---
+
+#### cpus()
+
+```typescript
+cpus(count: number): this
+```
+
+Set the number of virtual CPUs. This is a limit, not a reservation.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| count | `number` | Number of vCPUs |
+
+---
+
+#### create()
+
+```typescript
+create(): Promise<Sandbox>
+```
+
+Build and boot the sandbox in attached mode. The sandbox stops when your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`Sandbox`](#instance-methods)`>` | Running sandbox |
+
+---
+
+#### createDetached()
+
+```typescript
+createDetached(): Promise<Sandbox>
+```
+
+Build and boot the sandbox in detached mode. The sandbox survives after your process exits.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`Sandbox`](#instance-methods)`>` | Running sandbox |
+
+---
+
+#### disableNetwork()
+
+```typescript
+disableNetwork(): this
+```
+
+Fully disable networking. No network interface is created.
+
+---
+
+#### entrypoint()
+
+```typescript
+entrypoint(cmd: Iterable<string>): this
+```
+
+Override the OCI image's entrypoint.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| cmd | `Iterable<string>` | Entrypoint command and arguments |
+
+---
+
+#### env()
+
+```typescript
+env(key: string, value: string): this
+```
+
+Add a single environment variable visible to all commands. Per-command env vars are merged on top.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| key | `string` | Variable name |
+| value | `string` | Variable value |
+
+---
+
+#### envs()
+
+```typescript
+envs(vars: Iterable<readonly [string, string]> | Record<string, string>): this
+```
+
+Add many environment variables at once.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| vars | `Iterable<[string, string]> \| Record<string, string>` | Env vars as entries or a plain object |
+
+---
+
+#### hostname()
+
+```typescript
+hostname(name: string): this
+```
+
+Set the guest hostname.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Hostname |
+
+---
+
+#### idleTimeout()
+
+```typescript
+idleTimeout(secs: number): this
+```
+
+Auto-drain the sandbox after this many seconds of inactivity (no active exec sessions). Enforced on the host side.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `number` | Idle timeout in seconds |
+
+---
+
+#### image()
+
+```typescript
+image(src: string | RootfsSource): this
+```
+
+Set the root filesystem source. Accepts an OCI image name (`"alpine"`), a local rootfs path, or a `RootfsSource` discriminated union. The format is auto-detected. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| src | `string \| RootfsSource` | OCI image name, directory path, or disk image path |
+
+---
+
+#### libkrunfwPath()
+
+```typescript
+libkrunfwPath(path: string): this
+```
+
+Override the libkrunfw shared library path for this sandbox.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Filesystem path to libkrunfw |
+
+---
+
+#### logLevel()
+
+```typescript
+logLevel(level: LogLevel): this
+```
+
+Override the sandbox process's log verbosity.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| level | [`LogLevel`](#loglevel) | Log level |
+
+---
+
+#### maxDuration()
+
+```typescript
+maxDuration(secs: number): this
+```
+
+Set the maximum sandbox lifetime in seconds. When exceeded, the sandbox is drained and stopped. Enforced on the host side — the guest cannot override it.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| secs | `number` | Maximum lifetime in seconds |
+
+---
+
+#### memory()
+
+```typescript
+memory(size: number): this
+```
+
+Set the guest memory size in MiB. Physical pages are only allocated as the guest touches them, so this is a limit, not an upfront reservation. Default: `512`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `number` | Memory in MiB |
+
+---
+
+#### network()
+
+```typescript
+network(configure: (n: NetworkBuilder) => NetworkBuilder): this
+```
+
+Configure networking — DNS, TLS interception, policy, secrets. See [Networking](/sdk/typescript/networking) for the full builder API.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | [`NetworkBuilder`](/sdk/typescript/networking#networkbuilder) callback | Configure the network |
+
+---
+
+#### patch()
+
+```typescript
+patch(configure: (p: PatchBuilder) => PatchBuilder): this
+```
+
+Modify the rootfs before the VM boots. Patches go into the writable layer — the base image is untouched. See [Snapshots](/sdk/typescript/snapshots) for available operations.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | `PatchBuilder` callback | Configure rootfs patches |
+
+---
+
+#### port()
+
+```typescript
+port(hostPort: number, guestPort: number): this
+```
+
+Publish a TCP port from the sandbox to the host.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPort | `number` | Port on the host |
+| guestPort | `number` | Port inside the sandbox |
+
+---
+
+#### portUdp()
+
+```typescript
+portUdp(hostPort: number, guestPort: number): this
+```
+
+Publish a UDP port.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| hostPort | `number` | Port on the host |
+| guestPort | `number` | Port inside the sandbox |
+
+---
+
+#### pullPolicy()
+
+```typescript
+pullPolicy(policy: PullPolicy): this
+```
+
+Control when the OCI image is pulled from the registry.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| policy | [`PullPolicy`](#pullpolicy) | Pull behavior |
+
+---
+
+#### quietLogs()
+
+```typescript
+quietLogs(): this
+```
+
+Suppress log output from the sandbox process.
+
+---
+
+#### registry()
+
+```typescript
+registry(configure: (r: RegistryConfigBuilder) => RegistryConfigBuilder): this
+```
+
+Configure the OCI registry connection — auth, insecure HTTP, custom CA bundles.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | `RegistryConfigBuilder` callback | Configure the registry |
+
+---
+
+#### replace()
+
+```typescript
+replace(): this
+```
+
+If a sandbox with the same name already exists, stop it, remove it, and create a fresh one. Without this, creation fails on name conflict.
+
+---
+
+#### script()
+
+```typescript
+script(name: string, content: string): this
+```
+
+Add a named script at `/.msb/scripts/<name>` inside the guest. Scripts are added to `PATH` and can be called by name via `exec()` or `shell()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Script name (becomes the filename) |
+| content | `string` | Script content |
+
+---
+
+#### scripts()
+
+```typescript
+scripts(scripts: Iterable<readonly [string, string]> | Record<string, string>): this
+```
+
+Add many scripts at once.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| scripts | `Iterable<[string, string]> \| Record<string, string>` | Scripts as entries or a plain object |
+
+---
+
+#### secret()
+
+```typescript
+secret(configure: (b: SecretBuilder) => SecretBuilder): this
+```
+
+Add a secret with full configuration. See [Secrets](/sdk/typescript/secrets) for the builder API. Automatically enables TLS interception.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| configure | [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) callback | Configure the secret |
+
+---
+
+#### secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Shorthand for adding a header-injected secret. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Secret value |
+| allowedHost | `string` | Allowed destination host |
+
+---
+
+#### shell()
+
+```typescript
+shell(shell: string): this
+```
+
+Set the shell used by [`sandbox.shell(...)`](/sdk/typescript/execution#shell). Default: `/bin/sh`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| shell | `string` | Shell path (e.g. `"/bin/bash"`) |
+
+---
+
+#### user()
+
+```typescript
+user(user: string): this
+```
+
+Set the default guest user for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| user | `string` | User name or UID |
+
+---
+
+#### volume()
+
+```typescript
+volume(guestPath: string, configure: (m: MountBuilder) => MountBuilder): this
+```
+
+Add a volume mount. See [Volumes](/sdk/typescript/volumes) for mount types.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| guestPath | `string` | Mount point inside the sandbox |
+| configure | [`MountBuilder`](/sdk/typescript/volumes#mountbuilder) callback | Configure the mount |
+
+---
+
+#### workdir()
+
+```typescript
+workdir(path: string): this
+```
+
+Set the default working directory for all commands.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| path | `string` | Absolute path inside the guest |
+
+---
+
 ## Types
-
-### SandboxBuilder
-
-Fluent configuration builder returned by `Sandbox.builder(name)`. Every setter returns the same builder so calls can be chained.
-
-| Method | Description |
-|--------|-------------|
-| `image(src)` | OCI image (`"alpine"`), local rootfs path, or a `RootfsSource`. **Required.** |
-| `cpus(n)` | Virtual CPUs |
-| `memory(mib)` | Guest memory in MiB |
-| `logLevel(level)` | Override log verbosity |
-| `quietLogs()` | Suppress log output |
-| `workdir(path)` | Default working directory for commands |
-| `shell(shell)` | Shell binary used by `sandbox.shell(...)` |
-| `entrypoint(iter)` | Override the image entrypoint |
-| `hostname(name)` | Guest hostname |
-| `user(user)` | Default guest user |
-| `pullPolicy(policy)` | Image pull behavior |
-| `libkrunfwPath(path)` | Override the bundled libkrunfw shared library |
-| `env(key, value)` | Add a single env var |
-| `envs(record \| iter)` | Add many env vars |
-| `script(name, content)` | Mount a script at `/.msb/scripts/<name>` |
-| `scripts(record \| iter)` | Mount many scripts |
-| `replace()` | Replace any existing sandbox with the same name |
-| `maxDuration(secs)` | Maximum sandbox lifetime |
-| `idleTimeout(secs)` | Stop the sandbox after this many idle seconds |
-| `volume(guestPath, m => ...)` | Mount a volume — see [Volumes](/sdk/typescript/volumes) |
-| `patch(p => ...)` | Modify the rootfs before boot — see [Snapshots](/sdk/typescript/snapshots) |
-| `addPatch(patch)` | Append a pre-built `Patch` |
-| `registry(r => r.auth(...).insecure().caCertsPath(...))` | Configure the OCI registry |
-| `port(host, guest)` | Publish a TCP port |
-| `portUdp(host, guest)` | Publish a UDP port |
-| `disableNetwork()` | Disable networking entirely |
-| `network(n => ...)` | Configure DNS / TLS / policy / secrets — see [Networking](/sdk/typescript/networking) |
-| `secret(s => ...)` | Add a secret via [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder) |
-| `secretEnv(envVar, value, allowedHost)` | Auto-placeholder shorthand. Generates `$MSB_<ENV_VAR>`. |
-| `build(): SandboxConfig` | Materialize without booting |
-| `create(): Promise<Sandbox>` | Build and boot in attached mode |
-| `createDetached(): Promise<Sandbox>` | Build and boot in detached mode |
 
 ### LogLevel
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -41,32 +41,201 @@ The same `secret(...)` and `secretEnv(...)` methods are also available inside `S
 
 Fluent builder used inside `SandboxBuilder.secret(s => ...)` or `NetworkBuilder.secret(s => ...)`. Every setter returns the same builder so calls can be chained.
 
-| Method | Description |
-|--------|-------------|
-| `env(varName)` | Environment variable to expose the placeholder under. **Required.** |
-| `value(value)` | The real secret value (stays on the host). **Required.** |
-| `placeholder(placeholder)` | Custom placeholder. Auto-generated as `$MSB_<ENV_VAR>` when omitted. |
-| `allowHost(host)` | Allow substitution to a specific host (exact match). |
-| `allowHostPattern(pattern)` | Allow substitution to any host matching a wildcard. |
-| `allowAnyHostDangerous(true)` | Permit substitution to any host. Acknowledge the risk explicitly. |
-| `requireTlsIdentity(enabled)` | Require a verified TLS identity before substituting. Default `true`. |
-| `injectHeaders(enabled)` | Allow substitution in HTTP headers. Default `true`. |
-| `injectBasicAuth(enabled)` | Allow substitution in HTTP Basic Auth. Default `true`. |
-| `injectQuery(enabled)` | Allow substitution in URL query parameters. Default `false`. |
-| `injectBody(enabled)` | Allow substitution in the HTTP request body. Default `false`. |
-| `build()` | Produce a [`SecretEntry`](#secretentry). |
+---
+
+#### allowAnyHostDangerous()
+
+```typescript
+allowAnyHostDangerous(iUnderstandTheRisk: boolean): this
+```
+
+Permit substitution to any host. The argument name forces an explicit acknowledgement of the risk: a leaked secret can be exfiltrated to attacker-controlled servers.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| iUnderstandTheRisk | `boolean` | Must pass `true` to enable |
+
+---
+
+#### allowHost()
+
+```typescript
+allowHost(host: string): this
+```
+
+Allow substitution to a specific host (exact match). Can be called multiple times.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `string` | Hostname (e.g. `"api.openai.com"`) |
+
+---
+
+#### allowHostPattern()
+
+```typescript
+allowHostPattern(pattern: string): this
+```
+
+Allow substitution to any host matching a wildcard pattern.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| pattern | `string` | Wildcard pattern (e.g. `"*.stripe.com"`) |
+
+---
+
+#### build()
+
+```typescript
+build(): SecretEntry
+```
+
+Materialize the secret. Throws `InvalidConfigError` if `.env(...)` or `.value(...)` was never called.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`SecretEntry`](#secretentry) | Frozen secret entry |
+
+---
+
+#### env()
+
+```typescript
+env(varName: string): this
+```
+
+Environment variable to expose the placeholder under. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| varName | `string` | Env var name (e.g. `"OPENAI_API_KEY"`) |
+
+---
+
+#### injectBasicAuth()
+
+```typescript
+injectBasicAuth(enabled: boolean): this
+```
+
+Allow substitution in HTTP Basic Auth credentials. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `false` disables Basic Auth injection |
+
+---
+
+#### injectBody()
+
+```typescript
+injectBody(enabled: boolean): this
+```
+
+Allow substitution in the HTTP request body. `Content-Length` is rewritten. Default: `false`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `true` enables body injection |
+
+---
+
+#### injectHeaders()
+
+```typescript
+injectHeaders(enabled: boolean): this
+```
+
+Allow substitution in HTTP headers. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `false` disables header injection |
+
+---
+
+#### injectQuery()
+
+```typescript
+injectQuery(enabled: boolean): this
+```
+
+Allow substitution in URL query parameters. Default: `false`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `true` enables query injection |
+
+---
+
+#### placeholder()
+
+```typescript
+placeholder(placeholder: string): this
+```
+
+Custom placeholder string the guest will see in the env var. Auto-generated as `$MSB_<ENV_VAR>` when omitted.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| placeholder | `string` | Placeholder string |
+
+---
+
+#### requireTlsIdentity()
+
+```typescript
+requireTlsIdentity(enabled: boolean): this
+```
+
+Require a verified TLS identity before substituting. Default: `true`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enabled | `boolean` | `false` disables verification |
+
+---
+
+#### value()
+
+```typescript
+value(value: string): this
+```
+
+The real secret value. Stays on the host; never crosses into the guest. **Required.**
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| value | `string` | Secret value |
 
 ---
 
 ## Convenience helpers
-
-#### SandboxBuilder.secretEnv()
-
-```typescript
-secretEnv(envVar: string, value: string, allowedHost: string): this
-```
-
-Three-argument shorthand. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
 
 #### NetworkBuilder.secretEnv()
 
@@ -80,6 +249,33 @@ secretEnv(
 ```
 
 Four-argument shorthand. Same as the `SandboxBuilder` form but lets you provide the placeholder explicitly.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Secret value |
+| placeholder | `string` | Custom placeholder |
+| allowedHost | `string` | Allowed destination host |
+
+---
+
+#### SandboxBuilder.secretEnv()
+
+```typescript
+secretEnv(envVar: string, value: string, allowedHost: string): this
+```
+
+Three-argument shorthand. Auto-generates the placeholder as `$MSB_<ENV_VAR>` and allows substitution only on `allowedHost`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| envVar | `string` | Environment variable name |
+| value | `string` | Secret value |
+| allowedHost | `string` | Allowed destination host |
 
 ---
 

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -101,6 +101,30 @@ Delete a named volume and its contents. Fails if the volume is currently mounted
 
 ## Instance properties
 
+---
+
+#### fs()
+
+```typescript
+fs(): VolumeFs
+```
+
+Get a host-side filesystem handle for this volume — no sandbox required.
+
+```typescript
+const vfs = data.fs();
+await vfs.write("seed.txt", "hello");
+console.log(await vfs.list(""));
+```
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeFs`](#volumefs) | Host-side filesystem handle |
+
+---
+
 #### name
 
 ```typescript
@@ -121,25 +145,80 @@ Absolute host path to the volume's directory.
 
 ---
 
-#### fs()
+## VolumeBuilder
 
-```typescript
-fs(): VolumeFs
-```
-
-Get a host-side filesystem handle for this volume — no sandbox required.
-
-```typescript
-const vfs = data.fs();
-await vfs.write("seed.txt", "hello");
-console.log(await vfs.list(""));
-```
+Fluent builder returned by [`Volume.builder(name)`](#volumebuilder). Every setter returns the same builder. Terminate with `.create()` or `.build()`.
 
 ---
 
-## Mounts
+#### build()
 
-Volume mounts attach a host directory, named volume, tmpfs, or disk image to a guest path. Configure them via `SandboxBuilder.volume(guestPath, m => ...)`:
+```typescript
+build(): VolumeConfig
+```
+
+Materialize the accumulated state without creating the volume.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| [`VolumeConfig`](#volumeconfig) | Frozen volume configuration |
+
+---
+
+#### create()
+
+```typescript
+create(): Promise<Volume>
+```
+
+Build and create the volume on disk.
+
+**Returns**
+
+| Type | Description |
+|------|-------------|
+| `Promise<`[`Volume`](#volume)`>` | Created volume |
+
+---
+
+#### label()
+
+```typescript
+label(key: string, value: string): this
+```
+
+Add a metadata label. Can be called multiple times.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| key | `string` | Label key |
+| value | `string` | Label value |
+
+---
+
+#### quota()
+
+```typescript
+quota(size: number): this
+```
+
+Maximum storage size in MiB. Floor of the value is taken; negative inputs clamp to `0`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `number` | Quota in MiB |
+
+---
+
+## MountBuilder
+
+Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind ([`bind()`](#bind), [`named()`](#named), [`tmpfs()`](#tmpfs), or [`disk()`](#disk)), then chain modifiers.
 
 ```typescript
 await using sb = await Sandbox.builder("worker")
@@ -151,21 +230,155 @@ await using sb = await Sandbox.builder("worker")
   .create();
 ```
 
-### MountBuilder
+---
 
-Used inside `SandboxBuilder.volume(guestPath, m => ...)`. Pick exactly one mount kind, then chain modifiers.
+#### bind()
 
-| Method | Description |
-|--------|-------------|
-| `bind(host)` | Mount a host directory into the guest. |
-| `named(name)` | Mount a named volume created via [`Volume.builder`](#volumebuilder). |
-| `tmpfs()` | Mount an in-memory filesystem. |
-| `disk(host)` | Mount a host disk image as a virtio-blk device. |
-| `format(fmt)` | Disk image format (`'qcow2' \| 'raw' \| 'vmdk'`). Defaults to the file extension. Disk only. |
-| `fstype(fs)` | Inner filesystem type (e.g. `"ext4"`). Disk only; omit to autodetect. |
-| `readonly()` | Mount read-only. |
-| `size(mib)` | Cap in MiB. Tmpfs only. |
-| `build()` | Internal — produce a `VolumeMount`. |
+```typescript
+bind(host: string): this
+```
+
+Mount a host directory into the guest.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `string` | Absolute host path |
+
+---
+
+#### disk()
+
+```typescript
+disk(host: string): this
+```
+
+Mount a host disk image as a virtio-blk device.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| host | `string` | Path to the disk image on the host |
+
+---
+
+#### format()
+
+```typescript
+format(format: DiskImageFormat): this
+```
+
+Override the disk image format. Disk only — defaults to the file extension.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| format | [`DiskImageFormat`](#diskimageformat) | `"qcow2"`, `"raw"`, or `"vmdk"` |
+
+---
+
+#### fstype()
+
+```typescript
+fstype(fstype: string): this
+```
+
+Inner filesystem type for a disk image (e.g. `"ext4"`). Disk only; omit to autodetect. Must not contain `,`, `;`, `:`, or `=`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| fstype | `string` | Filesystem type |
+
+---
+
+#### named()
+
+```typescript
+named(name: string): this
+```
+
+Mount a named volume created via [`Volume.builder`](#volumebuilder).
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | `string` | Volume name |
+
+---
+
+#### readonly()
+
+```typescript
+readonly(): this
+```
+
+Prevent writes to this mount.
+
+---
+
+#### size()
+
+```typescript
+size(size: number): this
+```
+
+Size cap in MiB. Tmpfs only — calling on other kinds throws at `.build()`.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| size | `number` | Cap in MiB |
+
+---
+
+#### tmpfs()
+
+```typescript
+tmpfs(): this
+```
+
+Mount an in-memory filesystem. Pair with [`size()`](#size) to cap usage.
+
+---
+
+## Types
+
+### VolumeConfig
+
+Frozen configuration produced by [`VolumeBuilder.build()`](#build).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Maximum storage size in MiB |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+
+### VolumeHandle
+
+Handle returned by [`Volume.get()`](#volumeget) or in the array from [`Volume.list()`](#volumelist).
+
+| Property / Method | Type | Description |
+|-------------------|------|-------------|
+| name | `string` | Volume name |
+| quotaMib | `number \| null` | Storage quota |
+| usedBytes | `number` | Current disk usage in bytes |
+| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
+| createdAt | `Date \| null` | Creation timestamp |
+| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
+| remove() | `Promise<void>` | Delete this volume (live handles only) |
+
+Handles in the array returned by [`Volume.list()`](#volumelist) are read-only: calling `.fs()` or `.remove()` throws. Use [`Volume.get(name)`](#volumeget) to upgrade.
+
+### VolumeFs
+
+Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (`read`, `readToString`, `readStream`, `write`, `writeStream`, `list`, `mkdir`, `removeDir`, `remove`, `copy`, `rename`, `stat`, `exists`) — but operates directly on the host without booting a sandbox.
 
 ### VolumeMount
 
@@ -191,44 +404,3 @@ type VolumeMount =
 ```typescript
 type DiskImageFormat = "qcow2" | "raw" | "vmdk";
 ```
-
----
-
-## Types
-
-### VolumeBuilder
-
-| Method | Description |
-|--------|-------------|
-| `quota(mib)` | Maximum storage size in MiB |
-| `label(key, value)` | Add a metadata label |
-| `build()` | Materialize a [`VolumeConfig`](#volumeconfig) |
-| `create()` | Build and create the volume; returns a [`Volume`](#volume) |
-
-### VolumeConfig
-
-Frozen configuration produced by `VolumeBuilder.build()`.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| name | `string` | Volume name |
-| quotaMib | `number \| null` | Maximum storage size in MiB |
-| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
-
-### VolumeHandle
-
-| Property / Method | Type | Description |
-|-------------------|------|-------------|
-| name | `string` | Volume name |
-| quotaMib | `number \| null` | Storage quota |
-| usedBytes | `number` | Current disk usage in bytes |
-| labels | `ReadonlyArray<readonly [string, string]>` | Metadata labels |
-| createdAt | `Date \| null` | Creation timestamp |
-| fs() | [`VolumeFs`](#volumefs) | Host-side filesystem on this volume (live handles only) |
-| remove() | `Promise<void>` | Delete this volume (live handles only) |
-
-Handles in the array returned by `Volume.list()` are read-only: calling `.fs()` or `.remove()` throws. Use `Volume.get(name)` to upgrade.
-
-### VolumeFs
-
-Host-side filesystem operations on a volume's directory. Same surface area as [`SandboxFs`](/sdk/typescript/filesystem) (read, readToString, readStream, write, writeStream, list, mkdir, removeDir, remove, copy, rename, stat, exists) — but operates directly on the host without booting a sandbox.


### PR DESCRIPTION
reformatted builder and factory sections across the rust, typescript, and python sdk reference pages so each method gets its own h4 sub-heading with a code block, description, parameters, and returns instead of being collapsed into single tables. also normalized section structure (instance properties splits, types-vs-builders placement, dropped redundant type prefixes, de-duplicated entries) and sorted methods alphabetically within every reformatted section.