### PR TITLE
domain-rule enforcement at DNS, SNI, and policy layers

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -101,14 +101,28 @@ pub struct SandboxOpts {
     #[arg(long = "no-net")]
     pub no_net: bool,
 
-    /// Block DNS lookups for a domain (returns REFUSED).
+    /// Deny egress to a domain (DNS REFUSED + TCP block by SNI).
+    /// Repeatable. Equivalent to a `deny Domain("...")` policy rule.
     #[cfg(feature = "net")]
-    #[arg(long)]
+    #[arg(long = "deny-domain", value_name = "NAME")]
+    pub deny_domain: Vec<String>,
+
+    /// Deny egress to all subdomains of a suffix (e.g. `.ads.example`).
+    /// Repeatable. Equivalent to a `deny DomainSuffix("...")` policy rule.
+    #[cfg(feature = "net")]
+    #[arg(long = "deny-domain-suffix", value_name = "SUFFIX")]
+    pub deny_domain_suffix: Vec<String>,
+
+    /// Deprecated alias for `--deny-domain`. Kept for back-compat;
+    /// emits a warning on use.
+    #[cfg(feature = "net")]
+    #[arg(long, hide = true)]
     pub dns_block_domain: Vec<String>,
 
-    /// Block DNS lookups for all subdomains of a suffix (e.g. .ads.com).
+    /// Deprecated alias for `--deny-domain-suffix`. Kept for
+    /// back-compat; emits a warning on use.
     #[cfg(feature = "net")]
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub dns_block_suffix: Vec<String>,
 
     /// Allow DNS responses pointing to private/internal IP addresses.
@@ -243,6 +257,8 @@ impl SandboxOpts {
         #[cfg(feature = "net")]
         let net = !self.port.is_empty()
             || self.no_net
+            || !self.deny_domain.is_empty()
+            || !self.deny_domain_suffix.is_empty()
             || !self.dns_block_domain.is_empty()
             || !self.dns_block_suffix.is_empty()
             || self.no_dns_rebind_protection
@@ -422,7 +438,9 @@ fn apply_network_opts(
     }
 
     // DNS, TLS, and other network configuration.
-    let has_network_config = !opts.dns_block_domain.is_empty()
+    let has_network_config = !opts.deny_domain.is_empty()
+        || !opts.deny_domain_suffix.is_empty()
+        || !opts.dns_block_domain.is_empty()
         || !opts.dns_block_suffix.is_empty()
         || opts.no_dns_rebind_protection
         || !opts.dns_nameserver.is_empty()
@@ -442,6 +460,21 @@ fn apply_network_opts(
         || opts.on_secret_violation.is_some();
 
     if has_network_config {
+        // Warn on the deprecated aliases, but accept them. New flags
+        // and old flags concatenate into a single deny-rule list.
+        if !opts.dns_block_domain.is_empty() {
+            eprintln!("warning: --dns-block-domain is deprecated; use --deny-domain instead");
+        }
+        if !opts.dns_block_suffix.is_empty() {
+            eprintln!(
+                "warning: --dns-block-suffix is deprecated; use --deny-domain-suffix instead"
+            );
+        }
+        let mut deny_domains = opts.deny_domain.clone();
+        deny_domains.extend(opts.dns_block_domain.iter().cloned());
+        let mut deny_domain_suffixes = opts.deny_domain_suffix.clone();
+        deny_domain_suffixes.extend(opts.dns_block_suffix.iter().cloned());
+
         let no_dns_rebind = opts.no_dns_rebind_protection;
         let dns_nameservers = opts
             .dns_nameserver
@@ -453,8 +486,8 @@ fn apply_network_opts(
             &opts.net_rule,
             opts.net_default_egress.as_deref(),
             opts.net_default_ingress.as_deref(),
-            &opts.dns_block_domain,
-            &opts.dns_block_suffix,
+            &deny_domains,
+            &deny_domain_suffixes,
         )?;
         let max_conn = opts.max_connections;
         let trust_host_cas = opts.trust_host_cas;
@@ -559,16 +592,16 @@ pub fn parse_duration_secs(s: &str) -> anyhow::Result<u64> {
 }
 
 /// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default-*`
-/// and the legacy `--dns-block-domain` / `--dns-block-suffix` flags.
-/// Returns `None` when no flag was set (caller falls back to the
-/// sandbox default).
+/// and the bulk-deny flags (`--deny-domain` / `--deny-domain-suffix`,
+/// plus the deprecated `--dns-block-domain` / `--dns-block-suffix`
+/// aliases the caller has already merged in). Returns `None` when no
+/// flag was set (caller falls back to the sandbox default).
 ///
-/// `--dns-block-domain` and `--dns-block-suffix` are convenience
-/// shortcuts for `deny Domain(...)` / `deny DomainSuffix(...)` rules;
-/// they are prepended to the rule list so they take precedence over any
-/// later allow rules. When these are the only policy flags set, the
-/// defaults flip to Allow on egress to preserve the legacy "full
-/// network minus blocked domains" semantics.
+/// Bulk-deny flags are convenience shortcuts for `deny Domain(...)` /
+/// `deny DomainSuffix(...)` rules; they are prepended to the rule list
+/// so they take precedence over any later allow rules. When these are
+/// the only policy flags set, the defaults flip to Allow on egress to
+/// preserve the legacy "full network minus blocked domains" semantics.
 ///
 /// Multiple `--net-rule` invocations concatenate in argv order; tokens
 /// inside each value are comma-separated and likewise preserved.
@@ -577,8 +610,8 @@ fn build_network_policy(
     rule_args: &[String],
     default_egress: Option<&str>,
     default_ingress: Option<&str>,
-    dns_block_domain: &[String],
-    dns_block_suffix: &[String],
+    deny_domains: &[String],
+    deny_domain_suffixes: &[String],
 ) -> anyhow::Result<Option<microsandbox_network::policy::NetworkPolicy>> {
     use anyhow::Context;
     use microsandbox_network::policy::{Action, Destination, DomainName, NetworkPolicy, Rule};
@@ -587,26 +620,24 @@ fn build_network_policy(
 
     let no_rule_flags =
         rule_args.is_empty() && default_egress.is_none() && default_ingress.is_none();
-    let no_block_flags = dns_block_domain.is_empty() && dns_block_suffix.is_empty();
+    let no_block_flags = deny_domains.is_empty() && deny_domain_suffixes.is_empty();
     if no_rule_flags && no_block_flags {
         return Ok(None);
     }
 
     let mut rules = Vec::new();
 
-    // Prepend deny rules from --dns-block-domain / --dns-block-suffix
-    // so they take precedence over any later allow rules. The user's
-    // intent in writing these flags is unambiguous: refuse these names.
-    for d in dns_block_domain {
-        let domain: DomainName = d
-            .parse()
-            .with_context(|| format!("--dns-block-domain {d:?}"))?;
+    // Prepend deny rules from the bulk-deny flags so they take
+    // precedence over any later allow rules. The user's intent in
+    // writing these flags is unambiguous: refuse these names.
+    for d in deny_domains {
+        let domain: DomainName = d.parse().with_context(|| format!("--deny-domain {d:?}"))?;
         rules.push(Rule::deny_egress(Destination::Domain(domain)));
     }
-    for s in dns_block_suffix {
+    for s in deny_domain_suffixes {
         let suffix: DomainName = s
             .parse()
-            .with_context(|| format!("--dns-block-suffix {s:?}"))?;
+            .with_context(|| format!("--deny-domain-suffix {s:?}"))?;
         rules.push(Rule::deny_egress(Destination::DomainSuffix(suffix)));
     }
 

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -101,14 +101,15 @@ pub struct SandboxOpts {
     #[arg(long = "no-net")]
     pub no_net: bool,
 
-    /// Deny egress to a domain (DNS REFUSED + TCP block by SNI).
-    /// Repeatable. Equivalent to a `deny Domain("...")` policy rule.
+    /// Deny egress to a domain. Equivalent to a `deny Domain("...")`
+    /// policy rule appended after any `--net-rule` entries.
     #[cfg(feature = "net")]
     #[arg(long = "deny-domain", value_name = "NAME")]
     pub deny_domain: Vec<String>,
 
     /// Deny egress to all subdomains of a suffix (e.g. `.ads.example`).
-    /// Repeatable. Equivalent to a `deny DomainSuffix("...")` policy rule.
+    /// Equivalent to a `deny DomainSuffix("...")` rule appended after
+    /// any `--net-rule` entries.
     #[cfg(feature = "net")]
     #[arg(long = "deny-domain-suffix", value_name = "SUFFIX")]
     pub deny_domain_suffix: Vec<String>,
@@ -470,22 +471,18 @@ fn apply_network_opts(
         let violation_action = parse_violation_action(&opts.on_secret_violation)?;
 
         builder = builder.network(move |mut n| {
-            let has_dns =
-                no_dns_rebind || !dns_nameservers.is_empty() || dns_query_timeout_ms.is_some();
-            if has_dns {
-                n = n.dns(move |mut d| {
-                    if no_dns_rebind {
-                        d = d.rebind_protection(false);
-                    }
-                    if !dns_nameservers.is_empty() {
-                        d = d.nameservers(dns_nameservers);
-                    }
-                    if let Some(ms) = dns_query_timeout_ms {
-                        d = d.query_timeout_ms(ms);
-                    }
-                    d
-                });
-            }
+            n = n.dns(move |mut d| {
+                if no_dns_rebind {
+                    d = d.rebind_protection(false);
+                }
+                if !dns_nameservers.is_empty() {
+                    d = d.nameservers(dns_nameservers);
+                }
+                if let Some(ms) = dns_query_timeout_ms {
+                    d = d.query_timeout_ms(ms);
+                }
+                d
+            });
             if let Some(policy) = network_policy {
                 n = n.policy(policy);
             }
@@ -561,18 +558,8 @@ pub fn parse_duration_secs(s: &str) -> anyhow::Result<u64> {
 }
 
 /// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default-*`
-/// and the bulk-deny flags (`--deny-domain` / `--deny-domain-suffix`).
-/// Returns `None` when no flag was set (caller falls back to the
-/// sandbox default).
-///
-/// Bulk-deny flags are convenience shortcuts for `deny Domain(...)` /
-/// `deny DomainSuffix(...)` rules; they are prepended to the rule list
-/// so they take precedence over any later allow rules. When these are
-/// the only policy flags set, the defaults flip to Allow on egress to
-/// preserve the legacy "full network minus blocked domains" semantics.
-///
-/// Multiple `--net-rule` invocations concatenate in argv order; tokens
-/// inside each value are comma-separated and likewise preserved.
+/// and the bulk-deny flags. Returns `None` when no flag is set.
+/// Multiple `--net-rule` invocations concatenate in argv order.
 #[cfg(feature = "net")]
 fn build_network_policy(
     rule_args: &[String],
@@ -595,9 +582,7 @@ fn build_network_policy(
 
     let mut rules = Vec::new();
 
-    // Prepend deny rules from the bulk-deny flags so they take
-    // precedence over any later allow rules. The user's intent in
-    // writing these flags is unambiguous: refuse these names.
+    // Prepend bulk-deny flags so they outrank later allow rules.
     for d in deny_domains {
         let domain: DomainName = d.parse().with_context(|| format!("--deny-domain {d:?}"))?;
         rules.push(Rule::deny_egress(Destination::Domain(domain)));
@@ -622,22 +607,23 @@ fn build_network_policy(
         }
     };
 
-    // When the user sets no defaults explicitly, preserve today's
-    // asymmetric behavior: egress = Deny (rules open things);
-    // ingress = Allow (unfiltered published-port behavior). Exception:
-    // if only --deny-domain / --deny-domain-suffix were set (no
-    // --net-rule, no --net-default-*), default egress flips to Allow so
-    // the rest of the network keeps working — these flags add deny
-    // entries on top of permissive defaults, leaving non-denied
-    // traffic unaffected.
+    // When the user sets no defaults explicitly, fall through to
+    // NetworkPolicy::public_only's defaults so behaviour stays in sync
+    // with the preset.
+    //
+    // Exception: if only --deny-domain / --deny-domain-suffix were set
+    // (no --net-rule, no --net-default-*), default egress flips to
+    // Allow so the rest of the network keeps working — these flags
+    // add deny entries on top of permissive defaults.
+    let preset = NetworkPolicy::public_only();
     let default_egress = match default_egress {
         Some(raw) => parse_action("--net-default-egress", raw)?,
         None if no_rule_flags => Action::Allow,
-        None => Action::Deny,
+        None => preset.default_egress,
     };
     let default_ingress = match default_ingress {
         Some(raw) => parse_action("--net-default-ingress", raw)?,
-        None => Action::Allow,
+        None => preset.default_ingress,
     };
 
     Ok(Some(NetworkPolicy {

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -442,8 +442,6 @@ fn apply_network_opts(
         || opts.on_secret_violation.is_some();
 
     if has_network_config {
-        let dns_block_domain = opts.dns_block_domain.clone();
-        let dns_block_suffix = opts.dns_block_suffix.clone();
         let no_dns_rebind = opts.no_dns_rebind_protection;
         let dns_nameservers = opts
             .dns_nameserver
@@ -455,6 +453,8 @@ fn apply_network_opts(
             &opts.net_rule,
             opts.net_default_egress.as_deref(),
             opts.net_default_ingress.as_deref(),
+            &opts.dns_block_domain,
+            &opts.dns_block_suffix,
         )?;
         let max_conn = opts.max_connections;
         let trust_host_cas = opts.trust_host_cas;
@@ -468,19 +468,10 @@ fn apply_network_opts(
         let violation_action = parse_violation_action(&opts.on_secret_violation)?;
 
         builder = builder.network(move |mut n| {
-            let has_dns = !dns_block_domain.is_empty()
-                || !dns_block_suffix.is_empty()
-                || no_dns_rebind
-                || !dns_nameservers.is_empty()
-                || dns_query_timeout_ms.is_some();
+            let has_dns =
+                no_dns_rebind || !dns_nameservers.is_empty() || dns_query_timeout_ms.is_some();
             if has_dns {
                 n = n.dns(move |mut d| {
-                    for domain in &dns_block_domain {
-                        d = d.block_domain(domain);
-                    }
-                    for suffix in &dns_block_suffix {
-                        d = d.block_domain_suffix(suffix);
-                    }
                     if no_dns_rebind {
                         d = d.rebind_protection(false);
                     }
@@ -567,10 +558,17 @@ pub fn parse_duration_secs(s: &str) -> anyhow::Result<u64> {
     }
 }
 
-/// Assemble a [`NetworkPolicy`] from the new `--net-rule` /
-/// `--net-default-egress` / `--net-default-ingress` flag set, or
-/// `None` if no flag was set (caller falls back to the sandbox
-/// default).
+/// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default-*`
+/// and the legacy `--dns-block-domain` / `--dns-block-suffix` flags.
+/// Returns `None` when no flag was set (caller falls back to the
+/// sandbox default).
+///
+/// `--dns-block-domain` and `--dns-block-suffix` are convenience
+/// shortcuts for `deny Domain(...)` / `deny DomainSuffix(...)` rules;
+/// they are prepended to the rule list so they take precedence over any
+/// later allow rules. When these are the only policy flags set, the
+/// defaults flip to Allow on egress to preserve the legacy "full
+/// network minus blocked domains" semantics.
 ///
 /// Multiple `--net-rule` invocations concatenate in argv order; tokens
 /// inside each value are comma-separated and likewise preserved.
@@ -579,16 +577,39 @@ fn build_network_policy(
     rule_args: &[String],
     default_egress: Option<&str>,
     default_ingress: Option<&str>,
+    dns_block_domain: &[String],
+    dns_block_suffix: &[String],
 ) -> anyhow::Result<Option<microsandbox_network::policy::NetworkPolicy>> {
-    use microsandbox_network::policy::{Action, NetworkPolicy};
+    use anyhow::Context;
+    use microsandbox_network::policy::{Action, Destination, DomainName, NetworkPolicy, Rule};
 
     use crate::net_rule::parse_rule_list;
 
-    if rule_args.is_empty() && default_egress.is_none() && default_ingress.is_none() {
+    let no_rule_flags =
+        rule_args.is_empty() && default_egress.is_none() && default_ingress.is_none();
+    let no_block_flags = dns_block_domain.is_empty() && dns_block_suffix.is_empty();
+    if no_rule_flags && no_block_flags {
         return Ok(None);
     }
 
     let mut rules = Vec::new();
+
+    // Prepend deny rules from --dns-block-domain / --dns-block-suffix
+    // so they take precedence over any later allow rules. The user's
+    // intent in writing these flags is unambiguous: refuse these names.
+    for d in dns_block_domain {
+        let domain: DomainName = d
+            .parse()
+            .with_context(|| format!("--dns-block-domain {d:?}"))?;
+        rules.push(Rule::deny_egress(Destination::Domain(domain)));
+    }
+    for s in dns_block_suffix {
+        let suffix: DomainName = s
+            .parse()
+            .with_context(|| format!("--dns-block-suffix {s:?}"))?;
+        rules.push(Rule::deny_egress(Destination::DomainSuffix(suffix)));
+    }
+
     for arg in rule_args {
         let parsed = parse_rule_list(arg).map_err(anyhow::Error::from)?;
         rules.extend(parsed);
@@ -604,9 +625,15 @@ fn build_network_policy(
 
     // When the user sets no defaults explicitly, preserve today's
     // asymmetric behavior: egress = Deny (rules open things);
-    // ingress = Allow (unfiltered published-port behavior).
+    // ingress = Allow (unfiltered published-port behavior). Exception:
+    // if only --dns-block-domain / --dns-block-suffix were set (no
+    // --net-rule, no --net-default-*), default egress flips to Allow so
+    // the rest of the network keeps working — these flags add deny
+    // entries on top of permissive defaults, mirroring the legacy
+    // DNS-only block list's lack of side effects on TCP egress.
     let default_egress = match default_egress {
         Some(raw) => parse_action("--net-default-egress", raw)?,
+        None if no_rule_flags => Action::Allow,
         None => Action::Deny,
     };
     let default_ingress = match default_ingress {

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -113,18 +113,6 @@ pub struct SandboxOpts {
     #[arg(long = "deny-domain-suffix", value_name = "SUFFIX")]
     pub deny_domain_suffix: Vec<String>,
 
-    /// Deprecated alias for `--deny-domain`. Kept for back-compat;
-    /// emits a warning on use.
-    #[cfg(feature = "net")]
-    #[arg(long, hide = true)]
-    pub dns_block_domain: Vec<String>,
-
-    /// Deprecated alias for `--deny-domain-suffix`. Kept for
-    /// back-compat; emits a warning on use.
-    #[cfg(feature = "net")]
-    #[arg(long, hide = true)]
-    pub dns_block_suffix: Vec<String>,
-
     /// Allow DNS responses pointing to private/internal IP addresses.
     #[cfg(feature = "net")]
     #[arg(long)]
@@ -259,8 +247,6 @@ impl SandboxOpts {
             || self.no_net
             || !self.deny_domain.is_empty()
             || !self.deny_domain_suffix.is_empty()
-            || !self.dns_block_domain.is_empty()
-            || !self.dns_block_suffix.is_empty()
             || self.no_dns_rebind_protection
             || !self.dns_nameserver.is_empty()
             || self.dns_query_timeout_ms.is_some()
@@ -440,8 +426,6 @@ fn apply_network_opts(
     // DNS, TLS, and other network configuration.
     let has_network_config = !opts.deny_domain.is_empty()
         || !opts.deny_domain_suffix.is_empty()
-        || !opts.dns_block_domain.is_empty()
-        || !opts.dns_block_suffix.is_empty()
         || opts.no_dns_rebind_protection
         || !opts.dns_nameserver.is_empty()
         || opts.dns_query_timeout_ms.is_some()
@@ -460,21 +444,6 @@ fn apply_network_opts(
         || opts.on_secret_violation.is_some();
 
     if has_network_config {
-        // Warn on the deprecated aliases, but accept them. New flags
-        // and old flags concatenate into a single deny-rule list.
-        if !opts.dns_block_domain.is_empty() {
-            eprintln!("warning: --dns-block-domain is deprecated; use --deny-domain instead");
-        }
-        if !opts.dns_block_suffix.is_empty() {
-            eprintln!(
-                "warning: --dns-block-suffix is deprecated; use --deny-domain-suffix instead"
-            );
-        }
-        let mut deny_domains = opts.deny_domain.clone();
-        deny_domains.extend(opts.dns_block_domain.iter().cloned());
-        let mut deny_domain_suffixes = opts.deny_domain_suffix.clone();
-        deny_domain_suffixes.extend(opts.dns_block_suffix.iter().cloned());
-
         let no_dns_rebind = opts.no_dns_rebind_protection;
         let dns_nameservers = opts
             .dns_nameserver
@@ -486,8 +455,8 @@ fn apply_network_opts(
             &opts.net_rule,
             opts.net_default_egress.as_deref(),
             opts.net_default_ingress.as_deref(),
-            &deny_domains,
-            &deny_domain_suffixes,
+            &opts.deny_domain,
+            &opts.deny_domain_suffix,
         )?;
         let max_conn = opts.max_connections;
         let trust_host_cas = opts.trust_host_cas;
@@ -592,10 +561,9 @@ pub fn parse_duration_secs(s: &str) -> anyhow::Result<u64> {
 }
 
 /// Assemble a [`NetworkPolicy`] from `--net-rule` / `--net-default-*`
-/// and the bulk-deny flags (`--deny-domain` / `--deny-domain-suffix`,
-/// plus the deprecated `--dns-block-domain` / `--dns-block-suffix`
-/// aliases the caller has already merged in). Returns `None` when no
-/// flag was set (caller falls back to the sandbox default).
+/// and the bulk-deny flags (`--deny-domain` / `--deny-domain-suffix`).
+/// Returns `None` when no flag was set (caller falls back to the
+/// sandbox default).
 ///
 /// Bulk-deny flags are convenience shortcuts for `deny Domain(...)` /
 /// `deny DomainSuffix(...)` rules; they are prepended to the rule list
@@ -657,11 +625,11 @@ fn build_network_policy(
     // When the user sets no defaults explicitly, preserve today's
     // asymmetric behavior: egress = Deny (rules open things);
     // ingress = Allow (unfiltered published-port behavior). Exception:
-    // if only --dns-block-domain / --dns-block-suffix were set (no
+    // if only --deny-domain / --deny-domain-suffix were set (no
     // --net-rule, no --net-default-*), default egress flips to Allow so
     // the rest of the network keeps working — these flags add deny
-    // entries on top of permissive defaults, mirroring the legacy
-    // DNS-only block list's lack of side effects on TCP egress.
+    // entries on top of permissive defaults, leaving non-denied
+    // traffic unaffected.
     let default_egress = match default_egress {
         Some(raw) => parse_action("--net-default-egress", raw)?,
         None if no_rule_flags => Action::Allow,

--- a/crates/microsandbox/README.md
+++ b/crates/microsandbox/README.md
@@ -161,14 +161,19 @@ let sandbox = Sandbox::builder("isolated")
     .create()
     .await?;
 
-// DNS filtering.
+// Domain blocking via policy rules (refused at DNS and at TCP egress).
+use microsandbox_network::policy::{Destination, Rule};
+
+let mut policy = NetworkPolicy::default();
+policy.rules.push(Rule::deny_egress(Destination::Domain(
+    "blocked.example.com".parse()?,
+)));
+policy.rules.push(Rule::deny_egress(Destination::DomainSuffix(
+    ".evil.com".parse()?,
+)));
 let sandbox = Sandbox::builder("filtered")
     .image("alpine")
-    .network(|n| {
-        n.dns(|d| d
-            .block_domain("blocked.example.com")
-            .block_domain_suffix(".evil.com"))
-    })
+    .network(|n| n.policy(policy))
     .create()
     .await?;
 ```

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -265,10 +265,13 @@ impl SandboxBuilder {
     /// .network(|n| n
     ///     .port(8080, 80)
     ///     .policy(NetworkPolicy::public_only())
-    ///     .dns(|d| d.block_domain("evil.com"))
     ///     .tls(|t| t.bypass("*.internal.com"))
     /// )
     /// ```
+    ///
+    /// Domain blocking lives on the policy: add a
+    /// `Rule::deny_egress(Destination::Domain("evil.com".parse()?))` to
+    /// the `NetworkPolicy` instead of using a separate DNS block list.
     #[cfg(feature = "net")]
     pub fn network(mut self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self {
         let network = std::mem::take(&mut self.config.network);

--- a/crates/microsandbox/lib/sandbox/builder.rs
+++ b/crates/microsandbox/lib/sandbox/builder.rs
@@ -268,10 +268,6 @@ impl SandboxBuilder {
     ///     .tls(|t| t.bypass("*.internal.com"))
     /// )
     /// ```
-    ///
-    /// Domain blocking lives on the policy: add a
-    /// `Rule::deny_egress(Destination::Domain("evil.com".parse()?))` to
-    /// the `NetworkPolicy` instead of using a separate DNS block list.
     #[cfg(feature = "net")]
     pub fn network(mut self, f: impl FnOnce(NetworkBuilder) -> NetworkBuilder) -> Self {
         let network = std::mem::take(&mut self.config.network);

--- a/crates/microsandbox/tests/dns_matrix/main.rs
+++ b/crates/microsandbox/tests/dns_matrix/main.rs
@@ -143,8 +143,7 @@ async fn dns_matrix_dot() {
 
 /// Apply the network config shared by both sandboxes: the deny-resolver
 /// policy with deny-Domain rules for the test block list (exact +
-/// suffix). Block-list enforcement now flows through policy rules
-/// instead of the legacy `block_domain` builder API.
+/// suffix). Block-list enforcement flows through policy rules.
 fn with_policy_and_block_list(n: NetworkBuilder, mut policy: NetworkPolicy) -> NetworkBuilder {
     let exact: DomainName = BLOCKED_EXACT.parse().expect("BLOCKED_EXACT parses");
     let suffix: DomainName = BLOCKED_SUFFIX.parse().expect("BLOCKED_SUFFIX parses");

--- a/crates/microsandbox/tests/dns_matrix/main.rs
+++ b/crates/microsandbox/tests/dns_matrix/main.rs
@@ -30,7 +30,6 @@ mod scenario;
 
 use microsandbox::{NetworkPolicy, Sandbox};
 use microsandbox_network::builder::NetworkBuilder;
-use microsandbox_network::policy::{Destination, DomainName, Rule};
 use test_utils::msb_test;
 
 use crate::sandbox::{deny_resolver, setup_sandbox};
@@ -142,18 +141,12 @@ async fn dns_matrix_dot() {
 //--------------------------------------------------------------------------------------------------
 
 /// Apply the network config shared by both sandboxes: the deny-resolver
-/// policy with deny-Domain rules for the test block list (exact +
-/// suffix). Block-list enforcement flows through policy rules.
-fn with_policy_and_block_list(n: NetworkBuilder, mut policy: NetworkPolicy) -> NetworkBuilder {
-    let exact: DomainName = BLOCKED_EXACT.parse().expect("BLOCKED_EXACT parses");
-    let suffix: DomainName = BLOCKED_SUFFIX.parse().expect("BLOCKED_SUFFIX parses");
-    // Prepend so the deny rules outrank any later allow rules in the
-    // policy (the deny-resolver policy is otherwise permissive).
-    policy
-        .rules
-        .insert(0, Rule::deny_egress(Destination::DomainSuffix(suffix)));
-    policy
-        .rules
-        .insert(0, Rule::deny_egress(Destination::Domain(exact)));
+/// policy plus deny rules for the test block list.
+fn with_policy_and_block_list(n: NetworkBuilder, policy: NetworkPolicy) -> NetworkBuilder {
+    let policy = policy
+        .deny_domain(BLOCKED_EXACT)
+        .expect("BLOCKED_EXACT parses")
+        .deny_domain_suffix(BLOCKED_SUFFIX)
+        .expect("BLOCKED_SUFFIX parses");
     n.policy(policy)
 }

--- a/crates/microsandbox/tests/dns_matrix/main.rs
+++ b/crates/microsandbox/tests/dns_matrix/main.rs
@@ -30,6 +30,7 @@ mod scenario;
 
 use microsandbox::{NetworkPolicy, Sandbox};
 use microsandbox_network::builder::NetworkBuilder;
+use microsandbox_network::policy::{Destination, DomainName, Rule};
 use test_utils::msb_test;
 
 use crate::sandbox::{deny_resolver, setup_sandbox};
@@ -141,10 +142,19 @@ async fn dns_matrix_dot() {
 //--------------------------------------------------------------------------------------------------
 
 /// Apply the network config shared by both sandboxes: the deny-resolver
-/// policy and the DNS block list (exact + suffix).
-fn with_policy_and_block_list(n: NetworkBuilder, policy: NetworkPolicy) -> NetworkBuilder {
-    n.policy(policy).dns(|d| {
-        d.block_domain(BLOCKED_EXACT)
-            .block_domain_suffix(BLOCKED_SUFFIX)
-    })
+/// policy with deny-Domain rules for the test block list (exact +
+/// suffix). Block-list enforcement now flows through policy rules
+/// instead of the legacy `block_domain` builder API.
+fn with_policy_and_block_list(n: NetworkBuilder, mut policy: NetworkPolicy) -> NetworkBuilder {
+    let exact: DomainName = BLOCKED_EXACT.parse().expect("BLOCKED_EXACT parses");
+    let suffix: DomainName = BLOCKED_SUFFIX.parse().expect("BLOCKED_SUFFIX parses");
+    // Prepend so the deny rules outrank any later allow rules in the
+    // policy (the deny-resolver policy is otherwise permissive).
+    policy
+        .rules
+        .insert(0, Rule::deny_egress(Destination::DomainSuffix(suffix)));
+    policy
+        .rules
+        .insert(0, Rule::deny_egress(Destination::Domain(exact)));
+    n.policy(policy)
 }

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -170,6 +170,102 @@ async fn domain_policy_allows_whitelisted_https() {
     let _ = Sandbox::remove(name).await;
 }
 
+/// `deny Domain("example.com")` must cause DNS resolution for that
+/// name to fail at the gateway resolver (REFUSED), while unrelated
+/// names continue to resolve normally. The deny lives at the DNS layer
+/// because `dns_query_denied` consults Domain rules before the
+/// forwarder forwards upstream.
+#[msb_test]
+async fn domain_policy_deny_domain_refuses_dns() {
+    let name = "net-domain-policy-deny-dns";
+    let policy = NetworkPolicy {
+        default_egress: Action::Allow,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::deny_egress(Destination::Domain(
+            "example.com".parse().expect("valid domain"),
+        ))],
+    };
+    let sb = setup_alpine(name, policy).await;
+
+    // Denied: gateway returns REFUSED, getent prints nothing.
+    let denied = sb
+        .shell("getent hosts example.com | awk '{print $1; exit}'")
+        .await
+        .expect("dns probe denied");
+    let denied_out = denied.stdout().unwrap_or_default().trim().to_string();
+    assert!(
+        denied_out.is_empty(),
+        "example.com DNS lookup should be refused: got `{denied_out}`"
+    );
+
+    // Companion: an unrelated name still resolves.
+    let allowed = sb
+        .shell("getent hosts pypi.org | awk '{print $1; exit}'")
+        .await
+        .expect("dns probe allowed");
+    let allowed_out = allowed.stdout().unwrap_or_default().trim().to_string();
+    assert!(
+        !allowed_out.is_empty(),
+        "pypi.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
+    );
+
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}
+
+/// `deny DomainSuffix(".example.com")` must refuse DNS for the apex
+/// and any subdomain. Mirrors the suffix-match invariant tested for
+/// allow rules: `matches_suffix` is label-aware, so the apex itself
+/// matches as well as deeper labels.
+#[msb_test]
+async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
+    let name = "net-domain-policy-deny-suffix-dns";
+    let policy = NetworkPolicy {
+        default_egress: Action::Allow,
+        default_ingress: Action::Allow,
+        rules: vec![Rule::deny_egress(Destination::DomainSuffix(
+            ".example.com".parse().expect("valid domain suffix"),
+        ))],
+    };
+    let sb = setup_alpine(name, policy).await;
+
+    // Apex: `.example.com` suffix matches `example.com` itself.
+    let apex = sb
+        .shell("getent hosts example.com | awk '{print $1; exit}'")
+        .await
+        .expect("dns probe apex");
+    let apex_out = apex.stdout().unwrap_or_default().trim().to_string();
+    assert!(
+        apex_out.is_empty(),
+        "example.com (apex) should be refused by .example.com suffix: got `{apex_out}`"
+    );
+
+    // Subdomain: `www.example.com` also matches.
+    let sub = sb
+        .shell("getent hosts www.example.com | awk '{print $1; exit}'")
+        .await
+        .expect("dns probe subdomain");
+    let sub_out = sub.stdout().unwrap_or_default().trim().to_string();
+    assert!(
+        sub_out.is_empty(),
+        "www.example.com should be refused by .example.com suffix: got `{sub_out}`"
+    );
+
+    // Companion: an unrelated suffix still resolves.
+    let allowed = sb
+        .shell("getent hosts pypi.org | awk '{print $1; exit}'")
+        .await
+        .expect("dns probe allowed");
+    let allowed_out = allowed.stdout().unwrap_or_default().trim().to_string();
+    assert!(
+        !allowed_out.is_empty(),
+        "pypi.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
+    );
+
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}
+
 /// `Destination::DomainSuffix` must match subdomains but not unrelated
 /// hosts. One sandbox, two probes:
 ///

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -111,17 +111,8 @@ fn reached_server(probe_output: &str) -> bool {
 // Tests
 //--------------------------------------------------------------------------------------------------
 
-/// A default-deny policy with explicit allow rules for `pypi.org` and
-/// `files.pythonhosted.org` must permit HTTPS to those hostnames after
-/// the guest resolves them via the in-process DNS interceptor.
-///
-/// Bundles three probes into one sandbox to amortise image-pull and
-/// VM-boot cost:
-///
-/// 1. `pypi.org:443` is whitelisted → reaches server.
-/// 2. `files.pythonhosted.org:443` is whitelisted → reaches server.
-/// 3. `example.com:443` is not whitelisted → curl fails (sandbox
-///    dropped the TCP SYN).
+/// Default-deny policy with explicit allow rules for `cloudflare.com`
+/// and `www.cloudflare.com` permits HTTPS to both, denies the rest.
 #[msb_test]
 async fn domain_policy_allows_whitelisted_https() {
     let name = "net-domain-policy-allow";
@@ -129,8 +120,8 @@ async fn domain_policy_allows_whitelisted_https() {
         default_egress: Action::Deny,
         default_ingress: Action::Allow,
         rules: vec![
-            allow_domain_https("pypi.org"),
-            allow_domain_https("files.pythonhosted.org"),
+            allow_domain_https("cloudflare.com"),
+            allow_domain_https("www.cloudflare.com"),
         ],
     };
     let sb = setup_alpine(name, policy).await;
@@ -139,25 +130,25 @@ async fn domain_policy_allows_whitelisted_https() {
     // the egress policy for queries aimed at the gateway, so the
     // guest can populate its cache before the policy-gated connect.
     let dns = sb
-        .shell("getent hosts pypi.org | awk '{print $1; exit}'")
+        .shell("getent hosts cloudflare.com | awk '{print $1; exit}'")
         .await
         .expect("dns probe");
     let dns_out = dns.stdout().unwrap_or_default().trim().to_string();
     assert!(
         !dns_out.is_empty(),
-        "DNS resolution of pypi.org should succeed via the gateway resolver"
+        "DNS resolution of cloudflare.com should succeed via the gateway resolver"
     );
 
-    let pypi = probe_https(&sb, "https://pypi.org/simple/pip/").await;
+    let apex = probe_https(&sb, "https://cloudflare.com/").await;
     assert!(
-        reached_server(&pypi),
-        "HTTPS to pypi.org should be allowed: got `{pypi}`"
+        reached_server(&apex),
+        "HTTPS to cloudflare.com should be allowed: got `{apex}`"
     );
 
-    let files = probe_https(&sb, "https://files.pythonhosted.org/").await;
+    let www = probe_https(&sb, "https://www.cloudflare.com/").await;
     assert!(
-        reached_server(&files),
-        "HTTPS to files.pythonhosted.org should be allowed: got `{files}`"
+        reached_server(&www),
+        "HTTPS to www.cloudflare.com should be allowed: got `{www}`"
     );
 
     let example = probe_https(&sb, "https://example.com/").await;
@@ -197,13 +188,13 @@ async fn domain_policy_deny_domain_refuses_dns() {
 
     // Companion: an unrelated name still resolves.
     let allowed = sb
-        .shell("getent hosts pypi.org | awk '{print $1; exit}'")
+        .shell("getent hosts cloudflare.com | awk '{print $1; exit}'")
         .await
         .expect("dns probe allowed");
     let allowed_out = allowed.stdout().unwrap_or_default().trim().to_string();
     assert!(
         !allowed_out.is_empty(),
-        "pypi.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
+        "cloudflare.com DNS lookup should succeed under default-allow: got `{allowed_out}`"
     );
 
     sb.stop_and_wait().await.expect("stop");
@@ -248,13 +239,13 @@ async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
 
     // Companion: an unrelated suffix still resolves.
     let allowed = sb
-        .shell("getent hosts pypi.org | awk '{print $1; exit}'")
+        .shell("getent hosts cloudflare.com | awk '{print $1; exit}'")
         .await
         .expect("dns probe allowed");
     let allowed_out = allowed.stdout().unwrap_or_default().trim().to_string();
     assert!(
         !allowed_out.is_empty(),
-        "pypi.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
+        "cloudflare.com DNS lookup should succeed under default-allow: got `{allowed_out}`"
     );
 
     sb.stop_and_wait().await.expect("stop");
@@ -307,38 +298,29 @@ async fn domain_policy_sni_disambiguates_shared_cdn_ip() {
     let _ = Sandbox::remove(name).await;
 }
 
-/// `Destination::DomainSuffix` must match subdomains but not unrelated
-/// hosts. One sandbox, two probes:
-///
-/// 1. `files.pythonhosted.org:443` matches `.pythonhosted.org` →
-///    reaches server.
-/// 2. `example.com:443` does not match the suffix → curl fails.
-///
-/// The negative case deliberately uses `example.com` (Akamai) rather
-/// than another Fastly-hosted site like `pypi.org`: both `pypi.org` and
-/// `*.pythonhosted.org` share Fastly CDN IPs, so once both names are in
-/// the DNS cache the shared IP would match the suffix rule through the
-/// wrong hostname and defeat the assertion.
+/// `Destination::DomainSuffix` matches subdomains but not unrelated
+/// hosts: `www.cloudflare.com` matches `.cloudflare.com`,
+/// `example.com` does not.
 #[msb_test]
 async fn domain_policy_suffix_allows_subdomain_https() {
     let name = "net-domain-policy-suffix";
     let policy = NetworkPolicy {
         default_egress: Action::Deny,
         default_ingress: Action::Allow,
-        rules: vec![allow_domain_suffix_https(".pythonhosted.org")],
+        rules: vec![allow_domain_suffix_https(".cloudflare.com")],
     };
     let sb = setup_alpine(name, policy).await;
 
-    let files = probe_https(&sb, "https://files.pythonhosted.org/").await;
+    let www = probe_https(&sb, "https://www.cloudflare.com/").await;
     assert!(
-        reached_server(&files),
-        "files.pythonhosted.org should match .pythonhosted.org suffix: got `{files}`"
+        reached_server(&www),
+        "www.cloudflare.com should match .cloudflare.com suffix: got `{www}`"
     );
 
     let example = probe_https(&sb, "https://example.com/").await;
     assert_eq!(
         example, CURL_FAIL,
-        "example.com should not match .pythonhosted.org suffix: got `{example}`"
+        "example.com should not match .cloudflare.com suffix: got `{example}`"
     );
 
     sb.stop_and_wait().await.expect("stop");

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -123,6 +123,21 @@ fn curl_failed(probe_output: &str) -> bool {
     probe_output.starts_with(CURL_FAIL)
 }
 
+/// `probe_https` with a small retry for the success case. Self-hosted
+/// runners occasionally drop a single TLS handshake to shared-CDN
+/// edges; the policy under test is unchanged across retries, so a
+/// one-shot probe is the only thing that flakes.
+async fn probe_https_with_retry(sb: &Sandbox, url: &str) -> String {
+    let mut last = String::new();
+    for _ in 0..3 {
+        last = probe_https(sb, url).await;
+        if reached_server(&last) {
+            return last;
+        }
+    }
+    last
+}
+
 /// `getent hosts <name>` with a small retry. Self-hosted CI runners
 /// occasionally drop a single DNS forward; the policy under test is
 /// unchanged across retries, so a one-shot probe is the only thing
@@ -167,13 +182,13 @@ async fn domain_policy_allows_whitelisted_https() {
         "DNS resolution of cloudflare.com should succeed via the gateway resolver"
     );
 
-    let apex = probe_https(&sb, "https://cloudflare.com/").await;
+    let apex = probe_https_with_retry(&sb, "https://cloudflare.com/").await;
     assert!(
         reached_server(&apex),
         "HTTPS to cloudflare.com should be allowed: got `{apex}`"
     );
 
-    let www = probe_https(&sb, "https://www.cloudflare.com/").await;
+    let www = probe_https_with_retry(&sb, "https://www.cloudflare.com/").await;
     assert!(
         reached_server(&www),
         "HTTPS to www.cloudflare.com should be allowed: got `{www}`"
@@ -299,7 +314,7 @@ async fn domain_policy_sni_disambiguates_shared_cdn_ip() {
         .expect("dns probe files.pythonhosted.org");
 
     // Allowed name: SNI matches the rule, connection proceeds.
-    let allowed = probe_https(&sb, "https://files.pythonhosted.org/").await;
+    let allowed = probe_https_with_retry(&sb, "https://files.pythonhosted.org/").await;
     assert!(
         reached_server(&allowed),
         "files.pythonhosted.org should be allowed: got `{allowed}`"
@@ -331,7 +346,7 @@ async fn domain_policy_suffix_allows_subdomain_https() {
     };
     let sb = setup_alpine(name, policy).await;
 
-    let www = probe_https(&sb, "https://www.cloudflare.com/").await;
+    let www = probe_https_with_retry(&sb, "https://www.cloudflare.com/").await;
     assert!(
         reached_server(&www),
         "www.cloudflare.com should match .cloudflare.com suffix: got `{www}`"

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -266,6 +266,63 @@ async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
     let _ = Sandbox::remove(name).await;
 }
 
+/// SNI-based enforcement for shared-CDN IPs (the over-allow fix).
+///
+/// `pypi.org` and `files.pythonhosted.org` are both served from Fastly
+/// and frequently share IPs. Allow only `files.pythonhosted.org` and
+/// resolve both names so the DNS cache associates the same Fastly IP
+/// with both. Cache-only matching (pre-SNI) would mis-allow a request
+/// for `pypi.org` whenever it lands on a Fastly IP previously cached
+/// for `files.pythonhosted.org`. With first-flight SNI deferral,
+/// `Sni="pypi.org"` no longer matches the `files.pythonhosted.org`
+/// rule and the connection is denied.
+///
+/// Real-CDN signal: depends on Fastly's IP allocation actually
+/// overlapping at test time. If the IPs diverge the negative probe
+/// degrades to "denied because no rule matched" rather than "denied
+/// because SNI disambiguated"; either way the assertion holds.
+#[msb_test]
+async fn domain_policy_sni_disambiguates_shared_cdn_ip() {
+    let name = "net-domain-policy-sni-shared-ip";
+    let policy = NetworkPolicy {
+        default_egress: Action::Deny,
+        default_ingress: Action::Allow,
+        // Allow only files.pythonhosted.org. pypi.org has no allow rule.
+        rules: vec![allow_domain_https("files.pythonhosted.org")],
+    };
+    let sb = setup_alpine(name, policy).await;
+
+    // Resolve both names so the DNS cache associates each with its IP
+    // (and any shared Fastly addresses with both names). The
+    // disallowed name's resolution succeeds because there is no deny
+    // rule for it — only its connection is gated.
+    sb.shell("getent hosts pypi.org > /dev/null")
+        .await
+        .expect("dns probe pypi.org");
+    sb.shell("getent hosts files.pythonhosted.org > /dev/null")
+        .await
+        .expect("dns probe files.pythonhosted.org");
+
+    // Allowed name: SNI matches the rule, connection proceeds.
+    let allowed = probe_https(&sb, "https://files.pythonhosted.org/").await;
+    assert!(
+        reached_server(&allowed),
+        "files.pythonhosted.org should be allowed: got `{allowed}`"
+    );
+
+    // Disallowed name: even if the destination IP is shared with the
+    // allowed name's cache entry, SNI disambiguates and the rule no
+    // longer matches.
+    let denied = probe_https(&sb, "https://pypi.org/simple/pip/").await;
+    assert_eq!(
+        denied, CURL_FAIL,
+        "pypi.org should be denied even on shared Fastly IP: got `{denied}`"
+    );
+
+    sb.stop_and_wait().await.expect("stop");
+    let _ = Sandbox::remove(name).await;
+}
+
 /// `Destination::DomainSuffix` must match subdomains but not unrelated
 /// hosts. One sandbox, two probes:
 ///

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -263,13 +263,10 @@ async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
         "www.example.com should be refused by .example.com suffix: got `{sub_out}`"
     );
 
-    // Companion: an unrelated suffix still resolves. The alpine mirror
-    // is a known-reachable name (resolved during setup_alpine).
-    let allowed_out = dns_lookup(&sb, "dl-cdn.alpinelinux.org").await;
-    assert!(
-        !allowed_out.is_empty(),
-        "dl-cdn.alpinelinux.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
-    );
+    // No baseline lookup here — `domain_policy_deny_domain_refuses_dns`
+    // already covers "unrelated names still resolve under default-allow,"
+    // and rapid back-to-back queries trip the runner's egress DNS
+    // rate-limit.
 
     sb.stop_and_wait().await.expect("stop");
     let _ = Sandbox::remove(name).await;

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -170,11 +170,8 @@ async fn domain_policy_allows_whitelisted_https() {
     let _ = Sandbox::remove(name).await;
 }
 
-/// `deny Domain("example.com")` must cause DNS resolution for that
-/// name to fail at the gateway resolver (REFUSED), while unrelated
-/// names continue to resolve normally. The deny lives at the DNS layer
-/// because `dns_query_denied` consults Domain rules before the
-/// forwarder forwards upstream.
+/// `deny Domain("example.com")` refuses DNS for that name; unrelated
+/// names still resolve.
 #[msb_test]
 async fn domain_policy_deny_domain_refuses_dns() {
     let name = "net-domain-policy-deny-dns";
@@ -213,10 +210,8 @@ async fn domain_policy_deny_domain_refuses_dns() {
     let _ = Sandbox::remove(name).await;
 }
 
-/// `deny DomainSuffix(".example.com")` must refuse DNS for the apex
-/// and any subdomain. Mirrors the suffix-match invariant tested for
-/// allow rules: `matches_suffix` is label-aware, so the apex itself
-/// matches as well as deeper labels.
+/// `deny DomainSuffix(".example.com")` refuses DNS for the apex and
+/// any subdomain.
 #[msb_test]
 async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
     let name = "net-domain-policy-deny-suffix-dns";
@@ -266,21 +261,10 @@ async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
     let _ = Sandbox::remove(name).await;
 }
 
-/// SNI-based enforcement for shared-CDN IPs (the over-allow fix).
-///
-/// `pypi.org` and `files.pythonhosted.org` are both served from Fastly
-/// and frequently share IPs. Allow only `files.pythonhosted.org` and
-/// resolve both names so the DNS cache associates the same Fastly IP
-/// with both. Cache-only matching (pre-SNI) would mis-allow a request
-/// for `pypi.org` whenever it lands on a Fastly IP previously cached
-/// for `files.pythonhosted.org`. With first-flight SNI deferral,
-/// `Sni="pypi.org"` no longer matches the `files.pythonhosted.org`
-/// rule and the connection is denied.
-///
-/// Real-CDN signal: depends on Fastly's IP allocation actually
-/// overlapping at test time. If the IPs diverge the negative probe
-/// degrades to "denied because no rule matched" rather than "denied
-/// because SNI disambiguated"; either way the assertion holds.
+/// SNI-based enforcement on shared-CDN IPs (the over-allow fix).
+/// Allow only `files.pythonhosted.org`, resolve both that name and
+/// `pypi.org` (often co-located on Fastly), and assert HTTPS to
+/// `pypi.org` fails while `files.pythonhosted.org` succeeds.
 #[msb_test]
 async fn domain_policy_sni_disambiguates_shared_cdn_ip() {
     let name = "net-domain-policy-sni-shared-ip";

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -123,6 +123,22 @@ fn curl_failed(probe_output: &str) -> bool {
     probe_output.starts_with(CURL_FAIL)
 }
 
+/// `getent hosts <name>` with a small retry. Self-hosted CI runners
+/// occasionally drop a single DNS forward; the policy under test is
+/// unchanged across retries, so a one-shot probe is the only thing
+/// that flakes — not the rule engine itself.
+async fn dns_lookup(sb: &Sandbox, name: &str) -> String {
+    let cmd = format!(
+        "for i in 1 2 3; do \
+           ip=$(getent hosts {name} | awk '{{print $1; exit}}'); \
+           [ -n \"$ip\" ] && {{ printf '%s' \"$ip\"; exit 0; }}; \
+           sleep 1; \
+         done"
+    );
+    let out = sb.shell(&cmd).await.expect("dns probe");
+    out.stdout().unwrap_or_default().trim().to_string()
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -145,11 +161,7 @@ async fn domain_policy_allows_whitelisted_https() {
     // DNS resolution itself must succeed: the interceptor bypasses
     // the egress policy for queries aimed at the gateway, so the
     // guest can populate its cache before the policy-gated connect.
-    let dns = sb
-        .shell("getent hosts cloudflare.com | awk '{print $1; exit}'")
-        .await
-        .expect("dns probe");
-    let dns_out = dns.stdout().unwrap_or_default().trim().to_string();
+    let dns_out = dns_lookup(&sb, "cloudflare.com").await;
     assert!(
         !dns_out.is_empty(),
         "DNS resolution of cloudflare.com should succeed via the gateway resolver"
@@ -203,11 +215,7 @@ async fn domain_policy_deny_domain_refuses_dns() {
     );
 
     // Companion: an unrelated name still resolves.
-    let allowed = sb
-        .shell("getent hosts cloudflare.com | awk '{print $1; exit}'")
-        .await
-        .expect("dns probe allowed");
-    let allowed_out = allowed.stdout().unwrap_or_default().trim().to_string();
+    let allowed_out = dns_lookup(&sb, "cloudflare.com").await;
     assert!(
         !allowed_out.is_empty(),
         "cloudflare.com DNS lookup should succeed under default-allow: got `{allowed_out}`"
@@ -254,11 +262,7 @@ async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
     );
 
     // Companion: an unrelated suffix still resolves.
-    let allowed = sb
-        .shell("getent hosts cloudflare.com | awk '{print $1; exit}'")
-        .await
-        .expect("dns probe allowed");
-    let allowed_out = allowed.stdout().unwrap_or_default().trim().to_string();
+    let allowed_out = dns_lookup(&sb, "cloudflare.com").await;
     assert!(
         !allowed_out.is_empty(),
         "cloudflare.com DNS lookup should succeed under default-allow: got `{allowed_out}`"

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -91,9 +91,18 @@ async fn setup_alpine(name: &str, policy: NetworkPolicy) -> Sandbox {
 /// Timeout is 30s rather than 10s so a slow CI runner isn't the thing
 /// tipping a probe over on the TLS handshake.
 async fn probe_https(sb: &Sandbox, url: &str) -> String {
+    // Capture curl's exit code and stderr alongside the http_code so a
+    // FAIL surfaces the specific reason (DNS, TCP, TLS, etc.) instead
+    // of an opaque sentinel.
     let cmd = format!(
-        "code=$(curl -sS --max-time 30 -o /dev/null -w '%{{http_code}}' {url} 2>/dev/null); \
-         case \"$code\" in 000|\"\") echo {CURL_FAIL};; *) printf '%s' \"$code\";; esac"
+        "tmp=$(mktemp); \
+         code=$(curl -sS --max-time 30 -o /dev/null -w '%{{http_code}}' {url} 2>\"$tmp\"); \
+         exit=$?; \
+         err=$(tr '\\n' ' ' <\"$tmp\"; rm -f \"$tmp\"); \
+         case \"$code\" in \
+             000|\"\") printf 'FAIL exit=%s err=%s' \"$exit\" \"$err\" ;; \
+             *) printf '%s' \"$code\" ;; \
+         esac"
     );
     let out = sb.shell(&cmd).await.expect("shell");
     out.stdout().unwrap_or_default().trim().to_string()
@@ -105,6 +114,13 @@ async fn probe_https(sb: &Sandbox, url: &str) -> String {
 /// means the policy let the connection through.
 fn reached_server(probe_output: &str) -> bool {
     probe_output.len() == 3 && probe_output.chars().all(|c| c.is_ascii_digit())
+}
+
+/// True when `probe_https` reported a curl-side failure (any output
+/// starting with [`CURL_FAIL`]). The full output includes curl's exit
+/// code and stderr so the failure reason is visible in test logs.
+fn curl_failed(probe_output: &str) -> bool {
+    probe_output.starts_with(CURL_FAIL)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -152,8 +168,8 @@ async fn domain_policy_allows_whitelisted_https() {
     );
 
     let example = probe_https(&sb, "https://example.com/").await;
-    assert_eq!(
-        example, CURL_FAIL,
+    assert!(
+        curl_failed(&example),
         "HTTPS to example.com should be denied by default-action: got `{example}`"
     );
 
@@ -289,8 +305,8 @@ async fn domain_policy_sni_disambiguates_shared_cdn_ip() {
     // allowed name's cache entry, SNI disambiguates and the rule no
     // longer matches.
     let denied = probe_https(&sb, "https://pypi.org/simple/pip/").await;
-    assert_eq!(
-        denied, CURL_FAIL,
+    assert!(
+        curl_failed(&denied),
         "pypi.org should be denied even on shared Fastly IP: got `{denied}`"
     );
 
@@ -318,8 +334,8 @@ async fn domain_policy_suffix_allows_subdomain_https() {
     );
 
     let example = probe_https(&sb, "https://example.com/").await;
-    assert_eq!(
-        example, CURL_FAIL,
+    assert!(
+        curl_failed(&example),
         "example.com should not match .cloudflare.com suffix: got `{example}`"
     );
 

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -214,11 +214,13 @@ async fn domain_policy_deny_domain_refuses_dns() {
         "example.com DNS lookup should be refused: got `{denied_out}`"
     );
 
-    // Companion: an unrelated name still resolves.
-    let allowed_out = dns_lookup(&sb, "cloudflare.com").await;
+    // Companion: an unrelated name still resolves. We pick the alpine
+    // mirror because `setup_alpine` just resolved it via apk, so the
+    // forwarder has demonstrably reached it once already.
+    let allowed_out = dns_lookup(&sb, "dl-cdn.alpinelinux.org").await;
     assert!(
         !allowed_out.is_empty(),
-        "cloudflare.com DNS lookup should succeed under default-allow: got `{allowed_out}`"
+        "dl-cdn.alpinelinux.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
     );
 
     sb.stop_and_wait().await.expect("stop");
@@ -261,11 +263,12 @@ async fn domain_policy_deny_suffix_refuses_dns_apex_and_subdomain() {
         "www.example.com should be refused by .example.com suffix: got `{sub_out}`"
     );
 
-    // Companion: an unrelated suffix still resolves.
-    let allowed_out = dns_lookup(&sb, "cloudflare.com").await;
+    // Companion: an unrelated suffix still resolves. The alpine mirror
+    // is a known-reachable name (resolved during setup_alpine).
+    let allowed_out = dns_lookup(&sb, "dl-cdn.alpinelinux.org").await;
     assert!(
         !allowed_out.is_empty(),
-        "cloudflare.com DNS lookup should succeed under default-allow: got `{allowed_out}`"
+        "dl-cdn.alpinelinux.org DNS lookup should succeed under default-allow: got `{allowed_out}`"
     );
 
     sb.stop_and_wait().await.expect("stop");

--- a/crates/microsandbox/tests/domain_policy.rs
+++ b/crates/microsandbox/tests/domain_policy.rs
@@ -305,13 +305,19 @@ async fn domain_policy_sni_disambiguates_shared_cdn_ip() {
     // Resolve both names so the DNS cache associates each with its IP
     // (and any shared Fastly addresses with both names). The
     // disallowed name's resolution succeeds because there is no deny
-    // rule for it — only its connection is gated.
-    sb.shell("getent hosts pypi.org > /dev/null")
-        .await
-        .expect("dns probe pypi.org");
-    sb.shell("getent hosts files.pythonhosted.org > /dev/null")
-        .await
-        .expect("dns probe files.pythonhosted.org");
+    // rule for it — only its connection is gated. Retry the priming
+    // lookups so a single transient forward doesn't leave curl
+    // resolving from scratch.
+    let pypi_ip = dns_lookup(&sb, "pypi.org").await;
+    let files_ip = dns_lookup(&sb, "files.pythonhosted.org").await;
+    assert!(
+        !pypi_ip.is_empty(),
+        "pypi.org should resolve under default-allow"
+    );
+    assert!(
+        !files_ip.is_empty(),
+        "files.pythonhosted.org should resolve under default-allow"
+    );
 
     // Allowed name: SNI matches the rule, connection proceeds.
     let allowed = probe_https_with_retry(&sb, "https://files.pythonhosted.org/").await;

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -111,9 +111,6 @@ impl NetworkBuilder {
     ///     .rebind_protection(false)
     /// )
     /// ```
-    ///
-    /// Domain blocking is expressed via network policy rules
-    /// (`deny Domain("...")` / `deny DomainSuffix("...")`), not here.
     pub fn dns(mut self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self {
         self.config.dns = f(DnsBuilder::new()).build();
         self

--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use crate::config::{DnsConfig, InterfaceOverrides, NetworkConfig, PortProtocol, PublishedPort};
 use crate::dns::Nameserver;
-use crate::policy::{BuildError, DomainName, NetworkPolicy};
+use crate::policy::{BuildError, NetworkPolicy};
 use crate::secrets::config::{HostPattern, SecretEntry, SecretInjection, ViolationAction};
 use crate::tls::TlsConfig;
 
@@ -25,7 +25,6 @@ pub struct NetworkBuilder {
 /// Fluent builder for [`DnsConfig`].
 pub struct DnsBuilder {
     config: DnsConfig,
-    errors: Vec<BuildError>,
 }
 
 /// Fluent builder for [`TlsConfig`].
@@ -108,17 +107,15 @@ impl NetworkBuilder {
     ///
     /// ```ignore
     /// .dns(|d| d
-    ///     .block_domain("malware.example.com")
-    ///     .block_domain_suffix(".tracking.com")
     ///     .nameservers(["1.1.1.1".parse::<Nameserver>()?])
+    ///     .rebind_protection(false)
     /// )
     /// ```
+    ///
+    /// Domain blocking is expressed via network policy rules
+    /// (`deny Domain("...")` / `deny DomainSuffix("...")`), not here.
     pub fn dns(mut self, f: impl FnOnce(DnsBuilder) -> DnsBuilder) -> Self {
-        let dns_builder = f(DnsBuilder::new());
-        match dns_builder.build() {
-            Ok(config) => self.config.dns = config,
-            Err(err) => self.errors.push(err),
-        }
+        self.config.dns = f(DnsBuilder::new()).build();
         self
     }
 
@@ -210,43 +207,7 @@ impl DnsBuilder {
     pub fn new() -> Self {
         Self {
             config: DnsConfig::default(),
-            errors: Vec::new(),
         }
-    }
-
-    /// Block a specific domain via DNS interception (returns REFUSED).
-    ///
-    /// Accepts any string-like input. The string is stored raw and
-    /// parsed via [`DomainName`] at [`Self::build`] time. Invalid
-    /// names accumulate as
-    /// [`BuildError::InvalidBlockedDomain`] and surface from the
-    /// outermost `.build()` in the chain — the chain itself stays
-    /// infallible (no `?` per call).
-    pub fn block_domain(mut self, domain: impl Into<String>) -> Self {
-        let raw: String = domain.into();
-        match raw.parse::<DomainName>() {
-            Ok(name) => self.config.blocked_domains.push(name.into()),
-            Err(source) => self
-                .errors
-                .push(BuildError::InvalidBlockedDomain { raw, source }),
-        }
-        self
-    }
-
-    /// Block a domain suffix via DNS interception (returns REFUSED).
-    ///
-    /// Same string-input + lazy-parse + accumulate behavior as
-    /// [`Self::block_domain`]. Invalid suffixes accumulate as
-    /// [`BuildError::InvalidBlockedDomainSuffix`].
-    pub fn block_domain_suffix(mut self, suffix: impl Into<String>) -> Self {
-        let raw: String = suffix.into();
-        match raw.parse::<DomainName>() {
-            Ok(name) => self.config.blocked_suffixes.push(name.into()),
-            Err(source) => self
-                .errors
-                .push(BuildError::InvalidBlockedDomainSuffix { raw, source }),
-        }
-        self
     }
 
     /// Enable or disable DNS rebinding protection. Default: true.
@@ -277,15 +238,8 @@ impl DnsBuilder {
     }
 
     /// Consume the builder and return the configuration.
-    ///
-    /// Surfaces the first parse error accumulated by `block_domain` /
-    /// `block_domain_suffix` (or any future lazy-parse method on this
-    /// builder). Successful chains return the populated `DnsConfig`.
-    pub fn build(mut self) -> Result<DnsConfig, BuildError> {
-        if let Some(err) = self.errors.drain(..).next() {
-            return Err(err);
-        }
-        Ok(self.config)
+    pub fn build(self) -> DnsConfig {
+        self.config
     }
 }
 
@@ -493,86 +447,13 @@ impl Default for SecretBuilder {
 mod tests {
     use super::*;
 
-    /// Valid block-domain entries land in the config. No errors on
-    /// the happy path.
-    #[test]
-    fn block_domain_happy_path() {
-        let cfg = DnsBuilder::new()
-            .block_domain("evil.com")
-            .block_domain_suffix(".tracking.example")
-            .build()
-            .unwrap();
-        assert_eq!(cfg.blocked_domains.len(), 1);
-        assert_eq!(cfg.blocked_suffixes.len(), 1);
-    }
-
-    /// Invalid block-domain accumulates as
-    /// `BuildError::InvalidBlockedDomain`; surfaces from `.build()`.
-    #[test]
-    fn block_domain_invalid_surfaces_at_build() {
-        let result = DnsBuilder::new().block_domain("not a domain!").build();
-        match result {
-            Err(BuildError::InvalidBlockedDomain { raw, .. }) => {
-                assert_eq!(raw, "not a domain!");
-            }
-            other => panic!("expected InvalidBlockedDomain, got {other:?}"),
-        }
-    }
-
-    /// Invalid suffix accumulates as
-    /// `BuildError::InvalidBlockedDomainSuffix`.
-    #[test]
-    fn block_domain_suffix_invalid_surfaces_at_build() {
-        let result = DnsBuilder::new()
-            .block_domain_suffix("...invalid!!!")
-            .build();
-        match result {
-            Err(BuildError::InvalidBlockedDomainSuffix { raw, .. }) => {
-                assert_eq!(raw, "...invalid!!!");
-            }
-            other => panic!("expected InvalidBlockedDomainSuffix, got {other:?}"),
-        }
-    }
-
-    /// First-error semantics: multiple bad inputs surface only the
-    /// first one (matching `NetworkPolicyBuilder`).
-    #[test]
-    fn block_domain_first_error_wins() {
-        let result = DnsBuilder::new()
-            .block_domain("first bad!")
-            .block_domain("second bad!")
-            .build();
-        match result {
-            Err(BuildError::InvalidBlockedDomain { raw, .. }) => {
-                assert_eq!(raw, "first bad!");
-            }
-            other => panic!("expected first-error InvalidBlockedDomain, got {other:?}"),
-        }
-    }
-
-    /// Errors accumulated by a `DnsBuilder` cascade up through
-    /// `NetworkBuilder::dns()` and surface from
-    /// `NetworkBuilder::build()`.
-    #[test]
-    fn dns_error_cascades_through_network_builder() {
-        let result = NetworkBuilder::new()
-            .dns(|d| d.block_domain("not a domain!"))
-            .build();
-        match result {
-            Err(BuildError::InvalidBlockedDomain { raw, .. }) => {
-                assert_eq!(raw, "not a domain!");
-            }
-            other => panic!("expected cascaded InvalidBlockedDomain, got {other:?}"),
-        }
-    }
-
     /// Network builder happy path returns the config unchanged.
     #[test]
     fn network_builder_happy_path_returns_config() {
         let cfg = NetworkBuilder::new()
-            .dns(|d| d.block_domain("evil.com"))
+            .dns(|d| d.rebind_protection(false))
             .build()
             .unwrap();
-        assert_eq!(cfg.dns.blocked_domains.len(), 1);
+        assert!(!cfg.dns.rebind_protection);
     }
 }

--- a/crates/network/lib/config.rs
+++ b/crates/network/lib/config.rs
@@ -92,14 +92,6 @@ pub struct InterfaceOverrides {
 /// DNS interception settings for the sandbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DnsConfig {
-    /// Exact domains to refuse locally.
-    #[serde(default)]
-    pub blocked_domains: Vec<String>,
-
-    /// Domain suffixes to refuse locally.
-    #[serde(default)]
-    pub blocked_suffixes: Vec<String>,
-
     /// Whether DNS rebinding protection is enabled.
     #[serde(default = "default_true")]
     pub rebind_protection: bool,
@@ -170,8 +162,6 @@ impl Default for NetworkConfig {
 impl Default for DnsConfig {
     fn default() -> Self {
         Self {
-            blocked_domains: Vec::new(),
-            blocked_suffixes: Vec::new(),
             rebind_protection: true,
             nameservers: Vec::new(),
             query_timeout_ms: default_query_timeout_ms(),

--- a/crates/network/lib/dns/common/config.rs
+++ b/crates/network/lib/dns/common/config.rs
@@ -2,12 +2,9 @@
 //! per-query path can consult without re-allocating on every match.
 //!
 //! [`crate::dns::forwarder::DnsForwarder`] holds an
-//! `Arc<NormalizedDnsConfig>` built once at startup. Block lists are
-//! lowercased and `.suffix`-dotted up-front so [`super::filter`]
-//! doesn't have to `format!` on every query; the raw-millisecond
+//! `Arc<NormalizedDnsConfig>` built once at startup. The raw-millisecond
 //! timeout is converted once to a [`Duration`] for hickory.
 
-use std::collections::HashSet;
 use std::time::Duration;
 
 use crate::config::DnsConfig;
@@ -17,19 +14,12 @@ use crate::dns::nameserver::Nameserver;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Pre-processed DNS config with lowercased block lists (avoids
-/// per-query allocations).
+/// Pre-processed DNS config (avoids per-query allocations).
 ///
 /// Fields are visible across the `dns` module so the forwarder and the
 /// filter predicates can read them directly; construction goes through
 /// [`Self::from_config`].
 pub(in crate::dns) struct NormalizedDnsConfig {
-    /// O(1) exact-match lookup for blocked domains.
-    pub(in crate::dns) blocked_domains: HashSet<String>,
-    /// Lowercased suffixes WITHOUT leading dot (for exact match against the suffix itself).
-    pub(in crate::dns) blocked_suffixes: Vec<String>,
-    /// Dot-prefixed lowercased suffixes (for `ends_with` matching without per-query `format!`).
-    pub(in crate::dns) blocked_suffixes_dotted: Vec<String>,
     pub(in crate::dns) rebind_protection: bool,
     /// Explicit nameservers (unresolved specs). Empty means fall back
     /// to the host's configured resolvers. Hostnames are resolved once
@@ -44,25 +34,9 @@ pub(in crate::dns) struct NormalizedDnsConfig {
 //--------------------------------------------------------------------------------------------------
 
 impl NormalizedDnsConfig {
-    /// Build a normalized config from a raw [`DnsConfig`]. Lowercases
-    /// and dot-prefixes the block lists once, up-front, so the query
-    /// path doesn't allocate per match.
+    /// Build a normalized config from a raw [`DnsConfig`].
     pub(in crate::dns) fn from_config(config: DnsConfig) -> Self {
-        let blocked_suffixes: Vec<String> = config
-            .blocked_suffixes
-            .iter()
-            .map(|s| s.to_lowercase().trim_start_matches('.').to_string())
-            .collect();
-        let blocked_suffixes_dotted: Vec<String> =
-            blocked_suffixes.iter().map(|s| format!(".{s}")).collect();
         Self {
-            blocked_domains: config
-                .blocked_domains
-                .into_iter()
-                .map(|d| d.to_lowercase())
-                .collect(),
-            blocked_suffixes,
-            blocked_suffixes_dotted,
             rebind_protection: config.rebind_protection,
             nameservers: config.nameservers,
             query_timeout: Duration::from_millis(config.query_timeout_ms),

--- a/crates/network/lib/dns/common/filter.rs
+++ b/crates/network/lib/dns/common/filter.rs
@@ -1,38 +1,9 @@
-//! DNS filter predicates: block-list matching and private-IP detection.
+//! DNS filter predicates: private-IP detection for rebind protection.
 //!
 //! Pure, synchronous helpers used by the forwarder to decide whether a
-//! query should be refused locally (block list) or whether a response
-//! contains addresses that trip rebind protection.
+//! response contains addresses that trip rebind protection.
 
 use std::net::{Ipv4Addr, Ipv6Addr};
-
-use super::config::NormalizedDnsConfig;
-
-/// Check if a domain is blocked by the DNS config.
-///
-/// Block lists are pre-lowercased in [`NormalizedDnsConfig`], so only the
-/// queried domain needs lowercasing (once per query instead of per entry).
-pub(in crate::dns) fn is_domain_blocked(domain: &str, config: &NormalizedDnsConfig) -> bool {
-    let domain_lower = domain.to_lowercase();
-
-    // Check exact domain matches — O(1) via HashSet.
-    if config.blocked_domains.contains(&domain_lower) {
-        return true;
-    }
-
-    // Check suffix matches (already lowercased with pre-computed dot-prefixed forms).
-    for (suffix, dotted) in config
-        .blocked_suffixes
-        .iter()
-        .zip(config.blocked_suffixes_dotted.iter())
-    {
-        if domain_lower == *suffix || domain_lower.ends_with(dotted.as_str()) {
-            return true;
-        }
-    }
-
-    false
-}
 
 /// Check if an IPv4 address is in a private/reserved range (for rebind protection).
 pub(in crate::dns) fn is_private_ipv4(addr: Ipv4Addr) -> bool {
@@ -53,62 +24,4 @@ pub(in crate::dns) fn is_private_ipv6(addr: Ipv6Addr) -> bool {
         || (segments[0] & 0xfe00) == 0xfc00  // fc00::/7 (ULA)
         || (segments[0] & 0xffc0) == 0xfe80  // fe80::/10 (link-local)
         || addr.is_unspecified() // ::
-}
-
-//--------------------------------------------------------------------------------------------------
-// Tests
-//--------------------------------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashSet;
-    use std::time::Duration;
-
-    use super::*;
-    use crate::dns::nameserver::Nameserver;
-
-    fn normalized(domains: Vec<&str>, suffixes: Vec<&str>) -> NormalizedDnsConfig {
-        let blocked_suffixes: Vec<String> = suffixes
-            .iter()
-            .map(|s| s.to_lowercase().trim_start_matches('.').to_string())
-            .collect();
-
-        let blocked_suffixes_dotted = blocked_suffixes.iter().map(|s| format!(".{s}")).collect();
-
-        NormalizedDnsConfig {
-            blocked_domains: domains
-                .iter()
-                .map(|d| d.to_lowercase())
-                .collect::<HashSet<_>>(),
-            blocked_suffixes,
-            blocked_suffixes_dotted,
-            rebind_protection: false,
-            nameservers: Vec::<Nameserver>::new(),
-            query_timeout: Duration::from_millis(5000),
-        }
-    }
-
-    #[test]
-    fn test_exact_domain_blocked() {
-        let config = normalized(vec!["evil.com"], vec![]);
-        assert!(is_domain_blocked("evil.com", &config));
-        assert!(is_domain_blocked("Evil.COM", &config));
-        assert!(!is_domain_blocked("not-evil.com", &config));
-        assert!(!is_domain_blocked("sub.evil.com", &config));
-    }
-
-    #[test]
-    fn test_suffix_domain_blocked() {
-        let config = normalized(vec![], vec![".evil.com"]);
-        assert!(is_domain_blocked("sub.evil.com", &config));
-        assert!(is_domain_blocked("deep.sub.evil.com", &config));
-        assert!(is_domain_blocked("evil.com", &config));
-        assert!(!is_domain_blocked("notevil.com", &config));
-    }
-
-    #[test]
-    fn test_no_blocks_nothing_blocked() {
-        let config = normalized(vec![], vec![]);
-        assert!(!is_domain_blocked("anything.com", &config));
-    }
 }

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -41,7 +41,7 @@ use tokio::sync::{OnceCell, watch};
 
 use super::client::{build_direct_client, build_tcp_client, build_udp_client};
 use super::common::config::NormalizedDnsConfig;
-use super::common::filter::{is_domain_blocked, is_private_ipv4, is_private_ipv6};
+use super::common::filter::{is_private_ipv4, is_private_ipv6};
 use super::common::transport::Transport;
 use super::nameserver::{read_host_dns_servers, resolve_nameservers};
 use crate::policy::NetworkPolicy;
@@ -159,12 +159,6 @@ impl DnsForwarder {
         let query_type = question.query_type();
         let domain = question.name().to_string();
         let domain = domain.trim_end_matches('.').to_owned();
-
-        // Block list: synthesize REFUSED.
-        if is_domain_blocked(&domain, &self.config) {
-            tracing::debug!(domain = %domain, "DNS query blocked by domain policy");
-            return build_status_response(&query_msg, ResponseCode::Refused);
-        }
 
         // Network policy `deny Domain` / `deny DomainSuffix`: synthesize REFUSED.
         if self.network_policy.dns_query_denied(&domain) {

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -44,7 +44,7 @@ use super::common::config::NormalizedDnsConfig;
 use super::common::filter::{is_private_ipv4, is_private_ipv6};
 use super::common::transport::Transport;
 use super::nameserver::{read_host_dns_servers, resolve_nameservers};
-use crate::policy::NetworkPolicy;
+use crate::policy::{DomainName, NetworkPolicy};
 use crate::shared::{ResolvedHostnameFamily, SharedState};
 use crate::stack::GatewayIps;
 
@@ -161,7 +161,12 @@ impl DnsForwarder {
         let domain = domain.trim_end_matches('.').to_owned();
 
         // Network policy `deny Domain` / `deny DomainSuffix`: synthesize REFUSED.
-        if self.network_policy.dns_query_denied(&domain) {
+        // Wire-form names that fail DomainName validation can never match a
+        // (validated) rule destination, so we fail-open and let the query
+        // proceed to host-alias synthesis / upstream forwarding.
+        if let Ok(canonical) = domain.parse::<DomainName>()
+            && self.network_policy.dns_query_denied(&canonical)
+        {
             tracing::debug!(domain = %domain, "DNS query refused by network policy");
             return build_status_response(&query_msg, ResponseCode::Refused);
         }

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -160,10 +160,7 @@ impl DnsForwarder {
         let domain = question.name().to_string();
         let domain = domain.trim_end_matches('.').to_owned();
 
-        // Network policy `deny Domain` / `deny DomainSuffix`: synthesize REFUSED.
-        // Wire-form names that fail DomainName validation can never match a
-        // (validated) rule destination, so we fail-open and let the query
-        // proceed to host-alias synthesis / upstream forwarding.
+        // Refuse queries denied by the network policy.
         if let Ok(canonical) = domain.parse::<DomainName>()
             && self.network_policy.dns_query_denied(&canonical)
         {

--- a/crates/network/lib/dns/forwarder.rs
+++ b/crates/network/lib/dns/forwarder.rs
@@ -166,6 +166,12 @@ impl DnsForwarder {
             return build_status_response(&query_msg, ResponseCode::Refused);
         }
 
+        // Network policy `deny Domain` / `deny DomainSuffix`: synthesize REFUSED.
+        if self.network_policy.dns_query_denied(&domain) {
+            tracing::debug!(domain = %domain, "DNS query refused by network policy");
+            return build_status_response(&query_msg, ResponseCode::Refused);
+        }
+
         // Locally synthesize answers for the host alias; MX / TXT / etc.
         // fall through to upstream.
         if is_host_alias_query(&domain)

--- a/crates/network/lib/policy/builder.rs
+++ b/crates/network/lib/policy/builder.rs
@@ -486,6 +486,72 @@ impl RuleBuilder {
         self
     }
 
+    // -- bulk-domain shortcuts --------------------------------------
+
+    /// Allow each name in `names` as a `Destination::Domain` rule. One
+    /// rule per name; subject to the closure's current direction,
+    /// protocol, and port state.
+    ///
+    /// Inputs are stored raw and parsed via [`DomainName`] at
+    /// [`NetworkPolicyBuilder::build`] time; invalid names accumulate
+    /// as [`BuildError::InvalidDomain`].
+    pub fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for name in names {
+            self.commit_rule(Action::Allow, PendingDestination::Domain(name.into()));
+        }
+        self
+    }
+
+    /// Deny each name in `names` as a `Destination::Domain` rule.
+    /// Mirrors [`Self::allow_domains`].
+    pub fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for name in names {
+            self.commit_rule(Action::Deny, PendingDestination::Domain(name.into()));
+        }
+        self
+    }
+
+    /// Allow each suffix in `suffixes` as a `Destination::DomainSuffix`
+    /// rule. Each suffix matches the apex itself and any subdomain
+    /// (label-aligned). One rule per suffix.
+    pub fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for suffix in suffixes {
+            self.commit_rule(
+                Action::Allow,
+                PendingDestination::DomainSuffix(suffix.into()),
+            );
+        }
+        self
+    }
+
+    /// Deny each suffix in `suffixes` as a `Destination::DomainSuffix`
+    /// rule. Mirrors [`Self::allow_domain_suffixes`].
+    pub fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for suffix in suffixes {
+            self.commit_rule(
+                Action::Deny,
+                PendingDestination::DomainSuffix(suffix.into()),
+            );
+        }
+        self
+    }
+
     // -- explicit-rule entry ----------------------------------------
 
     /// Begin an explicit-destination rule with action `Allow`. Returns
@@ -1030,5 +1096,114 @@ mod tests {
         assert!(direction_covers(Ingress, Ingress));
         assert!(!direction_covers(Ingress, Egress));
         assert!(!direction_covers(Ingress, Any));
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Bulk-domain shortcuts
+    //----------------------------------------------------------------------------------------------
+
+    /// `deny_domains` produces one deny-Domain rule per input name,
+    /// inheriting the closure's direction, protocol, and port state.
+    #[test]
+    fn deny_domains_produces_one_rule_per_name() {
+        let p = NetworkPolicy::builder()
+            .default_allow()
+            .egress(|e| e.deny_domains(["evil.com", "tracker.example"]))
+            .build()
+            .unwrap();
+        assert_eq!(p.rules.len(), 2);
+        for rule in &p.rules {
+            assert_eq!(rule.action, Action::Deny);
+            assert_eq!(rule.direction, Direction::Egress);
+            assert!(rule.protocols.is_empty(), "no protocol filter");
+            assert!(rule.ports.is_empty(), "no port filter");
+        }
+        assert!(matches!(
+            &p.rules[0].destination,
+            Destination::Domain(d) if d.as_str() == "evil.com",
+        ));
+        assert!(matches!(
+            &p.rules[1].destination,
+            Destination::Domain(d) if d.as_str() == "tracker.example",
+        ));
+    }
+
+    /// `deny_domain_suffixes` mirrors `deny_domains` but produces
+    /// `Destination::DomainSuffix` rules.
+    #[test]
+    fn deny_domain_suffixes_produces_one_rule_per_suffix() {
+        let p = NetworkPolicy::builder()
+            .default_allow()
+            .egress(|e| e.deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
+            .build()
+            .unwrap();
+        assert_eq!(p.rules.len(), 2);
+        assert!(matches!(
+            &p.rules[0].destination,
+            Destination::DomainSuffix(d) if d.as_str() == "ads.example",
+        ));
+        assert!(matches!(
+            &p.rules[1].destination,
+            Destination::DomainSuffix(d) if d.as_str() == "doubleclick.net",
+        ));
+    }
+
+    /// Bulk shortcuts inherit the closure's protocol and port state, so
+    /// users can narrow the bulk in the same call.
+    #[test]
+    fn deny_domains_inherits_protocol_and_port_filter() {
+        let p = NetworkPolicy::builder()
+            .default_allow()
+            .egress(|e| e.tcp().port(443).deny_domains(["evil.com"]))
+            .build()
+            .unwrap();
+        assert_eq!(p.rules[0].protocols, vec![Protocol::Tcp]);
+        assert_eq!(p.rules[0].ports, vec![PortRange::single(443)]);
+    }
+
+    /// `allow_domains` symmetric with `deny_domains` — same shape,
+    /// `Action::Allow`.
+    #[test]
+    fn allow_domains_produces_allow_rules() {
+        let p = NetworkPolicy::builder()
+            .default_deny()
+            .egress(|e| e.allow_domains(["pypi.org", "files.pythonhosted.org"]))
+            .build()
+            .unwrap();
+        assert_eq!(p.rules.len(), 2);
+        for rule in &p.rules {
+            assert_eq!(rule.action, Action::Allow);
+        }
+    }
+
+    /// Empty input is a no-op — no rules pushed.
+    #[test]
+    fn deny_domains_empty_input_is_noop() {
+        let p = NetworkPolicy::builder()
+            .default_allow()
+            .egress(|e| e.deny_domains(Vec::<&str>::new()))
+            .build()
+            .unwrap();
+        assert!(p.rules.is_empty());
+    }
+
+    /// Invalid names accumulate as `BuildError::InvalidDomain` and the
+    /// FIRST one surfaces from `.build()`. Mirrors the per-rule
+    /// `.domain(...)` lazy-parse contract.
+    #[test]
+    fn deny_domains_invalid_input_surfaces_at_build() {
+        let result = NetworkPolicy::builder()
+            .default_allow()
+            .egress(|e| e.deny_domains(["evil.com", "not a domain!"]))
+            .build();
+        match result {
+            Err(BuildError::InvalidDomain { raw, .. }) => {
+                // First-error-wins: but here both rules go into the
+                // pending list and parse runs on each in order. The
+                // first invalid one (index 1) surfaces.
+                assert_eq!(raw, "not a domain!");
+            }
+            other => panic!("expected InvalidDomain, got {other:?}"),
+        }
     }
 }

--- a/crates/network/lib/policy/builder.rs
+++ b/crates/network/lib/policy/builder.rs
@@ -488,13 +488,7 @@ impl RuleBuilder {
 
     // -- bulk-domain shortcuts --------------------------------------
 
-    /// Allow each name in `names` as a `Destination::Domain` rule. One
-    /// rule per name; subject to the closure's current direction,
-    /// protocol, and port state.
-    ///
-    /// Inputs are stored raw and parsed via [`DomainName`] at
-    /// [`NetworkPolicyBuilder::build`] time; invalid names accumulate
-    /// as [`BuildError::InvalidDomain`].
+    /// Allow each name as a `Destination::Domain` rule.
     pub fn allow_domains<I, S>(&mut self, names: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
@@ -506,8 +500,7 @@ impl RuleBuilder {
         self
     }
 
-    /// Deny each name in `names` as a `Destination::Domain` rule.
-    /// Mirrors [`Self::allow_domains`].
+    /// Deny each name as a `Destination::Domain` rule.
     pub fn deny_domains<I, S>(&mut self, names: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
@@ -519,9 +512,7 @@ impl RuleBuilder {
         self
     }
 
-    /// Allow each suffix in `suffixes` as a `Destination::DomainSuffix`
-    /// rule. Each suffix matches the apex itself and any subdomain
-    /// (label-aligned). One rule per suffix.
+    /// Allow each suffix as a `Destination::DomainSuffix` rule.
     pub fn allow_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
@@ -536,8 +527,7 @@ impl RuleBuilder {
         self
     }
 
-    /// Deny each suffix in `suffixes` as a `Destination::DomainSuffix`
-    /// rule. Mirrors [`Self::allow_domain_suffixes`].
+    /// Deny each suffix as a `Destination::DomainSuffix` rule.
     pub fn deny_domain_suffixes<I, S>(&mut self, suffixes: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
@@ -1197,11 +1187,13 @@ mod tests {
             .egress(|e| e.deny_domains(["evil.com", "not a domain!"]))
             .build();
         match result {
-            Err(BuildError::InvalidDomain { raw, .. }) => {
-                // First-error-wins: but here both rules go into the
-                // pending list and parse runs on each in order. The
-                // first invalid one (index 1) surfaces.
+            Err(BuildError::InvalidDomain {
+                raw, rule_index, ..
+            }) => {
                 assert_eq!(raw, "not a domain!");
+                // The valid evil.com is rule 0; the invalid one is
+                // rule 1, which is what the parser reports.
+                assert_eq!(rule_index, 1);
             }
             other => panic!("expected InvalidDomain, got {other:?}"),
         }

--- a/crates/network/lib/policy/builder.rs
+++ b/crates/network/lib/policy/builder.rs
@@ -96,24 +96,6 @@ pub enum BuildError {
         "rule #{rule_index}: ICMP protocols are egress-only; ingress and any-direction rules cannot include icmpv4 or icmpv6"
     )]
     IngressDoesNotSupportIcmp { rule_index: usize },
-
-    /// `DnsBuilder::block_domain(&str)` received a value that doesn't
-    /// parse as a [`DomainName`].
-    #[error("invalid blocked domain `{raw}`: {source}")]
-    InvalidBlockedDomain {
-        raw: String,
-        #[source]
-        source: DomainNameError,
-    },
-
-    /// `DnsBuilder::block_domain_suffix(&str)` received a value that
-    /// doesn't parse as a [`DomainName`].
-    #[error("invalid blocked domain suffix `{raw}`: {source}")]
-    InvalidBlockedDomainSuffix {
-        raw: String,
-        #[source]
-        source: DomainNameError,
-    },
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -245,6 +245,18 @@ pub enum HostnameSource<'a> {
     Deferred,
 }
 
+impl HostnameSource<'_> {
+    /// Short, stable label suitable for tracing tags / logs (e.g.
+    /// `"sni"`, `"cache"`, `"deferred"`).
+    pub fn label(&self) -> &'static str {
+        match self {
+            HostnameSource::Sni(_) => "sni",
+            HostnameSource::CacheOnly => "cache",
+            HostnameSource::Deferred => "deferred",
+        }
+    }
+}
+
 /// Outcome of an egress evaluation. Extends [`Action`] with a
 /// "decision deferred until SNI is known" state that is reachable only
 /// under [`HostnameSource::Deferred`].

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -332,6 +332,35 @@ impl NetworkPolicy {
         }
         self.default_ingress
     }
+
+    /// Should the DNS forwarder refuse a query for `name`?
+    ///
+    /// Returns `true` iff the first matching `Domain` / `DomainSuffix`
+    /// rule (in egress-applicable direction) has action `Deny`. Port and
+    /// protocol filters are ignored — DNS queries don't carry a
+    /// destination port, so even a port-narrow deny rule still refuses
+    /// at this layer; the port filter still applies at TCP egress.
+    ///
+    /// `Cidr` / `Group` / `Any` rules cannot match a hostname string and
+    /// are skipped. `default_egress` is not consulted: deny-by-default
+    /// does not refuse all DNS, only explicit deny rules do.
+    pub fn dns_query_denied(&self, name: &str) -> bool {
+        let canonical = name.trim_end_matches('.').to_ascii_lowercase();
+        for rule in &self.rules {
+            if !matches!(rule.direction, Direction::Egress | Direction::Any) {
+                continue;
+            }
+            let matched = match &rule.destination {
+                Destination::Domain(d) => canonical == d.as_str(),
+                Destination::DomainSuffix(s) => matches_suffix(&canonical, s.as_str()),
+                _ => false,
+            };
+            if matched {
+                return rule.action == Action::Deny;
+            }
+        }
+        false
+    }
 }
 
 impl Action {
@@ -1079,5 +1108,135 @@ mod tests {
         assert!(egress_tcp(&policy, "127.0.0.1", &shared).is_deny());
         // Metadata is not in Public.
         assert!(egress_tcp(&policy, "169.254.169.254", &shared).is_deny());
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // dns_query_denied
+    //----------------------------------------------------------------------------------------------
+
+    fn deny_domain_policy(dest: Destination) -> NetworkPolicy {
+        NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_egress(dest)],
+        }
+    }
+
+    #[test]
+    fn dns_query_denied_matches_exact_domain() {
+        let policy = deny_domain_policy(Destination::Domain("evil.com".parse().unwrap()));
+        assert!(policy.dns_query_denied("evil.com"));
+        assert!(!policy.dns_query_denied("good.com"));
+    }
+
+    #[test]
+    fn dns_query_denied_matches_suffix_apex_and_subdomain() {
+        let policy = deny_domain_policy(Destination::DomainSuffix(".evil.com".parse().unwrap()));
+        assert!(policy.dns_query_denied("evil.com"), "apex must match");
+        assert!(
+            policy.dns_query_denied("foo.evil.com"),
+            "subdomain must match"
+        );
+        assert!(
+            policy.dns_query_denied("deep.sub.evil.com"),
+            "deeper subdomain must match"
+        );
+    }
+
+    #[test]
+    fn dns_query_denied_does_not_match_disjoint_suffix() {
+        let policy = deny_domain_policy(Destination::DomainSuffix(".evil.com".parse().unwrap()));
+        assert!(!policy.dns_query_denied("notevil.com"));
+    }
+
+    #[test]
+    fn dns_query_denied_ignores_cidr_group_any_rules() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![
+                Rule::deny_egress(Destination::Any),
+                Rule::deny_egress(Destination::Cidr("10.0.0.0/8".parse().unwrap())),
+                Rule::deny_egress(Destination::Group(DestinationGroup::Public)),
+            ],
+        };
+        assert!(!policy.dns_query_denied("anything.example"));
+    }
+
+    #[test]
+    fn dns_query_denied_first_match_wins_when_allow_precedes_deny() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![
+                Rule::allow_egress(Destination::Domain("evil.com".parse().unwrap())),
+                Rule::deny_egress(Destination::DomainSuffix(".evil.com".parse().unwrap())),
+            ],
+        };
+        // Allow rule comes first; DNS resolution must proceed.
+        assert!(!policy.dns_query_denied("evil.com"));
+        // Deny suffix still catches subdomains the allow rule didn't cover.
+        assert!(policy.dns_query_denied("foo.evil.com"));
+    }
+
+    #[test]
+    fn dns_query_denied_ignores_port_and_protocol_filters() {
+        // A narrow rule (only TCP/443) must still refuse DNS — DNS does
+        // not carry a destination port.
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule {
+                direction: Direction::Egress,
+                destination: Destination::Domain("evil.com".parse().unwrap()),
+                protocols: vec![Protocol::Tcp],
+                ports: vec![PortRange::single(443)],
+                action: Action::Deny,
+            }],
+        };
+        assert!(policy.dns_query_denied("evil.com"));
+    }
+
+    #[test]
+    fn dns_query_denied_ignores_default_egress() {
+        // Deny-by-default with no Domain rules: DNS proceeds.
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![],
+        };
+        assert!(!policy.dns_query_denied("anything.example"));
+    }
+
+    #[test]
+    fn dns_query_denied_normalizes_case_and_trailing_dot() {
+        let policy = deny_domain_policy(Destination::Domain("evil.com".parse().unwrap()));
+        assert!(policy.dns_query_denied("Evil.COM"));
+        assert!(policy.dns_query_denied("evil.com."));
+        assert!(policy.dns_query_denied("EVIL.COM."));
+    }
+
+    #[test]
+    fn dns_query_denied_skips_ingress_only_rules() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_ingress(Destination::Domain(
+                "evil.com".parse().unwrap(),
+            ))],
+        };
+        assert!(!policy.dns_query_denied("evil.com"));
+    }
+
+    #[test]
+    fn dns_query_denied_any_direction_rule_applies() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_any(Destination::Domain(
+                "evil.com".parse().unwrap(),
+            ))],
+        };
+        assert!(policy.dns_query_denied("evil.com"));
     }
 }

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -206,48 +206,22 @@ pub struct PortRange {
     pub end: u16,
 }
 
-/// Source of the hostname used to match `Domain` / `DomainSuffix` rules
-/// during an egress evaluation.
-///
-/// Each variant maps to one of the three points in a TCP connection's
-/// lifecycle where Domain rules can be evaluated:
-///
-/// - [`Sni`]: TLS first-flight, after SNI extraction. Authoritative for
-///   the flow; the resolved-hostname cache is not consulted.
-/// - [`CacheOnly`]: no SNI available — fall back to
-///   [`SharedState::any_resolved_hostname`]. Used for non-TCP paths,
-///   non-TLS TCP traffic, and TLS connections whose SNI extraction
-///   timed out, returned no name, or hit the buffer cap.
-/// - [`Deferred`]: TCP SYN time. A matching `Domain` / `DomainSuffix`
-///   rule short-circuits the walk with
-///   [`EgressEvaluation::DeferUntilHostname`] so the caller can accept
-///   the SYN and re-evaluate at first-flight.
-///
-/// The SNI string passed in [`Self::Sni`] is expected in canonical form
-/// (lowercase ASCII, no trailing dot) so byte equality against rule
-/// destinations works directly.
-///
-/// [`Sni`]: Self::Sni
-/// [`CacheOnly`]: Self::CacheOnly
-/// [`Deferred`]: Self::Deferred
-/// [`SharedState::any_resolved_hostname`]: crate::shared::SharedState::any_resolved_hostname
+/// Source of the hostname used to match `Domain` / `DomainSuffix`
+/// rules during an egress evaluation.
 #[derive(Debug, Clone, Copy)]
 pub enum HostnameSource<'a> {
-    /// Authoritative hostname extracted from a TLS ClientHello SNI
-    /// extension. Canonicalized at the boundary.
+    /// Hostname from a TLS ClientHello, canonicalized.
     Sni(&'a str),
-    /// No authoritative hostname — match `Domain` / `DomainSuffix` via
-    /// the resolved-hostname cache. Used for UDP, ICMP, plain TCP, and
-    /// SNI-absent TLS first-flight fallback.
+    /// No SNI — match `Domain` rules via the resolved-hostname cache.
     CacheOnly,
-    /// Pre-first-flight TCP SYN. A matching `Domain` / `DomainSuffix`
-    /// rule short-circuits to [`EgressEvaluation::DeferUntilHostname`].
+    /// SYN time, before SNI is known. A matching `Domain` /
+    /// `DomainSuffix` rule short-circuits to
+    /// [`EgressEvaluation::DeferUntilHostname`].
     Deferred,
 }
 
 impl HostnameSource<'_> {
-    /// Short, stable label suitable for tracing tags / logs (e.g.
-    /// `"sni"`, `"cache"`, `"deferred"`).
+    /// Short label for tracing tags (`"sni"`, `"cache"`, `"deferred"`).
     pub fn label(&self) -> &'static str {
         match self {
             HostnameSource::Sni(_) => "sni",
@@ -257,18 +231,16 @@ impl HostnameSource<'_> {
     }
 }
 
-/// Outcome of an egress evaluation. Extends [`Action`] with a
-/// "decision deferred until SNI is known" state that is reachable only
-/// under [`HostnameSource::Deferred`].
+/// Outcome of an egress evaluation. Like [`Action`] plus a deferred
+/// state reachable only under [`HostnameSource::Deferred`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EgressEvaluation {
     /// Permit the connection.
     Allow,
     /// Refuse the connection.
     Deny,
-    /// First-match was a `Domain` / `DomainSuffix` rule and the source
-    /// was [`HostnameSource::Deferred`]. The caller should accept the
-    /// SYN and re-evaluate once the SNI hostname is known.
+    /// First match was a Domain / DomainSuffix rule and the SNI isn't
+    /// known yet — accept the SYN and re-evaluate at first-flight.
     DeferUntilHostname,
 }
 
@@ -327,10 +299,6 @@ impl NetworkPolicy {
     /// Iterates rules in order, considering only rules where
     /// `direction ∈ {Egress, Any}`. Returns the action from the first
     /// matching rule, or `default_egress` if no rule matches.
-    ///
-    /// Back-compat wrapper around [`Self::evaluate_egress_with_source`]
-    /// using [`HostnameSource::CacheOnly`]; existing callers (UDP, the
-    /// DNS forwarder, SYN-time IP-rule checks) keep their signature.
     pub fn evaluate_egress(
         &self,
         dst: SocketAddr,
@@ -347,12 +315,9 @@ impl NetworkPolicy {
         .into()
     }
 
-    /// Evaluate an outbound ICMP packet against the rule list.
-    ///
-    /// Same as [`Self::evaluate_egress`] but without port matching —
-    /// ICMP has no ports. Rules with a non-empty `ports` filter are
-    /// skipped since applying a port range to a portless protocol would
-    /// be semantically incorrect.
+    /// Evaluate an outbound ICMP packet against the rule list. Like
+    /// [`Self::evaluate_egress`] but skips rules with a port filter
+    /// (ICMP has no ports).
     pub fn evaluate_egress_ip(
         &self,
         dst: IpAddr,
@@ -363,29 +328,10 @@ impl NetworkPolicy {
             .into()
     }
 
-    /// Evaluate an outbound connection against the rule list with an
-    /// explicit hostname source for `Domain` / `DomainSuffix` matching.
-    ///
-    /// Three sources are supported (see [`HostnameSource`]):
-    ///
-    /// - [`HostnameSource::Sni`]: caller has the authoritative hostname
-    ///   from a TLS ClientHello. Domain rules match against this name
-    ///   directly; the resolved-hostname cache is not consulted.
-    /// - [`HostnameSource::CacheOnly`]: caller has no hostname.
-    ///   `Domain` / `DomainSuffix` rules consult the cache via
-    ///   [`SharedState::any_resolved_hostname`]. Equivalent to
-    ///   [`Self::evaluate_egress`].
-    /// - [`HostnameSource::Deferred`]: caller is the TCP SYN handler
-    ///   and has no hostname yet. A matching `Domain` / `DomainSuffix`
-    ///   rule short-circuits with [`EgressEvaluation::DeferUntilHostname`];
-    ///   the caller should accept the SYN and re-evaluate at
-    ///   first-flight.
-    ///
-    /// First-match-wins, walk order, and protocol/port filtering are
-    /// invariant across sources — only the `Domain` / `DomainSuffix`
-    /// match predicate varies.
-    ///
-    /// [`SharedState::any_resolved_hostname`]: crate::shared::SharedState::any_resolved_hostname
+    /// Evaluate an outbound connection with an explicit
+    /// [`HostnameSource`] for `Domain` / `DomainSuffix` matching.
+    /// Walk order and protocol/port filtering are identical across
+    /// sources — only the Domain match predicate varies.
     pub fn evaluate_egress_with_source(
         &self,
         dst: SocketAddr,
@@ -396,9 +342,8 @@ impl NetworkPolicy {
         self.egress_walk(dst.ip(), Some(dst.port()), protocol, shared, source)
     }
 
-    /// Internal: shared rule walk for the egress public methods. `port`
-    /// is `None` on the ICMP path; rules with a non-empty port set are
-    /// skipped in that case.
+    /// Shared rule walk for the egress public methods. `port = None`
+    /// is the ICMP path; rules with a port filter are skipped there.
     fn egress_walk(
         &self,
         addr: IpAddr,
@@ -460,21 +405,10 @@ impl NetworkPolicy {
 
     /// Should the DNS forwarder refuse a query for `name`?
     ///
-    /// Returns `true` iff the first matching `Domain` / `DomainSuffix`
-    /// rule (in egress-applicable direction) has action `Deny`. Port and
-    /// protocol filters are ignored — DNS queries don't carry a
-    /// destination port, so even a port-narrow deny rule still refuses
-    /// at this layer; the port filter still applies at TCP egress.
-    ///
-    /// `Cidr` / `Group` / `Any` rules cannot match a hostname string and
-    /// are skipped. `default_egress` is not consulted: deny-by-default
-    /// does not refuse all DNS, only explicit deny rules do.
-    ///
-    /// `name` is a validated [`DomainName`] (lowercase ASCII, no
-    /// trailing dot) so matching collapses to byte equality. Callers
-    /// that hold a wire-form string parse it via [`str::parse`] first;
-    /// names that fail to parse cannot match any (validated) rule and
-    /// the caller should fail-open by skipping the check.
+    /// Returns `true` iff the first matching Domain / DomainSuffix
+    /// rule has action `Deny`. Port and protocol filters and
+    /// `default_egress` are not consulted — only explicit deny rules
+    /// refuse a query.
     pub fn dns_query_denied(&self, name: &DomainName) -> bool {
         for rule in &self.rules {
             if !matches!(rule.direction, Direction::Egress | Direction::Any) {
@@ -492,36 +426,28 @@ impl NetworkPolicy {
         false
     }
 
-    /// Prepend a single `deny Domain(name)` egress rule. Sugar over
-    /// [`Self::deny_domains`] for the one-name case.
+    /// Single-name sugar over [`Self::deny_domains`].
     pub fn deny_domain<S: AsRef<str>>(self, name: S) -> Result<Self, DomainNameError> {
         self.deny_domains([name])
     }
 
-    /// Prepend a single `allow Domain(name)` egress rule. Sugar over
-    /// [`Self::allow_domains`].
+    /// Single-name sugar over [`Self::allow_domains`].
     pub fn allow_domain<S: AsRef<str>>(self, name: S) -> Result<Self, DomainNameError> {
         self.allow_domains([name])
     }
 
-    /// Prepend a single `deny DomainSuffix(suffix)` egress rule. Sugar
-    /// over [`Self::deny_domain_suffixes`].
+    /// Single-suffix sugar over [`Self::deny_domain_suffixes`].
     pub fn deny_domain_suffix<S: AsRef<str>>(self, suffix: S) -> Result<Self, DomainNameError> {
         self.deny_domain_suffixes([suffix])
     }
 
-    /// Prepend a single `allow DomainSuffix(suffix)` egress rule.
-    /// Sugar over [`Self::allow_domain_suffixes`].
+    /// Single-suffix sugar over [`Self::allow_domain_suffixes`].
     pub fn allow_domain_suffix<S: AsRef<str>>(self, suffix: S) -> Result<Self, DomainNameError> {
         self.allow_domain_suffixes([suffix])
     }
 
-    /// Prepend `deny Domain(name)` egress rules for each input.
-    /// Prepending (not appending) lets the deny outrank catch-all
-    /// allows already in the policy — without it, a deny placed after
-    /// `allow Public` would never fire for a domain on a public IP.
-    /// Names parse via [`DomainName`]; the first invalid input returns
-    /// [`DomainNameError`].
+    /// Prepend `deny Domain(name)` egress rules. Prepending lets the
+    /// deny outrank catch-all allows like `allow Public`.
     pub fn deny_domains<I, S>(self, names: I) -> Result<Self, DomainNameError>
     where
         I: IntoIterator<Item = S>,
@@ -530,8 +456,7 @@ impl NetworkPolicy {
         self.prepend_egress_rules(names, |d| Rule::deny_egress(Destination::Domain(d)))
     }
 
-    /// Prepend `allow Domain(name)` egress rules for each input. See
-    /// [`Self::deny_domains`] for ordering semantics.
+    /// Prepend `allow Domain(name)` egress rules.
     pub fn allow_domains<I, S>(self, names: I) -> Result<Self, DomainNameError>
     where
         I: IntoIterator<Item = S>,
@@ -540,9 +465,8 @@ impl NetworkPolicy {
         self.prepend_egress_rules(names, |d| Rule::allow_egress(Destination::Domain(d)))
     }
 
-    /// Prepend `deny DomainSuffix(suffix)` egress rules for each input.
-    /// Each suffix matches the apex itself and any subdomain
-    /// (label-aligned). See [`Self::deny_domains`] for ordering.
+    /// Prepend `deny DomainSuffix(suffix)` egress rules. Suffixes
+    /// match the apex and any subdomain (label-aligned).
     pub fn deny_domain_suffixes<I, S>(self, suffixes: I) -> Result<Self, DomainNameError>
     where
         I: IntoIterator<Item = S>,
@@ -553,8 +477,7 @@ impl NetworkPolicy {
         })
     }
 
-    /// Prepend `allow DomainSuffix(suffix)` egress rules for each
-    /// input. See [`Self::deny_domains`] for ordering.
+    /// Prepend `allow DomainSuffix(suffix)` egress rules.
     pub fn allow_domain_suffixes<I, S>(self, suffixes: I) -> Result<Self, DomainNameError>
     where
         I: IntoIterator<Item = S>,
@@ -618,11 +541,9 @@ impl From<Action> for EgressEvaluation {
 }
 
 impl From<EgressEvaluation> for Action {
-    /// Convert an [`EgressEvaluation`] back into an [`Action`].
-    /// `DeferUntilHostname` is unreachable when an evaluator is called
-    /// with a non-`Deferred` source, which is the only way an
-    /// [`Action`] is requested. Debug builds panic on the unreachable
-    /// case; release builds map to `Deny` as a safe default.
+    /// `DeferUntilHostname` is unreachable here (only the SYN handler
+    /// asks for deferral, and it doesn't request an `Action`). Debug
+    /// builds panic; release falls back to `Deny`.
     fn from(eval: EgressEvaluation) -> Self {
         match eval {
             EgressEvaluation::Allow => Action::Allow,

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -345,20 +345,19 @@ impl NetworkPolicy {
     /// are skipped. `default_egress` is not consulted: deny-by-default
     /// does not refuse all DNS, only explicit deny rules do.
     ///
-    /// `name` is canonicalized through [`DomainName`]. Inputs that fail
-    /// label validation can never match a (validated) rule destination,
-    /// so we fail-open and let the query proceed.
-    pub fn dns_query_denied(&self, name: &str) -> bool {
-        let Ok(canonical) = name.parse::<DomainName>() else {
-            return false;
-        };
+    /// `name` is a validated [`DomainName`] (lowercase ASCII, no
+    /// trailing dot) so matching collapses to byte equality. Callers
+    /// that hold a wire-form string parse it via [`str::parse`] first;
+    /// names that fail to parse cannot match any (validated) rule and
+    /// the caller should fail-open by skipping the check.
+    pub fn dns_query_denied(&self, name: &DomainName) -> bool {
         for rule in &self.rules {
             if !matches!(rule.direction, Direction::Egress | Direction::Any) {
                 continue;
             }
             let matched = match &rule.destination {
-                Destination::Domain(d) => canonical.as_str() == d.as_str(),
-                Destination::DomainSuffix(s) => matches_suffix(canonical.as_str(), s.as_str()),
+                Destination::Domain(d) => name.as_str() == d.as_str(),
+                Destination::DomainSuffix(s) => matches_suffix(name.as_str(), s.as_str()),
                 _ => false,
             };
             if matched {
@@ -1128,31 +1127,38 @@ mod tests {
         }
     }
 
+    fn name(s: &str) -> DomainName {
+        s.parse().expect("valid domain name")
+    }
+
     #[test]
     fn dns_query_denied_matches_exact_domain() {
-        let policy = deny_domain_policy(Destination::Domain("evil.com".parse().unwrap()));
-        assert!(policy.dns_query_denied("evil.com"));
-        assert!(!policy.dns_query_denied("good.com"));
+        let policy = deny_domain_policy(Destination::Domain(name("evil.com")));
+        assert!(policy.dns_query_denied(&name("evil.com")));
+        assert!(!policy.dns_query_denied(&name("good.com")));
     }
 
     #[test]
     fn dns_query_denied_matches_suffix_apex_and_subdomain() {
-        let policy = deny_domain_policy(Destination::DomainSuffix(".evil.com".parse().unwrap()));
-        assert!(policy.dns_query_denied("evil.com"), "apex must match");
+        let policy = deny_domain_policy(Destination::DomainSuffix(name(".evil.com")));
         assert!(
-            policy.dns_query_denied("foo.evil.com"),
+            policy.dns_query_denied(&name("evil.com")),
+            "apex must match"
+        );
+        assert!(
+            policy.dns_query_denied(&name("foo.evil.com")),
             "subdomain must match"
         );
         assert!(
-            policy.dns_query_denied("deep.sub.evil.com"),
+            policy.dns_query_denied(&name("deep.sub.evil.com")),
             "deeper subdomain must match"
         );
     }
 
     #[test]
     fn dns_query_denied_does_not_match_disjoint_suffix() {
-        let policy = deny_domain_policy(Destination::DomainSuffix(".evil.com".parse().unwrap()));
-        assert!(!policy.dns_query_denied("notevil.com"));
+        let policy = deny_domain_policy(Destination::DomainSuffix(name(".evil.com")));
+        assert!(!policy.dns_query_denied(&name("notevil.com")));
     }
 
     #[test]
@@ -1166,7 +1172,7 @@ mod tests {
                 Rule::deny_egress(Destination::Group(DestinationGroup::Public)),
             ],
         };
-        assert!(!policy.dns_query_denied("anything.example"));
+        assert!(!policy.dns_query_denied(&name("anything.example")));
     }
 
     #[test]
@@ -1175,14 +1181,14 @@ mod tests {
             default_egress: Action::Allow,
             default_ingress: Action::Allow,
             rules: vec![
-                Rule::allow_egress(Destination::Domain("evil.com".parse().unwrap())),
-                Rule::deny_egress(Destination::DomainSuffix(".evil.com".parse().unwrap())),
+                Rule::allow_egress(Destination::Domain(name("evil.com"))),
+                Rule::deny_egress(Destination::DomainSuffix(name(".evil.com"))),
             ],
         };
         // Allow rule comes first; DNS resolution must proceed.
-        assert!(!policy.dns_query_denied("evil.com"));
+        assert!(!policy.dns_query_denied(&name("evil.com")));
         // Deny suffix still catches subdomains the allow rule didn't cover.
-        assert!(policy.dns_query_denied("foo.evil.com"));
+        assert!(policy.dns_query_denied(&name("foo.evil.com")));
     }
 
     #[test]
@@ -1194,13 +1200,13 @@ mod tests {
             default_ingress: Action::Allow,
             rules: vec![Rule {
                 direction: Direction::Egress,
-                destination: Destination::Domain("evil.com".parse().unwrap()),
+                destination: Destination::Domain(name("evil.com")),
                 protocols: vec![Protocol::Tcp],
                 ports: vec![PortRange::single(443)],
                 action: Action::Deny,
             }],
         };
-        assert!(policy.dns_query_denied("evil.com"));
+        assert!(policy.dns_query_denied(&name("evil.com")));
     }
 
     #[test]
@@ -1211,15 +1217,7 @@ mod tests {
             default_ingress: Action::Allow,
             rules: vec![],
         };
-        assert!(!policy.dns_query_denied("anything.example"));
-    }
-
-    #[test]
-    fn dns_query_denied_normalizes_case_and_trailing_dot() {
-        let policy = deny_domain_policy(Destination::Domain("evil.com".parse().unwrap()));
-        assert!(policy.dns_query_denied("Evil.COM"));
-        assert!(policy.dns_query_denied("evil.com."));
-        assert!(policy.dns_query_denied("EVIL.COM."));
+        assert!(!policy.dns_query_denied(&name("anything.example")));
     }
 
     #[test]
@@ -1227,11 +1225,9 @@ mod tests {
         let policy = NetworkPolicy {
             default_egress: Action::Allow,
             default_ingress: Action::Allow,
-            rules: vec![Rule::deny_ingress(Destination::Domain(
-                "evil.com".parse().unwrap(),
-            ))],
+            rules: vec![Rule::deny_ingress(Destination::Domain(name("evil.com")))],
         };
-        assert!(!policy.dns_query_denied("evil.com"));
+        assert!(!policy.dns_query_denied(&name("evil.com")));
     }
 
     #[test]
@@ -1239,10 +1235,8 @@ mod tests {
         let policy = NetworkPolicy {
             default_egress: Action::Allow,
             default_ingress: Action::Allow,
-            rules: vec![Rule::deny_any(Destination::Domain(
-                "evil.com".parse().unwrap(),
-            ))],
+            rules: vec![Rule::deny_any(Destination::Domain(name("evil.com")))],
         };
-        assert!(policy.dns_query_denied("evil.com"));
+        assert!(policy.dns_query_denied(&name("evil.com")));
     }
 }

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -517,18 +517,11 @@ impl NetworkPolicy {
     }
 
     /// Prepend `deny Domain(name)` egress rules for each input.
-    ///
-    /// Useful for augmenting a preset such as [`Self::default`] /
-    /// [`Self::public_only`] with deny entries: the new rules are
-    /// prepended (not appended) so they take precedence over any
-    /// catch-all allow rules already in the policy. Without that, a
-    /// `deny Domain("evil.com")` appended after `allow Public` would
-    /// never fire — `evil.com` is a public IP, so `allow Public` would
-    /// match first.
-    ///
-    /// Names are parsed via [`DomainName`]; the first invalid name
-    /// short-circuits with [`DomainNameError`]. Input order is
-    /// preserved within the prepended block.
+    /// Prepending (not appending) lets the deny outrank catch-all
+    /// allows already in the policy — without it, a deny placed after
+    /// `allow Public` would never fire for a domain on a public IP.
+    /// Names parse via [`DomainName`]; the first invalid input returns
+    /// [`DomainNameError`].
     pub fn deny_domains<I, S>(self, names: I) -> Result<Self, DomainNameError>
     where
         I: IntoIterator<Item = S>,

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -344,15 +344,21 @@ impl NetworkPolicy {
     /// `Cidr` / `Group` / `Any` rules cannot match a hostname string and
     /// are skipped. `default_egress` is not consulted: deny-by-default
     /// does not refuse all DNS, only explicit deny rules do.
+    ///
+    /// `name` is canonicalized through [`DomainName`]. Inputs that fail
+    /// label validation can never match a (validated) rule destination,
+    /// so we fail-open and let the query proceed.
     pub fn dns_query_denied(&self, name: &str) -> bool {
-        let canonical = name.trim_end_matches('.').to_ascii_lowercase();
+        let Ok(canonical) = name.parse::<DomainName>() else {
+            return false;
+        };
         for rule in &self.rules {
             if !matches!(rule.direction, Direction::Egress | Direction::Any) {
                 continue;
             }
             let matched = match &rule.destination {
-                Destination::Domain(d) => canonical == d.as_str(),
-                Destination::DomainSuffix(s) => matches_suffix(&canonical, s.as_str()),
+                Destination::Domain(d) => canonical.as_str() == d.as_str(),
+                Destination::DomainSuffix(s) => matches_suffix(canonical.as_str(), s.as_str()),
                 _ => false,
             };
             if matched {

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -206,6 +206,60 @@ pub struct PortRange {
     pub end: u16,
 }
 
+/// Source of the hostname used to match `Domain` / `DomainSuffix` rules
+/// during an egress evaluation.
+///
+/// Each variant maps to one of the three points in a TCP connection's
+/// lifecycle where Domain rules can be evaluated:
+///
+/// - [`Sni`]: TLS first-flight, after SNI extraction. Authoritative for
+///   the flow; the resolved-hostname cache is not consulted.
+/// - [`CacheOnly`]: no SNI available — fall back to
+///   [`SharedState::any_resolved_hostname`]. Used for non-TCP paths,
+///   non-TLS TCP traffic, and TLS connections whose SNI extraction
+///   timed out, returned no name, or hit the buffer cap.
+/// - [`Deferred`]: TCP SYN time. A matching `Domain` / `DomainSuffix`
+///   rule short-circuits the walk with
+///   [`EgressEvaluation::DeferUntilHostname`] so the caller can accept
+///   the SYN and re-evaluate at first-flight.
+///
+/// The SNI string passed in [`Self::Sni`] is expected in canonical form
+/// (lowercase ASCII, no trailing dot) so byte equality against rule
+/// destinations works directly.
+///
+/// [`Sni`]: Self::Sni
+/// [`CacheOnly`]: Self::CacheOnly
+/// [`Deferred`]: Self::Deferred
+/// [`SharedState::any_resolved_hostname`]: crate::shared::SharedState::any_resolved_hostname
+#[derive(Debug, Clone, Copy)]
+pub enum HostnameSource<'a> {
+    /// Authoritative hostname extracted from a TLS ClientHello SNI
+    /// extension. Canonicalized at the boundary.
+    Sni(&'a str),
+    /// No authoritative hostname — match `Domain` / `DomainSuffix` via
+    /// the resolved-hostname cache. Used for UDP, ICMP, plain TCP, and
+    /// SNI-absent TLS first-flight fallback.
+    CacheOnly,
+    /// Pre-first-flight TCP SYN. A matching `Domain` / `DomainSuffix`
+    /// rule short-circuits to [`EgressEvaluation::DeferUntilHostname`].
+    Deferred,
+}
+
+/// Outcome of an egress evaluation. Extends [`Action`] with a
+/// "decision deferred until SNI is known" state that is reachable only
+/// under [`HostnameSource::Deferred`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EgressEvaluation {
+    /// Permit the connection.
+    Allow,
+    /// Refuse the connection.
+    Deny,
+    /// First-match was a `Domain` / `DomainSuffix` rule and the source
+    /// was [`HostnameSource::Deferred`]. The caller should accept the
+    /// SYN and re-evaluate once the SNI hostname is known.
+    DeferUntilHostname,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -261,22 +315,24 @@ impl NetworkPolicy {
     /// Iterates rules in order, considering only rules where
     /// `direction ∈ {Egress, Any}`. Returns the action from the first
     /// matching rule, or `default_egress` if no rule matches.
+    ///
+    /// Back-compat wrapper around [`Self::evaluate_egress_with_source`]
+    /// using [`HostnameSource::CacheOnly`]; existing callers (UDP, the
+    /// DNS forwarder, SYN-time IP-rule checks) keep their signature.
     pub fn evaluate_egress(
         &self,
         dst: SocketAddr,
         protocol: Protocol,
         shared: &SharedState,
     ) -> Action {
-        for rule in &self.rules {
-            if !matches!(rule.direction, Direction::Egress | Direction::Any) {
-                continue;
-            }
-            if !rule_matches(rule, dst.ip(), Some(dst.port()), protocol, shared) {
-                continue;
-            }
-            return rule.action;
-        }
-        self.default_egress
+        self.egress_walk(
+            dst.ip(),
+            Some(dst.port()),
+            protocol,
+            shared,
+            HostnameSource::CacheOnly,
+        )
+        .into()
     }
 
     /// Evaluate an outbound ICMP packet against the rule list.
@@ -291,19 +347,76 @@ impl NetworkPolicy {
         protocol: Protocol,
         shared: &SharedState,
     ) -> Action {
+        self.egress_walk(dst, None, protocol, shared, HostnameSource::CacheOnly)
+            .into()
+    }
+
+    /// Evaluate an outbound connection against the rule list with an
+    /// explicit hostname source for `Domain` / `DomainSuffix` matching.
+    ///
+    /// Three sources are supported (see [`HostnameSource`]):
+    ///
+    /// - [`HostnameSource::Sni`]: caller has the authoritative hostname
+    ///   from a TLS ClientHello. Domain rules match against this name
+    ///   directly; the resolved-hostname cache is not consulted.
+    /// - [`HostnameSource::CacheOnly`]: caller has no hostname.
+    ///   `Domain` / `DomainSuffix` rules consult the cache via
+    ///   [`SharedState::any_resolved_hostname`]. Equivalent to
+    ///   [`Self::evaluate_egress`].
+    /// - [`HostnameSource::Deferred`]: caller is the TCP SYN handler
+    ///   and has no hostname yet. A matching `Domain` / `DomainSuffix`
+    ///   rule short-circuits with [`EgressEvaluation::DeferUntilHostname`];
+    ///   the caller should accept the SYN and re-evaluate at
+    ///   first-flight.
+    ///
+    /// First-match-wins, walk order, and protocol/port filtering are
+    /// invariant across sources — only the `Domain` / `DomainSuffix`
+    /// match predicate varies.
+    ///
+    /// [`SharedState::any_resolved_hostname`]: crate::shared::SharedState::any_resolved_hostname
+    pub fn evaluate_egress_with_source(
+        &self,
+        dst: SocketAddr,
+        protocol: Protocol,
+        shared: &SharedState,
+        source: HostnameSource<'_>,
+    ) -> EgressEvaluation {
+        self.egress_walk(dst.ip(), Some(dst.port()), protocol, shared, source)
+    }
+
+    /// Internal: shared rule walk for the egress public methods. `port`
+    /// is `None` on the ICMP path; rules with a non-empty port set are
+    /// skipped in that case.
+    fn egress_walk(
+        &self,
+        addr: IpAddr,
+        port: Option<u16>,
+        protocol: Protocol,
+        shared: &SharedState,
+        source: HostnameSource<'_>,
+    ) -> EgressEvaluation {
         for rule in &self.rules {
             if !matches!(rule.direction, Direction::Egress | Direction::Any) {
                 continue;
             }
+            if !rule.protocols.is_empty() && !rule.protocols.contains(&protocol) {
+                continue;
+            }
             if !rule.ports.is_empty() {
-                continue;
+                let Some(p) = port else {
+                    continue;
+                };
+                if !rule.ports.iter().any(|range| range.contains(p)) {
+                    continue;
+                }
             }
-            if !rule_matches(rule, dst, None, protocol, shared) {
-                continue;
+            match matches_destination_with_source(&rule.destination, addr, shared, source) {
+                DestinationMatch::Match => return rule.action.into(),
+                DestinationMatch::Defer => return EgressEvaluation::DeferUntilHostname,
+                DestinationMatch::NoMatch => continue,
             }
-            return rule.action;
         }
-        self.default_egress
+        self.default_egress.into()
     }
 
     /// Evaluate an inbound connection against the rule list.
@@ -387,6 +500,36 @@ impl Action {
     /// Helper for `#[serde(default)]` — returns [`Action::Deny`].
     pub fn deny() -> Self {
         Action::Deny
+    }
+}
+
+impl From<Action> for EgressEvaluation {
+    fn from(action: Action) -> Self {
+        match action {
+            Action::Allow => EgressEvaluation::Allow,
+            Action::Deny => EgressEvaluation::Deny,
+        }
+    }
+}
+
+impl From<EgressEvaluation> for Action {
+    /// Convert an [`EgressEvaluation`] back into an [`Action`].
+    /// `DeferUntilHostname` is unreachable when an evaluator is called
+    /// with a non-`Deferred` source, which is the only way an
+    /// [`Action`] is requested. Debug builds panic on the unreachable
+    /// case; release builds map to `Deny` as a safe default.
+    fn from(eval: EgressEvaluation) -> Self {
+        match eval {
+            EgressEvaluation::Allow => Action::Allow,
+            EgressEvaluation::Deny => Action::Deny,
+            EgressEvaluation::DeferUntilHostname => {
+                debug_assert!(
+                    false,
+                    "EgressEvaluation::DeferUntilHostname leaked through a CacheOnly/Sni evaluator"
+                );
+                Action::Deny
+            }
+        }
     }
 }
 
@@ -490,19 +633,73 @@ fn rule_matches(
     matches_destination(&rule.destination, addr, shared)
 }
 
-/// Check if an IP address matches a destination specification.
-fn matches_destination(dest: &Destination, addr: IpAddr, shared: &SharedState) -> bool {
-    match dest {
-        Destination::Any => true,
-        Destination::Cidr(network) => matches_cidr(network, addr),
-        Destination::Group(group) => matches_group(*group, addr, shared),
-        Destination::Domain(domain) => {
-            shared.any_resolved_hostname(addr, |hostname| hostname == domain.as_str())
-        }
-        Destination::DomainSuffix(suffix) => {
-            shared.any_resolved_hostname(addr, |hostname| matches_suffix(hostname, suffix.as_str()))
+/// Internal three-state result for [`matches_destination_with_source`].
+/// `Defer` is reachable only when the source is
+/// [`HostnameSource::Deferred`] and the destination is `Domain` or
+/// `DomainSuffix`.
+enum DestinationMatch {
+    Match,
+    NoMatch,
+    Defer,
+}
+
+impl From<bool> for DestinationMatch {
+    fn from(matched: bool) -> Self {
+        if matched {
+            DestinationMatch::Match
+        } else {
+            DestinationMatch::NoMatch
         }
     }
+}
+
+/// Check if an IP / hostname source matches a destination specification.
+///
+/// IP-based destinations (`Any`, `Cidr`, `Group`) ignore `source` since
+/// they decide on the address alone. `Domain` / `DomainSuffix` consult
+/// `source`:
+///
+/// - [`HostnameSource::Sni`]: byte-equality against the canonicalized
+///   SNI string (or label-aware suffix match).
+/// - [`HostnameSource::CacheOnly`]: query the resolved-hostname cache
+///   on `shared` for any prior resolution of `addr` that matches.
+/// - [`HostnameSource::Deferred`]: short-circuits to
+///   [`DestinationMatch::Defer`].
+fn matches_destination_with_source(
+    dest: &Destination,
+    addr: IpAddr,
+    shared: &SharedState,
+    source: HostnameSource<'_>,
+) -> DestinationMatch {
+    match dest {
+        Destination::Any => DestinationMatch::Match,
+        Destination::Cidr(network) => matches_cidr(network, addr).into(),
+        Destination::Group(group) => matches_group(*group, addr, shared).into(),
+        Destination::Domain(domain) => match source {
+            HostnameSource::Sni(name) => (name == domain.as_str()).into(),
+            HostnameSource::CacheOnly => shared
+                .any_resolved_hostname(addr, |hostname| hostname == domain.as_str())
+                .into(),
+            HostnameSource::Deferred => DestinationMatch::Defer,
+        },
+        Destination::DomainSuffix(suffix) => match source {
+            HostnameSource::Sni(name) => matches_suffix(name, suffix.as_str()).into(),
+            HostnameSource::CacheOnly => shared
+                .any_resolved_hostname(addr, |hostname| matches_suffix(hostname, suffix.as_str()))
+                .into(),
+            HostnameSource::Deferred => DestinationMatch::Defer,
+        },
+    }
+}
+
+/// Cache-only destination match used by the ingress evaluator. Wraps
+/// [`matches_destination_with_source`] with [`HostnameSource::CacheOnly`]
+/// since ingress has no SNI concept.
+fn matches_destination(dest: &Destination, addr: IpAddr, shared: &SharedState) -> bool {
+    matches!(
+        matches_destination_with_source(dest, addr, shared, HostnameSource::CacheOnly),
+        DestinationMatch::Match,
+    )
 }
 
 /// Label-aware suffix match on pre-canonicalized strings.
@@ -1238,5 +1435,192 @@ mod tests {
             rules: vec![Rule::deny_any(Destination::Domain(name("evil.com")))],
         };
         assert!(policy.dns_query_denied(&name("evil.com")));
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // evaluate_egress_with_source / HostnameSource
+    //----------------------------------------------------------------------------------------------
+
+    /// Cache says IP X corresponds to `evil.com`; policy allows
+    /// `pypi.org`; SNI says `pypi.org`. SNI must take precedence over
+    /// the cache and the connection must be allowed. (Fixes over-block.)
+    #[test]
+    fn hostname_source_sni_ignores_dns_cache() {
+        let shared = shared_with_host("evil.com", PYPI_V4);
+        let policy = allow_rule(Destination::Domain(name("pypi.org")));
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni("pypi.org"),
+        );
+        assert_eq!(eval, EgressEvaluation::Allow);
+    }
+
+    /// Cache says IP X corresponds to `pypi.org`; policy allows
+    /// `pypi.org`; SNI says `evil.com`. The cache would over-allow,
+    /// but SNI is authoritative — connection denied. (Fixes over-allow.)
+    #[test]
+    fn hostname_source_sni_denies_when_cache_would_allow() {
+        let shared = shared_with_host("pypi.org", PYPI_V4);
+        let policy = allow_rule(Destination::Domain(name("pypi.org")));
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni("evil.com"),
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+    }
+
+    /// Deferred mode: a matching `Domain` rule short-circuits the walk
+    /// with `DeferUntilHostname` regardless of the rule's action.
+    #[test]
+    fn deferred_returns_defer_for_first_matching_domain_rule() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress(Destination::Domain(name("pypi.org")))],
+        };
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Deferred,
+        );
+        assert_eq!(eval, EgressEvaluation::DeferUntilHostname);
+    }
+
+    /// An earlier matching IP-layer allow wins before the deferred
+    /// Domain rule is reached — SYN proceeds without deferral.
+    #[test]
+    fn deferred_returns_allow_for_earlier_matching_cidr_allow() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![
+                Rule::allow_egress(Destination::Cidr("151.101.0.0/16".parse().unwrap())),
+                Rule::allow_egress(Destination::Domain(name("pypi.org"))),
+            ],
+        };
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Deferred,
+        );
+        assert_eq!(eval, EgressEvaluation::Allow);
+    }
+
+    /// An earlier matching IP-layer deny wins before any Domain rule —
+    /// SYN dropped at the IP layer.
+    #[test]
+    fn deferred_returns_deny_for_earlier_matching_cidr_deny() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![
+                Rule::deny_egress(Destination::Cidr("151.101.0.0/16".parse().unwrap())),
+                Rule::allow_egress(Destination::Domain(name("pypi.org"))),
+            ],
+        };
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Deferred,
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+    }
+
+    /// Domain rules pruned by the protocol or port filter never match
+    /// in `Deferred` mode — they don't trigger deferral, the walk falls
+    /// through to whatever comes next (here, the default action).
+    #[test]
+    fn deferred_skips_domain_rule_pruned_by_protocol_or_port_filter() {
+        let shared = SharedState::new(4);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule {
+                direction: Direction::Egress,
+                destination: Destination::Domain(name("pypi.org")),
+                protocols: vec![Protocol::Udp], // wrong protocol
+                ports: vec![],
+                action: Action::Allow,
+            }],
+        };
+        let eval = policy.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Deferred,
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+
+        let policy_port = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule {
+                direction: Direction::Egress,
+                destination: Destination::Domain(name("pypi.org")),
+                protocols: vec![],
+                ports: vec![PortRange::single(80)], // wrong port
+                action: Action::Allow,
+            }],
+        };
+        let eval = policy_port.evaluate_egress_with_source(
+            sock(PYPI_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Deferred,
+        );
+        assert_eq!(eval, EgressEvaluation::Deny);
+    }
+
+    /// `evaluate_egress_with_source(CacheOnly)` reproduces the exact
+    /// behaviour of the back-compat `evaluate_egress` wrapper.
+    #[test]
+    fn cache_only_source_matches_evaluate_egress_wrapper() {
+        let shared = shared_with_host("pypi.org", PYPI_V4);
+        let policy = allow_rule(Destination::Domain(name("pypi.org")));
+        let dst = sock(PYPI_V4, 443);
+
+        let wrapper = policy.evaluate_egress(dst, Protocol::Tcp, &shared);
+        let with_source = policy.evaluate_egress_with_source(
+            dst,
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::CacheOnly,
+        );
+        assert_eq!(wrapper, Action::Allow);
+        assert_eq!(with_source, EgressEvaluation::Allow);
+    }
+
+    /// `Sni` against a `DomainSuffix` rule: label-aware suffix match
+    /// applied directly to the SNI string, no cache consulted.
+    #[test]
+    fn hostname_source_sni_matches_domain_suffix() {
+        let shared = SharedState::new(4); // empty cache
+        let policy = allow_rule(Destination::DomainSuffix(name(".pythonhosted.org")));
+        let eval = policy.evaluate_egress_with_source(
+            sock(FILES_V4, 443),
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni("files.pythonhosted.org"),
+        );
+        assert_eq!(eval, EgressEvaluation::Allow);
+    }
+
+    /// `From<EgressEvaluation> for Action` debug-panics on
+    /// `DeferUntilHostname`; in release it falls back to `Deny`. The
+    /// debug panic is what makes the wrapper safe.
+    #[test]
+    #[should_panic(expected = "DeferUntilHostname")]
+    fn defer_through_action_conversion_debug_panics() {
+        let _: Action = EgressEvaluation::DeferUntilHostname.into();
     }
 }

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -403,6 +403,18 @@ impl NetworkPolicy {
         self.default_ingress
     }
 
+    /// True if any rule references a `Domain` or `DomainSuffix`
+    /// destination. The TCP proxy uses this to skip its SNI peek when
+    /// no rule could possibly need a hostname for evaluation.
+    pub fn has_domain_rules(&self) -> bool {
+        self.rules.iter().any(|r| {
+            matches!(
+                r.destination,
+                Destination::Domain(_) | Destination::DomainSuffix(_)
+            )
+        })
+    }
+
     /// Should the DNS forwarder refuse a query for `name`?
     ///
     /// Returns `true` iff the first matching Domain / DomainSuffix

--- a/crates/network/lib/policy/types.rs
+++ b/crates/network/lib/policy/types.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use crate::shared::SharedState;
 
 use super::destination::{matches_cidr, matches_group};
-use super::name::DomainName;
+use super::name::{DomainName, DomainNameError};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -490,6 +490,106 @@ impl NetworkPolicy {
             }
         }
         false
+    }
+
+    /// Prepend a single `deny Domain(name)` egress rule. Sugar over
+    /// [`Self::deny_domains`] for the one-name case.
+    pub fn deny_domain<S: AsRef<str>>(self, name: S) -> Result<Self, DomainNameError> {
+        self.deny_domains([name])
+    }
+
+    /// Prepend a single `allow Domain(name)` egress rule. Sugar over
+    /// [`Self::allow_domains`].
+    pub fn allow_domain<S: AsRef<str>>(self, name: S) -> Result<Self, DomainNameError> {
+        self.allow_domains([name])
+    }
+
+    /// Prepend a single `deny DomainSuffix(suffix)` egress rule. Sugar
+    /// over [`Self::deny_domain_suffixes`].
+    pub fn deny_domain_suffix<S: AsRef<str>>(self, suffix: S) -> Result<Self, DomainNameError> {
+        self.deny_domain_suffixes([suffix])
+    }
+
+    /// Prepend a single `allow DomainSuffix(suffix)` egress rule.
+    /// Sugar over [`Self::allow_domain_suffixes`].
+    pub fn allow_domain_suffix<S: AsRef<str>>(self, suffix: S) -> Result<Self, DomainNameError> {
+        self.allow_domain_suffixes([suffix])
+    }
+
+    /// Prepend `deny Domain(name)` egress rules for each input.
+    ///
+    /// Useful for augmenting a preset such as [`Self::default`] /
+    /// [`Self::public_only`] with deny entries: the new rules are
+    /// prepended (not appended) so they take precedence over any
+    /// catch-all allow rules already in the policy. Without that, a
+    /// `deny Domain("evil.com")` appended after `allow Public` would
+    /// never fire — `evil.com` is a public IP, so `allow Public` would
+    /// match first.
+    ///
+    /// Names are parsed via [`DomainName`]; the first invalid name
+    /// short-circuits with [`DomainNameError`]. Input order is
+    /// preserved within the prepended block.
+    pub fn deny_domains<I, S>(self, names: I) -> Result<Self, DomainNameError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.prepend_egress_rules(names, |d| Rule::deny_egress(Destination::Domain(d)))
+    }
+
+    /// Prepend `allow Domain(name)` egress rules for each input. See
+    /// [`Self::deny_domains`] for ordering semantics.
+    pub fn allow_domains<I, S>(self, names: I) -> Result<Self, DomainNameError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.prepend_egress_rules(names, |d| Rule::allow_egress(Destination::Domain(d)))
+    }
+
+    /// Prepend `deny DomainSuffix(suffix)` egress rules for each input.
+    /// Each suffix matches the apex itself and any subdomain
+    /// (label-aligned). See [`Self::deny_domains`] for ordering.
+    pub fn deny_domain_suffixes<I, S>(self, suffixes: I) -> Result<Self, DomainNameError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.prepend_egress_rules(suffixes, |d| {
+            Rule::deny_egress(Destination::DomainSuffix(d))
+        })
+    }
+
+    /// Prepend `allow DomainSuffix(suffix)` egress rules for each
+    /// input. See [`Self::deny_domains`] for ordering.
+    pub fn allow_domain_suffixes<I, S>(self, suffixes: I) -> Result<Self, DomainNameError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.prepend_egress_rules(suffixes, |d| {
+            Rule::allow_egress(Destination::DomainSuffix(d))
+        })
+    }
+
+    fn prepend_egress_rules<I, S, F>(
+        mut self,
+        names: I,
+        mk_rule: F,
+    ) -> Result<Self, DomainNameError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+        F: Fn(DomainName) -> Rule,
+    {
+        let mut new_rules = Vec::new();
+        for name in names {
+            let domain: DomainName = name.as_ref().parse()?;
+            new_rules.push(mk_rule(domain));
+        }
+        new_rules.extend(std::mem::take(&mut self.rules));
+        self.rules = new_rules;
+        Ok(self)
     }
 }
 
@@ -1634,5 +1734,132 @@ mod tests {
     #[should_panic(expected = "DeferUntilHostname")]
     fn defer_through_action_conversion_debug_panics() {
         let _: Action = EgressEvaluation::DeferUntilHostname.into();
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // NetworkPolicy::deny_domains / deny_domain_suffixes (and allow_*)
+    //----------------------------------------------------------------------------------------------
+
+    #[test]
+    fn deny_domains_prepends_one_rule_per_name() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::allow_egress(Destination::Group(
+                DestinationGroup::Public,
+            ))],
+        };
+        let policy = policy
+            .deny_domains(["evil.com", "tracker.example"])
+            .unwrap();
+        assert_eq!(policy.rules.len(), 3);
+        // Prepended in input order; existing allow Public moves to the back.
+        assert!(matches!(
+            &policy.rules[0],
+            Rule { action: Action::Deny, destination: Destination::Domain(d), .. }
+                if d.as_str() == "evil.com"
+        ));
+        assert!(matches!(
+            &policy.rules[1],
+            Rule { action: Action::Deny, destination: Destination::Domain(d), .. }
+                if d.as_str() == "tracker.example"
+        ));
+        assert!(matches!(
+            &policy.rules[2].destination,
+            Destination::Group(DestinationGroup::Public),
+        ));
+    }
+
+    /// Prepending matters: appended denies are shadowed by an earlier
+    /// `allow Public` rule when the denied domain resolves to a public
+    /// IP. Verifies the helper makes the deny actually fire.
+    #[test]
+    fn deny_domains_outranks_existing_allow_public() {
+        let shared = shared_with_host("evil.com", PYPI_V4);
+        let policy = NetworkPolicy::default().deny_domains(["evil.com"]).unwrap();
+        assert!(egress_tcp(&policy, PYPI_V4, &shared).is_deny());
+    }
+
+    #[test]
+    fn deny_domain_suffixes_prepends_suffix_rules() {
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![],
+        };
+        let policy = policy.deny_domain_suffixes([".evil.com"]).unwrap();
+        assert!(matches!(
+            &policy.rules[0],
+            Rule {
+                action: Action::Deny,
+                destination: Destination::DomainSuffix(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn allow_domains_and_deny_domains_chain() {
+        let policy = NetworkPolicy::default()
+            .deny_domains(["evil.com"])
+            .unwrap()
+            .allow_domains(["pypi.org"])
+            .unwrap();
+        // Last call prepends, so allow pypi.org comes before deny evil.com.
+        assert!(matches!(
+            &policy.rules[0],
+            Rule { action: Action::Allow, destination: Destination::Domain(d), .. }
+                if d.as_str() == "pypi.org"
+        ));
+        assert!(matches!(
+            &policy.rules[1],
+            Rule { action: Action::Deny, destination: Destination::Domain(d), .. }
+                if d.as_str() == "evil.com"
+        ));
+    }
+
+    #[test]
+    fn deny_domains_invalid_input_returns_error() {
+        let result = NetworkPolicy::default().deny_domains(["not a domain!"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deny_domains_empty_input_is_noop() {
+        let before = NetworkPolicy::default();
+        let after = before.clone().deny_domains(Vec::<&str>::new()).unwrap();
+        assert_eq!(after.rules.len(), before.rules.len());
+    }
+
+    #[test]
+    fn singular_domain_helpers_match_plural_one_element_form() {
+        let plural = NetworkPolicy::default().deny_domains(["evil.com"]).unwrap();
+        let singular = NetworkPolicy::default().deny_domain("evil.com").unwrap();
+        assert_eq!(plural.rules.len(), singular.rules.len());
+        assert!(matches!(
+            (&plural.rules[0], &singular.rules[0]),
+            (
+                Rule { destination: Destination::Domain(a), .. },
+                Rule { destination: Destination::Domain(b), .. },
+            ) if a == b
+        ));
+    }
+
+    #[test]
+    fn singular_domain_suffix_helper_chains() {
+        let policy = NetworkPolicy::default()
+            .deny_domain("evil.com")
+            .unwrap()
+            .deny_domain_suffix(".tracking.example")
+            .unwrap();
+        // Last call prepends, so the suffix rule sits at index 0.
+        assert!(matches!(
+            &policy.rules[0].destination,
+            Destination::DomainSuffix(_),
+        ));
+        assert!(matches!(
+            &policy.rules[1].destination,
+            Destination::Domain(_),
+        ));
     }
 }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -88,7 +88,7 @@ async fn tcp_proxy_task(
         EgressEvaluation::Deny => {
             tracing::debug!(
                 dst = %dst,
-                source = %hostname_source_label(source),
+                source = source.label(),
                 "TCP egress denied by domain policy",
             );
             return Ok(());
@@ -210,16 +210,6 @@ async fn peek_for_sni(
 
     let canonical = raw_sni.map(|s| s.trim_end_matches('.').to_ascii_lowercase());
     (buf, canonical)
-}
-
-/// Short label for tracing tags, identifying which hostname source was
-/// used for an egress decision.
-fn hostname_source_label(source: HostnameSource<'_>) -> &'static str {
-    match source {
-        HostnameSource::Sni(_) => "sni",
-        HostnameSource::CacheOnly => "cache",
-        HostnameSource::Deferred => "deferred",
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -39,21 +39,31 @@ const PEEK_BUDGET: Duration = Duration::from_secs(5);
 
 /// Spawn a TCP proxy task for a newly established connection.
 ///
-/// Connects to `dst` via tokio, then bidirectionally relays data between
-/// the smoltcp socket (via channels) and the real server. Wakes the poll
-/// thread via `shared.proxy_wake` whenever data is sent toward the guest.
+/// `guest_dst` is what the guest dialed — the address policy rules
+/// match against. `connect_dst` is the host-side address tokio actually
+/// dials; for host-alias connections it's loopback (gateway rewritten).
+/// For everything else the two are identical.
 pub fn spawn_tcp_proxy(
     handle: &tokio::runtime::Handle,
-    dst: SocketAddr,
+    guest_dst: SocketAddr,
+    connect_dst: SocketAddr,
     from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
 ) {
     handle.spawn(async move {
-        if let Err(e) = tcp_proxy_task(dst, from_smoltcp, to_smoltcp, shared, network_policy).await
+        if let Err(e) = tcp_proxy_task(
+            guest_dst,
+            connect_dst,
+            from_smoltcp,
+            to_smoltcp,
+            shared,
+            network_policy,
+        )
+        .await
         {
-            tracing::debug!(dst = %dst, error = %e, "TCP proxy task ended");
+            tracing::debug!(dst = %connect_dst, error = %e, "TCP proxy task ended");
         }
     });
 }
@@ -61,53 +71,58 @@ pub fn spawn_tcp_proxy(
 /// Core TCP proxy: peek for SNI, evaluate egress policy, then either
 /// connect and relay or drop the channels.
 async fn tcp_proxy_task(
-    dst: SocketAddr,
+    guest_dst: SocketAddr,
+    connect_dst: SocketAddr,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
 ) -> io::Result<()> {
     // Peek only when there's a Domain/DomainSuffix rule that could
-    // need an SNI to refine. Otherwise the SYN handler's decision
-    // already accepted this connection — re-evaluating here would be
-    // redundant (and wrong: the proxy receives a translated dst for
-    // host-alias connections, which the policy can't match against).
+    // need an SNI to refine. Otherwise the SYN handler's decision is
+    // authoritative.
     let (initial_buf, sni) = if network_policy.has_domain_rules() {
         peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await
     } else {
         (Vec::new(), None)
     };
 
-    // Re-evaluate egress only when we actually extracted an SNI. SNI
-    // can override an over-allow that matched the cache against a
-    // shared CDN IP, so this is the only refinement worth doing here.
-    if let Some(name) = sni.as_deref() {
-        let source = HostnameSource::Sni(name);
-        match network_policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source) {
+    // Re-evaluate egress against the *guest* dst — the address the
+    // guest dialed, not the post-rewrite host-side address. SNI
+    // refines over-allow when the cache matched a shared CDN IP;
+    // CacheOnly is the non-TLS fallback path so Domain rules still
+    // gate plain HTTP / SSH / etc.
+    if network_policy.has_domain_rules() {
+        let source = match sni.as_deref() {
+            Some(name) => HostnameSource::Sni(name),
+            None => HostnameSource::CacheOnly,
+        };
+        match network_policy.evaluate_egress_with_source(guest_dst, Protocol::Tcp, &shared, source)
+        {
             EgressEvaluation::Allow => {}
             EgressEvaluation::Deny => {
                 tracing::debug!(
-                    dst = %dst,
-                    sni = name,
-                    "TCP egress denied by SNI gate",
+                    dst = %guest_dst,
+                    source = source.label(),
+                    "TCP egress denied by domain policy",
                 );
                 return Ok(());
             }
             EgressEvaluation::DeferUntilHostname => {
-                debug_assert!(false, "DeferUntilHostname under HostnameSource::Sni");
+                debug_assert!(false, "DeferUntilHostname leaked into TCP proxy task");
                 return Ok(());
             }
         }
     }
 
-    let stream = TcpStream::connect(dst).await?;
+    let stream = TcpStream::connect(connect_dst).await?;
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     // Replay the buffered first flight before relay starts.
     if !initial_buf.is_empty()
         && let Err(e) = server_tx.write_all(&initial_buf).await
     {
-        tracing::debug!(dst = %dst, error = %e, "replay of buffered first flight failed");
+        tracing::debug!(dst = %connect_dst, error = %e, "replay of buffered first flight failed");
         return Ok(());
     }
 
@@ -124,7 +139,7 @@ async fn tcp_proxy_task(
                 match data {
                     Some(bytes) => {
                         if let Err(e) = server_tx.write_all(&bytes).await {
-                            tracing::debug!(dst = %dst, error = %e, "write to server failed");
+                            tracing::debug!(dst = %connect_dst, error = %e, "write to server failed");
                             break;
                         }
                     }
@@ -148,7 +163,7 @@ async fn tcp_proxy_task(
                         shared.proxy_wake.wake();
                     }
                     Err(e) => {
-                        tracing::debug!(dst = %dst, error = %e, "read from server failed");
+                        tracing::debug!(dst = %connect_dst, error = %e, "read from server failed");
                         break;
                     }
                 }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -67,7 +67,15 @@ async fn tcp_proxy_task(
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
 ) -> io::Result<()> {
-    let (initial_buf, sni) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+    // Skip the peek entirely when no Domain/DomainSuffix rule exists —
+    // peek can only refine those, and waiting for guest bytes before
+    // connecting upstream adds latency that breaks short-timeout
+    // clients on plain TCP (e.g. wget --timeout=N).
+    let (initial_buf, sni) = if network_policy.has_domain_rules() {
+        peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await
+    } else {
+        (Vec::new(), None)
+    };
     let source = match sni.as_deref() {
         Some(name) => HostnameSource::Sni(name),
         None => HostnameSource::CacheOnly,

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -67,34 +67,36 @@ async fn tcp_proxy_task(
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
 ) -> io::Result<()> {
-    // Skip the peek entirely when no Domain/DomainSuffix rule exists —
-    // peek can only refine those, and waiting for guest bytes before
-    // connecting upstream adds latency that breaks short-timeout
-    // clients on plain TCP (e.g. wget --timeout=N).
+    // Peek only when there's a Domain/DomainSuffix rule that could
+    // need an SNI to refine. Otherwise the SYN handler's decision
+    // already accepted this connection — re-evaluating here would be
+    // redundant (and wrong: the proxy receives a translated dst for
+    // host-alias connections, which the policy can't match against).
     let (initial_buf, sni) = if network_policy.has_domain_rules() {
         peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await
     } else {
         (Vec::new(), None)
     };
-    let source = match sni.as_deref() {
-        Some(name) => HostnameSource::Sni(name),
-        None => HostnameSource::CacheOnly,
-    };
 
-    match network_policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source) {
-        EgressEvaluation::Allow => {}
-        EgressEvaluation::Deny => {
-            tracing::debug!(
-                dst = %dst,
-                source = source.label(),
-                "TCP egress denied by domain policy",
-            );
-            return Ok(());
-        }
-        EgressEvaluation::DeferUntilHostname => {
-            // Only the SYN handler asks for deferral; treat as Deny.
-            debug_assert!(false, "DeferUntilHostname leaked into TCP proxy task");
-            return Ok(());
+    // Re-evaluate egress only when we actually extracted an SNI. SNI
+    // can override an over-allow that matched the cache against a
+    // shared CDN IP, so this is the only refinement worth doing here.
+    if let Some(name) = sni.as_deref() {
+        let source = HostnameSource::Sni(name);
+        match network_policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source) {
+            EgressEvaluation::Allow => {}
+            EgressEvaluation::Deny => {
+                tracing::debug!(
+                    dst = %dst,
+                    sni = name,
+                    "TCP egress denied by SNI gate",
+                );
+                return Ok(());
+            }
+            EgressEvaluation::DeferUntilHostname => {
+                debug_assert!(false, "DeferUntilHostname under HostnameSource::Sni");
+                return Ok(());
+            }
         }
     }
 

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -27,13 +27,10 @@ use crate::tls::sni;
 const SERVER_READ_BUF_SIZE: usize = 16384;
 
 /// Max bytes to buffer while peeking for the ClientHello's SNI.
-/// Matches the TLS proxy's [`tls::proxy::CLIENT_HELLO_BUF_SIZE`].
 const PEEK_BUF_SIZE: usize = 16384;
 
-/// Upper bound on time spent buffering the first flight before falling
-/// back to a cache-only egress decision. Smaller than the TLS proxy's
-/// own 10 s SNI timeout because we're only waiting for the guest's
-/// first write, not a full TLS handshake.
+/// Upper bound on time spent buffering the first flight before
+/// falling back to a cache-only egress decision.
 const PEEK_BUDGET: Duration = Duration::from_secs(5);
 
 //--------------------------------------------------------------------------------------------------
@@ -61,9 +58,8 @@ pub fn spawn_tcp_proxy(
     });
 }
 
-/// Core TCP proxy: peek for SNI, evaluate egress policy with the
-/// resulting hostname source, then either connect and relay or drop the
-/// channels.
+/// Core TCP proxy: peek for SNI, evaluate egress policy, then either
+/// connect and relay or drop the channels.
 async fn tcp_proxy_task(
     dst: SocketAddr,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
@@ -71,13 +67,7 @@ async fn tcp_proxy_task(
     shared: Arc<SharedState>,
     network_policy: Arc<NetworkPolicy>,
 ) -> io::Result<()> {
-    // Phase 0: peek for SNI. Returns the buffered first-flight bytes
-    // (replayed verbatim to upstream below) and the canonicalized SNI
-    // string when present.
     let (initial_buf, sni) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
-
-    // Map peek result to a hostname source. SNI is authoritative when
-    // present; otherwise fall back to the resolved-hostname cache.
     let source = match sni.as_deref() {
         Some(name) => HostnameSource::Sni(name),
         None => HostnameSource::CacheOnly,
@@ -94,12 +84,8 @@ async fn tcp_proxy_task(
             return Ok(());
         }
         EgressEvaluation::DeferUntilHostname => {
-            // The proxy task never asks for deferral — only the SYN
-            // handler does. Treat as Deny defensively.
-            debug_assert!(
-                false,
-                "EgressEvaluation::DeferUntilHostname leaked into the TCP proxy task",
-            );
+            // Only the SYN handler asks for deferral; treat as Deny.
+            debug_assert!(false, "DeferUntilHostname leaked into TCP proxy task");
             return Ok(());
         }
     }
@@ -107,7 +93,7 @@ async fn tcp_proxy_task(
     let stream = TcpStream::connect(dst).await?;
     let (mut server_rx, mut server_tx) = stream.into_split();
 
-    // Replay the buffered first flight before entering the relay loop.
+    // Replay the buffered first flight before relay starts.
     if !initial_buf.is_empty()
         && let Err(e) = server_tx.write_all(&initial_buf).await
     {
@@ -163,21 +149,15 @@ async fn tcp_proxy_task(
     Ok(())
 }
 
-/// Buffer the first flight from the guest until the TLS ClientHello's
-/// SNI extension can be extracted, or one of the bail-out conditions is
-/// hit (channel close, buffer cap, timeout). Never errors — non-TLS
-/// traffic and slow / malformed clients all fall through to a `None`
-/// SNI, leaving the caller to decide whether to fall back.
+/// Buffer the first flight until SNI can be extracted, or until one
+/// of the bail-out conditions hits (channel close, buffer cap,
+/// timeout). Never errors; non-TLS / slow / malformed input all
+/// fall through to `None`.
 ///
-/// On success, the SNI string is canonicalized (lowercase ASCII +
-/// trailing-dot trim) so byte equality against rule destinations
-/// (validated `DomainName` values) works directly.
-///
-/// The returned buffer holds whatever bytes were consumed from the
-/// channel and must be replayed to upstream verbatim before the
-/// caller's relay loop starts — otherwise the upstream sees a
-/// truncated TLS record (or, for non-TLS traffic, missing leading
-/// bytes).
+/// On hit, the SNI is canonicalized (lowercase + trim trailing dot)
+/// for byte-equal matching against rule destinations. The returned
+/// buffer must be replayed verbatim to upstream before the caller
+/// starts its relay loop.
 async fn peek_for_sni(
     rx: &mut mpsc::Receiver<Bytes>,
     max: usize,
@@ -339,11 +319,6 @@ mod tests {
     //----------------------------------------------------------------------------------------------
     // peek_for_sni × evaluate_egress_with_source — combined integration tests
     //----------------------------------------------------------------------------------------------
-    //
-    // These exercise the path tcp_proxy_task takes after the SYN flip:
-    // peek the first flight, pick a HostnameSource, then walk policy
-    // rules. They cover the over-allow / over-block scenarios end-to-end
-    // at the proxy-task logic level (no real upstream TcpStream needed).
 
     use std::net::IpAddr;
     use std::time::Duration as StdDuration;
@@ -374,10 +349,8 @@ mod tests {
         }
     }
 
-    /// Over-allow case: cache associates a Fastly IP with the allowed
-    /// `pypi.org`; the guest opens a TLS connection to that IP carrying
-    /// SNI `evil.com`. Pre-SNI, the cache match would let the connection
-    /// through; with `peek_for_sni` + `Sni` source the policy walk denies.
+    /// Over-allow case: cache says IP X is `pypi.org` (allowed); SNI
+    /// is `evil.com`. SNI must override the cache and deny.
     #[tokio::test]
     async fn integration_sni_overrides_cache_for_over_allow() {
         let shared = shared_with("pypi.org", SHARED_FASTLY_IP);
@@ -410,11 +383,8 @@ mod tests {
         );
     }
 
-    /// Over-block case: cache associates an IP with the denied
-    /// `ads.example.com`; a connection lands on that IP with SNI
-    /// `api.example.com`. Pre-SNI, the cache match would deny;
-    /// with `Sni` source the unrelated SNI does not match the deny rule
-    /// and the connection is allowed under the default egress.
+    /// Over-block case: cache says IP X is `ads.example.com` (denied);
+    /// SNI is `api.example.com`. SNI must override the cache and allow.
     #[tokio::test]
     async fn integration_sni_overrides_cache_for_over_block() {
         let shared = shared_with("ads.example.com", SHARED_FASTLY_IP);
@@ -448,10 +418,8 @@ mod tests {
         );
     }
 
-    /// Non-TLS first-flight: peek_for_sni returns `(buf, None)`,
-    /// caller falls back to `HostnameSource::CacheOnly`, and the cache
-    /// match decides. Verifies the fallback path (PR #605 behaviour
-    /// preserved for non-TLS allow rules).
+    /// Non-TLS first-flight falls back to `CacheOnly`; the cache
+    /// match decides.
     #[tokio::test]
     async fn integration_non_tls_falls_back_to_cache() {
         let shared = shared_with("pypi.org", SHARED_FASTLY_IP);
@@ -490,8 +458,7 @@ mod tests {
         );
     }
 
-    /// SNI matches a `DomainSuffix` rule directly without hitting the
-    /// cache — pure SNI-side suffix logic at the proxy-task layer.
+    /// SNI matches a `DomainSuffix` rule directly without the cache.
     #[tokio::test]
     async fn integration_sni_matches_domain_suffix_without_cache() {
         let shared = SharedState::new(4); // empty cache

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -8,13 +8,16 @@
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
+use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
 use crate::shared::SharedState;
+use crate::tls::sni;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -22,6 +25,16 @@ use crate::shared::SharedState;
 
 /// Buffer size for reading from the real server.
 const SERVER_READ_BUF_SIZE: usize = 16384;
+
+/// Max bytes to buffer while peeking for the ClientHello's SNI.
+/// Matches the TLS proxy's [`tls::proxy::CLIENT_HELLO_BUF_SIZE`].
+const PEEK_BUF_SIZE: usize = 16384;
+
+/// Upper bound on time spent buffering the first flight before falling
+/// back to a cache-only egress decision. Smaller than the TLS proxy's
+/// own 10 s SNI timeout because we're only waiting for the guest's
+/// first write, not a full TLS handshake.
+const PEEK_BUDGET: Duration = Duration::from_secs(5);
 
 //--------------------------------------------------------------------------------------------------
 // Functions
@@ -38,23 +51,69 @@ pub fn spawn_tcp_proxy(
     from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
+    network_policy: Arc<NetworkPolicy>,
 ) {
     handle.spawn(async move {
-        if let Err(e) = tcp_proxy_task(dst, from_smoltcp, to_smoltcp, shared).await {
+        if let Err(e) = tcp_proxy_task(dst, from_smoltcp, to_smoltcp, shared, network_policy).await
+        {
             tracing::debug!(dst = %dst, error = %e, "TCP proxy task ended");
         }
     });
 }
 
-/// Core TCP proxy: connect to real destination and relay bidirectionally.
+/// Core TCP proxy: peek for SNI, evaluate egress policy with the
+/// resulting hostname source, then either connect and relay or drop the
+/// channels.
 async fn tcp_proxy_task(
     dst: SocketAddr,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
+    network_policy: Arc<NetworkPolicy>,
 ) -> io::Result<()> {
+    // Phase 0: peek for SNI. Returns the buffered first-flight bytes
+    // (replayed verbatim to upstream below) and the canonicalized SNI
+    // string when present.
+    let (initial_buf, sni) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+
+    // Map peek result to a hostname source. SNI is authoritative when
+    // present; otherwise fall back to the resolved-hostname cache.
+    let source = match sni.as_deref() {
+        Some(name) => HostnameSource::Sni(name),
+        None => HostnameSource::CacheOnly,
+    };
+
+    match network_policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source) {
+        EgressEvaluation::Allow => {}
+        EgressEvaluation::Deny => {
+            tracing::debug!(
+                dst = %dst,
+                source = %hostname_source_label(source),
+                "TCP egress denied by domain policy",
+            );
+            return Ok(());
+        }
+        EgressEvaluation::DeferUntilHostname => {
+            // The proxy task never asks for deferral — only the SYN
+            // handler does. Treat as Deny defensively.
+            debug_assert!(
+                false,
+                "EgressEvaluation::DeferUntilHostname leaked into the TCP proxy task",
+            );
+            return Ok(());
+        }
+    }
+
     let stream = TcpStream::connect(dst).await?;
     let (mut server_rx, mut server_tx) = stream.into_split();
+
+    // Replay the buffered first flight before entering the relay loop.
+    if !initial_buf.is_empty()
+        && let Err(e) = server_tx.write_all(&initial_buf).await
+    {
+        tracing::debug!(dst = %dst, error = %e, "replay of buffered first flight failed");
+        return Ok(());
+    }
 
     let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];
 
@@ -102,4 +161,188 @@ async fn tcp_proxy_task(
     }
 
     Ok(())
+}
+
+/// Buffer the first flight from the guest until the TLS ClientHello's
+/// SNI extension can be extracted, or one of the bail-out conditions is
+/// hit (channel close, buffer cap, timeout). Never errors — non-TLS
+/// traffic and slow / malformed clients all fall through to a `None`
+/// SNI, leaving the caller to decide whether to fall back.
+///
+/// On success, the SNI string is canonicalized (lowercase ASCII +
+/// trailing-dot trim) so byte equality against rule destinations
+/// (validated `DomainName` values) works directly.
+///
+/// The returned buffer holds whatever bytes were consumed from the
+/// channel and must be replayed to upstream verbatim before the
+/// caller's relay loop starts — otherwise the upstream sees a
+/// truncated TLS record (or, for non-TLS traffic, missing leading
+/// bytes).
+async fn peek_for_sni(
+    rx: &mut mpsc::Receiver<Bytes>,
+    max: usize,
+    budget: Duration,
+) -> (Vec<u8>, Option<String>) {
+    let mut buf = Vec::with_capacity(PEEK_BUF_SIZE.min(8192));
+    let timeout_fut = tokio::time::sleep(budget);
+    tokio::pin!(timeout_fut);
+
+    let raw_sni = loop {
+        tokio::select! {
+            biased;
+            _ = &mut timeout_fut => break None,
+            data = rx.recv() => {
+                match data {
+                    Some(bytes) => {
+                        buf.extend_from_slice(&bytes);
+                        if let Some(name) = sni::extract_sni(&buf) {
+                            break Some(name);
+                        }
+                        if buf.len() >= max {
+                            break None;
+                        }
+                    }
+                    None => break None,
+                }
+            }
+        }
+    };
+
+    let canonical = raw_sni.map(|s| s.trim_end_matches('.').to_ascii_lowercase());
+    (buf, canonical)
+}
+
+/// Short label for tracing tags, identifying which hostname source was
+/// used for an egress decision.
+fn hostname_source_label(source: HostnameSource<'_>) -> &'static str {
+    match source {
+        HostnameSource::Sni(_) => "sni",
+        HostnameSource::CacheOnly => "cache",
+        HostnameSource::Deferred => "deferred",
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic TLS ClientHello carrying SNI `example.com`. Bytes
+    /// borrowed from `tls::sni` test fixtures so the parser sees a
+    /// well-formed record.
+    fn synthetic_client_hello(sni: &str) -> Vec<u8> {
+        // Minimal but valid TLS 1.2 ClientHello with one SNI entry.
+        // Layout: record header (5) + handshake header (4) + body.
+        let host_bytes = sni.as_bytes();
+        let host_len = host_bytes.len() as u16;
+        let server_name_list_len = 3 + host_len; // type(1) + len(2) + host
+        let extension_data_len = 2 + server_name_list_len; // list-len(2) + list
+        let extensions_total = 4 + extension_data_len; // type(2) + len(2) + data
+
+        let mut body = Vec::new();
+        // Client version
+        body.extend_from_slice(&[0x03, 0x03]);
+        // Random (32 bytes)
+        body.extend_from_slice(&[0u8; 32]);
+        // Session id length + (empty)
+        body.push(0);
+        // Cipher suites length + one cipher
+        body.extend_from_slice(&[0x00, 0x02, 0x00, 0x2f]);
+        // Compression methods length + null
+        body.extend_from_slice(&[0x01, 0x00]);
+        // Extensions length
+        body.extend_from_slice(&(extensions_total as u16).to_be_bytes());
+        // SNI extension: type 0x0000
+        body.extend_from_slice(&[0x00, 0x00]);
+        body.extend_from_slice(&(extension_data_len as u16).to_be_bytes());
+        body.extend_from_slice(&(server_name_list_len as u16).to_be_bytes());
+        body.push(0x00); // host_name type
+        body.extend_from_slice(&host_len.to_be_bytes());
+        body.extend_from_slice(host_bytes);
+
+        let handshake_len = body.len() as u32;
+        let mut hs = Vec::new();
+        hs.push(0x01); // ClientHello
+        hs.extend_from_slice(&handshake_len.to_be_bytes()[1..]); // 24-bit length
+        hs.extend_from_slice(&body);
+
+        let record_len = hs.len() as u16;
+        let mut record = Vec::new();
+        record.extend_from_slice(&[0x16, 0x03, 0x01]); // Handshake, TLS 1.0
+        record.extend_from_slice(&record_len.to_be_bytes());
+        record.extend_from_slice(&hs);
+
+        record
+    }
+
+    #[tokio::test]
+    async fn peek_for_sni_extracts_and_canonicalizes() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let hello = synthetic_client_hello("Example.COM");
+        tx.send(Bytes::from(hello.clone())).await.unwrap();
+        drop(tx); // close so peek returns even if SNI didn't satisfy
+
+        let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert_eq!(sni.as_deref(), Some("example.com"));
+        assert_eq!(buf, hello);
+    }
+
+    #[tokio::test]
+    async fn peek_for_sni_returns_none_on_channel_close_without_data() {
+        let (tx, mut rx) = mpsc::channel::<Bytes>(1);
+        drop(tx);
+        let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert!(buf.is_empty());
+        assert_eq!(sni, None);
+    }
+
+    #[tokio::test]
+    async fn peek_for_sni_returns_none_on_non_tls_data() {
+        let (tx, mut rx) = mpsc::channel(4);
+        // Plaintext HTTP request; not a TLS record so extract_sni returns None.
+        tx.send(Bytes::from_static(
+            b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+        let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert!(
+            !buf.is_empty(),
+            "buffered bytes must be returned for replay"
+        );
+        assert_eq!(sni, None);
+    }
+
+    #[tokio::test]
+    async fn peek_for_sni_falls_back_on_timeout() {
+        let (tx, mut rx) = mpsc::channel::<Bytes>(1);
+        // Hold the sender open but send nothing — peek must time out.
+        let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, Duration::from_millis(50)).await;
+        drop(tx);
+        assert!(buf.is_empty());
+        assert_eq!(sni, None);
+    }
+
+    #[tokio::test]
+    async fn peek_for_sni_caps_at_max_bytes() {
+        let (tx, mut rx) = mpsc::channel(4);
+        // Hand over more than the cap with no SNI in sight.
+        let chunk = vec![0u8; 8192];
+        tx.send(Bytes::from(chunk.clone())).await.unwrap();
+        tx.send(Bytes::from(chunk.clone())).await.unwrap();
+        tx.send(Bytes::from(chunk)).await.unwrap();
+        drop(tx);
+
+        let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert_eq!(sni, None, "no SNI in non-TLS data");
+        assert!(
+            buf.len() >= PEEK_BUF_SIZE,
+            "buffer must hit the cap before bail-out: got {}",
+            buf.len()
+        );
+    }
 }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -345,4 +345,193 @@ mod tests {
             buf.len()
         );
     }
+
+    //----------------------------------------------------------------------------------------------
+    // peek_for_sni × evaluate_egress_with_source — combined integration tests
+    //----------------------------------------------------------------------------------------------
+    //
+    // These exercise the path tcp_proxy_task takes after the SYN flip:
+    // peek the first flight, pick a HostnameSource, then walk policy
+    // rules. They cover the over-allow / over-block scenarios end-to-end
+    // at the proxy-task logic level (no real upstream TcpStream needed).
+
+    use std::net::IpAddr;
+    use std::time::Duration as StdDuration;
+
+    use crate::policy::{Action, Destination, NetworkPolicy, PortRange, Rule};
+    use crate::shared::{ResolvedHostnameFamily, SharedState};
+
+    const SHARED_FASTLY_IP: &str = "151.101.0.223";
+
+    fn shared_with(host: &str, ip: &str) -> SharedState {
+        let shared = SharedState::new(4);
+        shared.cache_resolved_hostname(
+            host,
+            ResolvedHostnameFamily::Ipv4,
+            [ip.parse::<IpAddr>().unwrap()],
+            StdDuration::from_secs(60),
+        );
+        shared
+    }
+
+    fn allow_https(domain: &str) -> Rule {
+        Rule {
+            direction: crate::policy::Direction::Egress,
+            destination: Destination::Domain(domain.parse().unwrap()),
+            protocols: vec![Protocol::Tcp],
+            ports: vec![PortRange::single(443)],
+            action: Action::Allow,
+        }
+    }
+
+    /// Over-allow case: cache associates a Fastly IP with the allowed
+    /// `pypi.org`; the guest opens a TLS connection to that IP carrying
+    /// SNI `evil.com`. Pre-SNI, the cache match would let the connection
+    /// through; with `peek_for_sni` + `Sni` source the policy walk denies.
+    #[tokio::test]
+    async fn integration_sni_overrides_cache_for_over_allow() {
+        let shared = shared_with("pypi.org", SHARED_FASTLY_IP);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![allow_https("pypi.org")],
+        };
+        let dst = SocketAddr::new(SHARED_FASTLY_IP.parse().unwrap(), 443);
+
+        let (tx, mut rx) = mpsc::channel(4);
+        tx.send(Bytes::from(synthetic_client_hello("evil.com")))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let (initial_buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert_eq!(sni.as_deref(), Some("evil.com"));
+        assert!(!initial_buf.is_empty());
+
+        let source = sni
+            .as_deref()
+            .map(HostnameSource::Sni)
+            .unwrap_or(HostnameSource::CacheOnly);
+        let eval = policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source);
+        assert_eq!(
+            eval,
+            EgressEvaluation::Deny,
+            "SNI=evil.com must not piggy-back on the cached pypi.org match",
+        );
+    }
+
+    /// Over-block case: cache associates an IP with the denied
+    /// `ads.example.com`; a connection lands on that IP with SNI
+    /// `api.example.com`. Pre-SNI, the cache match would deny;
+    /// with `Sni` source the unrelated SNI does not match the deny rule
+    /// and the connection is allowed under the default egress.
+    #[tokio::test]
+    async fn integration_sni_overrides_cache_for_over_block() {
+        let shared = shared_with("ads.example.com", SHARED_FASTLY_IP);
+        let policy = NetworkPolicy {
+            default_egress: Action::Allow,
+            default_ingress: Action::Allow,
+            rules: vec![Rule::deny_egress(Destination::Domain(
+                "ads.example.com".parse().unwrap(),
+            ))],
+        };
+        let dst = SocketAddr::new(SHARED_FASTLY_IP.parse().unwrap(), 443);
+
+        let (tx, mut rx) = mpsc::channel(4);
+        tx.send(Bytes::from(synthetic_client_hello("api.example.com")))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let (_initial_buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert_eq!(sni.as_deref(), Some("api.example.com"));
+
+        let source = sni
+            .as_deref()
+            .map(HostnameSource::Sni)
+            .unwrap_or(HostnameSource::CacheOnly);
+        let eval = policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source);
+        assert_eq!(
+            eval,
+            EgressEvaluation::Allow,
+            "SNI=api.example.com must not be caught by the deny on ads.example.com",
+        );
+    }
+
+    /// Non-TLS first-flight: peek_for_sni returns `(buf, None)`,
+    /// caller falls back to `HostnameSource::CacheOnly`, and the cache
+    /// match decides. Verifies the fallback path (PR #605 behaviour
+    /// preserved for non-TLS allow rules).
+    #[tokio::test]
+    async fn integration_non_tls_falls_back_to_cache() {
+        let shared = shared_with("pypi.org", SHARED_FASTLY_IP);
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![allow_https("pypi.org")],
+        };
+        let dst = SocketAddr::new(SHARED_FASTLY_IP.parse().unwrap(), 443);
+
+        let (tx, mut rx) = mpsc::channel(4);
+        // Plain HTTP request; not a TLS record.
+        tx.send(Bytes::from_static(
+            b"GET / HTTP/1.1\r\nHost: pypi.org\r\n\r\n",
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+
+        let (initial_buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        assert_eq!(sni, None, "non-TLS data → no SNI");
+        assert!(
+            !initial_buf.is_empty(),
+            "buffered bytes must survive for replay"
+        );
+
+        let source = sni
+            .as_deref()
+            .map(HostnameSource::Sni)
+            .unwrap_or(HostnameSource::CacheOnly);
+        let eval = policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source);
+        assert_eq!(
+            eval,
+            EgressEvaluation::Allow,
+            "cache-only fallback must still allow the cached hostname's IP",
+        );
+    }
+
+    /// SNI matches a `DomainSuffix` rule directly without hitting the
+    /// cache — pure SNI-side suffix logic at the proxy-task layer.
+    #[tokio::test]
+    async fn integration_sni_matches_domain_suffix_without_cache() {
+        let shared = SharedState::new(4); // empty cache
+        let policy = NetworkPolicy {
+            default_egress: Action::Deny,
+            default_ingress: Action::Allow,
+            rules: vec![Rule {
+                direction: crate::policy::Direction::Egress,
+                destination: Destination::DomainSuffix(".pythonhosted.org".parse().unwrap()),
+                protocols: vec![Protocol::Tcp],
+                ports: vec![PortRange::single(443)],
+                action: Action::Allow,
+            }],
+        };
+        let dst = SocketAddr::new(SHARED_FASTLY_IP.parse().unwrap(), 443);
+
+        let (tx, mut rx) = mpsc::channel(4);
+        tx.send(Bytes::from(synthetic_client_hello(
+            "files.pythonhosted.org",
+        )))
+        .await
+        .unwrap();
+        drop(tx);
+
+        let (_buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        let source = sni
+            .as_deref()
+            .map(HostnameSource::Sni)
+            .unwrap_or(HostnameSource::CacheOnly);
+        let eval = policy.evaluate_egress_with_source(dst, Protocol::Tcp, &shared, source);
+        assert_eq!(eval, EgressEvaluation::Allow);
+    }
 }

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -175,6 +175,13 @@ async fn peek_for_sni(
                 match data {
                     Some(bytes) => {
                         buf.extend_from_slice(&bytes);
+                        // First byte of a TLS record is the ContentType;
+                        // 0x16 is handshake. Anything else can't be a
+                        // ClientHello, so don't burn the full budget on
+                        // plain HTTP / SSH / etc.
+                        if buf.first() != Some(&0x16) {
+                            break None;
+                        }
                         if let Some(name) = sni::extract_sni(&buf) {
                             break Some(name);
                         }
@@ -300,11 +307,14 @@ mod tests {
     #[tokio::test]
     async fn peek_for_sni_caps_at_max_bytes() {
         let (tx, mut rx) = mpsc::channel(4);
-        // Hand over more than the cap with no SNI in sight.
-        let chunk = vec![0u8; 8192];
-        tx.send(Bytes::from(chunk.clone())).await.unwrap();
-        tx.send(Bytes::from(chunk.clone())).await.unwrap();
-        tx.send(Bytes::from(chunk)).await.unwrap();
+        // First byte 0x16 keeps the peek collecting past the early
+        // non-TLS bail. Padding bytes are zero so the SNI parser never
+        // matches and the loop drives to the size cap.
+        let mut first = vec![0u8; 8192];
+        first[0] = 0x16;
+        tx.send(Bytes::from(first)).await.unwrap();
+        tx.send(Bytes::from(vec![0u8; 8192])).await.unwrap();
+        tx.send(Bytes::from(vec![0u8; 8192])).await.unwrap();
         drop(tx);
 
         let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
@@ -313,6 +323,28 @@ mod tests {
             buf.len() >= PEEK_BUF_SIZE,
             "buffer must hit the cap before bail-out: got {}",
             buf.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn peek_for_sni_bails_immediately_on_non_tls_first_byte() {
+        let (tx, mut rx) = mpsc::channel(4);
+        // Plain HTTP request: first byte 'G' (0x47) — clearly not TLS.
+        tx.send(Bytes::from_static(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n"))
+            .await
+            .unwrap();
+        drop(tx);
+
+        // 5-second nominal budget; assert we returned in well under
+        // that — the early-bail must not wait for the full window.
+        let started = std::time::Instant::now();
+        let (buf, sni) = peek_for_sni(&mut rx, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+        let elapsed = started.elapsed();
+        assert_eq!(sni, None);
+        assert!(buf.starts_with(b"GET"));
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "non-TLS bail must be fast: took {elapsed:?}"
         );
     }
 

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -418,6 +418,7 @@ pub fn smoltcp_poll_loop(
                     conn.to_smoltcp,
                     shared.clone(),
                     tls_state.clone(),
+                    network_policy.clone(),
                 );
                 continue;
             }

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -28,7 +28,7 @@ use crate::dns::{
     proxies::{dot::DotProxy, tcp::DnsTcpProxy},
 };
 use crate::icmp_relay::IcmpRelay;
-use crate::policy::{NetworkPolicy, Protocol};
+use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
 use crate::proxy;
 use crate::publisher::PortPublisher;
 use crate::shared::SharedState;
@@ -298,10 +298,21 @@ pub fn smoltcp_poll_loop(
                             tracing::debug!(%dst, "alternative-DNS TCP port refused; stub should fall back to TCP/53");
                             false
                         }
-                        // Other: regular outbound — apply egress policy.
-                        DnsPortType::Other => network_policy
-                            .evaluate_egress(dst, Protocol::Tcp, &shared)
-                            .is_allow(),
+                        // Other: regular outbound — defer Domain /
+                        // DomainSuffix rules to first-flight (SNI) and
+                        // accept the SYN unless an IP-layer rule denies
+                        // outright. The plain-TCP and TLS proxy tasks
+                        // re-evaluate with the authoritative hostname
+                        // before connecting upstream.
+                        DnsPortType::Other => match network_policy.evaluate_egress_with_source(
+                            dst,
+                            Protocol::Tcp,
+                            &shared,
+                            HostnameSource::Deferred,
+                        ) {
+                            EgressEvaluation::Allow | EgressEvaluation::DeferUntilHostname => true,
+                            EgressEvaluation::Deny => false,
+                        },
                     };
                     if allow && !conn_tracker.has_socket_for(&src, &dst) {
                         conn_tracker.create_tcp_socket(src, dst, &mut sockets);

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -469,10 +469,11 @@ pub fn smoltcp_poll_loop(
                 continue;
             }
             // Plain TCP proxy.
-            let dst = resolve_host_dst(conn.dst, config.gateway);
+            let connect_dst = resolve_host_dst(conn.dst, config.gateway);
             proxy::spawn_tcp_proxy(
                 &tokio_handle,
-                dst,
+                conn.dst,
+                connect_dst,
                 conn.from_smoltcp,
                 conn.to_smoltcp,
                 shared.clone(),

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -298,12 +298,8 @@ pub fn smoltcp_poll_loop(
                             tracing::debug!(%dst, "alternative-DNS TCP port refused; stub should fall back to TCP/53");
                             false
                         }
-                        // Other: regular outbound — defer Domain /
-                        // DomainSuffix rules to first-flight (SNI) and
-                        // accept the SYN unless an IP-layer rule denies
-                        // outright. The plain-TCP and TLS proxy tasks
-                        // re-evaluate with the authoritative hostname
-                        // before connecting upstream.
+                        // Other: regular outbound — defer Domain rules to first-flight;
+                        // accept unless an IP-layer rule denies.
                         DnsPortType::Other => match network_policy.evaluate_egress_with_source(
                             dst,
                             Protocol::Tcp,

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -469,6 +469,7 @@ pub fn smoltcp_poll_loop(
                 conn.from_smoltcp,
                 conn.to_smoltcp,
                 shared.clone(),
+                network_policy.clone(),
             );
         }
 

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -17,6 +17,7 @@ use tokio::sync::mpsc;
 
 use super::sni;
 use super::state::TlsState;
+use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
 use crate::secrets::handler::SecretsHandler;
 use crate::shared::SharedState;
 
@@ -42,9 +43,19 @@ pub fn spawn_tls_proxy(
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     tls_state: Arc<TlsState>,
+    network_policy: Arc<NetworkPolicy>,
 ) {
     handle.spawn(async move {
-        if let Err(e) = tls_proxy_task(dst, from_smoltcp, to_smoltcp, shared, tls_state).await {
+        if let Err(e) = tls_proxy_task(
+            dst,
+            from_smoltcp,
+            to_smoltcp,
+            shared,
+            tls_state,
+            network_policy,
+        )
+        .await
+        {
             tracing::debug!(dst = %dst, error = %e, "TLS proxy task ended");
         }
     });
@@ -57,6 +68,7 @@ async fn tls_proxy_task(
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
     tls_state: Arc<TlsState>,
+    network_policy: Arc<NetworkPolicy>,
 ) -> io::Result<()> {
     // Phase 0: Buffer initial data to extract SNI from ClientHello.
     // Timeout prevents a slow/malicious guest from holding a proxy slot indefinitely.
@@ -67,6 +79,29 @@ async fn tls_proxy_task(
     .await
     .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SNI extraction timed out"))?;
     let (sni_name, initial_buf) = sni_name?;
+
+    // Canonicalize once at the boundary so byte equality against rule
+    // destinations (which carry validated `DomainName` values) works
+    // directly. The existing `should_bypass` path already lowercases
+    // internally, so this is forwards-compatible with that.
+    let sni_name = sni_name.trim_end_matches('.').to_ascii_lowercase();
+
+    // Apply network-policy Domain / DomainSuffix rules with the SNI as
+    // the authoritative hostname. Distinct from the SYN-time IP-rule
+    // check (which deferred Domain rules) and from the TLS-bypass
+    // pattern list (which is interception config, not policy).
+    if matches!(
+        network_policy.evaluate_egress_with_source(
+            dst,
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni(&sni_name),
+        ),
+        EgressEvaluation::Deny,
+    ) {
+        tracing::debug!(sni = %sni_name, dst = %dst, "TLS egress denied by domain policy");
+        return Ok(());
+    }
 
     if tls_state.should_bypass(&sni_name) {
         tracing::debug!(sni = %sni_name, dst = %dst, "TLS bypass");

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -80,25 +80,17 @@ async fn tls_proxy_task(
     .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SNI extraction timed out"))?;
     let (sni_name, initial_buf) = sni_name?;
 
-    // Canonicalize once at the boundary so byte equality against rule
-    // destinations (which carry validated `DomainName` values) works
-    // directly. The existing `should_bypass` path already lowercases
-    // internally, so this is forwards-compatible with that.
+    // Canonicalize so byte equality against rule destinations works.
     let sni_name = sni_name.trim_end_matches('.').to_ascii_lowercase();
 
-    // Apply network-policy Domain / DomainSuffix rules with the SNI as
-    // the authoritative hostname. Distinct from the SYN-time IP-rule
-    // check (which deferred Domain rules) and from the TLS-bypass
-    // pattern list (which is interception config, not policy).
-    if matches!(
-        network_policy.evaluate_egress_with_source(
-            dst,
-            Protocol::Tcp,
-            &shared,
-            HostnameSource::Sni(&sni_name),
-        ),
-        EgressEvaluation::Deny,
-    ) {
+    // Apply Domain / DomainSuffix rules against the SNI.
+    let eval = network_policy.evaluate_egress_with_source(
+        dst,
+        Protocol::Tcp,
+        &shared,
+        HostnameSource::Sni(&sni_name),
+    );
+    if matches!(eval, EgressEvaluation::Deny) {
         tracing::debug!(sni = %sni_name, dst = %dst, "TLS egress denied by domain policy");
         return Ok(());
     }

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -58,8 +58,6 @@ msb run -d --name worker python -- python worker.py
 | `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
 | `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
 | `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
-| `--dns-block-domain` | Deprecated alias for `--deny-domain`; emits a warning on use |
-| `--dns-block-suffix` | Deprecated alias for `--deny-domain-suffix`; emits a warning on use |
 | `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -56,8 +56,10 @@ msb run -d --name worker python -- python worker.py
 | `--idle-timeout` | Stop the sandbox after this period of inactivity (e.g. `30s`, `5m`, `1h`) |
 | `--no-network` | Disable all network access |
 | `--network-policy` | Control which destinations are reachable from the sandbox. Accepted values: `none` (no network), `public-only` (default — public internet only), `nonlocal` (public + private/LAN; blocks loopback, link-local, and metadata), `allow-all` (unrestricted) |
-| `--dns-block-domain` | Block DNS lookups for a domain (returns REFUSED) |
-| `--dns-block-suffix` | Block DNS lookups for all subdomains of a suffix (e.g. `.ads.com`) |
+| `--deny-domain` | Deny egress to a domain. Repeatable. Adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback) |
+| `--deny-domain-suffix` | Deny egress to all subdomains of a suffix (e.g. `.ads.com`). Repeatable. Adds a `deny DomainSuffix("...")` policy rule |
+| `--dns-block-domain` | Deprecated alias for `--deny-domain`; emits a warning on use |
+| `--dns-block-suffix` | Deprecated alias for `--deny-domain-suffix`; emits a warning on use |
 | `--no-dns-rebind-protection` | Allow DNS responses pointing to private/internal IP addresses |
 | `--dns-nameserver` | Nameserver to forward DNS queries to (repeatable; `IP` or `IP:PORT`). Overrides the host's `/etc/resolv.conf` |
 | `--dns-query-timeout-ms` | Per-DNS-query timeout in milliseconds (default: 5000) |

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -72,9 +72,6 @@ msb create python --name safe-agent \
 
 </CodeGroup>
 
-<Note>
-**Deprecated:** the previous DNS-only block list (`DnsBuilder::block_domain` / `DnsConfig.block_domains` / `--dns-block-domain`) is kept as an alias for back-compat but emits a runtime deprecation warning on use. Migrate to the canonical names above; the new rules also enforce at TCP egress, not just DNS.
-</Note>
 
 ## Pinning nameservers
 

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -15,59 +15,66 @@ The knobs below cover the day-to-day controls. For the rebinding and TOCTOU prot
 
 ## Blocking domains
 
-Block lookups by exact match or suffix (e.g. `*.tracking.com`). Blocked queries get a local `REFUSED` response, so the upstream resolver never sees them.
+Domain blocking lives in the network policy as `deny Domain(...)` / `deny DomainSuffix(...)` rules. The interceptor enforces them at three layers:
+
+1. **DNS resolution** — denied names get a local `REFUSED` response; the upstream resolver never sees them.
+2. **TLS first-flight** — when a guest hardcodes an IP and opens a TLS connection, the SNI is checked against the same rules.
+3. **TCP egress (cache fallback)** — for non-TLS traffic, the resolved-hostname cache disambiguates by IP.
+
+The bulk-deny shortcuts in each SDK are convenience for `deny Domain` / `deny DomainSuffix` rules; they prepend onto whatever policy is set so the deny takes precedence over later allow rules.
 
 <CodeGroup>
 ```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["malware.example.com"])
+        .deny_domain_suffixes([".tracking.com"]))
+    .build()?;
+
 let sb = Sandbox::builder("safe-agent")
     .image("python")
-    .network(|n| n
-        .dns(|d| d
-            .block_domain("malware.example.com")
-            .block_domain_suffix(".tracking.com")
-        )
-    )
+    .network(|n| n.policy(policy))
     .create()
     .await?;
 ```
 
 ```typescript TypeScript
-import { NetworkPolicy, Sandbox } from "microsandbox";
+import { Sandbox } from "microsandbox";
 
 await using sb = await Sandbox.builder("safe-agent")
     .image("python")
-    .network((n) => n
-        .policy(NetworkPolicy.publicOnly())
-        .dns((d) => d
-            .blockDomain("malware.example.com")
-            .blockDomainSuffix(".tracking.com"),
-        ),
-    )
+    .network({
+        denyDomains: ["malware.example.com"],
+        denyDomainSuffixes: [".tracking.com"],
+    })
     .create();
 ```
 
 ```python Python
-from microsandbox import DnsConfig, Network, Sandbox
+from microsandbox import Network, Sandbox
 
 sb = await Sandbox.create(
     "safe-agent",
     image="python",
     network=Network(
-        dns=DnsConfig(
-            block_domains=("malware.example.com",),
-            block_domain_suffixes=(".tracking.com",),
-        ),
+        deny_domains=("malware.example.com",),
+        deny_domain_suffixes=(".tracking.com",),
     ),
 )
 ```
 
 ```bash CLI
 msb create python --name safe-agent \
-  --dns-block-domain malware.example.com \
-  --dns-block-suffix .tracking.com
+  --deny-domain malware.example.com \
+  --deny-domain-suffix .tracking.com
 ```
 
 </CodeGroup>
+
+<Note>
+**Deprecated:** the previous DNS-only block list (`DnsBuilder::block_domain` / `DnsConfig.block_domains` / `--dns-block-domain`) is kept as an alias for back-compat but emits a runtime deprecation warning on use. Migrate to the canonical names above; the new rules also enforce at TCP egress, not just DNS.
+</Note>
 
 ## Pinning nameservers
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -14,6 +14,8 @@ Frozen dataclass for sandbox network configuration. Use the class method presets
 Network(
     policy: str | NetworkPolicy | None = None,
     ports: Mapping[int, int] = {},
+    deny_domains: tuple[str, ...] = (),
+    deny_domain_suffixes: tuple[str, ...] = (),
     dns: DnsConfig | None = None,
     tls: TlsConfig | None = None,
     max_connections: int | None = None,
@@ -25,6 +27,8 @@ Network(
 |-------|------|---------|-------------|
 | policy | `str \| NetworkPolicy \| None` | `None` | Preset name or custom [`NetworkPolicy`](#networkpolicy) |
 | ports | `Mapping[int, int]` | `{}` | Port mappings from host to guest |
+| deny_domains | `tuple[str, ...]` | `()` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy so it takes precedence over later allow rules |
+| deny_domain_suffixes | `tuple[str, ...]` | `()` | Deny egress to all subdomains of these suffixes. Adds `deny DomainSuffix("...")` rules; same enforcement layers as `deny_domains` |
 | dns | [`DnsConfig`](#dnsconfig) ` \| None` | `None` | DNS interception configuration |
 | tls | [`TlsConfig`](#tlsconfig) ` \| None` | `None` | TLS interception configuration |
 | max_connections | `int \| None` | `None` | Maximum concurrent connections |
@@ -36,8 +40,6 @@ Frozen dataclass for DNS interception settings.
 
 ```python
 DnsConfig(
-    block_domains: tuple[str, ...] = (),
-    block_domain_suffixes: tuple[str, ...] = (),
     rebind_protection: bool = True,
     nameservers: tuple[str, ...] = (),
     query_timeout_ms: int | None = None,
@@ -46,11 +48,13 @@ DnsConfig(
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| block_domains | `tuple[str, ...]` | `()` | Block DNS for exact domains (returns REFUSED) |
-| block_domain_suffixes | `tuple[str, ...]` | `()` | Block DNS for all subdomains of a suffix |
 | rebind_protection | `bool` | `True` | Block DNS responses resolving to private IPs |
 | nameservers | `tuple[str, ...]` | `()` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
 | query_timeout_ms | `int \| None` | `None` | Per-DNS-query timeout in milliseconds (default: 5000) |
+
+<Note>
+**Deprecated:** `DnsConfig.blocked_domains` and `DnsConfig.blocked_suffixes` still work as aliases for `Network.deny_domains` / `Network.deny_domain_suffixes` but emit a `DeprecationWarning` on use. Migrate to the canonical fields above.
+</Note>
 
 ---
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -52,9 +52,6 @@ DnsConfig(
 | nameservers | `tuple[str, ...]` | `()` | Nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). Overrides the host's `/etc/resolv.conf` when set. Hostnames are resolved once at startup via the host's OS resolver |
 | query_timeout_ms | `int \| None` | `None` | Per-DNS-query timeout in milliseconds (default: 5000) |
 
-<Note>
-**Deprecated:** `DnsConfig.blocked_domains` and `DnsConfig.blocked_suffixes` still work as aliases for `Network.deny_domains` / `Network.deny_domain_suffixes` but emit a `DeprecationWarning` on use. Migrate to the canonical fields above.
-</Note>
 
 ---
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -165,8 +165,6 @@ Configure DNS interception. Errors accumulated by [`DnsBuilder`](#dnsbuilder) ca
 )
 ```
 
-Domain blocking is expressed as policy rules — see [`NetworkPolicyBuilder::deny_domains`](#deny_domains) — not on `DnsBuilder`.
-
 #### max_connections()
 
 ```rust
@@ -203,9 +201,7 @@ Set the action taken when a secret placeholder is detected in traffic destined f
 
 ## DnsBuilder
 
-Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`.
-
-Domain blocking is no longer here — express it as policy rules via [`NetworkPolicyBuilder::deny_domains`](#deny_domains) / [`deny_domain_suffixes`](#deny_domain_suffixes) instead. The DnsBuilder still owns rebind protection, nameserver pinning, and query timeouts.
+Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`. Owns rebind protection, nameserver pinning, and the per-query timeout.
 
 #### rebind_protection()
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -84,6 +84,22 @@ Inside `.rule(|r| ...)` (or any of the direction sub-builders), state setters an
 | `.allow_multicast() / .deny_multicast()` | `Group::Multicast` |
 | `.allow_host() / .deny_host()` | `Group::Host` (per-sandbox gateway IPs that back `host.microsandbox.internal`) |
 
+**Bulk-domain shortcuts** (one rule per name, inheriting current direction/protocol/port state):
+
+| Method | Effect |
+|--------|--------|
+| <a id="deny_domains"></a>`.allow_domains([..]) / .deny_domains([..])` | One `Destination::Domain` rule per name. Lazy-parse: invalid names surface as `BuildError::InvalidDomain` from `.build()` |
+| <a id="deny_domain_suffixes"></a>`.allow_domain_suffixes([..]) / .deny_domain_suffixes([..])` | One `Destination::DomainSuffix` rule per suffix. Same lazy-parse contract |
+
+```rust
+NetworkPolicy::builder()
+    .default_allow()
+    .egress(|e| e
+        .deny_domains(["evil.com", "tracker.example"])
+        .deny_domain_suffixes([".ads.example", ".doubleclick.net"]))
+    .build()?
+```
+
 **Composite sugar:**
 
 | Method | Effect |
@@ -143,13 +159,13 @@ Configure DNS interception. Errors accumulated by [`DnsBuilder`](#dnsbuilder) ca
 ```rust
 .network(|n| n
     .dns(|d| d
-        .block_domain("malware.example.com")
-        .block_domain_suffix(".tracking.com")
         .nameservers(["1.1.1.1".parse::<Nameserver>()?])
         .query_timeout_ms(3000)
     )
 )
 ```
+
+Domain blocking is expressed as policy rules — see [`NetworkPolicyBuilder::deny_domains`](#deny_domains) — not on `DnsBuilder`.
 
 #### max_connections()
 
@@ -189,23 +205,7 @@ Set the action taken when a secret placeholder is detected in traffic destined f
 
 Builder for DNS interception settings. Used in `NetworkBuilder::dns(|d| d...)`.
 
-`block_domain` and `block_domain_suffix` use the same lazy-parse + accumulate-at-`.build()` model as `NetworkPolicy::builder()` — string inputs are stored raw, errors surface as `BuildError::InvalidBlockedDomain` / `InvalidBlockedDomainSuffix` from the outermost `.build()` in the chain.
-
-#### block_domain()
-
-```rust
-fn block_domain(self, domain: impl Into<String>) -> Self
-```
-
-Block DNS lookups for an exact domain. The guest receives REFUSED for this domain.
-
-#### block_domain_suffix()
-
-```rust
-fn block_domain_suffix(self, suffix: impl Into<String>) -> Self
-```
-
-Block DNS lookups for all subdomains matching a suffix. For example, `.tracking.com` blocks `a.tracking.com`, `b.c.tracking.com`, etc.
+Domain blocking is no longer here — express it as policy rules via [`NetworkPolicyBuilder::deny_domains`](#deny_domains) / [`deny_domain_suffixes`](#deny_domain_suffixes) instead. The DnsBuilder still owns rebind protection, nameserver pinning, and query timeouts.
 
 #### rebind_protection()
 
@@ -376,8 +376,6 @@ Errors surfaced by the builders' `.build()` methods. The same enum covers `Netwo
 | `InvalidDomain { rule_index, raw, source }` | `.domain` or `.domain_suffix` got a value that failed `DomainName` parse |
 | `InvalidPortRange { rule_index, lo, hi }` | `.port_range(lo, hi)` had `lo > hi` |
 | `IngressDoesNotSupportIcmp { rule_index }` | ICMP protocol on a non-egress rule |
-| `InvalidBlockedDomain { raw, source }` | `DnsBuilder::block_domain` got an unparseable value |
-| `InvalidBlockedDomainSuffix { raw, source }` | `DnsBuilder::block_domain_suffix` got an unparseable value |
 
 Inside `SandboxBuilder::build()`, `BuildError` is wrapped as `MicrosandboxError::NetworkBuilder(BuildError)`.
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -151,11 +151,7 @@ Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter
 | `queryTimeoutMs(ms)` | Per-query timeout. |
 | `build()` | Internal — produce a [`DnsConfig`](#dnsconfig). |
 
-Domain blocking lives on `NetworkBuilder` now — see [`denyDomains`](#networkbuilder) below.
-
-<Note>
-**Deprecated:** `DnsBuilder.blockDomain(domain)` and `DnsBuilder.blockDomainSuffix(suffix)` still work but emit a `@deprecated` JSDoc warning. Migrate to `NetworkBuilder.denyDomains(...)` / `denyDomainSuffixes(...)`; the new methods also enforce at TLS first-flight (SNI) and TCP egress (cache fallback), not just DNS.
-</Note>
+Domain blocking lives on `NetworkBuilder` now — see [`denyDomains`](#networkbuilder) above.
 
 ---
 
@@ -279,8 +275,6 @@ interface PortRange {
 
 | Field | Type | Description |
 |-------|------|-------------|
-| blockedDomains | `readonly string[]` | Block DNS for exact domains (returns REFUSED) |
-| blockedSuffixes | `readonly string[]` | Block DNS for all subdomains of a suffix |
 | nameservers | `readonly string[]` | Upstream nameservers |
 | rebindProtection | `boolean \| null` | DNS rebinding protection toggle |
 | queryTimeoutMs | `number \| null` | Per-query timeout |

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -151,8 +151,6 @@ Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter
 | `queryTimeoutMs(ms)` | Per-query timeout. |
 | `build()` | Internal — produce a [`DnsConfig`](#dnsconfig). |
 
-Domain blocking lives on `NetworkBuilder` now — see [`denyDomains`](#networkbuilder) above.
-
 ---
 
 ## TlsBuilder

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -15,7 +15,7 @@ await using sb = await Sandbox.builder("filtered")
   .image("alpine")
   .network((n) => n
     .policy(NetworkPolicy.publicOnly())
-    .dns((d) => d.blockDomainSuffix(".evil.com"))
+    .denyDomainSuffixes(".evil.com")
     .tls((t) => t.bypass("*.googleapis.com")),
   )
   .create();
@@ -129,6 +129,8 @@ Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter
 | `port(host, guest)` | Publish a TCP port. |
 | `portUdp(host, guest)` | Publish a UDP port. |
 | `policy(NetworkPolicy)` | Set the policy. Use a [`NetworkPolicy`](#networkpolicy) factory or a literal. |
+| `denyDomains(...names)` | Deny egress to these exact domains. Each entry adds a `deny Domain("...")` policy rule that fires at DNS resolution (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback). Prepended onto the policy. |
+| `denyDomainSuffixes(...suffixes)` | Deny egress to all subdomains of these suffixes. Same enforcement layers. |
 | `dns(d => ...)` | Configure DNS — see [`DnsBuilder`](#dnsbuilder). |
 | `tls(t => ...)` | Configure TLS — see [`TlsBuilder`](#tlsbuilder). |
 | `secret(s => ...)` | Add a secret — see [`SecretBuilder`](/sdk/typescript/secrets#secretbuilder). |
@@ -144,12 +146,16 @@ Returned to the callback you pass to `SandboxBuilder.network(...)`. Every setter
 
 | Method | Description |
 |--------|-------------|
-| `blockDomain(domain)` | Block a specific FQDN (returns REFUSED). |
-| `blockDomainSuffix(suffix)` | Block any name ending in `suffix`. |
 | `nameservers(servers)` | Override upstream nameservers (`IP`, `IP:PORT`, `HOST`, or `HOST:PORT`). |
 | `rebindProtection(enabled)` | Toggle DNS rebinding protection. |
 | `queryTimeoutMs(ms)` | Per-query timeout. |
 | `build()` | Internal — produce a [`DnsConfig`](#dnsconfig). |
+
+Domain blocking lives on `NetworkBuilder` now — see [`denyDomains`](#networkbuilder) below.
+
+<Note>
+**Deprecated:** `DnsBuilder.blockDomain(domain)` and `DnsBuilder.blockDomainSuffix(suffix)` still work but emit a `@deprecated` JSDoc warning. Migrate to `NetworkBuilder.denyDomains(...)` / `denyDomainSuffixes(...)`; the new methods also enforce at TLS first-flight (SNI) and TCP egress (cache fallback), not just DNS.
+</Note>
 
 ---
 

--- a/examples/python/net-dns/main.py
+++ b/examples/python/net-dns/main.py
@@ -12,8 +12,8 @@ async def main():
         cpus=1,
         memory=512,
         network=Network(
-            block_domains=("blocked.example.com",),
-            block_domain_suffixes=(".evil.com",),
+            deny_domains=("blocked.example.com",),
+            deny_domain_suffixes=(".evil.com",),
         ),
         replace=True,
     )

--- a/examples/rust/net-dns/bin/main.rs
+++ b/examples/rust/net-dns/bin/main.rs
@@ -1,22 +1,25 @@
-//! DNS filtering — block specific domains and suffixes.
+//! Domain filtering — block specific domains and suffixes via policy
+//! rules.
 //!
-//! Demonstrates the DNS interceptor's domain blocking. Blocked domains
-//! get a SERVFAIL response; allowed domains resolve normally.
+//! Demonstrates domain blocking through the network policy: blocked
+//! domains get REFUSED at the DNS forwarder; allowed domains resolve
+//! normally.
 
-use microsandbox::Sandbox;
+use microsandbox::{NetworkPolicy, Sandbox};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let policy = NetworkPolicy::builder()
+        .default_allow()
+        .rule(|r| r.egress().deny().domain("blocked.example.com"))
+        .rule(|r| r.egress().deny().domain_suffix(".evil.com"))
+        .build()?;
+
     let sandbox = Sandbox::builder("net-dns")
         .image("alpine")
         .cpus(1)
         .memory(512)
-        .network(|n| {
-            n.dns(|d| {
-                d.block_domain("blocked.example.com")
-                    .block_domain_suffix(".evil.com")
-            })
-        })
+        .network(|n| n.policy(policy))
         .replace()
         .create()
         .await?;

--- a/examples/typescript/net-dns/main.ts
+++ b/examples/typescript/net-dns/main.ts
@@ -5,9 +5,9 @@ await using sandbox = await Sandbox.builder("net-dns")
   .cpus(1)
   .memory(512)
   .network((n) =>
-    n.dns((d) =>
-      d.blockDomain("blocked.example.com").blockDomainSuffix(".evil.com"),
-    ),
+    n
+      .denyDomains("blocked.example.com")
+      .denyDomainSuffixes(".evil.com"),
   )
   .replace()
   .create();

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -214,11 +214,15 @@ await using open = await Sandbox.builder("open")
   .network((n) => n.policy(NetworkPolicy.allowAll()))
   .create();
 
-// DNS filtering.
+// Domain filtering via policy rules.
 await using filtered = await Sandbox.builder("filtered")
   .image("alpine")
-  .network((n) => n.dns((d) =>
-    d.blockDomain("blocked.example.com").blockDomainSuffix(".evil.com"),
+  .network((n) => n.policy(
+    NetworkPolicy.builder()
+      .defaultAllow()
+      .denyDomain("blocked.example.com")
+      .denyDomainSuffix(".evil.com")
+      .build(),
   ))
   .create();
 

--- a/sdk/node-ts/native/dns_builder.rs
+++ b/sdk/node-ts/native/dns_builder.rs
@@ -12,8 +12,6 @@ use microsandbox_network::dns::Nameserver;
 #[derive(Clone)]
 #[napi(object, js_name = "DnsConfig")]
 pub struct JsDnsConfig {
-    pub blocked_domains: Vec<String>,
-    pub blocked_suffixes: Vec<String>,
     pub rebind_protection: bool,
     /// Nameservers serialized as their parse-roundtrippable string form
     /// (e.g. `"1.1.1.1:53"`, `"dns.google:53"`).
@@ -23,10 +21,6 @@ pub struct JsDnsConfig {
 }
 
 /// Fluent builder for DNS interception settings.
-///
-/// Mirrors `microsandbox_network::builder::DnsBuilder` 1:1; setters
-/// mutate in place and return `this`. Errors from invalid block-domain
-/// strings accumulate and surface from the terminal `.build()` call.
 #[napi(js_name = "DnsBuilder")]
 pub struct JsDnsBuilder {
     inner: Option<RustDnsBuilder>,
@@ -43,22 +37,6 @@ impl JsDnsBuilder {
         Self {
             inner: Some(RustDnsBuilder::new()),
         }
-    }
-
-    /// Block a specific FQDN (returns REFUSED at the resolver).
-    #[napi(js_name = "blockDomain")]
-    pub fn block_domain(&mut self, domain: String) -> &Self {
-        let prev = self.take_inner();
-        self.inner = Some(prev.block_domain(domain));
-        self
-    }
-
-    /// Block any name ending in `suffix`.
-    #[napi(js_name = "blockDomainSuffix")]
-    pub fn block_domain_suffix(&mut self, suffix: String) -> &Self {
-        let prev = self.take_inner();
-        self.inner = Some(prev.block_domain_suffix(suffix));
-        self
     }
 
     /// Enable or disable DNS rebinding protection. Default: true.
@@ -91,21 +69,15 @@ impl JsDnsBuilder {
         self
     }
 
-    /// Materialize the accumulated state into a `DnsConfig`. Surfaces
-    /// the first invalid-domain error accumulated by `blockDomain` /
-    /// `blockDomainSuffix`, if any.
+    /// Materialize the accumulated state into a `DnsConfig`.
     #[napi]
     pub fn build(&mut self) -> Result<JsDnsConfig> {
         let b = self
             .inner
             .take()
             .ok_or_else(|| napi::Error::from_reason("DnsBuilder.build() called more than once"))?;
-        let cfg = b
-            .build()
-            .map_err(|e| napi::Error::from_reason(format!("{e}")))?;
+        let cfg = b.build();
         Ok(JsDnsConfig {
-            blocked_domains: cfg.blocked_domains,
-            blocked_suffixes: cfg.blocked_suffixes,
             rebind_protection: cfg.rebind_protection,
             nameservers: cfg.nameservers.iter().map(|n| n.to_string()).collect(),
             query_timeout_ms: cfg.query_timeout_ms.try_into().unwrap_or(u32::MAX),

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -537,6 +537,22 @@ export declare class RuleBuilder {
   allowLocal(): this
   /** Deny `Loopback + LinkLocal + Host`. */
   denyLocal(): this
+  /** Allow `Destination::Domain(name)`. One rule per call. */
+  allowDomain(name: string): this
+  /** Deny `Destination::Domain(name)`. One rule per call. */
+  denyDomain(name: string): this
+  /** Allow each name as a `Destination::Domain` rule. */
+  allowDomains(names: Array<string>): this
+  /** Deny each name as a `Destination::Domain` rule. */
+  denyDomains(names: Array<string>): this
+  /** Allow `Destination::DomainSuffix(suffix)`. */
+  allowDomainSuffix(suffix: string): this
+  /** Deny `Destination::DomainSuffix(suffix)`. */
+  denyDomainSuffix(suffix: string): this
+  /** Allow each suffix as a `Destination::DomainSuffix` rule. */
+  allowDomainSuffixes(suffixes: Array<string>): this
+  /** Deny each suffix as a `Destination::DomainSuffix` rule. */
+  denyDomainSuffixes(suffixes: Array<string>): this
   /**
    * Begin an explicit-destination rule with action `Allow`. The
    * closure receives a `RuleDestinationBuilder` and must call exactly

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -21,19 +21,9 @@ export declare class AttachOptionsBuilder {
 }
 export type JsAttachOptionsBuilder = AttachOptionsBuilder
 
-/**
- * Fluent builder for DNS interception settings.
- *
- * Mirrors `microsandbox_network::builder::DnsBuilder` 1:1; setters
- * mutate in place and return `this`. Errors from invalid block-domain
- * strings accumulate and surface from the terminal `.build()` call.
- */
+/** Fluent builder for DNS interception settings. */
 export declare class DnsBuilder {
   constructor()
-  /** Block a specific FQDN (returns REFUSED at the resolver). */
-  blockDomain(domain: string): this
-  /** Block any name ending in `suffix`. */
-  blockDomainSuffix(suffix: string): this
   /** Enable or disable DNS rebinding protection. Default: true. */
   rebindProtection(enabled: boolean): this
   /**
@@ -44,11 +34,7 @@ export declare class DnsBuilder {
   nameservers(servers: Array<string>): this
   /** Set the per-query timeout in milliseconds. Default: 5000. */
   queryTimeoutMs(ms: number): this
-  /**
-   * Materialize the accumulated state into a `DnsConfig`. Surfaces
-   * the first invalid-domain error accumulated by `blockDomain` /
-   * `blockDomainSuffix`, if any.
-   */
+  /** Materialize the accumulated state into a `DnsConfig`. */
   build(): DnsConfig
 }
 export type JsDnsBuilder = DnsBuilder
@@ -1038,8 +1024,6 @@ export interface AttachOptions {
 
 /** DNS interception configuration produced by `DnsBuilder.build()`. */
 export interface DnsConfig {
-  blockedDomains: Array<string>
-  blockedSuffixes: Array<string>
   rebindProtection: boolean
   /**
    * Nameservers serialized as their parse-roundtrippable string form

--- a/sdk/node-ts/native/network_policy_builder.rs
+++ b/sdk/node-ts/native/network_policy_builder.rs
@@ -77,6 +77,10 @@ enum RuleOp {
     DenyGroup(RustDestinationGroup),
     AllowLocal,
     DenyLocal,
+    AllowDomains(Vec<String>),
+    DenyDomains(Vec<String>),
+    AllowDomainSuffixes(Vec<String>),
+    DenyDomainSuffixes(Vec<String>),
     Commit { action: RustAction, dest: DestKind },
 }
 
@@ -422,6 +426,66 @@ impl JsRuleBuilder {
         self
     }
 
+    // -- bulk-domain shortcuts --------------------------------------
+
+    /// Allow `Destination::Domain(name)`. One rule per call.
+    #[napi(js_name = "allowDomain")]
+    pub fn allow_domain(&mut self, name: String) -> &Self {
+        self.ops.push(RuleOp::AllowDomains(vec![name]));
+        self
+    }
+
+    /// Deny `Destination::Domain(name)`. One rule per call.
+    #[napi(js_name = "denyDomain")]
+    pub fn deny_domain(&mut self, name: String) -> &Self {
+        self.ops.push(RuleOp::DenyDomains(vec![name]));
+        self
+    }
+
+    /// Allow each name as a `Destination::Domain` rule.
+    #[napi(js_name = "allowDomains")]
+    pub fn allow_domains(&mut self, names: Vec<String>) -> &Self {
+        self.ops.push(RuleOp::AllowDomains(names));
+        self
+    }
+
+    /// Deny each name as a `Destination::Domain` rule.
+    #[napi(js_name = "denyDomains")]
+    pub fn deny_domains(&mut self, names: Vec<String>) -> &Self {
+        self.ops.push(RuleOp::DenyDomains(names));
+        self
+    }
+
+    /// Allow `Destination::DomainSuffix(suffix)`. Matches the apex and
+    /// any subdomain.
+    #[napi(js_name = "allowDomainSuffix")]
+    pub fn allow_domain_suffix(&mut self, suffix: String) -> &Self {
+        self.ops.push(RuleOp::AllowDomainSuffixes(vec![suffix]));
+        self
+    }
+
+    /// Deny `Destination::DomainSuffix(suffix)`. Matches the apex and
+    /// any subdomain.
+    #[napi(js_name = "denyDomainSuffix")]
+    pub fn deny_domain_suffix(&mut self, suffix: String) -> &Self {
+        self.ops.push(RuleOp::DenyDomainSuffixes(vec![suffix]));
+        self
+    }
+
+    /// Allow each suffix as a `Destination::DomainSuffix` rule.
+    #[napi(js_name = "allowDomainSuffixes")]
+    pub fn allow_domain_suffixes(&mut self, suffixes: Vec<String>) -> &Self {
+        self.ops.push(RuleOp::AllowDomainSuffixes(suffixes));
+        self
+    }
+
+    /// Deny each suffix as a `Destination::DomainSuffix` rule.
+    #[napi(js_name = "denyDomainSuffixes")]
+    pub fn deny_domain_suffixes(&mut self, suffixes: Vec<String>) -> &Self {
+        self.ops.push(RuleOp::DenyDomainSuffixes(suffixes));
+        self
+    }
+
     /// Begin an explicit-destination rule with action `Allow`. The
     /// closure receives a `RuleDestinationBuilder` and must call exactly
     /// one of `.ip()` / `.cidr()` / `.domain()` / `.domainSuffix()` /
@@ -613,6 +677,18 @@ fn apply_rule_ops(rb: &mut RustRuleBuilder, ops: Vec<RuleOp>) -> &mut RustRuleBu
             }
             RuleOp::DenyLocal => {
                 rb.deny_local();
+            }
+            RuleOp::AllowDomains(names) => {
+                rb.allow_domains(names);
+            }
+            RuleOp::DenyDomains(names) => {
+                rb.deny_domains(names);
+            }
+            RuleOp::AllowDomainSuffixes(suffixes) => {
+                rb.allow_domain_suffixes(suffixes);
+            }
+            RuleOp::DenyDomainSuffixes(suffixes) => {
+                rb.deny_domain_suffixes(suffixes);
             }
             RuleOp::Commit { action, dest } => {
                 let dab = match action {

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1870,6 +1870,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1885,6 +1888,9 @@
       "integrity": "sha512-eUiNzJcYpUB5vc8xLqoxS0yLHS+sACjdu1QcYgNe3dxXVINKI0FYBDm77D5m1kTfozToBl32E+PzZy/lhLM/iw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -426,8 +426,6 @@ export interface NapiAttachOptionsBuilder {
 }
 
 export interface NapiDnsBuilder {
-  blockDomain(domain: string): this;
-  blockDomainSuffix(suffix: string): this;
   rebindProtection(enabled: boolean): this;
   nameservers(servers: string[]): this;
   queryTimeoutMs(ms: number): this;
@@ -435,8 +433,6 @@ export interface NapiDnsBuilder {
 }
 
 export interface NapiDnsConfig {
-  readonly blockedDomains: string[];
-  readonly blockedSuffixes: string[];
   readonly rebindProtection: boolean;
   readonly nameservers: string[];
   readonly queryTimeoutMs: number;

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -581,6 +581,14 @@ export interface NapiRuleBuilder {
   denyHost(): this;
   allowLocal(): this;
   denyLocal(): this;
+  allowDomain(name: string): this;
+  denyDomain(name: string): this;
+  allowDomains(names: string[]): this;
+  denyDomains(names: string[]): this;
+  allowDomainSuffix(suffix: string): this;
+  denyDomainSuffix(suffix: string): this;
+  allowDomainSuffixes(suffixes: string[]): this;
+  denyDomainSuffixes(suffixes: string[]): this;
   allow(configure: (d: NapiRuleDestinationBuilder) => NapiRuleDestinationBuilder): this;
   deny(configure: (d: NapiRuleDestinationBuilder) => NapiRuleDestinationBuilder): this;
 }

--- a/sdk/node-ts/src/network-config.ts
+++ b/sdk/node-ts/src/network-config.ts
@@ -10,8 +10,6 @@ export interface PublishedPort {
 
 /** DNS interception configuration. */
 export interface DnsConfig {
-  readonly blockedDomains: readonly string[];
-  readonly blockedSuffixes: readonly string[];
   readonly nameservers: readonly string[];
   readonly rebindProtection: boolean | null;
   readonly queryTimeoutMs: number | null;

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -216,8 +216,8 @@ sandbox = await Sandbox.create(
     "filtered",
     image="alpine",
     network=Network(
-        block_domains=("blocked.example.com",),
-        block_domain_suffixes=(".evil.com",),
+        deny_domains=("blocked.example.com",),
+        deny_domain_suffixes=(".evil.com",),
     ),
 )
 ```

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -553,10 +553,6 @@ class TlsConfig:
 @dataclass(frozen=True, slots=True)
 class DnsConfig:
     """DNS interception configuration."""
-    block_domains: tuple[str, ...] = ()
-    """Block DNS lookups for exact domains (returns REFUSED)."""
-    block_domain_suffixes: tuple[str, ...] = ()
-    """Block DNS lookups for all subdomains of a suffix."""
     rebind_protection: bool = True
     """Block DNS responses resolving to private IPs. Default: True."""
     nameservers: tuple[str, ...] = ()
@@ -567,10 +563,6 @@ class DnsConfig:
 
     def _to_dict(self) -> dict:
         d: dict = {}
-        if self.block_domains:
-            d["blocked_domains"] = list(self.block_domains)
-        if self.block_domain_suffixes:
-            d["blocked_suffixes"] = list(self.block_domain_suffixes)
         if not self.rebind_protection:
             d["rebind_protection"] = False
         if self.nameservers:
@@ -585,6 +577,15 @@ class Network:
     """Network configuration for a sandbox."""
     policy: str | NetworkPolicy | None = None
     ports: Mapping[int, int] = field(default_factory=dict)
+    deny_domains: tuple[str, ...] = ()
+    """Deny egress to these exact domains. Each entry adds a
+    `deny Domain("...")` policy rule that fires at DNS resolution
+    (REFUSED), TLS first-flight (SNI), and TCP egress (cache fallback).
+    Prepended onto the policy so it takes precedence over later allow
+    rules."""
+    deny_domain_suffixes: tuple[str, ...] = ()
+    """Deny egress to all subdomains of these suffixes. Same enforcement
+    layers as `deny_domains`."""
     dns: DnsConfig | None = None
     tls: TlsConfig | None = None
     max_connections: int | None = None
@@ -610,6 +611,10 @@ class Network:
             d["custom_policy"] = self.policy._to_dict()
         if self.ports:
             d["ports"] = dict(self.ports)
+        if self.deny_domains:
+            d["deny_domains"] = list(self.deny_domains)
+        if self.deny_domain_suffixes:
+            d["deny_domain_suffixes"] = list(self.deny_domain_suffixes)
         if self.dns is not None:
             dns_dict = self.dns._to_dict()
             if dns_dict:

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -364,9 +364,45 @@ fn apply_network(
     mut builder: microsandbox::sandbox::SandboxBuilder,
     net: &Bound<'_, PyDict>,
 ) -> PyResult<microsandbox::sandbox::SandboxBuilder> {
+    // Pre-parse legacy `dns.blocked_domains` / `dns.blocked_suffixes`
+    // into deny-egress policy rules. They no longer flow through the
+    // DNS builder; instead they are prepended to whatever policy is
+    // selected so they take precedence over later allow rules.
+    let dns_deny_rules: Vec<microsandbox_network::policy::Rule> = if let Some(dns) =
+        net.get_item("dns")?
+        && !dns.is_none()
+    {
+        let dns = as_dict(&dns)?;
+        let mut rules = Vec::new();
+        if let Some(domains) = extract_opt::<Vec<String>>(&dns, "blocked_domains")? {
+            for d in domains {
+                let domain = d.parse().map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!("blocked_domains[{d:?}]: {e}"))
+                })?;
+                rules.push(microsandbox_network::policy::Rule::deny_egress(
+                    microsandbox_network::policy::Destination::Domain(domain),
+                ));
+            }
+        }
+        if let Some(suffixes) = extract_opt::<Vec<String>>(&dns, "blocked_suffixes")? {
+            for s in suffixes {
+                let suffix = s.parse().map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!("blocked_suffixes[{s:?}]: {e}"))
+                })?;
+                rules.push(microsandbox_network::policy::Rule::deny_egress(
+                    microsandbox_network::policy::Destination::DomainSuffix(suffix),
+                ));
+            }
+        }
+        rules
+    } else {
+        Vec::new()
+    };
+    let mut policy_set = false;
+
     // Check for preset policy string.
     if let Some(policy_str) = extract_opt::<String>(net, "policy")? {
-        let policy = match policy_str.as_str() {
+        let mut policy = match policy_str.as_str() {
             "none" => NetworkPolicy::none(),
             "public_only" | "public-only" => NetworkPolicy::public_only(),
             "allow_all" | "allow-all" => NetworkPolicy::allow_all(),
@@ -376,7 +412,11 @@ fn apply_network(
                 )));
             }
         };
+        let mut combined = dns_deny_rules.clone();
+        combined.extend(policy.rules);
+        policy.rules = combined;
         builder = builder.network(|n| n.policy(policy));
+        policy_set = true;
     }
 
     // Check for custom policy object.
@@ -526,22 +566,37 @@ fn apply_network(
             }
         }
 
+        let mut combined = dns_deny_rules.clone();
+        combined.extend(rules);
         let policy = NetworkPolicy {
             default_egress,
             default_ingress,
-            rules,
+            rules: combined,
+        };
+        builder = builder.network(|n| n.policy(policy));
+        policy_set = true;
+    }
+
+    // No preset / custom policy was specified, but legacy DNS block
+    // entries were. Use permissive defaults so the rest of the network
+    // keeps working — preserves the legacy "full network minus blocked
+    // domains" semantics.
+    if !policy_set && !dns_deny_rules.is_empty() {
+        let policy = NetworkPolicy {
+            default_egress: microsandbox_network::policy::Action::Allow,
+            default_ingress: microsandbox_network::policy::Action::Allow,
+            rules: dns_deny_rules,
         };
         builder = builder.network(|n| n.policy(policy));
     }
 
-    // DNS configuration (nested `dns` dict).
+    // DNS configuration (nested `dns` dict): rebind / nameservers /
+    // query timeout only — block lists are part of the policy now.
     if let Some(dns) = net.get_item("dns")?
         && !dns.is_none()
     {
         let dns = as_dict(&dns)?;
 
-        let block_domains = extract_opt::<Vec<String>>(&dns, "blocked_domains")?;
-        let block_suffixes = extract_opt::<Vec<String>>(&dns, "blocked_suffixes")?;
         let rebind = extract_opt::<bool>(&dns, "rebind_protection")?;
         let nameservers_raw = extract_opt::<Vec<String>>(&dns, "nameservers")?;
         let query_timeout_ms = extract_opt::<u64>(&dns, "query_timeout_ms")?;
@@ -553,30 +608,22 @@ fn apply_network(
             .collect::<Result<_, _>>()
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
-        builder = builder.network(move |n| {
-            n.dns(move |mut d| {
-                if let Some(domains) = block_domains {
-                    for item in &domains {
-                        d = d.block_domain(item);
+        if rebind.is_some() || !nameservers.is_empty() || query_timeout_ms.is_some() {
+            builder = builder.network(move |n| {
+                n.dns(move |mut d| {
+                    if let Some(r) = rebind {
+                        d = d.rebind_protection(r);
                     }
-                }
-                if let Some(suffixes) = block_suffixes {
-                    for item in &suffixes {
-                        d = d.block_domain_suffix(item);
+                    if !nameservers.is_empty() {
+                        d = d.nameservers(nameservers);
                     }
-                }
-                if let Some(r) = rebind {
-                    d = d.rebind_protection(r);
-                }
-                if !nameservers.is_empty() {
-                    d = d.nameservers(nameservers);
-                }
-                if let Some(ms) = query_timeout_ms {
-                    d = d.query_timeout_ms(ms);
-                }
-                d
-            })
-        });
+                    if let Some(ms) = query_timeout_ms {
+                        d = d.query_timeout_ms(ms);
+                    }
+                    d
+                })
+            });
+        }
     }
 
     // Max connections.

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -364,40 +364,70 @@ fn apply_network(
     mut builder: microsandbox::sandbox::SandboxBuilder,
     net: &Bound<'_, PyDict>,
 ) -> PyResult<microsandbox::sandbox::SandboxBuilder> {
-    // Pre-parse legacy `dns.blocked_domains` / `dns.blocked_suffixes`
-    // into deny-egress policy rules. They no longer flow through the
-    // DNS builder; instead they are prepended to whatever policy is
-    // selected so they take precedence over later allow rules.
-    let dns_deny_rules: Vec<microsandbox_network::policy::Rule> = if let Some(dns) =
-        net.get_item("dns")?
+    // Bulk deny-Domain rules from network.deny_domains /
+    // network.deny_domain_suffixes (canonical) and the deprecated
+    // network.dns.blocked_domains / blocked_suffixes (warns). Parse
+    // up-front so PyValueError propagates cleanly rather than getting
+    // swallowed inside the builder closure.
+    let mut dns_deny_rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
+
+    if let Some(domains) = extract_opt::<Vec<String>>(net, "deny_domains")? {
+        for d in domains {
+            let domain = d.parse().map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("deny_domains[{d:?}]: {e}"))
+            })?;
+            dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
+                microsandbox_network::policy::Destination::Domain(domain),
+            ));
+        }
+    }
+    if let Some(suffixes) = extract_opt::<Vec<String>>(net, "deny_domain_suffixes")? {
+        for s in suffixes {
+            let suffix = s.parse().map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("deny_domain_suffixes[{s:?}]: {e}"))
+            })?;
+            dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
+                microsandbox_network::policy::Destination::DomainSuffix(suffix),
+            ));
+        }
+    }
+    if let Some(dns) = net.get_item("dns")?
         && !dns.is_none()
     {
         let dns = as_dict(&dns)?;
-        let mut rules = Vec::new();
         if let Some(domains) = extract_opt::<Vec<String>>(&dns, "blocked_domains")? {
+            if !domains.is_empty() {
+                emit_deprecation_warning(
+                    net.py(),
+                    "network.dns.blocked_domains is deprecated; use network.deny_domains instead",
+                );
+            }
             for d in domains {
                 let domain = d.parse().map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!("blocked_domains[{d:?}]: {e}"))
                 })?;
-                rules.push(microsandbox_network::policy::Rule::deny_egress(
+                dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                     microsandbox_network::policy::Destination::Domain(domain),
                 ));
             }
         }
         if let Some(suffixes) = extract_opt::<Vec<String>>(&dns, "blocked_suffixes")? {
+            if !suffixes.is_empty() {
+                emit_deprecation_warning(
+                    net.py(),
+                    "network.dns.blocked_suffixes is deprecated; use network.deny_domain_suffixes instead",
+                );
+            }
             for s in suffixes {
                 let suffix = s.parse().map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!("blocked_suffixes[{s:?}]: {e}"))
                 })?;
-                rules.push(microsandbox_network::policy::Rule::deny_egress(
+                dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                     microsandbox_network::policy::Destination::DomainSuffix(suffix),
                 ));
             }
         }
-        rules
-    } else {
-        Vec::new()
-    };
+    }
     let mut policy_set = false;
 
     // Check for preset policy string.
@@ -786,4 +816,18 @@ fn extract_required<'py, T: FromPyObject<'py>>(
     dict.get_item(key)?
         .ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{key} is required")))?
         .extract()
+}
+
+/// Emit a `DeprecationWarning` via Python's `warnings` module so the
+/// deprecation surface respects the host's filter / -W flags.
+/// Failures are ignored — best-effort signal, never break the call.
+fn emit_deprecation_warning(py: Python<'_>, message: &str) {
+    let _ = pyo3::PyErr::warn(
+        py,
+        &py.get_type::<pyo3::exceptions::PyDeprecationWarning>(),
+        std::ffi::CString::new(message)
+            .unwrap_or_default()
+            .as_c_str(),
+        2,
+    );
 }

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -364,10 +364,8 @@ fn apply_network(
     mut builder: microsandbox::sandbox::SandboxBuilder,
     net: &Bound<'_, PyDict>,
 ) -> PyResult<microsandbox::sandbox::SandboxBuilder> {
-    // Bulk deny-Domain rules from network.deny_domains /
-    // network.deny_domain_suffixes. Parse up-front so PyValueError
-    // propagates cleanly rather than getting swallowed inside the
-    // builder closure.
+    // Parse bulk deny-Domain rules up-front so PyValueError propagates
+    // cleanly rather than being swallowed inside the builder closure.
     let mut bulk_deny_rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
 
     if let Some(domains) = extract_opt::<Vec<String>>(net, "deny_domains")? {
@@ -582,8 +580,6 @@ fn apply_network(
         builder = builder.network(|n| n.policy(policy));
     }
 
-    // DNS configuration (nested `dns` dict): rebind / nameservers /
-    // query timeout only — block lists are part of the policy now.
     if let Some(dns) = net.get_item("dns")?
         && !dns.is_none()
     {
@@ -600,22 +596,20 @@ fn apply_network(
             .collect::<Result<_, _>>()
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
-        if rebind.is_some() || !nameservers.is_empty() || query_timeout_ms.is_some() {
-            builder = builder.network(move |n| {
-                n.dns(move |mut d| {
-                    if let Some(r) = rebind {
-                        d = d.rebind_protection(r);
-                    }
-                    if !nameservers.is_empty() {
-                        d = d.nameservers(nameservers);
-                    }
-                    if let Some(ms) = query_timeout_ms {
-                        d = d.query_timeout_ms(ms);
-                    }
-                    d
-                })
-            });
-        }
+        builder = builder.network(move |n| {
+            n.dns(move |mut d| {
+                if let Some(r) = rebind {
+                    d = d.rebind_protection(r);
+                }
+                if !nameservers.is_empty() {
+                    d = d.nameservers(nameservers);
+                }
+                if let Some(ms) = query_timeout_ms {
+                    d = d.query_timeout_ms(ms);
+                }
+                d
+            })
+        });
     }
 
     // Max connections.

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -369,14 +369,14 @@ fn apply_network(
     // network.dns.blocked_domains / blocked_suffixes (warns). Parse
     // up-front so PyValueError propagates cleanly rather than getting
     // swallowed inside the builder closure.
-    let mut dns_deny_rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
+    let mut bulk_deny_rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
 
     if let Some(domains) = extract_opt::<Vec<String>>(net, "deny_domains")? {
         for d in domains {
             let domain = d.parse().map_err(|e| {
                 pyo3::exceptions::PyValueError::new_err(format!("deny_domains[{d:?}]: {e}"))
             })?;
-            dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
+            bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                 microsandbox_network::policy::Destination::Domain(domain),
             ));
         }
@@ -386,7 +386,7 @@ fn apply_network(
             let suffix = s.parse().map_err(|e| {
                 pyo3::exceptions::PyValueError::new_err(format!("deny_domain_suffixes[{s:?}]: {e}"))
             })?;
-            dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
+            bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                 microsandbox_network::policy::Destination::DomainSuffix(suffix),
             ));
         }
@@ -406,7 +406,7 @@ fn apply_network(
                 let domain = d.parse().map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!("blocked_domains[{d:?}]: {e}"))
                 })?;
-                dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
+                bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                     microsandbox_network::policy::Destination::Domain(domain),
                 ));
             }
@@ -422,7 +422,7 @@ fn apply_network(
                 let suffix = s.parse().map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!("blocked_suffixes[{s:?}]: {e}"))
                 })?;
-                dns_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
+                bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                     microsandbox_network::policy::Destination::DomainSuffix(suffix),
                 ));
             }
@@ -442,7 +442,7 @@ fn apply_network(
                 )));
             }
         };
-        let mut combined = dns_deny_rules.clone();
+        let mut combined = bulk_deny_rules.clone();
         combined.extend(policy.rules);
         policy.rules = combined;
         builder = builder.network(|n| n.policy(policy));
@@ -596,7 +596,7 @@ fn apply_network(
             }
         }
 
-        let mut combined = dns_deny_rules.clone();
+        let mut combined = bulk_deny_rules.clone();
         combined.extend(rules);
         let policy = NetworkPolicy {
             default_egress,
@@ -611,11 +611,11 @@ fn apply_network(
     // entries were. Use permissive defaults so the rest of the network
     // keeps working — preserves the legacy "full network minus blocked
     // domains" semantics.
-    if !policy_set && !dns_deny_rules.is_empty() {
+    if !policy_set && !bulk_deny_rules.is_empty() {
         let policy = NetworkPolicy {
             default_egress: microsandbox_network::policy::Action::Allow,
             default_ingress: microsandbox_network::policy::Action::Allow,
-            rules: dns_deny_rules,
+            rules: bulk_deny_rules,
         };
         builder = builder.network(|n| n.policy(policy));
     }

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -365,10 +365,9 @@ fn apply_network(
     net: &Bound<'_, PyDict>,
 ) -> PyResult<microsandbox::sandbox::SandboxBuilder> {
     // Bulk deny-Domain rules from network.deny_domains /
-    // network.deny_domain_suffixes (canonical) and the deprecated
-    // network.dns.blocked_domains / blocked_suffixes (warns). Parse
-    // up-front so PyValueError propagates cleanly rather than getting
-    // swallowed inside the builder closure.
+    // network.deny_domain_suffixes. Parse up-front so PyValueError
+    // propagates cleanly rather than getting swallowed inside the
+    // builder closure.
     let mut bulk_deny_rules: Vec<microsandbox_network::policy::Rule> = Vec::new();
 
     if let Some(domains) = extract_opt::<Vec<String>>(net, "deny_domains")? {
@@ -389,43 +388,6 @@ fn apply_network(
             bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
                 microsandbox_network::policy::Destination::DomainSuffix(suffix),
             ));
-        }
-    }
-    if let Some(dns) = net.get_item("dns")?
-        && !dns.is_none()
-    {
-        let dns = as_dict(&dns)?;
-        if let Some(domains) = extract_opt::<Vec<String>>(&dns, "blocked_domains")? {
-            if !domains.is_empty() {
-                emit_deprecation_warning(
-                    net.py(),
-                    "network.dns.blocked_domains is deprecated; use network.deny_domains instead",
-                );
-            }
-            for d in domains {
-                let domain = d.parse().map_err(|e| {
-                    pyo3::exceptions::PyValueError::new_err(format!("blocked_domains[{d:?}]: {e}"))
-                })?;
-                bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
-                    microsandbox_network::policy::Destination::Domain(domain),
-                ));
-            }
-        }
-        if let Some(suffixes) = extract_opt::<Vec<String>>(&dns, "blocked_suffixes")? {
-            if !suffixes.is_empty() {
-                emit_deprecation_warning(
-                    net.py(),
-                    "network.dns.blocked_suffixes is deprecated; use network.deny_domain_suffixes instead",
-                );
-            }
-            for s in suffixes {
-                let suffix = s.parse().map_err(|e| {
-                    pyo3::exceptions::PyValueError::new_err(format!("blocked_suffixes[{s:?}]: {e}"))
-                })?;
-                bulk_deny_rules.push(microsandbox_network::policy::Rule::deny_egress(
-                    microsandbox_network::policy::Destination::DomainSuffix(suffix),
-                ));
-            }
         }
     }
     let mut policy_set = false;
@@ -816,18 +778,4 @@ fn extract_required<'py, T: FromPyObject<'py>>(
     dict.get_item(key)?
         .ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{key} is required")))?
         .extract()
-}
-
-/// Emit a `DeprecationWarning` via Python's `warnings` module so the
-/// deprecation surface respects the host's filter / -W flags.
-/// Failures are ignored — best-effort signal, never break the call.
-fn emit_deprecation_warning(py: Python<'_>, message: &str) {
-    let _ = pyo3::PyErr::warn(
-        py,
-        &py.get_type::<pyo3::exceptions::PyDeprecationWarning>(),
-        std::ffi::CString::new(message)
-            .unwrap_or_default()
-            .as_c_str(),
-        2,
-    );
 }


### PR DESCRIPTION
## Summary

- DNS forwarder now refuses queries whose name matches a `deny Domain` / `deny DomainSuffix` policy rule (RCODE REFUSED).
- TLS proxy and plain TCP proxy peek the first flight, extract the SNI, and re-evaluate Domain rules with the authoritative hostname; fixes the over-allow / over-block bug on shared CDN IPs.
- Bulk-domain shortcuts on `NetworkPolicyBuilder`: `deny_domains([...])`, `deny_domain_suffixes([...])`, plus allow variants.
- New canonical names across all surfaces: `--deny-domain` / `--deny-domain-suffix` on the CLI, `denyDomains` / `denyDomainSuffixes` in the Node SDK, `deny_domains` / `deny_domain_suffixes` in the Python SDK.
- Removed the legacy `DnsBuilder::block_domain` API and the `dns.block_domains` field across all surfaces; 4.0 takes the clean break.

fixes https://github.com/superradcompany/microsandbox/issues/603

## Wire-behaviour change

Domain-rule denies that previously disappeared at SYN (no SYN-ACK) now produce a post-handshake FIN, since the decision is deferred to first-flight. Guests using `connect()` plus a short timeout see reset/EOF on the first read instead of `ECONNREFUSED`.

## Migration

```
--dns-block-domain X                →   --deny-domain X
--dns-block-suffix X                →   --deny-domain-suffix X
DnsConfig(block_domains=...)        →   Network(deny_domains=...)
.dns(d => d.blockDomain(...))       →   .denyDomains(...)
network.dns.blockDomains            →   network.denyDomains
```

## Test plan

- [x] cargo test -p microsandbox-network --lib
- [x] cargo nextest run -p microsandbox --tests --run-ignored=only (requires working msb / libkrunfw setup; verifies the new `domain_policy_sni_disambiguates_shared_cdn_ip` and `domain_policy_deny_domain_refuses_dns` end-to-end)
- [x] Manual: `msb run alpine --deny-domain example.com -- nslookup example.com` returns REFUSED
- [x] Manual: HTTPS to a denied SNI on a shared CDN IP fails post-handshake while a permitted SNI on the same IP succeeds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->