### PR TITLE
feat(packaging): install msb alias alongside microsandbox CLI

### DIFF
--- a/sdk/node-ts/bin/microsandbox.cjs
+++ b/sdk/node-ts/bin/microsandbox.cjs
@@ -4,7 +4,6 @@
 
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 
 const TRIPLES = {
@@ -33,22 +32,14 @@ function resolveMsb() {
     }
   }
 
-  const home = os.homedir();
-  if (home) {
-    const fallback = path.join(home, ".microsandbox", "bin", "msb");
-    if (fs.existsSync(fallback)) {
-      return { path: fallback, source: "home-dir" };
-    }
-  }
-
   return null;
 }
 
 const resolved = resolveMsb();
 if (!resolved) {
   console.error(
-    "microsandbox: msb binary not found. Run `npx microsandbox install` " +
-      "or set MSB_PATH to a working binary.",
+    "microsandbox: msb binary not found. Reinstall the package " +
+      "(npm i -g microsandbox) or set MSB_PATH to a working binary.",
   );
   process.exit(127);
 }

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -15,7 +15,8 @@
     }
   },
   "bin": {
-    "microsandbox": "bin/microsandbox.cjs"
+    "microsandbox": "bin/microsandbox.cjs",
+    "msb": "bin/microsandbox.cjs"
   },
   "napi": {
     "binaryName": "microsandbox",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -28,6 +28,7 @@ keywords = ["sandbox", "microvm", "isolation", "security", "vm"]
 
 [project.scripts]
 microsandbox = "microsandbox._cli:main"
+msb = "microsandbox._cli:main"
 
 [project.urls]
 Homepage = "https://github.com/superradcompany/microsandbox"


### PR DESCRIPTION
## TL;DR
Add `msb` as a second entry point in the npm and Python packages so `npm i -g microsandbox` and `uv tool install microsandbox` put both `microsandbox` and `msb` on PATH.

## Description
- Add `msb` to the `bin` map in `sdk/node-ts/package.json`, pointing at the same `bin/microsandbox.cjs` shim as `microsandbox`.
- Add `msb = "microsandbox._cli:main"` to `[project.scripts]` in `sdk/python/pyproject.toml` so uv/pip generate an `msb` launcher in addition to `microsandbox`.
- No changes to the shim or CLI logic, both names invoke the existing launcher which execs the bundled msb binary.

After installing, both commands are available:

```bash
npm i -g microsandbox
microsandbox --version
msb --version

uv tool install microsandbox
msb --help
```

## Test Plan
- [x] `npm pack` in `sdk/node-ts` and inspect the tarball, confirm both `microsandbox` and `msb` appear in `package.json` `bin`.
- [x] `npm i -g ./microsandbox-*.tgz` (or a CI prerelease) and confirm `which microsandbox` and `which msb` both resolve.
- [x] `uv tool install --from ./sdk/python microsandbox` and confirm `which msb` resolves and `msb --version` runs.
- [x] `microsandbox --version` and `msb --version` produce identical output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superradcompany/codesmith/microsandbox/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->