### PR TITLE
chore(release): fix npm exec bit and bump to 0.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,6 +370,9 @@ jobs:
             cp "node-artifacts/node-sdk-$dir/npm/$dir"/microsandbox.*.node "sdk/node-ts/npm/$dir/"
             cp "node-artifacts/node-sdk-$dir/npm/$dir/bin/msb" "sdk/node-ts/npm/$dir/bin/"
             cp "node-artifacts/node-sdk-$dir/npm/$dir/lib/"* "sdk/node-ts/npm/$dir/lib/"
+            # GitHub Actions artifacts strip Unix exec bits; restore before publish
+            # so the published tarball carries 0755 on the binary.
+            chmod +x "sdk/node-ts/npm/$dir/bin/msb"
           done
 
           # Copy napi-generated bindings into the root package's native/ dir

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2615,14 +2615,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "sea-orm",
 ]
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -2662,14 +2662,14 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "sea-orm-migration",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "core-foundation 0.9.4",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "futures",
  "ipnetwork",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libc",
  "scopeguard",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "test-macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/crates/agentd/Cargo.lock
+++ b/crates/agentd/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "ciborium",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "ciborium",

--- a/crates/agentd/Cargo.toml
+++ b/crates/agentd/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 [workspace.package]
 authors = ["Super Rad Company <developemnt@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -46,7 +46,7 @@ path = "lib/lib.rs"
 chrono.workspace = true
 ciborium.workspace = true
 libc.workspace = true
-microsandbox-protocol = { version = "0.4.1", path = "../protocol" }
+microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
 nix = { workspace = true, features = [
     "fs",
     "hostname",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,12 +36,12 @@ dirs.workspace = true
 indicatif.workspace = true
 ipnetwork = { workspace = true, optional = true }
 libc.workspace = true
-microsandbox = { version = "0.4.1", path = "../microsandbox", default-features = false }
-microsandbox-image = { version = "0.4.1", path = "../image" }
-microsandbox-network = { version = "0.4.1", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.1", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.1", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox = { version = "0.4.2", path = "../microsandbox", default-features = false }
+microsandbox-image = { version = "0.4.2", path = "../image" }
+microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.2", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 rand.workspace = true
 reqwest.workspace = true
 rpassword.workspace = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib/lib.rs"
 
 [dependencies]
 libc.workspace = true
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 msb_krun = "0.1.11"
 scopeguard.workspace = true
 tempfile.workspace = true
@@ -23,5 +23,5 @@ default = ["prebuilt"]
 prebuilt = ["dep:ureq"]
 
 [build-dependencies]
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 ureq = { workspace = true, optional = true }

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { workspace = true, features = ["gzip", "tokio", "zstd"] }
 futures.workspace = true
 hex.workspace = true
 libc.workspace = true
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 oci-client.workspace = true
 rustls-pemfile.workspace = true
 oci-spec.workspace = true

--- a/crates/microsandbox/Cargo.toml
+++ b/crates/microsandbox/Cargo.toml
@@ -30,14 +30,14 @@ dirs.workspace = true
 flate2.workspace = true
 futures.workspace = true
 libc.workspace = true
-microsandbox-db = { version = "0.4.1", path = "../db" }
-microsandbox-filesystem = { version = "0.4.1", path = "../filesystem", default-features = false }
-microsandbox-image = { version = "0.4.1", path = "../image" }
-microsandbox-migration = { version = "0.4.1", path = "../migration" }
-microsandbox-network = { version = "0.4.1", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.1", path = "../protocol" }
-microsandbox-runtime = { version = "0.4.1", path = "../runtime", default-features = false }
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox-db = { version = "0.4.2", path = "../db" }
+microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-features = false }
+microsandbox-image = { version = "0.4.2", path = "../image" }
+microsandbox-migration = { version = "0.4.2", path = "../migration" }
+microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
+microsandbox-runtime = { version = "0.4.2", path = "../runtime", default-features = false }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true
 reqwest.workspace = true

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,8 +23,8 @@ hickory-proto = { workspace = true, features = ["tls-ring"] }
 ipnetwork = { workspace = true }
 libc = { workspace = true }
 lru = { workspace = true }
-microsandbox-protocol = { version = "0.4.1", path = "../protocol" }
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 msb_krun = { version = "0.1.11", features = ["net"] }
 parking_lot = { workspace = true }
 pem = "3"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -22,11 +22,11 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
 crossbeam-queue = { workspace = true }
 libc.workspace = true
-microsandbox-db = { version = "0.4.1", path = "../db" }
-microsandbox-filesystem = { version = "0.4.1", path = "../filesystem", default-features = false }
-microsandbox-network = { version = "0.4.1", path = "../network", optional = true }
-microsandbox-protocol = { version = "0.4.1", path = "../protocol" }
-microsandbox-utils = { version = "0.4.1", path = "../utils" }
+microsandbox-db = { version = "0.4.2", path = "../db" }
+microsandbox-filesystem = { version = "0.4.2", path = "../filesystem", default-features = false }
+microsandbox-network = { version = "0.4.2", path = "../network", optional = true }
+microsandbox-protocol = { version = "0.4.2", path = "../protocol" }
+microsandbox-utils = { version = "0.4.2", path = "../utils" }
 msb_krun = { version = "0.1.11", features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rustls = { workspace = true }

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/shell-attach/package-lock.json
+++ b/examples/typescript/shell-attach/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../../sdk/node-ts": {
       "name": "microsandbox",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -26,9 +26,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.1",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.1",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.1"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.2",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.2",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.4.1"
+    "microsandbox": "0.4.2"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/sdk/node-ts/Cargo.toml
+++ b/sdk/node-ts/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.1", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.1", path = "../../crates/network" }
+microsandbox = { version = "0.4.2", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.2", path = "../../crates/network" }
 napi = { version = "3", default-features = false, features = [
     "async",
     "tokio_rt",

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs"
@@ -21,9 +21,9 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.4.1",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.1",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.1"
+        "@superradcompany/microsandbox-darwin-arm64": "0.4.2",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.2",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.4.2"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -47,9 +47,9 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.4.1",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.1",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.1"
+    "@superradcompany/microsandbox-darwin-arm64": "0.4.2",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.4.2",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.4.2"
   },
   "files": [
     "dist",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-microsandbox = { version = "0.4.1", path = "../../crates/microsandbox" }
-microsandbox-network = { version = "0.4.1", path = "../../crates/network" }
+microsandbox = { version = "0.4.2", path = "../../crates/microsandbox" }
+microsandbox-network = { version = "0.4.2", path = "../../crates/network" }
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 pyo3 = { version = "0.24", features = ["abi3-py310", "extension-module"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }


### PR DESCRIPTION
## TL;DR
The 0.4.1 npm platform packages shipped `bin/msb` without the executable bit set. This PR fixes the CI step that was stripping it and rolls a 0.4.2 bump across every microsandbox crate, SDK, platform package, example, and submodule.

## Description
- Add `chmod +x sdk/node-ts/npm/$dir/bin/msb` in the `npm-publish` job after the artifact `cp` so the published tarball carries `0755`. Root cause is `actions/upload-artifact@v4`, which documents that zipped uploads reset all files to `0644` on download.
- Bump every workspace crate (`microsandbox`, `microsandbox-cli`, `microsandbox-db`, `microsandbox-filesystem`, `microsandbox-image`, `microsandbox-migration`, `microsandbox-network`, `microsandbox-protocol`, `microsandbox-runtime`, `microsandbox-utils`, `microsandbox-agentd`, `test-macros`, `test-utils`) and update every internal `path = "..."` version pin from `0.4.1` to `0.4.2`.
- Bump the Node SDK (`microsandbox` + `@superradcompany/microsandbox-{darwin-arm64,linux-arm64-gnu,linux-x64-gnu}`), the Python SDK Cargo pins, and refresh the relevant `Cargo.lock` and `package-lock.json` entries.
- Bump all 12 TypeScript example `package.json` files and the `shell-attach` lockfile to track `microsandbox` 0.4.2.
- Bump the `mcp` submodule to `microsandbox-mcp` 0.4.2 and the `skills` submodule's Rust SDK reference snippet to 0.4.2, and advance both submodule pointers to the bumped commits on `main`.

## Test Plan
- [x] `cargo check --workspace` succeeds with the new versions
- [x] `cd sdk/node-ts && npm install && npm run build` succeeds
- [x] After the next tag push, inspect the published darwin-arm64 tarball: `npm pack @superradcompany/microsandbox-darwin-arm64@0.4.2 && tar -tvf superradcompany-microsandbox-darwin-arm64-0.4.2.tgz | grep msb` shows mode `-rwxr-xr-x`
- [x] `npm i microsandbox@0.4.2` on a clean machine produces an immediately runnable `msb` (no manual `chmod +x` required)
- [x] `git submodule status` shows `mcp` and `skills` at the new commits with no `-dirty` suffix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->